### PR TITLE
Don't reuse CurlMulti

### DIFF
--- a/src/Guzzle/Http/Client.php
+++ b/src/Guzzle/Http/Client.php
@@ -397,7 +397,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
     public function getCurlMulti()
     {
         if (!$this->curlMulti) {
-            $this->curlMulti = CurlMulti::getInstance();
+            $this->curlMulti = new CurlMulti();
         }
 
         return $this->curlMulti;

--- a/src/Guzzle/Http/Curl/CurlMulti.php
+++ b/src/Guzzle/Http/Curl/CurlMulti.php
@@ -79,22 +79,6 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
     private $scope = -1;
 
     /**
-     * Get a cached instance of the curl multi object
-     *
-     * @return CurlMulti
-     */
-    public static function getInstance()
-    {
-        // @codeCoverageIgnoreStart
-        if (!self::$instance) {
-            self::$instance = new self();
-        }
-        // @codeCoverageIgnoreEnd
-
-        return self::$instance;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public static function getAllEvents()

--- a/tests/Guzzle/Tests/Http/ClientTest.php
+++ b/tests/Guzzle/Tests/Http/ClientTest.php
@@ -677,4 +677,11 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
         $client = new Client();
         $client->setDefaultHeaders('foo');
     }
+
+    public function testDontReuseCurlMulti()
+    {
+        $client1 = new Client();
+        $client2 = new Client();
+        $this->assertNotSame($client1->getCurlMulti(), $client2->getCurlMulti());
+    }
 }

--- a/tests/Guzzle/Tests/Http/Curl/CurlMultiTest.php
+++ b/tests/Guzzle/Tests/Http/Curl/CurlMultiTest.php
@@ -43,16 +43,6 @@ class CurlMultiTest extends \Guzzle\Tests\GuzzleTestCase
     }
 
     /**
-     * @covers Guzzle\Http\Curl\CurlMulti::getInstance
-     */
-    public function testReturnsCachedInstance()
-    {
-        $c = CurlMulti::getInstance();
-        $this->assertInstanceOf('Guzzle\\Http\\Curl\\CurlMultiInterface', $c);
-        $this->assertSame($c, CurlMulti::getInstance());
-    }
-
-    /**
      * @covers Guzzle\Http\Curl\CurlMulti::__construct
      * @covers Guzzle\Http\Curl\CurlMulti::__destruct
      */


### PR DESCRIPTION
Considering distinct parts of a project can use Guzzle, if they share the CurlMulti instance unpredictable situations can occur (think about plugins added by one part affecting the other parts).
