### PR TITLE
Store cached responses for longer, allowing stales to be served

### DIFF
--- a/src/Guzzle/Plugin/Cache/DefaultCacheStorage.php
+++ b/src/Guzzle/Plugin/Cache/DefaultCacheStorage.php
@@ -48,6 +48,8 @@ class DefaultCacheStorage implements CacheStorageInterface
             $ttl = $this->defaultTtl;
         }
 
+        $ttl += $response->getMaxAge();
+
         if ($ttl) {
             $response->setHeader('X-Guzzle-Cache', "key={$key}; ttl={$ttl}");
             // Remove excluded headers from the response  (see RFC 2616:13.5.1)

--- a/src/Guzzle/Plugin/Cache/DefaultRevalidation.php
+++ b/src/Guzzle/Plugin/Cache/DefaultRevalidation.php
@@ -116,7 +116,9 @@ class DefaultRevalidation implements RevalidationInterface
         // Store this response in cache if possible
         if ($validateResponse->canCache()) {
             $this->storage->cache(
-                $this->cacheKey->getCacheKey($request), $validateResponse, $validateResponse->getMaxAge()
+                $this->cacheKey->getCacheKey($request),
+                $validateResponse,
+                $request->getParams()->get('cache.override_ttl')
             );
         }
 
@@ -151,7 +153,11 @@ class DefaultRevalidation implements RevalidationInterface
         }
         // Store the updated response in cache
         if ($modified && $response->canCache()) {
-            $this->storage->cache($this->cacheKey->getCacheKey($request), $response, $response->getMaxAge());
+            $this->storage->cache(
+                $this->cacheKey->getCacheKey($request),
+                $response,
+                $request->getParams()->get('cache.override_ttl')
+            );
         }
 
         return true;


### PR DESCRIPTION
This changes the cache plugin so that the TTL is now how long the response lives after it expires. This means that it's now possible to receive a stale response with the `max-stale` directive (and allows the future `stale-if-error` PR to work).
