### PR TITLE
Update src/Guzzle/Http/Client.php

### DIFF
--- a/src/Guzzle/Http/Client.php
+++ b/src/Guzzle/Http/Client.php
@@ -226,7 +226,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
             if (strpos($key, 'curl.') === 0) {
                 $curlOption = str_replace('curl.', '', $key);
                 if (defined($curlOption)) {
-                    $curlValue = defined($value) ? constant($value) : $value;
+                    $curlValue = is_string($value) && defined($value) ? constant($value) : $value;
                     $request->getCurlOptions()->set(constant($curlOption), $curlValue);
                 }
             }


### PR DESCRIPTION
$this->getConfig()->set('curl.CURLOPT_HTTPHEADER',array('Expect:','foo:bar'));

**Warning: defined() expects parameter 1 to be string, array given in D:\library\Guzzle\Http\Client.php on line 229**
