### PR TITLE
Throw a RuntimeException if the cURL extension is not present

### DIFF
--- a/src/Guzzle/Http/Client.php
+++ b/src/Guzzle/Http/Client.php
@@ -80,7 +80,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
     public function __construct($baseUrl = '', $config = null)
     {
         if (!extension_loaded('curl')) {
-            throw new RuntimeException('The PHP cURL extension must be installed to use the HTTP client.');
+            throw new RuntimeException('The PHP cURL extension must be installed to use Guzzle.');
         }
         $this->setConfig($config ?: new Collection());
         $this->initSsl();


### PR DESCRIPTION
Drupal is using Guzzle and needs to be able to gracefully handle the case when cURL is not available. This pull request causes the HTTP client class to throw an exception in the constructor.

Drupal's issue: http://drupal.org/node/1991298

I'm not the original author of the patch; I'm just connecting the two projects. I'm happy to pass along any feedback. 
