### PR TITLE
Fixed two issues with the date formatting logic in SchemaFormatter

### DIFF
--- a/src/Guzzle/Service/Description/SchemaFormatter.php
+++ b/src/Guzzle/Service/Description/SchemaFormatter.php
@@ -141,12 +141,15 @@ class SchemaFormatter
      */
     protected static function dateFormatter($dateTime, $format)
     {
-        if (is_string($dateTime)) {
-            $dateTime = new \DateTime($dateTime, self::getUtcTimeZone());
-            return $dateTime->format($format);
-        } elseif (is_numeric($dateTime)) {
+        if (is_numeric($dateTime)) {
             return gmdate($format, (int) $dateTime);
-        } elseif ($dateTime instanceof \DateTime) {
+        }
+
+        if (is_string($dateTime)) {
+            $dateTime = new \DateTime($dateTime);
+        }
+
+        if ($dateTime instanceof \DateTime) {
             return $dateTime->setTimezone(self::getUtcTimeZone())->format($format);
         }
 

--- a/tests/Guzzle/Tests/Service/Description/SchemaFormatterTest.php
+++ b/tests/Guzzle/Tests/Service/Description/SchemaFormatterTest.php
@@ -11,22 +11,27 @@ class SchemaFormatterTest extends \Guzzle\Tests\GuzzleTestCase
 {
     public function dateTimeProvider()
     {
-        $d = 'October 13, 2012 16:15:46 UTC';
+        $dateUtc = 'October 13, 2012 16:15:46 UTC';
+        $dateOffset = 'October 13, 2012 10:15:46 -06:00';
+        $expectedDateTime = '2012-10-13T16:15:46Z';
 
         return array(
             array('foo', 'does-not-exist', 'foo'),
-            array($d, 'date-time', '2012-10-13T16:15:46Z'),
-            array($d, 'date-time-http', 'Sat, 13 Oct 2012 16:15:46 GMT'),
-            array($d, 'date', '2012-10-13'),
-            array($d, 'timestamp', strtotime($d)),
-            array(new \DateTime($d), 'timestamp', strtotime($d)),
-            array($d, 'time', '16:15:46'),
-            array(strtotime($d), 'time', '16:15:46'),
-            array(strtotime($d), 'timestamp', strtotime($d)),
+            array($dateUtc, 'date-time', $expectedDateTime),
+            array($dateUtc, 'date-time-http', 'Sat, 13 Oct 2012 16:15:46 GMT'),
+            array($dateUtc, 'date', '2012-10-13'),
+            array($dateUtc, 'timestamp', strtotime($dateUtc)),
+            array(new \DateTime($dateUtc), 'timestamp', strtotime($dateUtc)),
+            array($dateUtc, 'time', '16:15:46'),
+            array(strtotime($dateUtc), 'time', '16:15:46'),
+            array(strtotime($dateUtc), 'timestamp', strtotime($dateUtc)),
             array('true', 'boolean-string', 'true'),
             array(true, 'boolean-string', 'true'),
             array('false', 'boolean-string', 'false'),
-            array(false, 'boolean-string', 'false')
+            array(false, 'boolean-string', 'false'),
+            array('1350144946', 'date-time', $expectedDateTime),
+            array(1350144946, 'date-time', $expectedDateTime),
+            array($dateOffset, 'date-time', $expectedDateTime)
         );
     }
 


### PR DESCRIPTION
This PR fixes two issues with the date formatting logic in `Guzzle\Service\Description\SchemaFormatter`.
1. Integer timestamps, if passed in as a string, previously caused an exception to be thrown like this: `Exception: DateTime::__construct(): Failed to parse time string`... I moved the `is_numeric()` condition to the top of `SchemaFormatter::dateFormatter` in order to handle this appropriately.
2. Date strings formatted with the timezone included previously caused unexpected results. The date outputted by the `SchemaFormatter` would be in UTC format, but still have the hour value from the originally specified timezone. This was happening because the timezone parameter in the constructor for `DateTime` is ignored when the timezone is specified in the time argument. I changed the `SchemaFormatter::dateFormatter` method to use the `setTimezone()` method instead.

I also added test cases to make use these types of values are exercised by the unit test.
