### PR TITLE
Process XML collection nodes consistently

### DIFF
--- a/src/Guzzle/Service/Command/LocationVisitor/Response/XmlVisitor.php
+++ b/src/Guzzle/Service/Command/LocationVisitor/Response/XmlVisitor.php
@@ -90,6 +90,9 @@ class XmlVisitor extends AbstractResponseVisitor
                 // value is set and not empty
                 $value = array($value);
             }
+        } else {
+            // If the node has attributes drop them
+            unset($value['@attributes']);
         }
 
         foreach ($value as &$item) {

--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/XmlVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/XmlVisitorTest.php
@@ -350,4 +350,29 @@ class XmlVisitorTest extends AbstractResponseVisitorTest
             )
         ), $value);
     }
+
+    public function testEnsuresArraysDropAttributes()
+    {
+        $visitor = new Visitor();
+        $param = new Parameter(array(
+            'name' => 'Items',
+            'type' => 'array',
+            'location' => 'xml',
+            'items' => array(
+                'sentAs' => 'Item',
+                'type' => 'object'
+            )
+        ));
+
+        $xml = '<wrap><Items size="1"><Item /></Items><Bar></Bar></wrap>';
+        $value = json_decode(json_encode(new \SimpleXMLElement($xml)), true);
+        $visitor->visit($this->command, $this->response, $param, $value);
+
+        $this->assertEquals(array(
+            'Bar' => array(),
+            'Items' => array(
+                array()
+            ),
+        ), $value);
+    }
 }


### PR DESCRIPTION
This fixes an issue where the `@attributes` element ends up as another item in the value of an array Parameter.

This is really specific so bear with me 

The `json_decode(json_encode())` XML conversion works differently when a collection wrapper node with only one child node, is not the only child of it's parent, has an attribute and appears on a single line.

eg. This XML without line breaks

``` xml
<root>
<Result>
  <Items size="1">
    <Item/>
  </Items>
  <Other/>
</Result>
</root>
```

converts to something like this 

``` php
'Items' => array(
  ['@attributes'] => array(
    'size' => 1
  ),
  [0] => array()
)
```

This commit just calls unset on `@attributes` when processing it. I figured testing for it with isset() would be an unnecessary overhead.
