### PR TITLE
Cache debug headers

### DIFF
--- a/src/Guzzle/Plugin/Cache/CachePlugin.php
+++ b/src/Guzzle/Plugin/Cache/CachePlugin.php
@@ -5,6 +5,7 @@ namespace Guzzle\Plugin\Cache;
 use Guzzle\Cache\CacheAdapterInterface;
 use Guzzle\Common\Event;
 use Guzzle\Common\Exception\InvalidArgumentException;
+use Guzzle\Common\Version;
 use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Http\Message\Response;
 use Guzzle\Cache\DoctrineCacheAdapter;
@@ -149,6 +150,9 @@ class CachePlugin implements EventSubscriberInterface
     public function onRequestBeforeSend(Event $event)
     {
         $request = $event['request'];
+
+        $request->addHeader('Via', sprintf('%s GuzzleCache/%s', $request->getProtocolVersion(), Version::VERSION));
+
         if (!$this->canCache->canCacheRequest($request)) {
             return;
         }
@@ -196,6 +200,8 @@ class CachePlugin implements EventSubscriberInterface
                 );
             }
         }
+
+        $response->addHeader('Via', sprintf('%s GuzzleCache/%s', $request->getProtocolVersion(), Version::VERSION));
 
         if ($this->debugHeaders) {
             if ($request->getParams()->get('cache.lookup') === true) {

--- a/tests/Guzzle/Tests/Plugin/Cache/CachePluginTest.php
+++ b/tests/Guzzle/Tests/Plugin/Cache/CachePluginTest.php
@@ -3,6 +3,7 @@
 namespace Guzzle\Tests\Plugin\Cache;
 
 use Guzzle\Common\Event;
+use Guzzle\Common\Version;
 use Guzzle\Cache\DoctrineCacheAdapter;
 use Guzzle\Http\Message\Request;
 use Guzzle\Http\Message\Response;
@@ -198,6 +199,8 @@ class CachePluginTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals($response[2], $request->getResponse()->getBody(true));
         $this->assertContains('key=', (string) $request->getResponse()->getHeader('X-Guzzle-Cache'));
         $this->assertTrue($request->getResponse()->hasHeader('Age'));
+        $this->assertSame(sprintf('%s GuzzleCache/%s', $request->getProtocolVersion(), Version::VERSION), $request->getHeader('Via', true));
+        $this->assertSame(sprintf('%s GuzzleCache/%s', $request->getProtocolVersion(), Version::VERSION), $request->getResponse()->getHeader('Via', true));
         $this->assertTrue($request->getParams()->get('cache.lookup'));
         $this->assertTrue($request->getParams()->get('cache.hit'));
 


### PR DESCRIPTION
This adds in (optional) debug headers to the cache plugin. The parameters `cache.lookup` and `cache.hit` are set to `true` if a cached response is found and if it's acceptable respectively. The `X-Cache` and `X-Cache-Lookup` headers are then set with either 'HIT from GuzzleCache' or 'MISS from GuzzleCache'.

At the moment you can't (I think) see `X-Cache: MISS` and `X-Cache-Lookup: HIT` together, but a future PR to add in `stale-if-error` support (see RFC 5861) will cause this as it will require the option to store cached responses for longer than they're (normally) allowed to be used.

The second commit adds the `Via` header to requests and responses. I made it a seperate commit in case you didn't want to add it (it's a 'MUST' in the RFC, but doesn't exactly have any use apart from seeing that the request has gone through the plugin!). 
