### PR TITLE
Remove request and response object from message string

### DIFF
--- a/src/Guzzle/Http/Exception/BadResponseException.php
+++ b/src/Guzzle/Http/Exception/BadResponseException.php
@@ -41,8 +41,6 @@ class BadResponseException extends RequestException
             '[status code] ' . $response->getStatusCode(),
             '[reason phrase] ' . $response->getReasonPhrase(),
             '[url] ' . $request->getUrl(),
-            '[request] ' . (string) $request,
-            '[response] ' . (string) $response
         ));
 
         $e = new $class($message);


### PR DESCRIPTION
Based on the discussion in http://drupal.org/node/1875792, here is a suggestion to simplify the error message: Remove the (string) version of the request and response completely.
1. IMHO that huge block of HTML adds so much visual clutter that I have to look for the actual error.
2. This seems to be in line with the curl exception which does just print the error + the url

The only disadvantage that I can see from this is that it could help to debug issues that can not be reproduced manually for example because it happens sporadically or due to the different environment or something. But the typical case there is I guess something firewall-ish (which is a curl exception) and access issues (which is clearly visible as a 403).

You can still access the response and request exception with the methods if you actually want to log or display detailed information from it.

The example output with this for a similar test as http://drupal.org/node/1875792#comment-6939170 is now: "The feed from not found seems to be broken because of error "Client error response [status code] 404 [reason phrase] Not Found [url] http://d8/rs.xml"."

That seems fine to me.
