### PR TITLE
Projects should depend on the last minor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,9 @@ The recommended way to install Guzzle is through [Composer](http://getcomposer.o
 
         {
             "require": {
-                "guzzle/guzzle": "*"
+                "guzzle/guzzle": "~3.1"
             }
         }
-
-    Consider tightening your dependencies to a known version when deploying mission critical applications (e.g. ``2.8.*``).
 
 2. Download and install Composer:
 


### PR DESCRIPTION
If I correctly understand how versioning is done, it follows http://semver.org/ and there are two branches: `master`, where version 3 is being developed, and `guzzle2`, where version 2 is maintained. This implies each of these major version branches has all the new features, bug fixes and other changes mixed.

With this scenario I would change a pair of things:

`README.md` suggests to require `*`. It means users can't do a `composer update` without having to check what changes were introduced (it can be a simple 3.1.2 patch or a whole new 4.0.0). 

OTOH http://guzzlephp.org/tour/installation.html recommends requiring `3.0.*` which is a nice conservative default to keep up only with the bug fixes. The problem with it is there isn't a 3.0 branch but a 3, so if the last 3.0.* version is 3.0.7 but a 3.1 already exists (3.1.1 right now) we can't release a 3.0.8 patch without including the changes introduced in 3.1.0. Now it seems a 3.1.2 would have to be released but users at `3.0.*` would never get it.

In result I would recommend to require one of these:
- `~3.1` for new installations. They would get all the new features and bug fixes but (presumably) no breaking changes.
- `~2.8` for 2.\* installations.
- `dev-master` only for those very close to the project (its developers basically)

Probably it can be explained better but I just wanted to open a discussion about it.
