### PR TITLE
Update src/Guzzle/Plugin/Cookie/CookieJar/ArrayCookieJar.php

### DIFF
--- a/src/Guzzle/Plugin/Cookie/CookieJar/ArrayCookieJar.php
+++ b/src/Guzzle/Plugin/Cookie/CookieJar/ArrayCookieJar.php
@@ -87,10 +87,10 @@ class ArrayCookieJar implements CookieJarInterface, \Serializable
         // Resolve conflicts with previously set cookies
         foreach ($this->cookies as $i => $c) {
 
-            // Check the regular comparison fields
-            if ($c->getPath() != $cookie->getPath() || $c->getMaxAge() != $cookie->getMaxAge() ||
-                $c->getDomain() != $cookie->getDomain() || $c->getHttpOnly() != $cookie->getHttpOnly() ||
-                $c->getPorts() != $cookie->getPorts() || $c->getSecure() != $cookie->getSecure() ||
+            // Continue with next cookie, if an identical cookie is already stored
+            if ($c->getPath() != $cookie->getPath() ||
+                $c->getDomain() != $cookie->getDomain() ||
+                $c->getPorts() != $cookie->getPorts() ||
                 $c->getName() != $cookie->getName()
             ) {
                 continue;


### PR DESCRIPTION
Bug fixed: certain cookie updates were handled incorrectly

Previously, changing the value of a cookie and at the same time a non-identity attribute (e.g. the security flag) resulted in storing the cookie twice. However RFC6265, Section 5.3., Item 11 states, that the old cookie must be replaced.
