### PR TITLE
Incorrect URL generation for service description with hostname.

### DIFF
--- a/src/Guzzle/Http/Url.php
+++ b/src/Guzzle/Http/Url.php
@@ -486,8 +486,8 @@ class Url
 
         if ($buffer = $url->getHost()) {
             $this->host = $buffer;
-			// All services that define a host must define the full path for each operation
-			$absolutePath = true;
+            // All services that define a host must define the full path for each operation
+            $absolutePath = true;
         }
 
         if ($buffer = $url->getPort()) {


### PR DESCRIPTION
Fixed issue where service url with domain name specified generates incorrect URL.

https://github.com/guzzle/guzzle/issues/288
