### PR TITLE
Response/XmlVisitor cannot accept 'xmlns' in response.

### DIFF
--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/XmlVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/XmlVisitorTest.php
@@ -25,6 +25,20 @@ class XmlVisitorTest extends AbstractResponseVisitorTest
         $this->assertEquals(array('Bar' => 'test'), $result);
     }
 
+    public function testBeforeMethodParsesXmlWithNamespace()
+    {
+        $visitor = new Visitor();
+        $command = $this->getMockBuilder('Guzzle\Service\Command\AbstractCommand')
+            ->setMethods(array('getResponse'))
+            ->getMockForAbstractClass();
+        $command->expects($this->once())
+            ->method('getResponse')
+            ->will($this->returnValue(new Response(200, null, '<foo xmlns="urn:foo"><bar:Bar xmlns:bar="urn:bar">test</bar:Bar></foo>')));
+        $result = array();
+        $visitor->before($command, $result);
+        $this->assertEquals(array('Bar' => 'test'), $result);
+    }
+
     public function testBeforeMethodParsesNestedXml()
     {
         $visitor = new Visitor();


### PR DESCRIPTION
The `XmlVisitor` class cannot deal with responses where the root node (or any other node for that matter) has an `xmlns` declaration. This is very common when interacting with SOAP services, RSS responses, etc.

``` php
<?php

$xml = <<<XML
<foo xmlns="urn:foo"><bar:Bar xmlns:bar="urn:bar">test</bar:Bar></foo>
XML;

$simple = simplexml_load_string($xml);

print_r(json_decode(json_encode($simple), true));
```

The above does not output the expected result. The code is identical to the one used in the `XmlVisitor::before` method.
