### PR TITLE
Add the ability to override the curl timeout value

### DIFF
--- a/src/Guzzle/Http/Curl/CurlHandle.php
+++ b/src/Guzzle/Http/Curl/CurlHandle.php
@@ -168,9 +168,10 @@ class CurlHandle
             }
         }
 
-        // Check if any headers or cURL options are blacklisted
+
         $client = $request->getClient();
         if ($client) {
+            // Check if any headers or cURL options are blacklisted
             $blacklist = $client->getConfig('curl.blacklist');
             if ($blacklist) {
                 foreach ($blacklist as $value) {
@@ -184,6 +185,12 @@ class CurlHandle
                         unset($curlOptions[$value]);
                     }
                 }
+            }
+
+            // Override the timeout
+            $timeout = $client->getConfig('curl.timeout');
+            if ($timeout !== null) {
+                $curlOptions[CURLOPT_CONNECTTIMEOUT] = $timeout;
             }
         }
 

--- a/tests/Guzzle/Tests/Http/Curl/CurlHandleTest.php
+++ b/tests/Guzzle/Tests/Http/Curl/CurlHandleTest.php
@@ -714,6 +714,47 @@ class CurlHandleTest extends \Guzzle\Tests\GuzzleTestCase
     }
 
     /**
+     * @covers Guzzle\Http\Curl\CurlHandle::factory
+     *
+     * @dataProvider provideDataForTimeout
+     */
+    public function testCurlTimeoutCanBeOverriden($params, $timeout)
+    {
+        $request = RequestFactory::getInstance()->create('PUT', $this->getServer()->getUrl());
+        $request->setClient(new Client('http://www.example.com', $params));
+
+        $handle = CurlHandle::factory($request);
+        $actualTimeout = $handle->getOptions()->get(CURLOPT_CONNECTTIMEOUT);
+        $this->assertEquals($timeout, $actualTimeout);
+    }
+
+    /**
+     * Data provider for testCurlTimeoutCanBeOverriden
+     *
+     * @return array
+     */
+    public function provideDataForTimeout()
+    {
+        return array(
+            // Data set 0
+            // Override the timeout
+            array(
+                array(
+                    'curl.timeout' => 99
+                ),
+                99
+            ),
+
+            // Data set 1
+            // Default of the timeout
+            array(
+                array(),
+                10
+            )
+        );
+    }
+
+    /**
      * @covers Guzzle\Http\Curl\CurlHandle::updateRequestFromTransfer
      */
     public function testEnsuresRequestsHaveResponsesWhenUpdatingFromTransfer()


### PR DESCRIPTION
I have a need to be able to override the default 10 seconds that is set for the curl timeout. Ideally I would like to define this on a per api command basis within the service description, but couldn't easily see a way to achieve that at this moment in time.
