### PR TITLE
Allow configuration to be specified on a service descriptor

### DIFF
--- a/src/Guzzle/Http/Curl/CurlHandle.php
+++ b/src/Guzzle/Http/Curl/CurlHandle.php
@@ -420,4 +420,30 @@ class CurlHandle
             }
         }
     }
+
+    /**
+     * Parse the configuration and replace curl.* configurators into the
+     * constant based values so it can be used elsewhere
+     *
+     * @param array|Collection $config The configuration we want to parse
+     *
+     * @return array|Collection
+     */
+    public static function parseCurlConfig($config)
+    {
+        $curlOptions = array();
+        foreach ($config as $key => $value) {
+            if (strpos($key, 'curl.') === 0) {
+                $curlOption = substr($key, 5);
+                // Convert constants represented as string to constant int values
+                if (defined($curlOption)) {
+                    $value = is_string($value) && defined($value) ? constant($value) : $value;
+                    $curlOption = constant($curlOption);
+                }
+                $curlOptions[$curlOption] = $value;
+            }
+        }
+
+        return $curlOptions;
+    }
 }

--- a/src/Guzzle/Service/Command/AbstractCommand.php
+++ b/src/Guzzle/Service/Command/AbstractCommand.php
@@ -7,6 +7,7 @@ use Guzzle\Common\Exception\BadMethodCallException;
 use Guzzle\Common\Exception\InvalidArgumentException;
 use Guzzle\Http\Message\Response;
 use Guzzle\Http\Message\RequestInterface;
+use Guzzle\Http\Curl\CurlHandle;
 use Guzzle\Service\Description\ApiCommand;
 use Guzzle\Service\ClientInterface;
 use Guzzle\Service\Inspector;
@@ -20,7 +21,6 @@ use Guzzle\Service\Exception\JsonException;
 abstract class AbstractCommand extends Collection implements CommandInterface
 {
     const HEADERS_OPTION = 'headers';
-    const CURL_OPTIONS = 'curl.options';
 
     /**
      * @var ClientInterface Client object used to execute the command
@@ -281,10 +281,11 @@ abstract class AbstractCommand extends Collection implements CommandInterface
                     $this->request->setHeader($key, $value);
                 }
             }
-
-            // Add custom curl options to requests if set
-            if ($curlOptions = $this->get(self::CURL_OPTIONS)) {
-                $this->request->getCurlOptions()->merge($curlOptions);
+            // Add any curl options to the request
+            $curlOptions = CurlHandle::parseCurlConfig($this->getAll());
+            // Override globals
+            foreach ($curlOptions as $key => $value) {
+                $this->request->getCurlOptions()->set($key, $value);
             }
         }
 

--- a/tests/Guzzle/Tests/Http/ClientTest.php
+++ b/tests/Guzzle/Tests/Http/ClientTest.php
@@ -200,6 +200,7 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
             'curl.foo' => 'bar'
         ));
         $request = $client->createRequest();
+
         $this->assertTrue($request->getCurlOptions()->get('debug'));
         $this->assertEquals('bar', $request->getCurlOptions()->get('foo'));
     }

--- a/tests/Guzzle/Tests/Service/Command/CommandTest.php
+++ b/tests/Guzzle/Tests/Service/Command/CommandTest.php
@@ -392,7 +392,7 @@ class CommandTest extends AbstractCommandTest
     {
         $command = new MockCommand(array(
             'foo' => 'bar',
-            'curl.options' => array(CURLOPT_PROXYPORT => 8080)
+            'curl.CURLOPT_PROXYPORT' => 8080
         ));
         $client = new Client();
         $command->setClient($client);


### PR DESCRIPTION
An example of this would be:
<config name="curl.CURLOPT_CONNECTTIMEOUT" value="100" />

This would override the configuration set by the instantiation:

new Client(
    'http://www.example.com',
    array('curl.CURLOPT_CONNECTTIMEOUT' => 100)
);

It hasn't been implemented for Json or Array Based Description Builders in case this was the wrong approach from the off. If it is the right approach, I will implement in both builders and then provide documentation in the documentation repo.
