### PR TITLE
Easy handling of PUT requests with data in application/x-www-form-urlencoded format

### DIFF
--- a/src/Guzzle/Http/Curl/CurlHandle.php
+++ b/src/Guzzle/Http/Curl/CurlHandle.php
@@ -9,6 +9,7 @@ use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Parser\ParserRegistry;
 use Guzzle\Http\Message\EntityEnclosingRequestInterface;
 use Guzzle\Http\Url;
+use Guzzle\Http\EntityBody;
 
 /**
  * Immutable wrapper for a cURL handle
@@ -138,6 +139,8 @@ class CurlHandle
                 }
                 break;
             case 'PUT':
+                if (count($request->getPostFields()) && $request->getHeader('Content-Type') == 'application/x-www-form-urlencoded')
+                    $request->setBody(EntityBody::factory((string)$request->getPostFields()));
             case 'PATCH':
             case 'DELETE':
             default:

--- a/src/Guzzle/Http/Message/RequestFactory.php
+++ b/src/Guzzle/Http/Message/RequestFactory.php
@@ -107,7 +107,7 @@ class RequestFactory implements RequestFactoryInterface
 
             $isChunked = (string) $request->getHeader('Transfer-Encoding') == 'chunked';
 
-            if ($method == 'POST' && (is_array($body) || $body instanceof Collection)) {
+            if (($method == 'POST' || $method == 'PUT') && (is_array($body) || $body instanceof Collection)) {
 
                 // Normalize PHP style cURL uploads with a leading '@' symbol
                 foreach ($body as $key => $value) {


### PR DESCRIPTION
Given this common example, a RESTful API exposing **PUT** entry points to update a resource and expecting incoming data in the **application/x-www-form-urlencoded** content-type, exactly like a POST (no attached file(s)).
### With a HttpClient

I think it would be logic to be able to create those PUT requests the same simple way POST requests are, just by passing an array as the $body parameter:

```
$client->put("/resource/1", null, array("name" => "New name"));
```
### With a ServiceClient

I ran into the same kind of problem trying to use a ServiceClient. Here is a sample extract of my service description JSON:

```
...
"sample" => array(
   "httpMethod" => "PUT",
   "uri" => "/resource/{id}",
   "parameters" => array(
      "id" => array(
         "type" => "integer",
         "location" => "uri",
         "required" => "true"
      ),
      "name" => array(
         "type" => "string",
         "location" => "postField",
         "required" => true
      )
   )
)
...
```

And the command call:

```
$client->getCommand("sample", array("id" => 1, "name" => "New name");
```

The problem in that case is that no **Content-Length** header is set in the request, thus preventing the analysis of the request body on the server side.

This commit aims to fix those 2 usecases. What do you think?

Thanks a lot for your reactivity with the pull requests!
