### PR TITLE
Replace undefined function canCache with canCacheRequest

### DIFF
--- a/src/Guzzle/Plugin/Cache/CallbackCanCacheStrategy.php
+++ b/src/Guzzle/Plugin/Cache/CallbackCanCacheStrategy.php
@@ -41,7 +41,7 @@ class CallbackCanCacheStrategy extends DefaultCanCacheStrategy
     {
         return $this->requestCallback
             ? call_user_func($this->requestCallback, $request)
-            : parent::canCache($request);
+            : parent::canCacheRequest($request);
     }
 
     public function canCacheResponse(Response $response)


### PR DESCRIPTION
Probably a bug from previous refactoring, just caught it as I tried to override only the response canCache mechanism.
