### PR TITLE
Oauth optional variables

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -176,7 +176,7 @@ class OauthPlugin implements EventSubscriberInterface
     /**
      * Get all of the parameters required to sign a request including:
      * * The oauth params
-     * * The request GET params.
+     * * The request GET params
      * * The params passed in the POST body (with a content-type of application/x-www-form-urlencoded)
      * 
      * @param RequestInterface $request   Request to generate a signature for

--- a/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
+++ b/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
@@ -211,8 +211,8 @@ class OauthPluginTest extends \Guzzle\Tests\GuzzleTestCase
         }
 
         //Technically this test is not universally valid. It would be allowable to have extra \n characters 
-        //in the Authorization header. However Guzzle does not does this, so we just perform a simple check
-        //on length to validate the Authorization header is composed of the strings above.
+        //in the Authorization header. However Guzzle does not do this, so we just perform a simple check
+        //on length to validate the Authorization header is composed of only the strings above.
         $this->assertEquals($totalLength, strlen($authorizationHeader), "Authorization has extra characters i.e. contains extra elements compared to stringsToCheck.");
     }
 


### PR DESCRIPTION
Hi Michael,

Here is the fix to stop null values being added to the list of parameters that need to be signed by oauth, as well as an extra test to stop them from being accidentally added again. 

I removed the duplication of code in onRequestBeforeSend and getParamsToSign. However this does have a side effect of making the parameters in the Authorization header not be in alphabetical order. I think this ok as the spec doesn't say that the Authorization header must have it's parameters in order (http://tools.ietf.org/html/rfc5849#section-3.5.1),  it's only when the signature is calculated that the params are done in order.

So I also changed the test 'testSignsOauthRequests()' so that the string tests is not hard coded to be in a specific order, but just checks for all the required elements anywhere in the string.

I think the above is correct and shouldn't cause issues, but thought I'd better draw your attention to it.

cheers
Dan 
