### PR TITLE
Allow Guzzle client to manage ResponseObject creation

### DIFF
--- a/src/Guzzle/Service/Client.php
+++ b/src/Guzzle/Service/Client.php
@@ -282,6 +282,23 @@ class Client extends HttpClient implements ClientInterface
     }
 
     /**
+     * Allows the client for an API to create the responseClass objects for a given command.
+     * Override this function to create the objects specific to the API you are using.
+     *
+     * @param $className The class name as defined in the service.
+     * @param AbstractCommand $command The command that was requested.
+     * @return null Default implementation does not create any classes.
+     */
+    function createObject(AbstractCommand $command){
+        //The className that should be created should be retrieved from:
+        //$className = $command->getOperation()->getResponseClass();
+
+        //The data returned be the API can be accessed via:
+        //$data = $command->getRequest()->getResponse()->getBody(TRUE);
+        return null;
+    }
+
+    /**
      * @deprecated
      * @codeCoverageIgnore
      */

--- a/src/Guzzle/Service/Command/OperationResponseParser.php
+++ b/src/Guzzle/Service/Command/OperationResponseParser.php
@@ -67,6 +67,11 @@ class OperationResponseParser extends DefaultResponseParser
         if ($type == OperationInterface::TYPE_MODEL) {
             $model = $operation->getServiceDescription()->getModel($operation->getResponseClass());
         } elseif ($type == OperationInterface::TYPE_CLASS) {
+            $object = $command->getClient()->createObject($command);
+            if ($object != null) {
+                return $object;
+            }
+
             $responseClassInterface = __NAMESPACE__ . '\ResponseClassInterface';
             $className = $operation->getResponseClass();
             if (!class_exists($className)) {


### PR DESCRIPTION
Allow Guzzle client to manage ResponseObject creation rather than requiring every object implement ResponseClassInterface.

Hi Michael,

This change removes the strong coupling between Guzzle and the actual domain objects created by the API, as the domain objects no longer have to implement ResponseClassInterface.

You said, you'd prefer these things to be discuessed first. I did ask at: https://groups.google.com/forum/?hl=en#!topic/guzzle/C6d2i1mpGec
but have no response hence the pull request, so have gone ahead and created a pull-request.

An example implementation is at https://github.com/Danack/FlickrGuzzle/blob/master/src/Intahwebz/FlickrGuzzle/FlickrGuzzleClient.php where you can see why having the object creation code outside of the objects is a lot nicer for some APIs.

cheers
Dan
