### PR TITLE
Upgrade guide

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -301,7 +301,9 @@ $client->addSubscriber($backoffPlugin);
 
 ### Known Issues
 
-#### [BUG] Accept-Encoding header behavior changed unintentionally. (See #217) (Fixed in 09daeb8c666fb44499a0646d655a8ae36456575e)
+#### [BUG] Accept-Encoding header behavior changed unintentionally. 
+
+(See #217) (Fixed in 09daeb8c666fb44499a0646d655a8ae36456575e)
 
 In version 2.8 setting the `Accept-Encoding` header would set the CURLOPT_ENCODING option, which permitted cURL to
 properly handle gzip/deflate compressed responses from the server. In versions affected by this bug this does not happen.


### PR DESCRIPTION
Fixes #161.

Adds an upgrade guide for version 2.8 to 3.x. This documents only the specific issues I encountered during the upgrade. I'm sure there are more, so add them as needd.
