### PR TITLE
Default value for the ServiceBuilder simpler instantiation

### DIFF
--- a/src/Guzzle/Service/Builder/ServiceBuilder.php
+++ b/src/Guzzle/Service/Builder/ServiceBuilder.php
@@ -55,7 +55,7 @@ class ServiceBuilder extends AbstractHasDispatcher implements ServiceBuilderInte
      *     - class: Client class to instantiate using a factory method
      *     - params: array of key value pair configuration settings for the builder
      */
-    public function __construct(array $serviceBuilderConfig)
+    public function __construct(array $serviceBuilderConfig = array())
     {
         $this->builderConfig = $serviceBuilderConfig;
     }

--- a/tests/Guzzle/Tests/Service/Builder/ServiceBuilderTest.php
+++ b/tests/Guzzle/Tests/Service/Builder/ServiceBuilderTest.php
@@ -326,7 +326,7 @@ class ServiceBuilderTest extends \Guzzle\Tests\GuzzleTestCase
 
     public function testCanUseArbitraryData()
     {
-        $b = new ServiceBuilder(array());
+        $b = new ServiceBuilder();
         $b['a'] = 'foo';
         $this->assertTrue(isset($b['a']));
         $this->assertEquals('foo', $b['a']);
@@ -336,7 +336,7 @@ class ServiceBuilderTest extends \Guzzle\Tests\GuzzleTestCase
 
     public function testCanRegisterServiceData()
     {
-        $b = new ServiceBuilder(array());
+        $b = new ServiceBuilder();
         $b['a'] = array(
             'class' => 'Guzzle\Tests\Service\Mock\MockClient',
             'params' => array(


### PR DESCRIPTION
This should be backwards compatible (Guzzle tests are still passing and AFAIK parameter defaults don't have to be the same for child classes) and makes it simpler to instantiate when you want an empty ServiceBuilder.
