### PR TITLE
Allow DELETE methods to accept an entity body.

### DIFF
--- a/src/Guzzle/Http/Curl/CurlHandle.php
+++ b/src/Guzzle/Http/Curl/CurlHandle.php
@@ -125,6 +125,16 @@ class CurlHandle
                     $request->removeHeader('Content-Length');
                 }
                 break;
+            case 'DELETE':
+                // Let cURL handle setting the Content-Length header
+                $contentLength = $request->getHeader('Content-Length');
+                if ($contentLength != null) {
+                    $contentLength = (int) (string) $contentLength;
+                    $curlOptions[CURLOPT_INFILESIZE] = $contentLength;
+                    $tempHeaders['Content-Length'] = $contentLength;
+                    $request->removeHeader('Content-Length');
+                }
+                break;
             case 'PUT':
             case 'PATCH':
                 if ($request->getMethod() == 'PATCH') {

--- a/src/Guzzle/Http/Message/RequestFactory.php
+++ b/src/Guzzle/Http/Message/RequestFactory.php
@@ -91,7 +91,7 @@ class RequestFactory implements RequestFactoryInterface
      */
     public function create($method, $url, $headers = null, $body = null)
     {
-        if ($method != 'POST' && $method != 'PUT' && $method != 'PATCH') {
+        if ($method != 'POST' && $method != 'PUT' && $method != 'PATCH' && $method != 'DELETE') {
             $c = $this->requestClass;
             $request = new $c($method, $url, $headers);
             if ($body) {


### PR DESCRIPTION
I don't see anywhere in the RFC2616(http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.7) where it says entity bodies are not allowed for the method DELETE; therefore I believe we should leave that choice up to the receiving server instead of restricting users of Guzzle.
