### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ HTTP basics
 
 use Guzzle\Http\Client;
 
-$client = new Client('http://www.example.com/api/v1/key/{{key}}', array(
+$client = new Client('http://www.example.com/api/v1/key/{key}', array(
     'key' => '***'
 ));
 


### PR DESCRIPTION
Fixes the URL template example which showed using double curly braces rather than single. Using this format causes parsing errors when Guzzle runs.
