### PR TITLE
[WIP] MockManager plugin

### DIFF
--- a/src/Guzzle/Plugin/Mock/Exception/UnmatchedRequestException.php
+++ b/src/Guzzle/Plugin/Mock/Exception/UnmatchedRequestException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Guzzle\Plugin\Mock\Exception;
+
+use OutOfBoundsException;
+
+/**
+ * Thrown when a request is not matched to a response.
+ */
+class UnmatchedRequestException extends OutOfBoundsException
+{
+}

--- a/src/Guzzle/Plugin/Mock/MockMatcherPlugin.php
+++ b/src/Guzzle/Plugin/Mock/MockMatcherPlugin.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Guzzle\Plugin\Mock;
+
+use Guzzle\Common\Event;
+use Guzzle\Plugin\Mock\Exception\UnmatchedRequestException;
+use Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface;
+use Guzzle\Plugin\Mock\UnmatchedRequestStrategy\UnmatchedRequestStrategyInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Match requests to mock responses.
+ */
+class MockMatcherPlugin implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'request.before_send' => array('onRequestBeforeSend', -256),
+        );
+    }
+
+    /**
+     * Request matchers.
+     *
+     * @var RequestMatcherInterface[]
+     */
+    protected $matchers = array();
+
+    /**
+     * Unmatched request strategy.
+     *
+     * @var UnmatchedRequestStrategyInterface|null
+     */
+    protected $unmatchedRequestStrategy;
+
+    /**
+     * Constructor.
+     *
+     * @param RequestMatcherInterface[]              $matchers                 Request matchers
+     * @param UnmatchedRequestStrategyInterface|null $unmatchedRequestStrategy Optional strategy to use when a request
+     *                                                                         is not matched to a response
+     */
+    public function __construct(
+        array $matchers = array(),
+        UnmatchedRequestStrategyInterface $unmatchedRequestStrategy = null
+    )
+    {
+        foreach ($matchers as $matcher) {
+            $this->addMatcher($matcher);
+        }
+
+        $this->unmatchedRequestStrategy = $unmatchedRequestStrategy;
+    }
+
+    /**
+     * Add a request matcher.
+     *
+     * @param RequestMatcherInterface $matcher Request Matcher
+     *
+     * @return self Reference to the plugin
+     */
+    public function addMatcher(RequestMatcherInterface $matcher)
+    {
+        $this->matchers[] = $matcher;
+
+        return $this;
+    }
+
+    /**
+     * Match a request to a response.
+     *
+     * @param Event $event Request before send event
+     *
+     * @throws UnmatchedRequestException If a request is not matched to a response and an unmatched request strategy is
+     *                                   not set
+     */
+    public function onRequestBeforeSend(Event $event)
+    {
+        $request = $event['request'];
+
+        if (null !== $request->getResponse()) {
+            return;
+        }
+
+        foreach ($this->matchers as $matcher) {
+            if (null !== $match = $matcher->match($request)) {
+                $request->setResponse($match, true);
+
+                return;
+            }
+        }
+
+        if (null !== $this->unmatchedRequestStrategy) {
+            $this->unmatchedRequestStrategy->handle($request);
+        } else {
+            throw new UnmatchedRequestException(sprintf(
+                'No matcher found for the request %s %s',
+                $request->getMethod(),
+                $request->getUrl()
+            ));
+        }
+    }
+}

--- a/src/Guzzle/Plugin/Mock/RequestMatcher/RequestMatcherInterface.php
+++ b/src/Guzzle/Plugin/Mock/RequestMatcher/RequestMatcherInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Guzzle\Plugin\Mock\RequestMatcher;
+
+use Guzzle\Http\Message\RequestInterface;
+use Guzzle\Http\Message\Response;
+
+/**
+ * Matches a request to a response.
+ */
+interface RequestMatcherInterface
+{
+    /**
+     * Try and match a request to a response.
+     *
+     * @param RequestInterface $request Request.
+     *
+     * @return Response|null Matched response, or `null`.
+     */
+    public function match(RequestInterface $request);
+}

