### PR TITLE
Not all HTTP Response status lines include text status

### DIFF
--- a/src/Guzzle/Http/Message/Request.php
+++ b/src/Guzzle/Http/Message/Request.php
@@ -492,7 +492,13 @@ class Request extends AbstractMessage implements RequestInterface
 
         if (strpos($data, 'HTTP/') === 0) {
 
-            list( , $code, $status) = explode(' ', $data, 3);
+            $statusLine = explode(' ', $data, 3);
+            if (isset($statusLine[2])) {
+                list( , $code, $status) = $statusLine;
+            } else {
+                $code = $statusLine[1];
+                $status = '';                
+            }
 
             // Only download the body of the response to the specified response
             // body when a successful response is received.

--- a/tests/Guzzle/Tests/Http/Message/RequestTest.php
+++ b/tests/Guzzle/Tests/Http/Message/RequestTest.php
@@ -788,4 +788,20 @@ class RequestTest extends \Guzzle\Tests\GuzzleTestCase
         $request->receiveResponseHeader('HTTP/1.1 503 Service Unavailable');
         $this->assertNotSame($body, $request->getResponse()->getBody());
     }
+
+    /**
+     * Many RESTful frameworks omit the text status from the header. That
+     * provides a response like "HTTP/1.1 200". Prevent an Undefined offset
+     * by checking to see how many parts of the status line are provided
+     * before trying to assign them.
+     *
+     * @covers Guzzle\Http\Message\Request::receiveResponseHeader
+     */
+    public function testReceivingShortStatusLineResponse()
+    {
+        $request = new Request('GET', $this->getServer()->getUrl());
+        $request->receiveResponseHeader('HTTP/1.1 200');
+        $this->assertSame(200, $request->getResponse()->getStatusCode());
+        $this->assertSame('OK', $request->getResponse()->getReasonPhrase());
+    }
 }


### PR DESCRIPTION
Many RESTful frameworks omit the text status from the header. That
provides a response like "HTTP/1.1 200". Prevent an Undefined offset
by checking to see how many parts of the status line are provided
before trying to assign them.
