### PR TITLE
Update src/Guzzle/Plugin/Cookie/CookieJar/ArrayCookieJar.php

### DIFF
--- a/src/Guzzle/Plugin/Cookie/CookieJar/ArrayCookieJar.php
+++ b/src/Guzzle/Plugin/Cookie/CookieJar/ArrayCookieJar.php
@@ -80,7 +80,7 @@ class ArrayCookieJar implements CookieJarInterface, \Serializable
      */
     public function add(Cookie $cookie)
     {
-        if (!$cookie->getValue() || !$cookie->getName() || !$cookie->getDomain()) {
+        if ($cookie->getValue() === false || $cookie->getName() === false || $cookie->getDomain() === false) {
             return false;
         }
 


### PR DESCRIPTION
Bug fixed: some cookies were not added

When used as conditional parameters, PHP will cast string or integer values to boolean; most of them to TRUE, but some also to FALSE, e.g. 0 (zero). See also: http://php.net/boolean

With this change, a cookie having a value, name or domain of e.g. "0" will now be accepted, which has not been the case before.
