### PR TITLE
Make 3.0.x-dev installable. (3.0.*@dev)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,5 +103,11 @@
                 }
             }
         }
-    ]
+    ],
+
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Batch/composer.json
+++ b/src/Guzzle/Batch/composer.json
@@ -22,5 +22,10 @@
         "guzzle/http": "self.version",
         "guzzle/service": "self.version"
     },
-    "target-dir": "Guzzle/Batch"
+    "target-dir": "Guzzle/Batch",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Cache/composer.json
+++ b/src/Guzzle/Cache/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Cache": "" }
     },
-    "target-dir": "Guzzle/Cache"
+    "target-dir": "Guzzle/Cache",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Common/composer.json
+++ b/src/Guzzle/Common/composer.json
@@ -11,5 +11,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Common": "" }
     },
-    "target-dir": "Guzzle/Common"
+    "target-dir": "Guzzle/Common",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Http/composer.json
+++ b/src/Guzzle/Http/composer.json
@@ -21,5 +21,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Http": "" }
     },
-    "target-dir": "Guzzle/Http"
+    "target-dir": "Guzzle/Http",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Inflection/composer.json
+++ b/src/Guzzle/Inflection/composer.json
@@ -17,5 +17,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Inflection": "" }
     },
-    "target-dir": "Guzzle/Inflection"
+    "target-dir": "Guzzle/Inflection",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Iterator/composer.json
+++ b/src/Guzzle/Iterator/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Iterator": "/" }
     },
-    "target-dir": "Guzzle/Log"
+    "target-dir": "Guzzle/Log",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Log/composer.json
+++ b/src/Guzzle/Log/composer.json
@@ -20,5 +20,10 @@
     "suggest": {
         "guzzle/http": "self.version"
     },
-    "target-dir": "Guzzle/Log"
+    "target-dir": "Guzzle/Log",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Parser/composer.json
+++ b/src/Guzzle/Parser/composer.json
@@ -10,5 +10,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Parser": "" }
     },
-    "target-dir": "Guzzle/Parser"
+    "target-dir": "Guzzle/Parser",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/Async/composer.json
+++ b/src/Guzzle/Plugin/Async/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\Async": "" }
     },
-    "target-dir": "Guzzle/Plugin/Async"
+    "target-dir": "Guzzle/Plugin/Async",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/Backoff/composer.json
+++ b/src/Guzzle/Plugin/Backoff/composer.json
@@ -19,5 +19,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\Backoff": "" }
     },
-    "target-dir": "Guzzle/Plugin/Backoff"
+    "target-dir": "Guzzle/Plugin/Backoff",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/Cache/composer.json
+++ b/src/Guzzle/Plugin/Cache/composer.json
@@ -19,5 +19,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\Cache": "" }
     },
-    "target-dir": "Guzzle/Plugin/Cache"
+    "target-dir": "Guzzle/Plugin/Cache",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/Cookie/composer.json
+++ b/src/Guzzle/Plugin/Cookie/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\Cookie": "" }
     },
-    "target-dir": "Guzzle/Plugin/Cookie"
+    "target-dir": "Guzzle/Plugin/Cookie",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/CurlAuth/composer.json
+++ b/src/Guzzle/Plugin/CurlAuth/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\CurlAuth": "" }
     },
-    "target-dir": "Guzzle/Plugin/CurlAuth"
+    "target-dir": "Guzzle/Plugin/CurlAuth",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/History/composer.json
+++ b/src/Guzzle/Plugin/History/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\History": "" }
     },
-    "target-dir": "Guzzle/Plugin/History"
+    "target-dir": "Guzzle/Plugin/History",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/Log/composer.json
+++ b/src/Guzzle/Plugin/Log/composer.json
@@ -19,5 +19,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\Log": "" }
     },
-    "target-dir": "Guzzle/Plugin/Log"
+    "target-dir": "Guzzle/Plugin/Log",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/Md5/composer.json
+++ b/src/Guzzle/Plugin/Md5/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\Md5": "" }
     },
-    "target-dir": "Guzzle/Plugin/Md5"
+    "target-dir": "Guzzle/Plugin/Md5",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/Mock/composer.json
+++ b/src/Guzzle/Plugin/Mock/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\Mock": "" }
     },
-    "target-dir": "Guzzle/Plugin/Mock"
+    "target-dir": "Guzzle/Plugin/Mock",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/Oauth/composer.json
+++ b/src/Guzzle/Plugin/Oauth/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Plugin\\Oauth": "" }
     },
-    "target-dir": "Guzzle/Plugin/Oauth"
+    "target-dir": "Guzzle/Plugin/Oauth",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Plugin/composer.json
+++ b/src/Guzzle/Plugin/composer.json
@@ -34,5 +34,10 @@
         "guzzle/plugin-md5": "self.version",
         "guzzle/plugin-mock": "self.version",
         "guzzle/plugin-oauth": "self.version"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
     }
 }

--- a/src/Guzzle/Service/composer.json
+++ b/src/Guzzle/Service/composer.json
@@ -20,5 +20,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Service": "" }
     },
-    "target-dir": "Guzzle/Service"
+    "target-dir": "Guzzle/Service",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }

--- a/src/Guzzle/Stream/composer.json
+++ b/src/Guzzle/Stream/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "Guzzle\\Stream": "" }
     },
-    "target-dir": "Guzzle/Stream"
+    "target-dir": "Guzzle/Stream",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    }
 }


### PR DESCRIPTION
Sets up branch aliases for dev-master to 3.0-dev which should (I think?) allow people to target dev versions of Guzzle via guzzle/[whatever]: 3.0.*@dev.
