### PR TITLE
Only set optional Oauth params if they're set in config.

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -173,11 +173,11 @@ class OauthPlugin implements EventSubscriberInterface
         
         if (array_key_exists('callback', $this->config) == true) {
             $params['oauth_callback'] = $this->config['callback'];
-		}
-
-		if (array_key_exists('verifier', $this->config) == true) {
-			$params['oauth_verifier'] = $this->config['verifier'];
-		}
+        }
+        
+        if (array_key_exists('verifier', $this->config) == true) {
+            $params['oauth_verifier'] = $this->config['verifier'];
+        }
 
         // Add query string parameters
         $params->merge($request->getQuery());


### PR DESCRIPTION
Don't add oauth_callback or oauth_verifier from the oauth config array to paramsToSign unless they are set. This prevents them being duplicated if they are set as parameters for a function in a service description.

The reason for doing this is that for me at least it's nicer to have the oauth_callback and oauth_verifier as part of the service description, so for any call that requires those parameters, a  Guzzle\Service\Exception\ValidationException is thrown before the API call, rather than just getting a generic error code from the server.

However having these parameters listed as part of the service rather than the oauth config means that they are added twice, once with null and once with the real values. The request is then submitted with both of them stored in an array, which makes the request invalid.

cheers
Dan
