### PR TITLE
Make a choice when max-age is present twice

### DIFF
--- a/src/Guzzle/Http/Message/AbstractMessage.php
+++ b/src/Guzzle/Http/Message/AbstractMessage.php
@@ -236,7 +236,17 @@ abstract class AbstractMessage implements MessageInterface
      */
     public function getCacheControlDirective($directive)
     {
-        return isset($this->cacheControl[$directive]) ? $this->cacheControl[$directive] : null;
+        if (!isset($this->cacheControl[$directive])) {
+            return null;
+        }
+
+        $directive = $this->cacheControl[$directive];
+
+        if (is_array($directive) && !empty($directive)) {
+            return $directive[0];
+        }
+
+        return $directive;
     }
 
     /**

--- a/tests/Guzzle/Tests/Http/Message/AbstractMessageTest.php
+++ b/tests/Guzzle/Tests/Http/Message/AbstractMessageTest.php
@@ -168,6 +168,25 @@ class AbstractMessageTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals(100, $mock->getCacheControlDirective('max-age'));
     }
 
+    /**
+     * In some rare cases. Like with the Twitter Search API:
+     *
+     *    http://search.twitter.com/search.json?q=from:mtdowling
+     *
+     * There is more than once Cache-Control added.
+     * Twice the max-age for example.
+     *
+     * @covers Guzzle\Http\Message\AbstractMessage
+     */
+    public function testDoubleCacheControlDirectives()
+    {
+        $mock = $this->mock;
+
+        $mock->setHeader('Cache-Control', 'max-age=15, must-revalidate, max-age=300');
+
+        $this->assertEquals(15, $mock->getCacheControlDirective('max-age'));
+    }
+
     public function tokenizedHeaderProvider()
     {
         return array(


### PR DESCRIPTION
Hi,

   I got a weird bug when using Guzzle to fetch the Twitter Search API alongside a Cache mechanism.

   It appears that the Search API return twice the parameter "max-age" for the Cache Control Directives.
   Then, computing the time to cache makes Guzzle ... going crazy.

   So I propose this modification. To make an unilateral choice of the first value.
   I am not really sure if it's the best solution but I don't see any other :p 

Any thought?

Thank you

Aurélien
