### PR TITLE
Fix request can use specific IP

### DIFF
--- a/src/Guzzle/Http/Curl/CurlHandle.php
+++ b/src/Guzzle/Http/Curl/CurlHandle.php
@@ -58,7 +58,7 @@ class CurlHandle
 
         // Array of default cURL options.
         $curlOptions = array(
-            CURLOPT_URL            => $request->getUrl(),
+            CURLOPT_URL            => $request->getClient()->getBaseUrl(),
             CURLOPT_CONNECTTIMEOUT => 10,
             CURLOPT_RETURNTRANSFER => false,
             CURLOPT_HEADER         => false,


### PR DESCRIPTION
When i want to use specific IP and specific Host request to my web server and my web server pass to specific Host to get some external web site like: tw.yahoo.com
I found this question;

guzzle throw Exception : Couldn't resolve host

So i edit src\Guzzle\Http\Curl\CurlHandle.php 

```
CURLOPT_URL   => $request->getUrl() 
```

to

```
CURLOPT_URL     => $request->getClient()->getBaseUrl(),
```
