### PR TITLE
Fix missing 'callback' parameter documentation in constructor docblock.

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -25,6 +25,7 @@ class OauthPlugin implements EventSubscriberInterface
      * Create a new OAuth 1.0 plugin
      *
      * @param array $config Configuration array containing these parameters:
+     *     - string 'callback'             OAuth callback
      *     - string 'consumer_key'         Consumer key
      *     - string 'consumer_secret'      Consumer secret
      *     - string 'token'                Token


### PR DESCRIPTION
Sorry, forgot that in my last pull request!