--- a/src/Guzzle/Plugin/Mock/RequestMatcher/UriRequestMatcher.php
+++ b/src/Guzzle/Plugin/Mock/RequestMatcher/UriRequestMatcher.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Guzzle\Plugin\Mock\RequestMatcher;
+
+use Guzzle\Http\Message\RequestInterface;
+use Guzzle\Http\Message\Response;
+
+/**
+ * Request handler that matches responses to URIs (either complete or partial).
+ */
+class UriRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * Request method.
+     *
+     * @var string
+     */
+    protected $method;
+
+    /**
+     * URI-response combinations.
+     *
+     * @var array
+     */
+    protected $responses = array();
+
+    /**
+     * Constructor.
+     *
+     * @param string $method    Method.
+     * @param array  $responses Associative array of complete or partial URIs as the keys and response objects, string
+     *                          responses or paths to files as the values
+     */
+    public function __construct($method = 'GET', array $responses = array())
+    {
+        $this->method = $method;
+        foreach ($responses as $uri => $response) {
+            $this->registerUri($uri, $response);
+        }
+    }
+
+    /**
+     * Register a URI.
+     *
+     * @param string          $uri      URI (either complete or partial)
+     * @param Response|string $response Response object, a string response or a path to a file containing a response
+     *
+     * @return self Reference to the matcher
+     */
+    public function registerUri($uri, $response)
+    {
+        if ($response instanceof Response) {
+            $this->responses[$uri] = $response;
+
+            return $this;
+        }
+
+        if (file_exists($response)) {
+            $response = file_get_contents($response);
+        }
+
+        $this->responses[$uri] = Response::fromMessage($response);
+
+        return $this;
+    }
+
+    public function match(RequestInterface $request)
+    {
+        if ($request->getMethod() !== $this->method) {
+            return null;
+        }
+
+        foreach ($this->responses as $uri => $response) {
+            if (false !== stripos($request->getUrl(), $uri)) {
+                return $response;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Guzzle/Plugin/Mock/UnmatchedRequestStrategy/NullUnmatchedRequestStrategy.php
+++ b/src/Guzzle/Plugin/Mock/UnmatchedRequestStrategy/NullUnmatchedRequestStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Guzzle\Plugin\Mock\UnmatchedRequestStrategy;
+
+use Guzzle\Http\Message\RequestInterface;
+
+/**
+ * Strategy that does nothing if a request is not matched to a response,
+ * allowing a real request to be made.
+ */
+class NullUnmatchedRequestStrategy implements UnmatchedRequestStrategyInterface
+{
+    public function handle(RequestInterface $request)
+    {
+        // do nothing
+    }
+}

--- a/src/Guzzle/Plugin/Mock/UnmatchedRequestStrategy/UnmatchedRequestStrategyInterface.php
+++ b/src/Guzzle/Plugin/Mock/UnmatchedRequestStrategy/UnmatchedRequestStrategyInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Guzzle\Plugin\Mock\UnmatchedRequestStrategy;
+
+use Guzzle\Http\Message\RequestInterface;
+
+/**
+ * Defines what happens when a request is not matched to a response.
+ */
+interface UnmatchedRequestStrategyInterface
+{
+    /**
+     * Handle an unmatched request.
+     *
+     * This may, for example set a response on the request, or do nothing.
+     *
+     * @param RequestInterface $request
+     */
+    public function handle(RequestInterface $request);
+}

--- a/tests/Guzzle/Tests/Plugin/Mock/Exception/UnmatchedRequestExceptionTest.php
+++ b/tests/Guzzle/Tests/Plugin/Mock/Exception/UnmatchedRequestExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Guzzle\Tests\Plugin\Mock\Exception;
+
+use Guzzle\Plugin\Mock\Exception\UnmatchedRequestException;
+use Guzzle\Tests\GuzzleTestCase;
+
+/**
+ * @covers Guzzle\Plugin\Mock\Exception\UnmatchedRequestException
+ */
+class UnmatchedRequestExceptionTest extends GuzzleTestCase
+{
+    public function testInstanceOf()
+    {
+        $exception = new UnmatchedRequestException();
+
+        $this->assertInstanceOf('OutOfBoundsException', $exception);
+    }
+}

--- a/tests/Guzzle/Tests/Plugin/Mock/MockMatcherPluginTest.php
+++ b/tests/Guzzle/Tests/Plugin/Mock/MockMatcherPluginTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Guzzle\Tests\Plugin\Mock;
+
+use Guzzle\Plugin\Mock\MockMatcherPlugin;
+use Guzzle\Tests\GuzzleTestCase;
+
+/**
+ * @covers Guzzle\Plugin\Mock\MockMatcherPlugin
+ */
+class MockMatcherPluginTest extends GuzzleTestCase
+{
+    public function testInstanceOf()
+    {
+        $this->assertInstanceOf('Symfony\Component\EventDispatcher\EventSubscriberInterface', new MockMatcherPlugin());
+        $this->assertArrayHasKey('request.before_send', MockMatcherPlugin::getSubscribedEvents());
+    }
+
+    public function testUsesConstructorMatchers()
+    {
+        $matcher1 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher1->expects($this->once())->method('match')->will($this->returnValue(null));
+        $response = $this->getMockBuilder('Guzzle\Http\Message\Response')->disableOriginalConstructor()->getMock();
+        $matcher2 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher2->expects($this->once())->method('match')->will($this->returnValue($response));
+
+        $plugin = new MockMatcherPlugin(array($matcher1, $matcher2));
+
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $event = $this->getMock('Guzzle\Common\Event');
+        $event->expects($this->any())->method('offsetGet')->with('request')->will($this->returnValue($request));
+
+        $request->expects($this->once())->method('setResponse')->with($response, true);
+
+        $plugin->onRequestBeforeSend($event);
+    }
+
+    public function testUsesAddedMatchers()
+    {
+        $matcher1 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher1->expects($this->once())->method('match')->will($this->returnValue(null));
+
+        $plugin = new MockMatcherPlugin(array($matcher1));
+
+        $response = $this->getMockBuilder('Guzzle\Http\Message\Response')->disableOriginalConstructor()->getMock();
+        $matcher2 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher2->expects($this->once())->method('match')->will($this->returnValue($response));
+
+        $this->assertSame($plugin, $plugin->addMatcher($matcher2));
+
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $event = $this->getMock('Guzzle\Common\Event');
+        $event->expects($this->any())->method('offsetGet')->with('request')->will($this->returnValue($request));
+
+        $request->expects($this->once())->method('setResponse')->with($response, true);
+
+        $plugin->onRequestBeforeSend($event);
+    }
+
+    /**
+     * @expectedException \Guzzle\Plugin\Mock\Exception\UnmatchedRequestException
+     */
+    public function testThrowsExceptionWhenAnUnmatchedRequestStrategyIsNotSet()
+    {
+        $matcher1 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher1->expects($this->once())->method('match')->will($this->returnValue(null));
+        $matcher2 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher2->expects($this->once())->method('match')->will($this->returnValue(null));
+
+        $plugin = new MockMatcherPlugin(array($matcher1, $matcher2));
+
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $event = $this->getMock('Guzzle\Common\Event');
+        $event->expects($this->any())->method('offsetGet')->with('request')->will($this->returnValue($request));
+
+        $request->expects($this->never())->method('setResponse');
+
+        $plugin->onRequestBeforeSend($event);
+    }
+
+    public function testUsesCustomUnmatchedRequestStrategy()
+    {
+        $matcher1 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher1->expects($this->once())->method('match')->will($this->returnValue(null));
+        $matcher2 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher2->expects($this->once())->method('match')->will($this->returnValue(null));
+
+        $unmatchedRequestStrategy = $this->getMock(
+            'Guzzle\Plugin\Mock\UnmatchedRequestStrategy\UnmatchedRequestStrategyInterface'
+        );
+
+        $plugin = new MockMatcherPlugin(array($matcher1, $matcher2), $unmatchedRequestStrategy);
+
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $event = $this->getMock('Guzzle\Common\Event');
+        $event->expects($this->any())->method('offsetGet')->with('request')->will($this->returnValue($request));
+
+        $request->expects($this->never())->method('setResponse');
+
+        $unmatchedRequestStrategy->expects($this->once())->method('handle')->with($request);
+
+        $plugin->onRequestBeforeSend($event);
+    }
+
+    public function testDoesNothingIfAResponseIsAlreadySet()
+    {
+        $matcher1 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher1->expects($this->never())->method('match');
+        $matcher2 = $this->getMock('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface');
+        $matcher2->expects($this->never())->method('match');
+
+        $unmatchedRequestStrategy = $this->getMock(
+            'Guzzle\Plugin\Mock\UnmatchedRequestStrategy\UnmatchedRequestStrategyInterface'
+        );
+
+        $plugin = new MockMatcherPlugin(array($matcher1, $matcher2), $unmatchedRequestStrategy);
+
+        $response = $this->getMockBuilder('Guzzle\Http\Message\Response')->disableOriginalConstructor()->getMock();
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->any())->method('getResponse')->will($this->returnValue($response));
+        $event = $this->getMock('Guzzle\Common\Event');
+        $event->expects($this->any())->method('offsetGet')->with('request')->will($this->returnValue($request));
+
+        $request->expects($this->never())->method('setResponse');
+
+        $unmatchedRequestStrategy->expects($this->never())->method('handle');
+
+        $plugin->onRequestBeforeSend($event);
+    }
+}

--- a/tests/Guzzle/Tests/Plugin/Mock/RequestMatcher/Fixtures/response.txt
+++ b/tests/Guzzle/Tests/Plugin/Mock/RequestMatcher/Fixtures/response.txt
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Date: Fri, 31 Dec 1999 23:59:59 GMT
+Content-Type: text/plain
+Content-Length: 8
+
+Foo bar.

--- a/tests/Guzzle/Tests/Plugin/Mock/RequestMatcher/UriRequestMatcherTest.php
+++ b/tests/Guzzle/Tests/Plugin/Mock/RequestMatcher/UriRequestMatcherTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Guzzle\Tests\Plugin\Mock\RequestMatcher;
+
+use Guzzle\Plugin\Mock\RequestMatcher\UriRequestMatcher;
+use Guzzle\Tests\GuzzleTestCase;
+
+/**
+ * @covers Guzzle\Plugin\Mock\RequestMatcher\UriRequestMatcher
+ */
+class UriRequestMatcherTest extends GuzzleTestCase
+{
+    public function testInstanceOf()
+    {
+        $matcher = new UriRequestMatcher();
+
+        $this->assertInstanceOf('Guzzle\Plugin\Mock\RequestMatcher\RequestMatcherInterface', $matcher);
+    }
+
+    public function testMatchesResponseObjectOnConstructor()
+    {
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->any())->method('getMethod')->will($this->returnValue('GET'));
+        $request->expects($this->any())->method('getUrl')->will($this->returnValue('http://example.com/foo'));
+
+        $response = $this->getMockBuilder('Guzzle\Http\Message\Response')->disableOriginalConstructor()->getMock();
+
+        $matcher = new UriRequestMatcher('GET', array('http://example.com/foo' => $response));
+
+        $this->assertSame($response, $matcher->match($request));
+    }
+
+    /**
+     * @dataProvider partialURIProvider
+     */
+    public function testMatchesResponseObjectOnConstructorWithAPartialURI($uri)
+    {
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->any())->method('getMethod')->will($this->returnValue('GET'));
+        $request->expects($this->any())->method('getUrl')->will($this->returnValue('http://example.com/foo'));
+
+        $response = $this->getMockBuilder('Guzzle\Http\Message\Response')->disableOriginalConstructor()->getMock();
+
+        $matcher = new UriRequestMatcher('GET', array($uri => $response));
+
+        $this->assertSame($response, $matcher->match($request));
+    }
+
+    public function partialURIProvider()
+    {
+        return array(
+            array('example.com'),
+            array('/foo'),
+        );
+    }
+
+    public function testDoesNotMatchResponseObjectOnConstructorWithADifferentMethod()
+    {
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->any())->method('getMethod')->will($this->returnValue('POST'));
+        $request->expects($this->any())->method('getUrl')->will($this->returnValue('http://example.com/foo'));
+
+        $response = $this->getMockBuilder('Guzzle\Http\Message\Response')->disableOriginalConstructor()->getMock();
+
+        $matcher = new UriRequestMatcher('GET', array('http://example.com/foo' => $response));
+
+        $this->assertNull($matcher->match($request));
+    }
+
+    public function testDoesNotMatchesResponseObjectOnConstructorWithADifferentURI()
+    {
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->any())->method('getMethod')->will($this->returnValue('GET'));
+        $request->expects($this->any())->method('getUrl')->will($this->returnValue('http://example.com/foo'));
+
+        $response = $this->getMockBuilder('Guzzle\Http\Message\Response')->disableOriginalConstructor()->getMock();
+
+        $matcher = new UriRequestMatcher('GET', array('foo.com' => $response));
+
+        $this->assertNull($matcher->match($request));
+    }
+
+    public function testMatchesRegisteredResponseObject()
+    {
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->any())->method('getMethod')->will($this->returnValue('GET'));
+        $request->expects($this->any())->method('getUrl')->will($this->returnValue('http://example.com/foo'));
+
+        $response = $this->getMockBuilder('Guzzle\Http\Message\Response')->disableOriginalConstructor()->getMock();
+
+        $matcher = new UriRequestMatcher();
+        $matcher->registerUri('http://example.com/foo', $response);
+
+        $this->assertSame($response, $matcher->match($request));
+    }
+
+    public function testMatchesRegisteredStringResponse()
+    {
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->any())->method('getMethod')->will($this->returnValue('GET'));
+        $request->expects($this->any())->method('getUrl')->will($this->returnValue('http://example.com/foo'));
+
+        $response = <<<EOT
+HTTP/1.1 200 OK
+Date: Fri, 31 Dec 1999 23:59:59 GMT
+Content-Type: text/plain
+Content-Length: 8
+
+Foo bar.
+EOT;
+
+        $matcher = new UriRequestMatcher();
+        $matcher->registerUri('http://example.com/foo', $response);
+
+        $this->assertSame('Foo bar.', (string) $matcher->match($request)->getBody(true));
+    }
+
+    public function testMatchesRegisteredFileResponse()
+    {
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->any())->method('getMethod')->will($this->returnValue('GET'));
+        $request->expects($this->any())->method('getUrl')->will($this->returnValue('http://example.com/foo'));
+
+        $response = __DIR__ . '/Fixtures/response.txt';
+
+        $matcher = new UriRequestMatcher();
+        $matcher->registerUri('http://example.com/foo', $response);
+
+        $this->assertSame('Foo bar.', (string) $matcher->match($request)->getBody(true));
+    }
+}

