### PR TITLE
[Revert] Delegate Response body processing to EntityBody::factory method

### DIFF
--- a/src/Guzzle/Http/Message/RequestFactory.php
+++ b/src/Guzzle/Http/Message/RequestFactory.php
@@ -95,7 +95,7 @@ class RequestFactory implements RequestFactoryInterface
             $request = new $this->requestClass($method, $url, $headers);
             if ($body) {
                 // The body is where the response body will be stored
-                $request->setResponseBody($body);
+                $request->setResponseBody(EntityBody:factory($body));
             }
             return $request;
         }


### PR DESCRIPTION
On commit 9da0ac2123ee3072078cd9da22e2a1dc3bc5dc49 (pushed on 2013-03-29 by @mtdowling), there was this change : 

``` php
if ($method == 'GET' || $method == 'HEAD' || $method == 'TRACE' || $method == 'OPTIONS') {
-            $c = $this->requestClass;
-            $request = new $c($method, $url, $headers);
+            // Handle non-entity-enclosing request methods
+            $request = new $this->requestClass($method, $url, $headers);
             if ($body) {
                 // The body is where the response body will be stored
-                $request->setResponseBody(EntityBody::factory($body));
+                $request->setResponseBody($body);
             }
             return $request;
         }
```

I have no idea why you have removed the usage of EntityBody::factory(...) but it causes some issues on RiakBundle, a bundle used to communicate with Riak NoSQL database thrue HTTP. All of our CurlMulti requests are failing since response bodies are all mixed up. I get things like `{"id":"actu_eyes","name":"Actu Eyes","fakeFullTextSearch":"all actu_eyes"}akeFullTextSearch":"all actual"}Search":"all acces_credit"}les_batteries"}` as  I am fetching three objects in parallal using CurlMulti. I can see that the three jsons are mixed up. 

Since Im' not a Guzzle expert, I have no idea why is that but by adding `EntityBody::factory(...)` back, everything seems to running just fine.
