### PR TITLE
URL gets mangled due to QueryString class behaviour

### DIFF
--- a/src/Guzzle/Http/QueryString.php
+++ b/src/Guzzle/Http/QueryString.php
@@ -64,7 +64,7 @@ class QueryString extends Collection
                 }
 
                 if (array_key_exists(1, $parts)) {
-                    $q->add($key, rawurldecode(str_replace('+', '%20', $parts[1])));
+                    $q->add($key, rawurldecode(str_replace('+', '%20', implode('=', array_slice($parts, 1)))));
                 } else {
                     $q->add($key, '');
                 }

--- a/tests/Guzzle/Tests/Http/ClientTest.php
+++ b/tests/Guzzle/Tests/Http/ClientTest.php
@@ -578,4 +578,16 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
         $client = new Client();
         $client->setDefaultHeaders('foo');
     }
+
+    /**
+     * @covers Guzzle\Http\Client
+     */
+    public function testQueryStringsDoubleEqualsSignBehaviour()
+    {
+        $client = new Client();
+
+        $request = $client->get('http://test.com/?query=http://foo.bar/?foo=bar&foo=bar');
+
+        $this->assertEquals('http://test.com/?query=http%3A%2F%2Ffoo.bar%2F%3Ffoo%3Dbar&foo=bar', $request->getUrl());
+    }
 }


### PR DESCRIPTION
Trying to do a GET request to an URL like:

http://test.com/?query=http://foo.bar/?foo=bar&foo=bar

Results in a request to this URL:

http://test.com/?query=http%3A%2F%2Ffoo.bar%2F%3Ffoo&foo=bar

But I would expect it to request this URL:

http://test.com/?query=http%3A%2F%2Ffoo.bar%2F%3Ffoo%3Dbar&foo=bar

Note the missing "%3Dbar" ("=bar")

To "fix" this might go against the applicable RFC, but in real-life scenarios this is expected behaviour (i.e. third-party click tags sending full redirect URL:s as query string parameters).
