### PR TITLE
Treat '+' as encoded space when parsing query string

### DIFF
--- a/src/Guzzle/Http/QueryString.php
+++ b/src/Guzzle/Http/QueryString.php
@@ -57,11 +57,18 @@ class QueryString extends Collection
             }
             foreach (explode('&', $query) as $kvp) {
                 $parts = explode('=', $kvp);
-                $key = rawurldecode($parts[0]);
+                $key   = rawurldecode($parts[0]);
+                $value = '';
+
                 if (substr($key, -2) == '[]') {
                     $key = substr($key, 0, -2);
                 }
-                $q->add($key, isset($parts[1]) ? rawurldecode($parts[1]) : '');
+
+                if (isset($parts[1])) {
+                    $value = rawurldecode(str_replace('+', '%20', $parts[1]));
+                }
+
+                $q->add($key, $value);
             }
         }
 

--- a/tests/Guzzle/Tests/Http/QueryStringTest.php
+++ b/tests/Guzzle/Tests/Http/QueryStringTest.php
@@ -246,4 +246,13 @@ class QueryStringTest extends \Guzzle\Tests\GuzzleTestCase
         $query = QueryString::fromString('?foo=baz&bar=boo');
         $this->assertEquals('?foo=baz&bar=boo', (string) $query);
     }
+
+    /**
+     * @covers Guzzle\Http\QueryString::fromString
+     */
+    public function testConvertsPlusSymbolsToSpaces()
+    {
+        $query = QueryString::fromString('var=foo+bar');
+        $this->assertEquals('foo bar', $query->get('var'));
+    }
 }


### PR DESCRIPTION
According to RFC1738 (implemented by urlencode) spaces are encoded as plus
symbols. However, RFC3986 (imeplemented by rawurlencode) states that spaces
should be encoded as '%20'.

When parsing a query string that was encoded with urlencode we should treat
plus symbols as spaces.

fixes #105
