### PR TITLE
Parse query vars containing equals sign (=)

### DIFF
--- a/src/Guzzle/Http/QueryString.php
+++ b/src/Guzzle/Http/QueryString.php
@@ -55,7 +55,7 @@ class QueryString extends Collection
                 $query = substr($query, 1);
             }
             foreach (explode('&', $query) as $kvp) {
-                $parts = explode('=', $kvp);
+                $parts = explode('=', $kvp, 2);
                 $key = rawurldecode($parts[0]);
 
                 if (substr($key, -2) == '[]') {

--- a/tests/Guzzle/Tests/Http/QueryStringTest.php
+++ b/tests/Guzzle/Tests/Http/QueryStringTest.php
@@ -279,4 +279,13 @@ class QueryStringTest extends \Guzzle\Tests\GuzzleTestCase
         ));
         $this->assertEquals('?foo=0&baz=0&bar=&boo=', (string) $query);
     }
+
+    /**
+     * @covers Guzzle\Http\QueryString::fromString
+     */
+    public function testFromStringDoesntStripTrailingEquals()
+    {
+        $query = QueryString::fromString('data=mF0b3IiLCJUZWFtIERldiJdfX0=');
+        $this->assertEquals('mF0b3IiLCJUZWFtIERldiJdfX0=', $query->get('data'));
+    }
 }


### PR DESCRIPTION
When a query variable contains an equals sign, the QueryString
parsing will strip the equals sign. One example of would be with
base64 encoded strings containing an equals sign at the end for
padding. While this issue can be prevented by simply urlencoding
the URL, cURL, for example, handles this gracefully.

Obviously this is open to discussion. I am only submitting the
pull request for consideration, I am perfectly fine if this doesn't get
accepted, just offering for consistency of use when transitioning
from using cURL directly.
