### PR TITLE
Add support for 'oauth_callback' parameter.

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -73,6 +73,7 @@ class OauthPlugin implements EventSubscriberInterface
         $nonce = $this->generateNonce($request);
 
         $authorizationParams = array(
+            'oauth_callback'         => $this->config['callback'],
             'oauth_consumer_key'     => $this->config['consumer_key'],
             'oauth_nonce'            => $nonce,
             'oauth_signature'        => $this->getSignature($request, $timestamp, $nonce),


### PR DESCRIPTION
For the 'request_token' step Twitter requires a 'oauth_callback' parameter which is currently not supported. 

@see https://dev.twitter.com/docs/api/1/post/oauth/request_token
