### PR TITLE
Curl requirement for Guzzle\Http composer

### DIFF
--- a/src/Guzzle/Http/composer.json
+++ b/src/Guzzle/Http/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
+        "ext-curl": "*",
         "guzzle/common": "self.version",
         "guzzle/parser": "self.version",
         "guzzle/stream": "self.version"


### PR DESCRIPTION
I get  an error  while using the Guzzle\Http component because my php was missing curl, and i think it would be great if i get warned in the installation process.

Detail:
PHP Fatal error:  Call to undefined function Guzzle\Http\Curl\curl_version() in /path/to/project/vendor/guzzle/http/Guzzle/Http/Curl/CurlVersion.php on line 47
