### PR TITLE
Adding support for additionalProperties for parameters

### DIFF
--- a/src/Guzzle/Service/Command/AbstractCommand.php
+++ b/src/Guzzle/Service/Command/AbstractCommand.php
@@ -374,6 +374,22 @@ abstract class AbstractCommand extends Collection implements CommandInterface
             }
         }
 
+        // Validate additional properties
+        if ($properties = $this->operation->getAdditionalProperties()) {
+            foreach ($this->getAll() as $name => $value) {
+                // It's only additional if it isn't defined in the schema
+                if (!$this->operation->hasParam($name)) {
+                    // Always set the name so that error messages are useful
+                    $properties->setName($name);
+                    if (!$validator->validate($properties, $value)) {
+                        $errors = array_merge($errors, $validator->getErrors());
+                    } elseif ($value !== $this->get($name)) {
+                        $this->data[$name] = $value;
+                    }
+                }
+            }
+        }
+
         if (!empty($errors)) {
             $e = new ValidationException('Validation errors: ' . implode("\n", $errors));
             $e->setErrors($errors);

--- a/src/Guzzle/Service/Description/Operation.php
+++ b/src/Guzzle/Service/Description/Operation.php
@@ -29,6 +29,11 @@ class Operation implements OperationInterface
     protected $parameters = array();
 
     /**
+     * @var Parameter Additional properties
+     */
+    protected $additionalProperties;
+
+    /**
      * @var string Name of the command
      */
     protected $name;
@@ -120,6 +125,8 @@ class Operation implements OperationInterface
      *                       error), and 'class' (a custom exception class that would be thrown if the error is
      *                       encountered).
      * - data:               (array) Any extra data that might be used to help build or serialize the operation
+     * - additionalProperties: (null|array) Parameter schema to use when an option is passed to the operation that is
+     *                                      not in the schema
      *
      * @param array                       $config      Array of configuration data
      * @param ServiceDescriptionInterface $description Service description used to resolve models if $ref tags are found
@@ -160,6 +167,14 @@ class Operation implements OperationInterface
                     $param['name'] = $name;
                     $this->addParam(new Parameter($param, $this->description));
                 }
+            }
+        }
+
+        if (isset($config['additionalProperties'])) {
+            if ($config['additionalProperties'] instanceof Parameter) {
+                $this->setAdditionalProperties($config['additionalProperties']);
+            } elseif (is_array($config['additionalProperties'])) {
+                $this->setAdditionalProperties(new Parameter($config['additionalProperties'], $this->description));
             }
         }
     }
@@ -578,6 +593,29 @@ class Operation implements OperationInterface
     public function setData($name, $value)
     {
         $this->data[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the additionalProperties/parameters of the operation
+     *
+     * @return Paramter|null
+     */
+    public function getAdditionalProperties()
+    {
+        return $this->additionalProperties;
+    }
+
+    /**
+     * Set the additionalProperties/parameters of the operation
+     *
+     * @param Parameter|null $parameter Parameter to set
+     */
+    public function setAdditionalProperties($parameter)
+    {
+        $this->additionalProperties = $parameter;
+        $this->additionalProperties->setParent($this);
 
         return $this;
     }

--- a/tests/Guzzle/Tests/Service/Command/CommandTest.php
+++ b/tests/Guzzle/Tests/Service/Command/CommandTest.php
@@ -10,6 +10,7 @@ use Guzzle\Service\Command\AbstractCommand;
 use Guzzle\Service\Description\Operation;
 use Guzzle\Service\Description\Parameter;
 use Guzzle\Service\Description\SchemaValidator;
+use Guzzle\Service\Description\ServiceDescription;
 use Guzzle\Tests\Service\Mock\Command\MockCommand;
 use Guzzle\Tests\Service\Mock\Command\Sub\Sub;
 
@@ -450,6 +451,31 @@ class CommandTest extends AbstractCommandTest
         $v->expects($this->any())->method('validate')->will($this->returnValue(false));
         $v->expects($this->any())->method('getErrors')->will($this->returnValue(array('[Foo] Baz', '[Bar] Boo')));
         $command->setValidator($v);
+        $command->prepare();
+    }
+
+    /**
+     * @expectedException \Guzzle\Service\Exception\ValidationException
+     * @expectedExceptionMessage Validation errors: [abc] must be of type string
+     */
+    public function testValidatesAdditionalProperties()
+    {
+        $description = ServiceDescription::factory(array(
+            'operations' => array(
+                'foo' => array(
+                    'parameters' => array(
+                        'baz' => array('type' => 'integer')
+                    ),
+                    'additionalProperties' => array(
+                        'type' => 'string'
+                    )
+                )
+            )
+        ));
+
+        $client = new Client();
+        $client->setDescription($description);
+        $command = $client->getCommand('foo', array('abc' => false));
         $command->prepare();
     }
 

--- a/tests/Guzzle/Tests/Service/Description/OperationTest.php
+++ b/tests/Guzzle/Tests/Service/Description/OperationTest.php
@@ -260,6 +260,19 @@ class OperationTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals('model', $o->setResponseType('model')->getResponseType());
     }
 
+    public function testHasAdditionalProperties()
+    {
+        $o = new Operation(array(
+            'additionalProperties' => array(
+                'type' => 'string', 'name' => 'binks'
+            ),
+            'parameters' => array(
+                'foo' => array('type' => 'integer')
+            )
+        ));
+        $this->assertEquals('string', $o->getAdditionalProperties()->getType());
+    }
+
     /**
      * @return Operation
      */


### PR DESCRIPTION
This PR is to support additional properties for top-level operation parameters. This allows you to define a schema and serialization for arbitrary parameters. See #270. I've named the new option "additionalProperties" to be consistent with JSON schema, but I wonder if anyone thinks that "additionalParameters" would be better?
