### PR TITLE
Used correct encoding for test setup and expectation.

### DIFF
--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/XmlVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/XmlVisitorTest.php
@@ -501,7 +501,7 @@ class XmlVisitorTest extends AbstractVisitorTestCase
     {
         $operation = new Operation(array(
             'data' => array(
-                'xmlEncoding' => 'utf8'
+                'xmlEncoding' => 'UTF-8'
             ),
             'parameters' => array(
                 'Foo' => array('location' => 'xml')
@@ -513,7 +513,7 @@ class XmlVisitorTest extends AbstractVisitorTestCase
         $command->setClient(new Client());
         $request = $command->prepare();
         $this->assertEquals(
-            '<?xml version="1.0" encoding="utf8"?>' . "\n"
+            '<?xml version="1.0" encoding="UTF-8"?>' . "\n"
                 . '<Request><Foo>test</Foo></Request>' . "\n",
             (string) $request->getBody()
         );


### PR DESCRIPTION
The XmlVisitorTest was not running for on OSX + 5.4, but was running fine for all versions of Linux.

I investigated this and it appears to be a bug on OSX in the libxml2 library which PHP uses in XMLWriter. If you call xmlwriter->startDocument with the non-standard spelling of 'utf8' it silently corrects it to 'UTF-8'. XMLWriter does not do this on Centos or Travis.

I think changing the test to use the correct spelling is the right thing to do. Even though it's not needed for Linux, it's nice for OSX people to be able to run the tests and there's almost zero chance of getting this fixed through the libxml2 library within a year.

For reference here is a minimal test of the different behaviour.

```
$writer = new XMLWriter();
$writer->openMemory();
$encoding = "utf8";

$writer->startDocument('1.0', $encoding);
$writer->startElement('foo');
$output = $writer->outputMemory();
echo $output;
```
# Mac OSX PHP5.4

```
<?xml version="1.0" encoding="UTF-8"?>
<foo
```
# Centos PHP5.5

```
<?xml version="1.0" encoding="utf8"?>
<foo
```
