### PR TITLE
Easy way to disable cookie plugin for single request.

### DIFF
--- a/src/Guzzle/Http/Plugin/CookiePlugin.php
+++ b/src/Guzzle/Http/Plugin/CookiePlugin.php
@@ -314,7 +314,10 @@ class CookiePlugin implements EventSubscriberInterface
      */
     public function onRequestBeforeSend(Event $event)
     {
-        $this->addCookies($event['request']);
+        $request = $event['request'];
+        if($request->getHeader('Cookie') !== false) {
+            $this->addCookies($event['request']);
+        }
     }
 
     /**


### PR DESCRIPTION
Useful fix to easy disabling cookie plugin
Now you can type:

``` $request->setHeader('Cookie',false);```
```
