### PR TITLE
Hard dependency on BackOffPlugin

### DIFF
--- a/src/Guzzle/Http/Curl/CurlMulti.php
+++ b/src/Guzzle/Http/Curl/CurlMulti.php
@@ -397,7 +397,8 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
                 $event['request'] = $request;
                 $request->dispatch(self::POLLING_REQUEST, $event);
                 ++$total;
-                if ($request->getParams()->hasKey(BackoffPlugin::DELAY_PARAM)) {
+                // BackOffPlugin is in a separate component and might not exist.
+                if (class_exists('Guzzle\Plugin\Backoff\BackoffPlugin') && $request->getParams()->hasKey(BackoffPlugin::DELAY_PARAM)) {
                     ++$waiting;
                 }
             }


### PR DESCRIPTION
Commit b92f4a3f9f8c86eea01328f25bc5cdfe9a7a1a57 introduced a hard dependency on guzzle/plugin-backoff by using a class constant from the class defined there.

This dependency should either be added in composer.json or (IMHO preferable) make that check condition on the existence of that class.

We noticed this when we tried to update our Guzzle version in Drupal 8 to the latest stable version in http://drupal.org/node/1875818#comment-6885260 as we just depend on the guzzle/http component and not the whole thing.
