### PR TITLE
Changes value of CURLOPT_SSL_VERIFYHOST set in Http Client

### DIFF
--- a/src/Guzzle/Http/Client.php
+++ b/src/Guzzle/Http/Client.php
@@ -138,7 +138,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
         } elseif ($certificateAuthority === false) {
             unset($opts[CURLOPT_CAINFO]);
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
-            $opts[CURLOPT_SSL_VERIFYHOST] = 1;
+            $opts[CURLOPT_SSL_VERIFYHOST] = 2;
         } elseif ($verifyPeer !== true && $verifyPeer !== false && $verifyPeer !== 1 && $verifyPeer !== 0) {
             throw new InvalidArgumentException('verifyPeer must be 1, 0 or boolean');
         } elseif ($verifyHost !== 0 && $verifyHost !== 1 && $verifyHost !== 2) {

--- a/tests/Guzzle/Tests/Http/ClientTest.php
+++ b/tests/Guzzle/Tests/Http/ClientTest.php
@@ -228,7 +228,7 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
         $options = $client->getConfig('curl.options');
         $this->assertArrayNotHasKey(CURLOPT_CAINFO, $options);
         $this->assertSame(false, $options[CURLOPT_SSL_VERIFYPEER]);
-        $this->assertSame(1, $options[CURLOPT_SSL_VERIFYHOST]);
+        $this->assertSame(2, $options[CURLOPT_SSL_VERIFYHOST]);
     }
 
     /**


### PR DESCRIPTION
1 as a value for CURLOPT_SSL_VERIFYHOST is deprecated
in libcurl 7.28.1, recommended value is now 2

Latest PHP stables (5.3.21 and 5.4.11) will trigger a notice if 1 is attempted to be set as the value of CURLOPT_SSL_VERIFYHOST. See https://bugs.php.net/bug.php?id=63795
