### PR TITLE
Fixed an undefined index notice when using sentAs with the response JsonVisitor

### DIFF
--- a/src/Guzzle/Service/Command/LocationVisitor/Response/JsonVisitor.php
+++ b/src/Guzzle/Service/Command/LocationVisitor/Response/JsonVisitor.php
@@ -67,10 +67,10 @@ class JsonVisitor extends AbstractResponseVisitor
                         $key = $property->getWireName();
                         if (isset($value[$key])) {
                             $this->recursiveProcess($property, $value[$key]);
-                        }
-                        if ($key != $name) {
-                            $value[$name] = $value[$key];
-                            unset($value[$key]);
+                            if ($key != $name) {
+                                $value[$name] = $value[$key];
+                                unset($value[$key]);
+                            }
                         }
                     }
                 }

--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/JsonVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/JsonVisitorTest.php
@@ -54,6 +54,24 @@ class JsonVisitorTest extends AbstractResponseVisitorTest
         $this->assertEquals(array('foo' => 'test'), $this->value);
     }
 
+    public function testRenamesDoesNotFailForNonExistentKey()
+    {
+        $visitor = new Visitor();
+        $param = new Parameter(array(
+            'name'          => 'foo',
+            'type'          => 'object',
+            'properties'    => array(
+                'bar' => array(
+                    'name'      => 'bar',
+                    'sentAs'    => 'baz',
+                ),
+            ),
+        ));
+        $this->value = array('foo' => array('unknown' => 'Unknown'));
+        $visitor->visit($this->command, $this->response, $param, $this->value);
+        $this->assertEquals(array('foo' => array('unknown' => 'Unknown')), $this->value);
+    }
+
     public function testTraversesObjectsAndAppliesFilters()
     {
         $visitor = new Visitor();


### PR DESCRIPTION
Hey there,

There is an "undefined index" notice when using the response json visitor when a property which is not top level has a 'sentAs' attribute referencing a name that does not exist.

This PR fixes it.

Regards.
