### PR TITLE
Updating the interface docblock for the previous ServiceBuilder change

### DIFF
--- a/src/Guzzle/Service/Builder/ServiceBuilderInterface.php
+++ b/src/Guzzle/Service/Builder/ServiceBuilderInterface.php
@@ -13,8 +13,9 @@ interface ServiceBuilderInterface
     /**
      * Get a service using a registered builder
      *
-     * @param string $name      Name of the registered client to retrieve
-     * @param bool   $throwAway Set to TRUE to not store the client for later retrieval from the ServiceBuilder
+     * @param string     $name      Name of the registered client to retrieve
+     * @param bool|array $throwAway Set to TRUE to not store the client for later retrieval from the ServiceBuilder.
+     *                              If an array is specified, that data will overwrite the configured params
      *
      * @return FromConfigInterface
      * @throws ServiceNotFoundException when a client cannot be found by name


### PR DESCRIPTION
Updating the docblock of the `ServiceBuilderInterface::get` method to allow for arrays.
