### PR TITLE
Fix for a situation where a "blank" (e.g. null, false) value for a query string

### DIFF
--- a/src/Guzzle/Http/QueryString.php
+++ b/src/Guzzle/Http/QueryString.php
@@ -357,9 +357,9 @@ class QueryString extends Collection
                     $value = rawurlencode($value);
                 }
                 if ($encodeFields) {
-                    $temp[rawurlencode($key)] = $value;
+                    $temp[rawurlencode($key)] = (string) $value;
                 } else {
-                    $temp[$key] = $value;
+                    $temp[$key] = (string) $value;
                 }
             }
         }

--- a/tests/Guzzle/Tests/Http/QueryStringTest.php
+++ b/tests/Guzzle/Tests/Http/QueryStringTest.php
@@ -153,17 +153,18 @@ class QueryStringTest extends \Guzzle\Tests\GuzzleTestCase
                 'v1',
                 'v2',
                 'v3'
-            )
+            ),
+            'test4' => null,
         );
         $this->q->replace($params);
-        $this->assertEquals('?test=value&test%202=this%20is%20a%20test%3F&test3%5B0%5D=v1&test3%5B1%5D=v2&test3%5B2%5D=v3', $this->q->__toString());
+        $this->assertEquals('?test=value&test%202=this%20is%20a%20test%3F&test3%5B0%5D=v1&test3%5B1%5D=v2&test3%5B2%5D=v3&test4=', $this->q->__toString());
         $this->q->setEncodeFields(false);
         $this->q->setEncodeValues(false);
-        $this->assertEquals('?test=value&test 2=this is a test?&test3[0]=v1&test3[1]=v2&test3[2]=v3', $this->q->__toString());
+        $this->assertEquals('?test=value&test 2=this is a test?&test3[0]=v1&test3[1]=v2&test3[2]=v3&test4=', $this->q->__toString());
 
         // Use an alternative aggregator
         $this->q->setAggregateFunction(array($this->q, 'aggregateUsingComma'));
-        $this->assertEquals('?test=value&test 2=this is a test?&test3=v1,v2,v3', $this->q->__toString());
+        $this->assertEquals('?test=value&test 2=this is a test?&test3=v1,v2,v3&test4=', $this->q->__toString());
     }
 
     /**


### PR DESCRIPTION
Hi guys!

I ran into a behavior that I didn't like with query strings, and this PR fixes it (and hopefully also touches as little as possible). If the fix is short-sighted or if you see any other issues, please let me know!
- Test suite passes with this change
- should _not_ be a BC break, but it could in theory be if people were setting data values that were something like an object, which may have been ignore before but would be cast into a string now

More details on the issue and the before/and after can be seen at sha: 3201541

Thanks!
