### PR TITLE
Offer the ability to adjust the defaultAggregator used by QueryString

### DIFF
--- a/src/Guzzle/Http/QueryString.php
+++ b/src/Guzzle/Http/QueryString.php
@@ -170,6 +170,32 @@ class QueryString extends Collection
     }
 
     /**
+     * Provide a function for defining the default query string aggregation method
+     *
+     * @param null|QueryAggregatorInterface $aggregator Pass in a QueryAggregatorInterface object to handle converting
+     *                                                  deeply nested query string variables into a flattened array.
+     *                                                  For legacy reasons, this function accepts a callable that must
+     *                                                  accept a $key, $value, and query object.
+     * @return self
+     */
+    public function setDefaultAggregator(QueryAggregatorInterface $aggregator)
+    {
+        self::$defaultAggregator = $aggregator;
+
+        return $this;
+    }
+
+    /**
+     * Provides the current default aggregator type
+     *
+     * @return string
+     */
+    public function getDefaultAggregatorType()
+    {
+        return (self::$defaultAggregator === null) ? 'null' : get_class(self::$defaultAggregator);
+    }
+
+    /**
      * Set whether or not field names and values should be rawurlencoded
      *
      * @param bool|string $encode Set to TRUE to use RFC 3986 encoding (rawurlencode), false to disable encoding, or

--- a/tests/Guzzle/Tests/Http/QueryStringTest.php
+++ b/tests/Guzzle/Tests/Http/QueryStringTest.php
@@ -3,6 +3,7 @@
 namespace Guzzle\Tests\Http;
 
 use Guzzle\Http\QueryString;
+use Guzzle\Http\QueryAggregator\PhpAggregator;
 use Guzzle\Http\QueryAggregator\DuplicateAggregator;
 use Guzzle\Http\QueryAggregator\CommaAggregator;
 
@@ -110,6 +111,32 @@ class QueryStringTest extends \Guzzle\Tests\GuzzleTestCase
         // Use the duplicate aggregator
         $q->setAggregator(new DuplicateAggregator());
         $this->assertEquals('facet=size&facet=width&facet.field=foo', $q->__toString());
+    }
+
+    public function testAllowsChangingDefaultAggregator()
+    {
+        $q = new QueryString();
+        // Use the DuplicateAggregator, since default is PhpAggregator
+        $q->setDefaultAggregator(new DuplicateAggregator());
+        $q->add('facet', 'size');
+        $q->add('facet', 'width');
+        $this->assertEquals('facet=size&facet=width', $q->__toString());
+
+        // Temporarily use the Comma Aggreagotor
+        $q = new QueryString();
+        $q->setAggregator(new CommaAggregator());
+        $q->add('facet', 'size');
+        $q->add('facet', 'width');
+        $this->assertEquals('facet=size,width', $q->__toString());
+
+        // Subsequent query strings, without aggregator explicitly set, should revert to defined default
+        $q = new QueryString();
+        $q->add('facet', 'size');
+        $q->add('facet', 'width');
+        $this->assertEquals('facet=size&facet=width', $q->__toString());
+
+        // Revert to the default default aggregator type
+        $q->setDefaultAggregator(new PhpAggregator());
     }
 
     public function testAllowsNestedQueryData()


### PR DESCRIPTION
It would be nice to adjust the `self::$defaultAggregator` and using something other than the default `PhpAggregator`.
