### PR TITLE
Build tweaks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -29,6 +29,7 @@
 
     <target name="clean">
         <delete dir="${dir.output}"/>
+        <delete dir="${project.basedir}/build/pearwork"/>
     </target>
 
     <target name="prepare" depends="clean,test-init,build-init">

--- a/phing/tasks/GuzzlePearPharPackageTask.php
+++ b/phing/tasks/GuzzlePearPharPackageTask.php
@@ -72,7 +72,7 @@ class GuzzlePearPharPackageTask extends Task
         if (!is_dir($pearwork)) {
             mkdir($pearwork, 0777, true);
         }
-        $pearlogs = (string) $this->basedir . '/build/logs';
+        $pearlogs = (string) $this->basedir . '/build/artifacts/logs';
         if (!is_dir($pearlogs)) {
             mkdir($pearlogs, 0777, true);
         }
@@ -164,12 +164,12 @@ class GuzzlePearPharPackageTask extends Task
         $pfm->setPhpDep($phpdep);
         $pfm->addExtensionDep('required', 'curl');
         $pfm->setPearinstallerDep('1.4.6');
-        $pfm->addPackageDepWithChannel('required', 'EventDispatcher', 'symfony2', '2.1.0');
+        $pfm->addPackageDepWithChannel('required', 'EventDispatcher', 'pear.symfony.com', '2.1.0');
         if (!empty($this->subpackages)) {
             foreach ($this->subpackages as $package) {
                 $pkg = dirname($package);
                 $pkg = str_replace('/', '_', $pkg);
-                $pfm->addConflictingPackageDepWithChannel($pkg, 'guzzle', false, $apiversion);
+                $pfm->addConflictingPackageDepWithChannel($pkg, 'guzzlephp.org/pear', false, $apiversion);
             }
         }
 
@@ -186,16 +186,16 @@ class GuzzlePearPharPackageTask extends Task
             // load up package file and build package
             $packager = new PEAR_Packager();
             echo "\n\n\nBUILDING PACKAGE FROM PACKAGE FILE:\n";
-            $dest_package = $packager->package($opts['packagedirectory'].'/package.xml');
+            $dest_package = $packager->package($opts['packagedirectory'].'package.xml');
             var_dump($dest_package);
         } else {
             echo "\n\n\nDEBUGGING RESULT:\n";
             var_dump($result);
         }
         echo "removing package.xml";
-        unlink($opts['packagedirectory'].'/package.xml');
+        unlink($opts['packagedirectory'].'package.xml');
         $log = ob_get_clean();
-        file_put_contents((string) $this->basedir . '/build/logs/pear_package.log', $log);
+        file_put_contents((string) $this->basedir . '/build/artifacts/logs/pear_package.log', $log);
         chdir($startdir);
     }
 
@@ -252,7 +252,7 @@ class GuzzlePearPharPackageTask extends Task
                 continue;
             }
             if ($type == 'symfony/event-dispatcher') {
-                $pfm->addPackageDepWithChannel('required', 'EventDispatcher', 'symfony2', '2.1.0');
+                $pfm->addPackageDepWithChannel('required', 'EventDispatcher', 'pear.symfony.com', '2.1.0');
             }
             if ($type == 'ext-curl') {
                 $pfm->addExtensionDep('required', 'curl');
@@ -261,12 +261,12 @@ class GuzzlePearPharPackageTask extends Task
                 $gdep = str_replace('/', ' ', $type);
                 $gdep = ucwords($gdep);
                 $gdep = str_replace(' ', '_', $gdep);
-                $pfm->addPackageDepWithChannel('required', $gdep, 'guzzle', $this->getVersion());
+                $pfm->addPackageDepWithChannel('required', $gdep, 'guzzlephp.org/pear', $this->getVersion());
             }
         }
 
         // can't have main Guzzle package AND sub-packages
-        $pfm->addConflictingPackageDepWithChannel('Guzzle', 'guzzle', false, $apiversion);
+        $pfm->addConflictingPackageDepWithChannel('Guzzle', 'guzzlephp.org/pear', false, $apiversion);
 
         ob_start();
         $startdir = getcwd();
@@ -290,7 +290,7 @@ class GuzzlePearPharPackageTask extends Task
         echo "removing package.xml";
         unlink($opts['packagedirectory'].'/package.xml');
         $log = ob_get_clean();
-        file_put_contents((string) $this->basedir . '/build/logs/pear_package_'.$package.'.log', $log);
+        file_put_contents((string) $this->basedir . '/build/artifacts/logs/pear_package_'.$package.'.log', $log);
         chdir($startdir);
     }
 


### PR DESCRIPTION
- `phing clean` will now delete pearwork directory properly.
- pear build logs now written to log directory under build/artifacts/logs
- GuzzlePearPharPackageTask now uses fully-qualified channel hostnames (instead of aliases) as specified in [package.xml docs](https://pear.php.net/manual/en/guide.developers.package2.channel.php). 
