### PR TITLE
Scream and shout

### DIFF
--- a/src/Guzzle/Http/Message/AbstractMessage.php
+++ b/src/Guzzle/Http/Message/AbstractMessage.php
@@ -131,7 +131,7 @@ abstract class AbstractMessage implements MessageInterface
      */
     public function getTokenizedHeader($header, $token = ';')
     {
-        return null;
+        throw new \BadMethodCallException('getTokenizedHeader is deprecated. Use $message->getHeader()->parseParams()');
     }
 
     /**


### PR DESCRIPTION
From 3.5 to 3.6 `getTokenizedHeader()` went from being a function to being _marked_ deprecated and silently failing.  Ratchet relies on this function (and others which had API breaks) and as of 3.6 always returned null, which in 3.5 meant that header did not exist. 

Semantic versioning states there should not be API breaks between minor versions.  Requiring guzzle/~3.0 means applications using it should be safe when upgrading and the only API changes should be additions unless security fixes. 

If a function is deprecated the developer should be given some kind of notice, not a silent failure. In this case, as the function no longer works it should throw an exception or be removed all together.

I would also suggest modifying all other functions marked as deprecated, but are currently still working, to call `trigger_error(` with level E_USER_DEPRECATED to warn developers that using deprecated methods may result in errors in _future_ versions. 
