### PR TITLE
Fixes #145: Match .prefix cookied domain names to parent, block subdomai...

### DIFF
--- a/src/Guzzle/Http/Cookie.php
+++ b/src/Guzzle/Http/Cookie.php
@@ -397,8 +397,30 @@ class Cookie
      */
     public function matchesDomain($domain)
     {
-        return !$this->getDomain() || !strcasecmp($domain, $this->getDomain()) ||
-            (strpos($this->getDomain(), '.') === 0 && preg_match('/' . preg_quote($this->getDomain()) . '$/i', $domain));
+        $cookie_domain = $this->getDomain();
+
+        // Domain not set or exact match.
+        if (!$cookie_domain || !strcasecmp($domain, $cookie_domain)) {
+            return true;
+        }
+
+        // . prefix match.
+        if (strpos($cookie_domain, '.') === 0) {
+            $real_domain = substr($cookie_domain, 1);
+
+            // Root domains don't match except for .local.
+            if (!substr_count($real_domain, '.') && strcasecmp($real_domain, 'local')) {
+                return false;
+            }
+
+            if (substr($domain, -strlen($real_domain)) === $real_domain) {
+                // Match exact or 1 deep subdomain.
+                return !strcasecmp($domain, $real_domain) ||
+                    substr_count(substr($domain, 0, -strlen($real_domain)), '.') === 1;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Guzzle/Tests/Http/CookieTest.php
+++ b/tests/Guzzle/Tests/Http/CookieTest.php
@@ -143,7 +143,16 @@ class CookieTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertTrue($cookie->matchesDomain('.baz.com'));
         $this->assertTrue($cookie->matchesDomain('foo.baz.com'));
         $this->assertFalse($cookie->matchesDomain('baz.bar.com'));
+        $this->assertTrue($cookie->matchesDomain('baz.com'));
+
+        $cookie->setDomain('.com');
         $this->assertFalse($cookie->matchesDomain('baz.com'));
+
+        $cookie->setDomain('.com.');
+        $this->assertFalse($cookie->matchesDomain('baz.com'));
+
+        $cookie->setDomain('.local');
+        $this->assertTrue($cookie->matchesDomain('example.local'));
     }
 
     public function testMatchesPath()


### PR DESCRIPTION
...n match of TLD cookies except .local.

See #145
