### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require": {
         "php": ">=5.3.2",
         "ext-curl": "*",
-        "symfony/event-dispatcher": ">=2.1.*"
+        "symfony/event-dispatcher": ">=2.1"
     },
 
     "autoload": {


### PR DESCRIPTION
Allow use of Symfony Event Dispatche releases later than 2.1, i.e., the current dev version.  (This is necessary for Drupal, which is tracking Symfony master.)
