### PR TITLE
Overwrite config params for throw-away clients in the service builder

### DIFF
--- a/src/Guzzle/Service/Builder/ServiceBuilder.php
+++ b/src/Guzzle/Service/Builder/ServiceBuilder.php
@@ -148,8 +148,14 @@ class ServiceBuilder extends AbstractHasDispatcher implements ServiceBuilderInte
             }
         }
 
+        // Get the configured parameters and merge in any parameters provided for throw-away clients
+        $config = $this->builderConfig[$name]['params'];
+        if (is_array($throwAway)) {
+            $config = $throwAway + $config;
+        }
+
         $class = $this->builderConfig[$name]['class'];
-        $client = $class::factory($this->builderConfig[$name]['params']);
+        $client = $class::factory($config);
 
         if (!$throwAway) {
             $this->clients[$name] = $client;

--- a/tests/Guzzle/Tests/Service/Builder/ServiceBuilderTest.php
+++ b/tests/Guzzle/Tests/Service/Builder/ServiceBuilderTest.php
@@ -301,4 +301,26 @@ class ServiceBuilderTest extends \Guzzle\Tests\GuzzleTestCase
         $b = new ServiceBuilder($this->arrayData);
         $this->assertSame($b->get('billy.mock'), $b->get('Hello!'));
     }
+
+    public function testCanOverwriteParametersForThrowawayClients()
+    {
+        $b = new ServiceBuilder($this->arrayData);
+
+        $c1 = $b->get('michael.mock');
+        $this->assertEquals('michael', $c1->getConfig('username'));
+
+        $c2 = $b->get('michael.mock', array('username' => 'jeremy'));
+        $this->assertEquals('jeremy', $c2->getConfig('username'));
+    }
+
+    public function testGettingAThrowawayClientWithParametersDoesNotAffectGettingOtherClients()
+    {
+        $b = new ServiceBuilder($this->arrayData);
+
+        $c1 = $b->get('michael.mock', array('username' => 'jeremy'));
+        $this->assertEquals('jeremy', $c1->getConfig('username'));
+
+        $c2 = $b->get('michael.mock');
+        $this->assertEquals('michael', $c2->getConfig('username'));
+    }
 }


### PR DESCRIPTION
``` php
$builder = new ServiceBuilder(array(
    'client' => array(
        'class' => 'My\Cool\Client',
        'params' => array(
            'base_url' => 'http://www.my-url.com/',
            'foo'      => 'bar',
        )
    )
));

// Normal client with normal config
$client1 = $builder->get('client');

// Throw-away client with normal config
$client2 = $builder->get('client', true);

// Throw-away client with modified config
$client3 = $builder->get('client', array('foo' => 'baz'));
```
