### PR TITLE
Fixing the bug when filters are not invoked for 'array' operation parameter type, adding unit test for this case as well

### DIFF
--- a/src/Guzzle/Service/Command/LocationVisitor/Request/AbstractRequestVisitor.php
+++ b/src/Guzzle/Service/Command/LocationVisitor/Request/AbstractRequestVisitor.php
@@ -69,6 +69,6 @@ abstract class AbstractRequestVisitor implements RequestVisitorInterface
             }
         }
 
-        return $value;
+        return $param->filter($value);
     }
 }

--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/AbstractVisitorTestCase.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/AbstractVisitorTestCase.php
@@ -78,4 +78,33 @@ abstract class AbstractVisitorTestCase extends \Guzzle\Tests\GuzzleTestCase
             )
         ));
     }
+
+    protected function getCommandWithArrayParamAndFilters()
+    {
+        $operation = new Operation(array(
+            'httpMethod' => 'POST',
+            'parameters' => array(
+                'foo' => new Parameter(array(
+                    'type' => 'string',
+                    'location' => 'query',
+                    'sentAs' => 'Foo',
+                    'required' => true,
+                    'default' => 'bar',
+                    'filters' => array('strtoupper')
+                        )),
+                'arr' => new Parameter(array(
+                    'type' => 'array',
+                    'location' => 'query',
+                    'sentAs' => 'Arr',
+                    'required' => true,
+                    'default' => array(123, 456, 789),
+                    'filters' => array(array('method' => 'implode', 'args' => array(',', '@value')))
+                        ))
+            )
+                ));
+        $command = new OperationCommand(array(), $operation);
+        $command->setClient(new MockClient());
+
+        return $command;
+    }
 }

--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/QueryVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/QueryVisitorTest.php
@@ -31,4 +31,21 @@ class QueryVisitorTest extends AbstractVisitorTestCase
             rawurldecode($request->getQuery())
         );
     }
+
+    /**
+     * @covers Guzzle\Service\Command\LocationVisitor\Request\AbstractRequestVisitor::resolveRecursively
+     */
+    public function testFiltersAreAppliedToArrayParamType()
+    {
+        $command = $this->getCommandWithArrayParamAndFilters();
+
+        $request = $command->prepare();
+
+        $query = $request->getQuery();
+
+        // param type 'string'
+        $this->assertEquals('BAR', $query->get('Foo'));
+        // param type 'array'
+        $this->assertEquals('123,456,789', $query->get('Arr'));
+    }
 }


### PR DESCRIPTION
It seems like when the the 3.1 update was released, one thing became broken. It's about filters and the way they are called. In 3.0 version of the library, the filters were applied to operation parameter during the validation in SchemaValidator class. But in 3.1 they were moved to the phase when Visitors are called. The logic inside visitor now behaves the way that sometimes the filters are not applied, although they have to be. I've added the test case illustrating the behavior, and the possible fix for this case.
