### PR TITLE
Deeply nested parameters aren't properly sorted when signing for OAuth

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -139,7 +139,7 @@ class OauthPlugin implements EventSubscriberInterface
         $params = $this->getParamsToSign($request, $timestamp, $nonce);
 
         // Convert booleans to strings.
-        $params = $this->convertBooleanToString($params);
+        $params = $this->prepareParameters($params);
 
         // Build signing string from combined params
         $parameterString = new QueryString($params);
@@ -218,17 +218,18 @@ class OauthPlugin implements EventSubscriberInterface
     }
 
     /**
-     * Convert booleans to strings.
+     * Convert booleans to strings, and sorts the array.
      *
      * @param array $data Data array
      *
      * @return array
      */
-    protected function convertBooleanToString($data)
+    protected function prepareParameters($data)
     {
+        ksort($data);
         foreach ($data as $key => $value) {
             if (is_array($value)) {
-                $data[$key] = $this->convertBooleanToString($value);
+                $data[$key] = self::prepareParameters($value);
             } elseif (is_bool($value)) {
                 $data[$key] = $value ? 'true' : 'false';
             }

--- a/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
+++ b/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
@@ -118,8 +118,8 @@ class OauthPluginTest extends \Guzzle\Tests\GuzzleTestCase
     {
         $p = new OauthPlugin($this->config);
         $request = $this->getRequest();
-        $request->getQuery()->set('a', array('b' => array('c' => 'd')));
-        $this->assertContains('&a%255Bb%255D%255Bc%255D%3Dd%26c%3Dd', $p->getStringToSign($request, self::TIMESTAMP, self::NONCE));
+        $request->getQuery()->set('a', array('b' => array('e' => 'f', 'c' => 'd')));
+        $this->assertContains('a%255Bb%255D%255Bc%255D%3Dd%26a%255Bb%255D%255Be%255D%3Df%26c%3Dd%26e%3Df%26', $p->getStringToSign($request, self::TIMESTAMP, self::NONCE));
     }
 
     /**


### PR DESCRIPTION
A little follow-up to https://github.com/guzzle/guzzle/pull/259.
