### PR TITLE
Updated client to not clobber user agent when setting default headers

### DIFF
--- a/src/Guzzle/Http/Client.php
+++ b/src/Guzzle/Http/Client.php
@@ -31,6 +31,11 @@ class Client extends AbstractHasDispatcher implements ClientInterface
     protected $defaultHeaders;
 
     /**
+     * @var string The user agent string to set on each request
+     */
+    protected $userAgent;
+
+    /**
      * @var Collection Parameter object holding configuration data
      */
     private $config;
@@ -240,6 +245,10 @@ class Client extends AbstractHasDispatcher implements ClientInterface
             $url = Url::factory($this->getBaseUrl())->combine($this->expandTemplate($uri, $templateVars));
         }
 
+        if ($this->userAgent) {
+            $this->defaultHeaders->set('User-Agent', $this->userAgent);
+        }
+
         // If default headers are provided, then merge them into existing headers
         // If a collision occurs, the header is completely replaced
         if (count($this->defaultHeaders)) {
@@ -283,7 +292,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
         if ($includeDefault) {
             $userAgent .= ' ' . Utils::getDefaultUserAgent();
         }
-        $this->defaultHeaders->set('User-Agent', $userAgent);
+        $this->userAgent = $userAgent;
 
         return $this;
     }

--- a/tests/Guzzle/Tests/Http/ClientTest.php
+++ b/tests/Guzzle/Tests/Http/ClientTest.php
@@ -159,9 +159,16 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
             'api' => 'v1'
         ));
 
+        // Set the user agent string and include the default user agent appended
         $this->assertSame($client, $client->setUserAgent('Test/1.0Ab', true));
         $this->assertEquals('Test/1.0Ab ' . Utils::getDefaultUserAgent(), $client->get()->getHeader('User-Agent'));
+
+        // Set the user agent string without the default appended
         $client->setUserAgent('Test/1.0Ab');
+        $this->assertEquals('Test/1.0Ab', $client->get()->getHeader('User-Agent'));
+
+        // Set default headers and make sure the user agent string is still set
+        $client->setDefaultHeaders(array());
         $this->assertEquals('Test/1.0Ab', $client->get()->getHeader('User-Agent'));
     }
 


### PR DESCRIPTION
When using the `Guzzle\Http\client::setUserAgent` method, it is unsafe to use the `Guzzle\Http\client::setDefaultHeaders` afterwards, because is will clobber the user agent string you previously set. While `setUserAgent` currently sets the `User-Agent` header in the default headers, this is really just an implementation detail. This PR updates the `Client` class to hold the user agent string in a different instance variable, which gets merged into the default headers when creating the request, so it can't be clobbered beforehand.
