### PR TITLE
Update src/Guzzle/Service/Command/LocationVisitor/Request/XmlVisitor.php

### DIFF
--- a/src/Guzzle/Service/Command/LocationVisitor/Request/XmlVisitor.php
+++ b/src/Guzzle/Service/Command/LocationVisitor/Request/XmlVisitor.php
@@ -179,15 +179,9 @@ class XmlVisitor extends AbstractRequestVisitor
                 if ($property = $param->getProperty($name)) {
                     if ($property->getType() == 'object' || $property->getType() == 'array') {
                         // Account for flat arrays, meaning the contents of the array are not wrapped in a container
-                        $child = $property->getData('xmlFlattened') ? $xml : $xml->addChild($property->getWireName());
-                        $this->addXml($child, $property, $v);
-                    } else {
-                        if ($property->getData('xmlAttribute')) {
-                            $xml->addAttribute($property->getWireName(), $v, $property->getData('xmlNamespace'));
-                        } else {
-                            $xml->addChild($property->getWireName(), $v, $property->getData('xmlNamespace'));
-                        }
+                        $xml = $property->getData('xmlFlattened') ? $xml : $xml->addChild($property->getWireName());
                     }
+                    $this->addXml($xml, $property, $v);
                 }
             }
         }


### PR DESCRIPTION
$property may have been configured with filters. 

When $property is an object or array these filters are applied by addXML, but other types are added directly to the SimpleXMLElement so that filters are never applied.

Modified to use addXml recursively instead of directly adding children/attributes to the simpleXMLElement, this accounts for filtering (and also removes the duplication relating to xmlAttribute)
