### PR TITLE
Moved decision of whether to sign post fields to a function.

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -203,7 +203,7 @@ class OauthPlugin implements EventSubscriberInterface
      * @param $request
      * @return bool Whether the post fields should be signed or not
      */
-    public function		shouldPostFieldsBeSigned($request)
+    public function shouldPostFieldsBeSigned($request)
     {
         if (!$this->config->get('disable_post_params') &&
             $request instanceof EntityEnclosingRequestInterface &&


### PR DESCRIPTION
Hi,

The commit is to make it easier to work with APIs that are very slightly broken. Some non-conformant APIs that have incorrect implementations of Oauth. The correct implementation of Oauth in Guzzle fails the signature check, as the signature is calculated incorrectly on the server side.

Without this change to work around this the whole of the function  getParamsToSign(RequestInterface $request, $timestamp, $nonce) in OauthPlugin needs to be overridden. Being able to override just a small snippet is a lot nicer such as:

https://github.com/Danack/FlickrGuzzle/blob/master/src/Intahwebz/FlickrGuzzle/FlickrOauthPlugin.php

cheers
Dan