--- a/tests/Guzzle/Tests/Plugin/Mock/UnmatchedRequestStrategy/NullUnmatchedRequestStrategyTest.php
+++ b/tests/Guzzle/Tests/Plugin/Mock/UnmatchedRequestStrategy/NullUnmatchedRequestStrategyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Guzzle\Tests\Plugin\Mock\UnmatchedRequestStrategy;
+
+use Guzzle\Plugin\Mock\UnmatchedRequestStrategy\NullUnmatchedRequestStrategy;
+use Guzzle\Tests\GuzzleTestCase;
+
+/**
+ * @covers Guzzle\Plugin\Mock\UnmatchedRequestStrategy\NullUnmatchedRequestStrategy
+ */
+class NullUnmatchedRequestStrategyTest extends GuzzleTestCase
+{
+    public function testInstanceOf()
+    {
+        $strategy = new NullUnmatchedRequestStrategy();
+
+        $this->assertInstanceOf(
+            'Guzzle\Plugin\Mock\UnmatchedRequestStrategy\UnmatchedRequestStrategyInterface',
+            $strategy
+        );
+    }
+
+    public function testHandle()
+    {
+        $strategy = new NullUnmatchedRequestStrategy();
+
+        $request = $this->getMock('Guzzle\Http\Message\RequestInterface');
+        $request->expects($this->never())->method($this->anything());
+
+        $strategy->handle($request);
+    }
+}


