### PR TITLE
Added check for malfored URLS instead of resulting in a FATAL ERROR

### DIFF
--- a/src/Guzzle/Http/Url.php
+++ b/src/Guzzle/Http/Url.php
@@ -33,10 +33,11 @@ class Url
         static $defaults = array('scheme' => null, 'host' => null, 'path' => null, 'port' => null, 'query' => null,
             'user' => null, 'pass' => null, 'fragment' => null);
 
-        if (parse_url($url))
-            $parts = parse_url($url) + $defaults;
-        else
+        if ($parts = parse_url($url)) {
+            $parts = $parts + $defaults;
+        } else {
             throw new InvalidArgumentException('Was unable to parse malformed url: ' . $url);
+        }
         // Convert the query string into a QueryString object
         if ($parts['query'] || 0 !== strlen($parts['query'])) {
             $parts['query'] = QueryString::fromString($parts['query']);


### PR DESCRIPTION
Had an issue where URIs that are unencoded such as:

/brand?min_last_modified=\'1/1/0001\'&start_element=24800&num_elements=100
/category?start_element=0&num_elements=100&min_last_modified=2013-06-19+12:47:57

were resulting in FATAL error since parse_url was returning false. Resulting in an invalid operand FATAL error with FALSE + defaults.

This patch resolves this issue. Please feel free to modify according to your rigorous standards.
