### PR TITLE
Fix construction when the response body is just "0"

### DIFF
--- a/src/Guzzle/Http/Message/Response.php
+++ b/src/Guzzle/Http/Message/Response.php
@@ -159,7 +159,7 @@ class Response extends AbstractMessage
     {
         $this->setStatus($statusCode);
         $this->params = new Collection();
-        $this->body = EntityBody::factory($body ?: '');
+        $this->body = EntityBody::factory($body !== null ? $body : '');
 
         if ($headers) {
             if (!is_array($headers) && !($headers instanceof Collection)) {

--- a/tests/Guzzle/Tests/Http/Message/ResponseTest.php
+++ b/tests/Guzzle/Tests/Http/Message/ResponseTest.php
@@ -76,6 +76,8 @@ class ResponseTest extends \Guzzle\Tests\GuzzleTestCase
         $response = new Response(200, null, EntityBody::factory('data'));
         $this->assertInstanceOf('Guzzle\\Http\\EntityBody', $response->getBody());
         $this->assertEquals('data', $response->getBody(true));
+        $response = new Response(200, null, '0');
+        $this->assertSame('0', $response->getBody(true), 'getBody(true) should return "0" if response body is "0".');
 
         // Make sure the proper exception is thrown
         try {


### PR DESCRIPTION
This commit fixes a bug that Guzzle\Http\Message\Response can't treat response body correctly when it is just "0".
