### PR TITLE
Use ToArrayInterface type check when accessing response headers

### DIFF
--- a/src/Guzzle/Http/Message/Response.php
+++ b/src/Guzzle/Http/Message/Response.php
@@ -3,7 +3,7 @@
 namespace Guzzle\Http\Message;
 
 use Guzzle\Common\Version;
-use Guzzle\Common\Collection;
+use Guzzle\Common\ToArrayInterface;
 use Guzzle\Common\Exception\RuntimeException;
 use Guzzle\Http\EntityBodyInterface;
 use Guzzle\Http\EntityBody;
@@ -130,7 +130,7 @@ class Response extends AbstractMessage implements \Serializable
      * Construct the response
      *
      * @param string                              $statusCode The response status code (e.g. 200, 404, etc)
-     * @param Collection|array                    $headers    The response headers
+     * @param ToArrayInterface|array              $headers    The response headers
      * @param string|resource|EntityBodyInterface $body       The body of the response
      *
      * @throws BadResponseException if an invalid response code is given
@@ -144,7 +144,7 @@ class Response extends AbstractMessage implements \Serializable
         if ($headers) {
             if (is_array($headers)) {
                 $this->setHeaders($headers);
-            } elseif ($headers instanceof Collection) {
+            } elseif ($headers instanceof ToArrayInterface) {
                 $this->setHeaders($headers->toArray());
             } else {
                 throw new BadResponseException('Invalid headers argument received');


### PR DESCRIPTION
I'm experiencing BadResponseExceptions when using [this client](https://github.com/rdohms/meetup-api-client) because a HeaderCollection is being passed into the `Http\Message\Response` class constructor - this may have been introduced by the recent HeaderCollection changes? I've altered the constructor to check for `Guzzle\Common\ToArrayInterface` instead, which should cater for all cases. 
