### PR TITLE
[batch] Getters/Setters added. Transfer and Divisor exposed via Exception

### DIFF
--- a/src/Guzzle/Common/Batch/Batch.php
+++ b/src/Guzzle/Common/Batch/Batch.php
@@ -64,7 +64,7 @@ class Batch implements BatchInterface
                     }
                 }
 
-                throw new BatchTransferException($batch, $e);
+                throw new BatchTransferException($batch, $e, $this->transferStrategy, $this->divisionStrategy);
             }
         }
 

--- a/src/Guzzle/Common/Batch/BatchSizeDivisor.php
+++ b/src/Guzzle/Common/Batch/BatchSizeDivisor.php
@@ -21,6 +21,30 @@ class BatchSizeDivisor implements BatchDivisorInterface
     }
 
     /**
+     * Set the size of each batch
+     *
+     * @param int $size Size of each batch
+     *
+     * @return BatchSizeDivisor
+     */
+    public function setSize($size)
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    /**
+     * Get the size of each batch
+     *
+     * @return int
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function createBatches(\SplQueue $queue)

--- a/src/Guzzle/Common/Batch/FlushingBatch.php
+++ b/src/Guzzle/Common/Batch/FlushingBatch.php
@@ -24,6 +24,29 @@ class FlushingBatch extends AbstractBatchDecorator
     }
 
     /**
+     * Set the auto-flush threshold
+     *
+     * @param int $threshold The auto-flush threshold
+     * @return FlushingBatch
+     */
+    public function setThreshold($threshold)
+    {
+        $this->threshold = $threshold;
+
+        return $this;
+    }
+
+    /**
+     * Get the auto-flush threshold
+     *
+     * @return int
+     */
+    public function getThreshold()
+    {
+        return $this->threshold;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function add($item)

--- a/src/Guzzle/Common/Exception/BatchTransferException.php
+++ b/src/Guzzle/Common/Exception/BatchTransferException.php
@@ -3,19 +3,47 @@
 namespace Guzzle\Common\Exception;
 
 use Guzzle\Common\GuzzleException;
+use Guzzle\Common\Batch\BatchTransferInterface as TransferStrategy;
+use Guzzle\Common\Batch\BatchDivisorInterface as DivisorStrategy;
 
 /**
  * Exception thrown during a batch transfer
  */
 class BatchTransferException extends \Exception implements GuzzleException
 {
+
     /**
-     * @param array      $batch     Batch being sent when the exception occurred
-     * @param \Exception $exception Exception encountered
+     * @var array The batch being sent when the exception occurred
      */
-    public function __construct(array $batch, \Exception $exception)
+    protected $batch;
+
+    /**
+     * @var TransferStrategy The transfer strategy in use when the exception occurred
+     */
+    protected $transferStrategy;
+
+    /**
+     * @var DivisorStrategy The divisor strategy in use when the exception occurred
+     */
+    protected $divisorStrategy;
+
+    /**
+     * @param array            $batch            The batch being sent when the exception occurred
+     * @param \Exception       $exception        Exception encountered
+     * @param TransferStrategy $transferStrategy The transfer strategy in use when the exception occurred
+     * @param DivisorStrategy  $divisorStrategy  The divisor strategy in use when the exception occurred
+     */
+    public function __construct(
+        array $batch,
+        \Exception $exception,
+        TransferStrategy $transferStrategy = null,
+        DivisorStrategy $divisorStrategy = null
+    )
     {
-        $this->batch = $batch;
+        $this->batch            = $batch;
+        $this->transferStrategy = $transferStrategy;
+        $this->divisorStrategy  = $divisorStrategy;
+
         parent::__construct('Exception encountered while transferring batch', $exception->getCode(), $exception);
     }
 
@@ -27,5 +55,25 @@ class BatchTransferException extends \Exception implements GuzzleException
     public function getBatch()
     {
         return $this->batch;
+    }
+
+    /**
+     * Get the transfer strategy
+     *
+     * @return TransferStrategy
+     */
+    public function getTransferStrategy()
+    {
+        return $this->transferStrategy;
+    }
+
+    /**
+     * Get the divisor strategy
+     *
+     * @return DivisorStrategy
+     */
+    public function getDivisorStrategy()
+    {
+        return $this->divisorStrategy;
     }
 }

--- a/tests/Guzzle/Tests/Common/Batch/BatchSizeDivisorTest.php
+++ b/tests/Guzzle/Tests/Common/Batch/BatchSizeDivisorTest.php
@@ -15,7 +15,9 @@ class BatchSizeDivisorTest extends \Guzzle\Tests\GuzzleTestCase
         $queue[] = 'foo';
         $queue[] = 'baz';
         $queue[] = 'bar';
-        $d = new BatchSizeDivisor(2);
+        $d = new BatchSizeDivisor(3);
+        $this->assertEquals(3, $d->getSize());
+        $d->setSize(2);
         $batches = $d->createBatches($queue);
         $this->assertEquals(array(array('foo', 'baz'), array('bar')), $batches);
     }

--- a/tests/Guzzle/Tests/Common/Batch/FlushingBatchTest.php
+++ b/tests/Guzzle/Tests/Common/Batch/FlushingBatchTest.php
@@ -31,7 +31,9 @@ class FlushingBatchTest extends \Guzzle\Tests\GuzzleTestCase
         $t->expects($this->exactly(2))
             ->method('transfer');
 
-        $flush = new FlushingBatch($batch, 2);
+        $flush = new FlushingBatch($batch, 3);
+        $this->assertEquals(3, $flush->getThreshold());
+        $flush->setThreshold(2);
         $flush->add('foo')->add('baz')->add('bar')->add('bee')->add('boo');
         $this->assertEquals(1, count($flush));
     }

--- a/tests/Guzzle/Tests/Common/Exception/BatchTransferExceptionTest.php
+++ b/tests/Guzzle/Tests/Common/Exception/BatchTransferExceptionTest.php
@@ -8,9 +8,13 @@ class BatchTransferExceptionTest extends \Guzzle\Tests\GuzzleTestCase
 {
     public function testContainsBatch()
     {
-        $a = new \Exception('Baz!');
-        $b = new BatchTransferException(array('foo'), $a);
-        $this->assertEquals(array('foo'), $b->getBatch());
-        $this->assertSame($a, $b->getPrevious());
+        $e = new \Exception('Baz!');
+        $t = $this->getMock('Guzzle\Common\Batch\BatchTransferInterface');
+        $d = $this->getMock('Guzzle\Common\Batch\BatchDivisorInterface');
+        $transferException = new BatchTransferException(array('foo'), $e, $t, $d);
+        $this->assertEquals(array('foo'), $transferException->getBatch());
+        $this->assertSame($t, $transferException->getTransferStrategy());
+        $this->assertSame($d, $transferException->getDivisorStrategy());
+        $this->assertSame($e, $transferException->getPrevious());
     }
 }


### PR DESCRIPTION
Added getters and setters to BatchSizeDivisor and FlushingBatch. Changed BatchTransferException to contain a reference to the transfer and divisor objects.
