### PR TITLE
Allow calling setAuth() with a blank password. Closes #239

### DIFF
--- a/src/Guzzle/Http/Message/Request.php
+++ b/src/Guzzle/Http/Message/Request.php
@@ -410,7 +410,7 @@ class Request extends AbstractMessage implements RequestInterface
     public function setAuth($user, $password = '', $scheme = CURLAUTH_BASIC)
     {
         // If we got false or null, disable authentication
-        if (!$user || !$password) {
+        if (!$user) {
             $this->password = $this->username = null;
             $this->removeHeader('Authorization');
             $this->getCurlOptions()->remove(CURLOPT_HTTPAUTH);

--- a/tests/Guzzle/Tests/Http/Message/RequestTest.php
+++ b/tests/Guzzle/Tests/Http/Message/RequestTest.php
@@ -386,6 +386,11 @@ class RequestTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals('michael', $this->request->getUsername());
         $this->assertEquals('123', $this->request->getPassword());
 
+        // Set an auth with blank password
+        $this->assertSame($this->request, $this->request->setAuth('michael', ''));
+        $this->assertEquals('michael', $this->request->getUsername());
+        $this->assertEquals('', $this->request->getPassword());
+
         // Remove the auth
         $this->request->setAuth(false);
         $this->assertEquals(null, $this->request->getUsername());


### PR DESCRIPTION
This supports APIs such as Stripe which only require a username to authenticate.
