### PR TITLE
Improve "[PARAM] is a required [TYPE]" message

### DIFF
--- a/src/Guzzle/Service/Description/SchemaValidator.php
+++ b/src/Guzzle/Service/Description/SchemaValidator.php
@@ -192,7 +192,7 @@ class SchemaValidator implements ValidatorInterface
 
         // If the value is required and the type is not null, then there is an error if the value is not set
         if ($required && $value === null && $type != 'null') {
-            $message = "{$path} is " . ($param->getType() ? ('a required ' . $param->getType()) : 'required');
+            $message = "{$path} is " . ($param->getType() ? ('a required ' . implode(' or ', (array) $param->getType())) : 'required');
             if ($param->getDescription()) {
                 $message .= ': ' . $param->getDescription();
             }

--- a/tests/Guzzle/Tests/Service/Description/SchemaValidatorTest.php
+++ b/tests/Guzzle/Tests/Service/Description/SchemaValidatorTest.php
@@ -295,6 +295,14 @@ class SchemaValidatorTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals('12', $value);
     }
 
+    public function testRequiredMessageIncludesType()
+    {
+        $param = new Parameter(array('name' => 'test', 'type' => array('string', 'boolean'), 'required' => true));
+        $value = null;
+        $this->assertFalse($this->validator->validate($param, $value));
+        $this->assertEquals(array('[test] is a required string or boolean'), $this->validator->getErrors());
+    }
+
     protected function getComplexParam()
     {
         return new Parameter(array(


### PR DESCRIPTION
There's an error when Guzzle is trying to create an error message of the form "ID is a required integer", but the type is an array (union) of types rather than a single type in a string.

In PHP 5.4, this causes a notice "array to string conversion", and in all versions of PHP, the message Guzzle generated reads "ID is a required Array" (where "Array" is the result of the array-to-string conversion, almost always not what you want).

This pull request adopts the convention elsewhere in the file of using `implode(' or ', (array) $param->getType())` to handle the case where the type is an array.

I also added a test case illustrating the expected behaviour.
