### PR TITLE
Handle ISO-8859-1 encoded JSON responses

### DIFF
--- a/src/Guzzle/Http/Message/Response.php
+++ b/src/Guzzle/Http/Message/Response.php
@@ -915,7 +915,17 @@ class Response extends AbstractMessage
      */
     public function json()
     {
-        $data = json_decode((string) $this->body, true);
+        $body = (string) $this->body;
+        $contentType = strtolower($this->getContentType());
+        $match = array();
+        if ( preg_match('/;\\s*charset\\s*=\\s*("[^"]*"|[^\\s;]+)/', $contentType, $match) )
+        {
+            if ( $match[1] == 'iso-8859-1' || $match[1] == '"iso-8859-1"' )
+            {
+                $body = utf8_encode($body);
+            }
+        }
+        $data = json_decode($body, true);
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new RuntimeException('Unable to parse response body into JSON: ' . json_last_error());
         }


### PR DESCRIPTION
Summary: This patch adds code to make Guzzle support JSON responses that use the ISO-8859-1 encoding, as long as they say so in their Content-Type header using a charset parameter.

Background:
I'm using a web service that returns JSON content using ISO-8859-1 and states so in the Content-Type header. This worked perfectly fine until I got some content that used characters from the set that isn't the same between ISO-8859-1 and UTF-8, which (obviously) caused the JSON decode to fail and an exception to be thrown.

(It can be argued that the service should be fixed rather than the client, because the JSON spec says it should be encoded using a Unicode encoding, and the application/json type doesn't specify a charset parameter, but actually getting the service fixed can be difficult, so it would be nice if the client supported it in the meantime.)
