### PR TITLE
Adjustments for OAuth 1.0a

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -168,6 +168,7 @@ class OauthPlugin implements EventSubscriberInterface
     public function getParamsToSign(RequestInterface $request, $timestamp, $nonce)
     {
         $params = new Collection(array(
+            'oauth_callback'         => $this->config['callback'],
             'oauth_consumer_key'     => $this->config['consumer_key'],
             'oauth_nonce'            => $nonce,
             'oauth_signature_method' => $this->config['signature_method'],


### PR DESCRIPTION
Further playing with the Twitter API revealed that, now they are enforcing OAuth 1.0a, we need to also send (and sign) the oauth_verifier attribute as well as the oauth_callback. Also, since the special check for 'oauth_token !== false' has been removed lately the entire thing can be removed from ->getParamsToSign() because ->prepareParameters() filters NULL anyways.
