### PR TITLE
Removed empty parameter from query string in OauthPlugin

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -219,6 +219,7 @@ class OauthPlugin implements EventSubscriberInterface
 
     /**
      * Convert booleans to strings, and sorts the array.
+     * Removes unset parameters
      *
      * @param array $data Data array
      *
@@ -228,10 +229,14 @@ class OauthPlugin implements EventSubscriberInterface
     {
         ksort($data);
         foreach ($data as $key => $value) {
-            if (is_array($value)) {
-                $data[$key] = self::prepareParameters($value);
-            } elseif (is_bool($value)) {
-                $data[$key] = $value ? 'true' : 'false';
+            if (is_null($value)) {
+                unset($data[$key]);
+            } else {
+                if (is_array($value)) {
+                    $data[$key] = self::prepareParameters($value);
+                } elseif (is_bool($value)) {
+                    $data[$key] = $value ? 'true' : 'false';
+                }
             }
         }
 

--- a/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
+++ b/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
@@ -111,6 +111,32 @@ class OauthPluginTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertContains('&a%3Dtrue%26c%3Dfalse', $p->getStringToSign($request, self::TIMESTAMP, self::NONCE));
     }
 
+    public function testCreatesStringToSignFromPostRequestWithNullValues()
+    {
+        $config = array(
+            'consumer_key'    => 'foo',
+            'consumer_secret' => 'bar',
+            'token'           => null,
+            'token_secret'    => 'dracula'
+        );
+
+        $p          = new OauthPlugin($config);
+        $request    = $this->getRequest();
+        $signString = $p->getStringToSign($request, self::TIMESTAMP, self::NONCE);
+
+        $this->assertContains('&e=f', rawurldecode($signString));
+
+        $expectedSignString = // Method and URL
+                'POST&http%3A%2F%2Fwww.test.com%2Fpath' .
+                // Sorted parameters from query string and body
+                '&a%3Db%26c%3Dd%26e%3Df%26oauth_consumer_key%3Dfoo' .
+                '%26oauth_nonce%3De7aa11195ca58349bec8b5ebe351d3497eb9e603%26' .
+                'oauth_signature_method%3DHMAC-SHA1' .
+                '%26oauth_timestamp%3D' . self::TIMESTAMP . '%26oauth_version%3D1.0';
+
+        $this->assertEquals($expectedSignString, $signString);
+    }
+
     /**
      * @depends testCreatesStringToSignFromPostRequest
      */


### PR DESCRIPTION
v3.3.1 fails when we request the Token to Twitter using OauthPlugin. (v3.3.0 works fine). That's because when Guzzle creates the POST request includes all default parameters  (even the empty ones. oauth_token in this case). Twitter throws an error (unauthorized).

I've changed OauthPlugin:prepareParameters to remove the empty parameters. I've also created a new test unit to check this issue (OauthPluginTest::testCreatesStringToSignFromPostRequestWithNullValues)
