### PR TITLE
Adding idempotent validation to Guzzle\Service\Inspector

### DIFF
--- a/src/Guzzle/Service/Command/AbstractCommand.php
+++ b/src/Guzzle/Service/Command/AbstractCommand.php
@@ -72,7 +72,6 @@ abstract class AbstractCommand extends Collection implements CommandInterface
 
             // Determine the name of the command based on the relation to the
             // client that executes the command
-
             $this->apiCommand = new ApiCommand(array(
                 'name'   => str_replace('\\_', '.', Inflector::snake(substr($className, strpos($className, 'Command') + 8))),
                 'class'  => $className,
@@ -80,8 +79,8 @@ abstract class AbstractCommand extends Collection implements CommandInterface
             ));
         }
 
-        // Set default values on the command
-        $this->getInspector()->validateConfig($this->apiCommand->getParams(), $this, false, false);
+        // Set default and static values on the command
+        $this->getInspector()->initConfig($this->apiCommand->getParams(), $this);
 
         $headers = $this->get('headers');
         if (!$headers instanceof Collection) {
@@ -310,7 +309,9 @@ abstract class AbstractCommand extends Collection implements CommandInterface
                 throw new CommandException('A Client object must be associated with the command before it can be prepared.');
             }
 
-            // Fail on missing required arguments
+            // Fail on missing required arguments, and change parameters via filters
+            // Perform a non-idempotent validation on the parameters.  Options that
+            // change during validation will persist (e.g. injection, filters).
             $this->getInspector()->validateConfig($this->apiCommand->getParams(), $this, true);
 
             $this->build();

--- a/tests/Guzzle/Tests/Service/Description/ServiceDescriptionTest.php
+++ b/tests/Guzzle/Tests/Service/Description/ServiceDescriptionTest.php
@@ -5,6 +5,7 @@ namespace Guzzle\Tests\Service\Description;
 use Guzzle\Common\Collection;
 use Guzzle\Service\Description\ServiceDescription;
 use Guzzle\Service\Description\ApiCommand;
+use Guzzle\Service\Client;
 
 class ServiceDescriptionTest extends \Guzzle\Tests\GuzzleTestCase
 {
@@ -67,5 +68,36 @@ class ServiceDescriptionTest extends \Guzzle\Tests\GuzzleTestCase
         $data = serialize($service);
         $d2 = unserialize($data);
         $this->assertEquals($service, $d2);
+    }
+
+    public function testAllowsForJsonBasedArrayParamsFunctionalTest()
+    {
+        $service = array(
+            'test' => new ApiCommand(array(
+                'method' => 'PUT',
+                'params' => array(
+                    'data'   => array(
+                        'required' => true,
+                        'type'     => 'type:array',
+                        'filters'  => 'json_encode',
+                        'location' => 'body'
+                    )
+                )
+            ))
+        );
+
+        $description = new ServiceDescription($service);
+        $client = new Client();
+        $client->setDescription($description);
+        $command = $client->getCommand('test', array(
+            'data' => array(
+                'foo' => 'bar'
+            )
+        ));
+
+        $request = $command->prepare();
+        $this->assertEquals(json_encode(array(
+            'foo' => 'bar'
+        )), (string) $request->getBody());
     }
 }


### PR DESCRIPTION
Filters are run after type validation.
The result of a filter is only written to the config object when a non
idempotent check is performed.  Commands will now first perform an
idempotent check on instantiation (this sets defaults values and static
values but does not change based on filters or parameter injection).
Commands then perform a non-idempotent validation when preparing a
request for sending.
Adding a functional test to ensure some of the JSON example service
description use cases will work.