### PR DESCRIPTION
As discussed at https://groups.google.com/forum/?fromgroups#!topic/guzzle/LzEOQSai7Hg here's my initial idea for mocking an entire web service (as opposed to individual requests). This is useful for more 'serious' testing, since you don't have to rely on requests being made once in a certain order and it actually blocks network access (so you can't accidentally send a request, which could be dangerous). It's also required for functionally testing Symfony apps (for example) where you don't have access to queue individual requests. This is far from complete, but the basic idea is here.

The `MockManagerPlugin` stores implementations of `RequestHandlerInterface`, which convert requests into responses. When a request is made it cycles through the handlers to find one that can handle the request; if one isn't found an `UnhandledRequestException` is thrown.

The only implementation (so far at least) is `UriMatchingRequestHandler`, which takes an array of URIs (actually regexs, so you can do partial matching) and responses. This should probably come with a few different implementations, but the user can write their own, and since you have access to the request object you could do all kinds of things (eg header/query string matching).

For example:

``` php
$mockManager = new \Guzzle\Plugin\MockManager\MockManagerPlugin();

$handler = new \Guzzle\Plugin\MockManager\RequestHandler\UriMatchingRequestHandler('GET', array(
    'index.php$' => 'HTTP/1.1 200 OK',
    'http://example.com/second.php' => 'HTTP/1.1 204 No Content',
));
$mockManager->addHandler($handler);

$client = new \Guzzle\Http\Client();
$client->addSubscriber($mockManager);

echo $client->createRequest('GET', 'http://example.com/index.php')->send(); // returns the 200
echo $client->createRequest('GET', 'http://example.com/second.php')->send(); // returns the 204
echo $client->createRequest('GET', 'http://example.com/broken.php')->send(); // isn't handled, so an exception is thrown
```
