### PR TITLE
Changed CurlMulti::perform to pass a smaller timeout to CurlMulti::executeHandles

### DIFF
--- a/src/Guzzle/Http/Curl/CurlMulti.php
+++ b/src/Guzzle/Http/Curl/CurlMulti.php
@@ -420,7 +420,7 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
             if ($active) {
                 // Select the curl handles until there is any activity on any of the open file descriptors
                 // See https://github.com/php/php-src/blob/master/ext/curl/multi.c#L170
-                $active = $this->executeHandles(true, 0.25);
+                $active = $this->executeHandles(true, 0.1);
             } else {
                 // Sleep to prevent eating CPU because no requests are actually pending a select call
                 usleep(500);


### PR DESCRIPTION
This pull request might be up for discussion. I noticed the default timeout sent to executeHandles is 250ms, is there any reason why we need to to be this high? In the pull request I noticed an increase in performance when changing the timeout to 100ms. curl_multi_select may be called more times, but it will end the call sooner.
