### PR TITLE
Skip tests when missing uri_template extension

### DIFF
--- a/tests/Guzzle/Tests/Parser/UriTemplate/PeclUriTemplateTest.php
+++ b/tests/Guzzle/Tests/Parser/UriTemplate/PeclUriTemplateTest.php
@@ -9,6 +9,16 @@ use Guzzle\Parser\UriTemplate\PeclUriTemplate;
  */
 class PeclUriTemplateTest extends AbstractUriTemplateTest
 {
+    public function setUp()
+    {
+        if (!extension_loaded('uri_template')) {
+            $this->markTestSkipped(
+                'The PECL uri_template extension is not loaded.'
+            );
+        }
+
+        parent::setUp();
+    }
     /**
      * @dataProvider templateProvider
      */


### PR DESCRIPTION
When the PECL uri_template extension is not installed, tests
which rely upon it should be skipped gracefully.
