### PR TITLE
[Batch] Added BatchClosureTransfer - fixes #75.

### DIFF
--- a/src/Guzzle/Common/Batch/BatchClosureTransfer.php
+++ b/src/Guzzle/Common/Batch/BatchClosureTransfer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Guzzle\Common\Batch;
+
+/**
+ * Batch transfer strategy where transfer logic can be defined via a Closure.
+ * This class is to be used with {@see Guzzle\Common\Batch\BatchInterface}
+ */
+class BatchClosureTransfer implements BatchTransferInterface
+{
+    /**
+     * @var Closure A closure that performs the transfer
+     */
+    protected $closure;
+
+    /**
+     * Constructor used to specify the closure for performing the transfer
+     *
+     * @param Closure $closure A closure that performs the transfer. The closure
+     *                         should have a single argument (array $batch)
+     *                         identical to the BatchTransferInterface::transfer
+     *                         method.
+     */
+    public function __construct(\Closure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function transfer(array $batch)
+    {
+        if (empty($batch)) {
+            return;
+        }
+
+        call_user_func($this->closure, $batch);
+    }
+}

--- a/tests/Guzzle/Tests/Common/Batch/BatchClosureTransferTest.php
+++ b/tests/Guzzle/Tests/Common/Batch/BatchClosureTransferTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Guzzle\Tests\Common;
+
+use Guzzle\Common\Batch\BatchClosureTransfer;
+
+/**
+ * @covers Guzzle\Common\Batch\BatchClosureTransfer
+ */
+class BatchClosureTransferTest extends \Guzzle\Tests\GuzzleTestCase
+{
+    /**
+     * @var Guzzle\Common\Batch\BatchClosureTransfer The transfer fixture
+     */
+    protected $transferStrategy;
+
+    /**
+     * @var array|null An array for keeping track of items passed into the transfer closure
+     */
+    protected $itemsTransferred;
+
+    protected function setUp()
+    {
+        $this->itemsTransferred = null;
+        $itemsTransferred =& $this->itemsTransferred;
+
+        $this->transferStrategy = new BatchClosureTransfer(function (array $batch) use (&$itemsTransferred) {
+            $itemsTransferred = $batch;
+            return;
+        });;
+    }
+
+    public function testTransfersBatch()
+    {
+        $batchedItems = array('foo', 'bar', 'baz');
+        $this->transferStrategy->transfer($batchedItems);
+
+        $this->assertEquals($batchedItems, $this->itemsTransferred);
+    }
+
+    public function testTransferBailsOnEmptyBatch()
+    {
+        $batchedItems = array();
+        $this->transferStrategy->transfer($batchedItems);
+
+        $this->assertNull($this->itemsTransferred);
+    }
+}


### PR DESCRIPTION
The BatchClosureTransfer allows a closure to be passed in for specifying transfer logic in the batch system.
