### PR TITLE
Make __call arguments required for consistency

### DIFF
--- a/src/Guzzle/Batch/AbstractBatchDecorator.php
+++ b/src/Guzzle/Batch/AbstractBatchDecorator.php
@@ -31,7 +31,7 @@ abstract class AbstractBatchDecorator implements BatchInterface
      * @return mixed
      * @codeCoverageIgnore
      */
-    public function __call($method, array $args = null)
+    public function __call($method, array $args)
     {
         return call_user_func_array(array($this->decoratedBatch, $method), $args);
     }

--- a/src/Guzzle/Http/AbstractEntityBodyDecorator.php
+++ b/src/Guzzle/Http/AbstractEntityBodyDecorator.php
@@ -40,7 +40,7 @@ class AbstractEntityBodyDecorator implements EntityBodyInterface
      *
      * @return mixed
      */
-    public function __call($method, array $args = null)
+    public function __call($method, array $args)
     {
         return call_user_func_array(array($this->body, $method), $args);
     }

--- a/src/Guzzle/Service/Client.php
+++ b/src/Guzzle/Service/Client.php
@@ -85,7 +85,7 @@ class Client extends HttpClient implements ClientInterface
      * @return mixed Returns the result of the command
      * @throws BadMethodCallException when a command is not found or magic methods are disabled
      */
-    public function __call($method, $args = null)
+    public function __call($method, $args)
     {
         if (!$this->enableMagicMethods) {
             throw new BadMethodCallException("Missing method {$method}. This client has not enabled magic methods.");


### PR DESCRIPTION
Making the second argument optional presents difficulty with some testing libraries (namely Mockery) which subclasses a given class and overrides __call() _without_ the second argument being optional. This gives a PHP error "Declaration must be compatible with that of {superclass}".

I did a `git blame` on the origin of these lines, apparently this is just how it's always been, there were no comments on why the second argument needed to be optional. The second argument is always provided by PHP, so there shouldn't be any need for a default.

This would make my life a lot easier, but if there's a reason for it then never mind. :smile:
