### PR TITLE
Adding Accept-Encoding header now sets CURLOPT_ENCODING - fixes #217

### DIFF
--- a/src/Guzzle/Http/Curl/CurlHandle.php
+++ b/src/Guzzle/Http/Curl/CurlHandle.php
@@ -72,6 +72,13 @@ class CurlHandle
             CURLOPT_SSL_VERIFYHOST => 2
         );
 
+        // Add CURLOPT_ENCODING if Accept-Encoding header is provided
+        if ($acceptEncodingHeader = $request->getHeader('Accept-Encoding')) {
+            $curlOptions[CURLOPT_ENCODING] = (string) $acceptEncodingHeader;
+            // Let cURL set the Accept-Encoding header, prevents duplicate values
+            $request->removeHeader('Accept-Encoding');
+        }
+
         // Enable the progress function if the 'progress' param was set
         if ($requestCurlOptions->get('progress')) {
             $curlOptions[CURLOPT_PROGRESSFUNCTION] = array($mediator, 'progress');

--- a/tests/Guzzle/Tests/Http/Curl/CurlHandleTest.php
+++ b/tests/Guzzle/Tests/Http/Curl/CurlHandleTest.php
@@ -959,4 +959,22 @@ class CurlHandleTest extends \Guzzle\Tests\GuzzleTestCase
         $received = $this->getServer()->getReceivedRequests(false);
         $this->assertContainsIns('expect: 100-continue', $received[0]);
     }
+
+    public function testSetsCurloptEncodingWhenAcceptEncodingHeaderIsSet()
+    {
+        $this->getServer()->flush();
+        $this->getServer()->enqueue("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndata");
+        $client = new Client($this->getServer()->getUrl());
+        $request = $client->get('/', array(
+                'Accept' => 'application/json',
+                'Accept-Encoding' => 'gzip, deflate',
+            ));
+        $this->updateForHandle($request);
+        $request->send();
+        $options = $this->requestHandle->getOptions()->getAll();
+        $this->assertSame('gzip, deflate', $options[CURLOPT_ENCODING]);
+        $received = $this->getServer()->getReceivedRequests(false);
+        $this->assertContainsIns('accept: application/json', $received[0]);
+        $this->assertContainsIns('accept-encoding: gzip, deflate', $received[0]);
+    }
 }


### PR DESCRIPTION
This fixes the issue I reported. Includes test case.
