### PR TITLE
add support for oauth_callback parameter in Authorization header

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -44,7 +44,8 @@ class OauthPlugin implements EventSubscriberInterface
             'signature_method' => 'HMAC-SHA1',
             'signature_callback' => function($stringToSign, $key) {
                 return hash_hmac('sha1', $stringToSign, $key, true);
-            }
+            },
+            'callback' => null
         ), array(
             'signature_method', 'signature_callback', 'version',
             'consumer_key', 'consumer_secret'
@@ -82,6 +83,7 @@ class OauthPlugin implements EventSubscriberInterface
             'oauth_timestamp'        => $timestamp,
             'oauth_token'            => $this->config['token'],
             'oauth_version'          => $this->config['version'],
+            'oauth_callback'         => $this->config['callback'],
         );
 
         $request->setHeader(

--- a/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
+++ b/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
@@ -52,6 +52,25 @@ class OauthPluginTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals('HMAC-SHA1', $config['signature_method']);
     }
 
+    public function testAcceptsConfigurationCallbackData()
+    {
+        $opt = array(
+            'callback' => 'http://magic.call.to/callmeback'
+        );
+        $cfg = array_merge($this->config, $opt);
+
+        $p = new OauthPlugin($cfg);
+
+        // Access the config object
+        $class = new \ReflectionClass($p);
+        $property = $class->getProperty('config');
+        $property->setAccessible(true);
+        $config = $property->getValue($p);
+
+        $this->assertEquals('http://magic.call.to/callmeback', $config['callback']);
+    }
+
+
     public function testCreatesStringToSignFromPostRequest()
     {
         $p = new OauthPlugin($this->config);


### PR DESCRIPTION
This commit makes it possible to add optional oauth_callback header param through 'callback' config key.
