### PR TITLE
Adds PSR-3 Log adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "doctrine/cache": "*",
         "symfony/class-loader": "*",
         "monolog/monolog": "1.*",
+        "psr/log": "1.0.*",
         "zendframework/zend-cache": "2.0.*",
         "zendframework/zend-log": "2.0.*",
         "zend/zend-log1": "1.12",

--- a/src/Guzzle/Log/PsrLogAdapter.php
+++ b/src/Guzzle/Log/PsrLogAdapter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Guzzle\Log;
+
+use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
+
+/**
+ * PSR-3 log adapter
+ *
+ * @link https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ */
+class PsrLogAdapter extends AbstractLogAdapter
+{
+    /**
+     * syslog to PSR-3 mappings
+     */
+    private static $mapping = array(
+        LOG_DEBUG   => LogLevel::DEBUG,
+        LOG_INFO    => LogLevel::INFO,
+        LOG_WARNING => LogLevel::WARNING,
+        LOG_ERR     => LogLevel::ERROR,
+        LOG_CRIT    => LogLevel::CRITICAL,
+        LOG_ALERT   => LogLevel::ALERT
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(LoggerInterface $logObject)
+    {
+        $this->log = $logObject;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($message, $priority = LOG_INFO, $extras = null)
+    {
+
+        $this->log->log(self::$mapping[$priority], $message, $extras);
+    }
+}

--- a/tests/Guzzle/Tests/Log/PsrLogAdapterTest.php
+++ b/tests/Guzzle/Tests/Log/PsrLogAdapterTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Guzzle\Tests\Log;
+
+use Guzzle\Log\MonologLogAdapter;
+use Monolog\Logger;
+use Monolog\Handler\TestHandler;
+
+/**
+ * @covers Guzzle\Log\PsrLogAdapter
+ */
+class PsrLogAdapterTest extends \Guzzle\Tests\GuzzleTestCase
+{
+    public function testLogsMessagesToAdaptedObject()
+    {
+        $log = new Logger('test');
+        $handler = new TestHandler();
+        $log->pushHandler($handler);
+        $adapter = new MonologLogAdapter($log);
+        $adapter->log('test!', LOG_INFO);
+        $this->assertTrue($handler->hasInfoRecords());
+    }
+}


### PR DESCRIPTION
Adds support for logging to any PSR-3 compliant interface.

This saves devs from having to write their own adapters for whatever PSR-3 log library they use. Technically this could also supplant the MonologLogAdapter entirely, but that's for another day.
