### PR TITLE
updated composer.json for new symfony beta version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
 
     "require-dev": {
-        "symfony/event-dispatcher": "2.1.0beta1",
+        "symfony/event-dispatcher": "2.1.0beta2",
         "doctrine/common": "*",
         "symfony/class-loader": "*",
         "monolog/monolog": "1.*",


### PR DESCRIPTION
running phing test-init:

Problem 1
    - Can only install one of: symfony/event-dispatcher v2.1.0-BETA1, symfony/event-dispatcher v2.1.0-BETA2.
    - Can only install one of: symfony/event-dispatcher v2.1.0-BETA2, symfony/event-dispatcher v2.1.0-BETA1.
    - Installation request for symfony/event-dispatcher 2.1.0beta1 -> satisfiable by symfony/event-dispatcher v2.1.0-BETA1.
    - Installation request for symfony/event-dispatcher == 2.1.0.0-beta2 -> satisfiable by symfony/event-dispatcher v2.1.0-BETA2.

This is a hack, it is probably better to get require and require-dev in sync?
