### PR TITLE
UriTemplate suppresses key name for empty arrays.

### DIFF
--- a/src/Guzzle/Parser/UriTemplate/UriTemplate.php
+++ b/src/Guzzle/Parser/UriTemplate/UriTemplate.php
@@ -184,7 +184,9 @@ class UriTemplate implements UriTemplateInterface
                     $kvp[$key] = $var;
                 }
 
-                if ($value['modifier'] == '*') {
+                if (empty($variable)) {
+                    $actuallyUseQueryString = false;
+                } else if ($value['modifier'] == '*') {
                     $expanded = implode($joiner, $kvp);
                     if ($isAssoc) {
                         // Don't prepend the value name when using the explode

--- a/tests/Guzzle/Tests/Parser/UriTemplate/UriTemplateTest.php
+++ b/tests/Guzzle/Tests/Parser/UriTemplate/UriTemplateTest.php
@@ -16,7 +16,6 @@ class UriTemplateTest extends \Guzzle\Tests\GuzzleTestCase
     {
         $t = array();
 
-        // Level 1 template tests
         $params = array(
             'var'   => 'value',
             'hello' => 'Hello World!',
@@ -30,7 +29,8 @@ class UriTemplateTest extends \Guzzle\Tests\GuzzleTestCase
                 "semi"  => ';',
                 "dot"   => '.',
                 "comma" => ','
-            )
+            ),
+            'empty_keys' => array(),
         );
 
         return array_map(function($t) use ($params) {
@@ -106,6 +106,8 @@ class UriTemplateTest extends \Guzzle\Tests\GuzzleTestCase
             array('{&keys*}',            '&semi=%3B&dot=.&comma=%2C'),
             array('{.null}',            ''),
             array('{.null,var}',        '.value'),
+            array('X{.empty_keys*}',     'X'),
+            array('X{.empty_keys}',      'X'),
             // Test that missing expansions are skipped
             array('test{&missing*}',     'test'),
             // Test that multiple expansions can be set


### PR DESCRIPTION
Example of correction:

```
params:            array()
template:          /path{?params*}
previous result:   /path?params=
correct result:    /path
```

Unfortunately PHP is unable to distinguish between an empty list array
and an empty associative array. However this doesn't matter, because the
empty case of either of these is considered "undefined" by the spec,
expanding to an empty string.

http://tools.ietf.org/html/draft-gregorio-uritemplate-08#section-2.3

> A variable defined as a list value is considered undefined if the
> list contains zero members.  A variable defined as an associative
> array of (name, value) pairs is considered undefined if the array
> contains zero members or if all member names in the array are
> associated with undefined values.

http://tools.ietf.org/html/draft-gregorio-uritemplate-08#section-3.2.1

> A variable that is undefined (Section 2.3) has no value and is
> ignored by the expansion process.  If all of the variables in an
> expression are undefined, then the expression's expansion is the
> empty string.

The two test cases I've added are directly from [section 3.2.5](http://tools.ietf.org/html/draft-gregorio-uritemplate-08#section-3.2.5) of the spec.
