### PR TITLE
Single PHP-style array values now parse into array.

### DIFF
--- a/src/Guzzle/Http/QueryString.php
+++ b/src/Guzzle/Http/QueryString.php
@@ -70,12 +70,17 @@ class QueryString extends Collection
                 $parts = explode('=', $kvp, 2);
                 $key = rawurldecode($parts[0]);
 
-                if (substr($key, -2) == '[]') {
+                $paramIsPHPStyleArray = substr($key, -2) == '[]';
+                if ($paramIsPHPStyleArray) {
                     $key = substr($key, 0, -2);
                 }
 
                 if (array_key_exists(1, $parts)) {
-                    $q->add($key, rawurldecode(str_replace('+', '%20', $parts[1])));
+                    $value = rawurldecode(str_replace('+', '%20', $parts[1]));
+                    if ($paramIsPHPStyleArray && !$q->hasKey($key)) {
+                        $value = array($value);
+                    }
+                    $q->add($key, $value);
                 } else {
                     $q->add($key, '');
                 }

--- a/tests/Guzzle/Tests/Http/QueryStringTest.php
+++ b/tests/Guzzle/Tests/Http/QueryStringTest.php
@@ -145,6 +145,10 @@ class QueryStringTest extends \Guzzle\Tests\GuzzleTestCase
             array('q[]=a&q[]=b', array(
                 'q' => array('a', 'b')
             )),
+            // Ensure that a single PHP array style query string value is parsed into an array
+            array('q[]=a', array(
+                'q' => array('a')
+            )),
             // Ensure that decimals are allowed in query strings
             array('q.a=a&q.b=b', array(
                 'q.a' => 'a',


### PR DESCRIPTION
The following query string example:
http://test.com/test.php?myarray[]=test
gets converted to
http://test.com/test.php?myarray=test

which means that PHP then receives a single value in $_GET instead of an array containing a single value.

This works fine with multiple values as follows:
http://test.com/test.php?myarray[]=test&myarray[]=test2

If you make a request for the original URL (http://test.com/test.php?myarray[]=test) from a browser, PHP will receive an array with a single element, which is the behaviour I would expect.

I'm not sure whether or not this is a bug or if this is intended behaviour. However, this PR "fixes" the problem.
