### PR TITLE
Added support for forms with method="get"

### DIFF
--- a/src/Guzzle/Http/EntityBody.php
+++ b/src/Guzzle/Http/EntityBody.php
@@ -35,6 +35,8 @@ class EntityBody extends Stream
             return new static($stream);
         } elseif ($resource instanceof self) {
             return $resource;
+        } elseif (is_array($resource)) {
+            return self::factory(http_build_query($resource));
         }
 
         throw new InvalidArgumentException('Invalid resource type');

--- a/tests/Guzzle/Tests/Http/EntityBodyTest.php
+++ b/tests/Guzzle/Tests/Http/EntityBodyTest.php
@@ -147,4 +147,13 @@ class EntityBodyTest extends \Guzzle\Tests\GuzzleTestCase
         $body = EntityBody::factory(fopen($this->getServer()->getUrl(), 'r'));
         $this->assertFalse($body->getContentMd5());
     }
+
+    /**
+     * @covers Guzzle\Http\EntityBody::factory
+     */
+    public function testGetTypeFormBodyFactoring()
+    {
+        $body = EntityBody::factory(array('key1' => 'val1', 'key2' => 'val2'));
+        $this->assertEquals('key1=val1&key2=val2', (string)$body);
+    }
 }


### PR DESCRIPTION
there's some forms with method unset or method="get",
like http://en.wikipedia.org/wiki/Main_Page. Those pages
were failing before this commit
