### PR TITLE
[Service] BC: Executing a command returns the command result rather than...

### DIFF
--- a/src/Guzzle/Service/Command/AbstractCommand.php
+++ b/src/Guzzle/Service/Command/AbstractCommand.php
@@ -129,9 +129,9 @@ abstract class AbstractCommand extends Collection implements CommandInterface
     }
 
     /**
-     * Execute the command
+     * Execute the command and return the result
      *
-     * @return Command
+     * @return mixed Returns the result of {@see AbstractCommand::execute}
      * @throws CommandException if a client has not been associated with the command
      */
     public function execute()
@@ -142,7 +142,7 @@ abstract class AbstractCommand extends Collection implements CommandInterface
 
         $this->client->execute($this);
 
-        return $this;
+        return $this->getResult();
     }
 
     /**

--- a/src/Guzzle/Service/Command/CommandInterface.php
+++ b/src/Guzzle/Service/Command/CommandInterface.php
@@ -39,9 +39,9 @@ interface CommandInterface
     function getApiCommand();
 
     /**
-     * Execute the command
+     * Execute the command and return the result
      *
-     * @return Command
+     * @return mixed Returns the result of {@see CommandInterface::execute}ß
      * @throws CommandException if a client has not been associated with the command
      */
     function execute();

--- a/tests/Guzzle/Tests/Service/Command/CommandTest.php
+++ b/tests/Guzzle/Tests/Service/Command/CommandTest.php
@@ -127,7 +127,9 @@ class CommandTest extends AbstractCommandTest
         $command = new MockCommand();
 
         $this->assertSame($command, $command->setClient($client));
-        $this->assertSame($command, $command->execute()); // Implicitly calls prepare
+
+        // Returns the result of the command
+        $this->assertInstanceOf('SimpleXMLElement', $command->execute());
 
         $this->assertTrue($command->isPrepared());
         $this->assertTrue($command->isExecuted());


### PR DESCRIPTION
... the command object

I'd like to merge this PR unless anyone has any objects.  In previous versions of Guzzle, when you execute a command, the execute method returned the command.  This means that you have to write stuff like this:

`$result = $client->getCommand('foo')->execute()->getResult();`

What I'm proposing is this:

`$result = $client->getCommand('foo')->execute();`

If there are no objects, I'll merge into master.
