### PR TITLE
Add CDATA support for XML requests

### DIFF
--- a/src/Guzzle/Common/SimpleXMLExtended.php
+++ b/src/Guzzle/Common/SimpleXMLExtended.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Guzzle\Common;
+
+/**
+ * @author Markus Bachmann <markus.bachmann@digital-connect.de>
+ */
+class SimpleXMLExtended extends \SimpleXMLElement
+{
+    public function addCDATASection($value)
+    {
+        $node = dom_import_simplexml($this);
+        $owner = $node->ownerDocument;
+        $node->appendChild($owner->createCDATASection($value));
+    }
+}

--- a/src/Guzzle/Service/Command/LocationVisitor/Request/XmlVisitor.php
+++ b/src/Guzzle/Service/Command/LocationVisitor/Request/XmlVisitor.php
@@ -6,6 +6,7 @@ use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Service\Command\CommandInterface;
 use Guzzle\Service\Description\Operation;
 use Guzzle\Service\Description\Parameter;
+use Guzzle\Common\SimpleXMLExtended;
 
 /**
  * Location visitor used to serialize XML bodies
@@ -93,14 +94,14 @@ class XmlVisitor extends AbstractRequestVisitor
 
         // Create the wrapping element with no namespaces if no namespaces were present
         if (empty($root['namespaces'])) {
-            return new \SimpleXMLElement("{$declaration}\n<{$root['name']}/>");
+            return new SimpleXMLExtended("{$declaration}\n<{$root['name']}/>");
         } else {
             // Create the wrapping element with an array of one or more namespaces
             $xml = "{$declaration}\n<{$root['name']} ";
             foreach ((array) $root['namespaces'] as $prefix => $uri) {
                 $xml .= is_numeric($prefix) ? "xmlns=\"{$uri}\" " : "xmlns:{$prefix}=\"{$uri}\" ";
             }
-            return new \SimpleXMLElement($xml . "/>");
+            return new SimpleXMLExtended($xml . "/>");
         }
     }
 
@@ -129,6 +130,9 @@ class XmlVisitor extends AbstractRequestVisitor
             }
         } elseif ($param->getData('xmlAttribute')) {
             $xml->addAttribute($param->getWireName(), $value, $param->getData('xmlNamespace'));
+        } elseif (preg_match('/(<|>|&)/', $value)) {
+            $xml->{$param->getWireName()} = null;
+            $xml->{$param->getWireName()}->addCDATASection($value);
         } else {
             $xml->addChild($param->getWireName(), $value, $param->getData('xmlNamespace'));
         }


### PR DESCRIPTION
Fix #341.

SimpleXML hasn't a native support for CDATA. 
This PR integrates a Workaround.
