### PR TITLE
Corrected encoding to be standard spelling.

### DIFF
--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/XmlVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/XmlVisitorTest.php
@@ -513,7 +513,7 @@ class XmlVisitorTest extends AbstractVisitorTestCase
         $command->setClient(new Client());
         $request = $command->prepare();
         $this->assertEquals(
-            '<?xml version="1.0" encoding="utf8"?>' . "\n"
+            '<?xml version="1.0" encoding="UTF-8"?>' . "\n"
                 . '<Request><Foo>test</Foo></Request>' . "\n",
             (string) $request->getBody()
         );


### PR DESCRIPTION
The test was failing as it expected encoding="utf8" but the actual response was encoding="UTF-8", which is the correct spelling.

However, although this fixes the tests, I had a look and it looks like the relevant PHPunit tests isn't actually running on travis e.g. https://travis-ci.org/guzzle/guzzle/jobs/8939161 

"sh: 1: ~/.nvm/nvm.sh run v0.6.14: not found
[testserver] could not start node server"

So presumably all the tests that involve mocks through Node.js are being skipped.
