### PR TITLE
Subtree splits need to have the correct branch alias.

### DIFF
--- a/src/Guzzle/Batch/composer.json
+++ b/src/Guzzle/Batch/composer.json
@@ -25,7 +25,7 @@
     "target-dir": "Guzzle/Batch",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Cache/composer.json
+++ b/src/Guzzle/Cache/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Cache",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Common/composer.json
+++ b/src/Guzzle/Common/composer.json
@@ -14,7 +14,7 @@
     "target-dir": "Guzzle/Common",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Http/composer.json
+++ b/src/Guzzle/Http/composer.json
@@ -26,7 +26,7 @@
     "target-dir": "Guzzle/Http",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Inflection/composer.json
+++ b/src/Guzzle/Inflection/composer.json
@@ -20,7 +20,7 @@
     "target-dir": "Guzzle/Inflection",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Iterator/composer.json
+++ b/src/Guzzle/Iterator/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Log",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Log/composer.json
+++ b/src/Guzzle/Log/composer.json
@@ -23,7 +23,7 @@
     "target-dir": "Guzzle/Log",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Parser/composer.json
+++ b/src/Guzzle/Parser/composer.json
@@ -13,7 +13,7 @@
     "target-dir": "Guzzle/Parser",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/Async/composer.json
+++ b/src/Guzzle/Plugin/Async/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Plugin/Async",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/Backoff/composer.json
+++ b/src/Guzzle/Plugin/Backoff/composer.json
@@ -22,7 +22,7 @@
     "target-dir": "Guzzle/Plugin/Backoff",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/Cache/composer.json
+++ b/src/Guzzle/Plugin/Cache/composer.json
@@ -22,7 +22,7 @@
     "target-dir": "Guzzle/Plugin/Cache",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/Cookie/composer.json
+++ b/src/Guzzle/Plugin/Cookie/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Plugin/Cookie",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/CurlAuth/composer.json
+++ b/src/Guzzle/Plugin/CurlAuth/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Plugin/CurlAuth",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/ErrorResponse/composer.json
+++ b/src/Guzzle/Plugin/ErrorResponse/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Plugin/ErrorResponse",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/History/composer.json
+++ b/src/Guzzle/Plugin/History/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Plugin/History",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/Log/composer.json
+++ b/src/Guzzle/Plugin/Log/composer.json
@@ -22,7 +22,7 @@
     "target-dir": "Guzzle/Plugin/Log",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/Md5/composer.json
+++ b/src/Guzzle/Plugin/Md5/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Plugin/Md5",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/Mock/composer.json
+++ b/src/Guzzle/Plugin/Mock/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Plugin/Mock",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/Oauth/composer.json
+++ b/src/Guzzle/Plugin/Oauth/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Plugin/Oauth",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Plugin/composer.json
+++ b/src/Guzzle/Plugin/composer.json
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Service/composer.json
+++ b/src/Guzzle/Service/composer.json
@@ -23,7 +23,7 @@
     "target-dir": "Guzzle/Service",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }

--- a/src/Guzzle/Stream/composer.json
+++ b/src/Guzzle/Stream/composer.json
@@ -21,7 +21,7 @@
     "target-dir": "Guzzle/Stream",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.3-dev"
         }
     }
 }


### PR DESCRIPTION
I'm running into a lot of weird issues with things now that the versioning stuff changed from 3.1.\* to 3.2 and 3.3. Trying to track things down, I noticed that the subtree splits did not get the memo on moving from 3.0-dev to 3.3-dev. This should fix them.
