### PR TITLE
Improved the iterator factory

### DIFF
--- a/tests/Guzzle/Tests/Service/Resource/ResourceIteratorClassFactoryTest.php
+++ b/tests/Guzzle/Tests/Service/Resource/ResourceIteratorClassFactoryTest.php
@@ -16,8 +16,20 @@ class ResourceIteratorClassFactoryTest extends \Guzzle\Tests\GuzzleTestCase
      */
     public function testValidatesCommand()
     {
-        $factory = new ResourceIteratorClassFactory('foo');
+        $factory = new ResourceIteratorClassFactory();
         $factory->build('foo');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Iterator was not found matching MockCommandIterator
+     */
+    public function testEnsuresIteratorClassExists()
+    {
+        $factory = new ResourceIteratorClassFactory(array('Foo', 'Bar'));
+        $factory->registerNamespace('Baz');
+        $command = new MockCommand();
+        $iterator = $factory->build($command);
     }
 
     public function testBuildsResourceIterators()


### PR DESCRIPTION
Improved the iterator factory so that it can look for iterators in multiple namespaces:

```
// Different options for instantiation
$factory1 = new ResourceIteratorClassFactory();
$factory2 = new ResourceIteratorClassFactory('My\Namespace');
$factory3 = new ResourceIteratorClassFactory(array(
    'My\Namespace',
    'My\Other\Namespace'
));

// Can now register namespaces on the object later
$factory1->registerNamespace('My\Friends\Namespace');
```

The factory will look in the most recently added namespace first when attempting to instantiate an iterator.
