### PR TITLE
Fix #399 - additionalParameters:false not enforced

### DIFF
--- a/src/Guzzle/Service/Command/LocationVisitor/Response/JsonVisitor.php
+++ b/src/Guzzle/Service/Command/LocationVisitor/Response/JsonVisitor.php
@@ -60,10 +60,12 @@ class JsonVisitor extends AbstractResponseVisitor
                 }
             } elseif ($type == 'object' && !isset($value[0])) {
                 // On the above line, we ensure that the array is associative and not numerically indexed
+                $knownProperties = array();
                 if ($properties = $param->getProperties()) {
                     foreach ($properties as $property) {
                         $name = $property->getName();
                         $key = $property->getWireName();
+                        $knownProperties[$name] = 1;
                         if (isset($value[$key])) {
                             $this->recursiveProcess($property, $value[$key]);
                             if ($key != $name) {
@@ -72,6 +74,11 @@ class JsonVisitor extends AbstractResponseVisitor
                             }
                         }
                     }
+                }
+
+                // Remove any unknown and potentially unsafe properties
+                if ($param->getAdditionalProperties() === false) {
+                    $value = array_intersect_key($value, $knownProperties);
                 }
             }
         }

--- a/src/Guzzle/Service/Command/LocationVisitor/Response/XmlVisitor.php
+++ b/src/Guzzle/Service/Command/LocationVisitor/Response/XmlVisitor.php
@@ -106,9 +106,11 @@ class XmlVisitor extends AbstractResponseVisitor
     {
         // Ensure that the array is associative and not numerically indexed
         if (!isset($value[0]) && ($properties = $param->getProperties())) {
+            $knownProperties = array();
             foreach ($properties as $property) {
                 $name = $property->getName();
                 $sentAs = $property->getWireName();
+                $knownProperties[$name] = 1;
                 if ($property->getData('xmlAttribute')) {
                     $this->processXmlAttribute($property, $value);
                 } elseif (isset($value[$sentAs])) {
@@ -118,6 +120,11 @@ class XmlVisitor extends AbstractResponseVisitor
                         unset($value[$sentAs]);
                     }
                 }
+            }
+
+            // Remove any unknown and potentially unsafe properties
+            if ($param->getAdditionalProperties() === false) {
+                $value = array_intersect_key($value, $knownProperties);
             }
         }
     }

--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/HeaderVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/HeaderVisitorTest.php
@@ -60,4 +60,39 @@ class HeaderVisitorTest extends AbstractResponseVisitorTest
             )
         ), $this->value);
     }
+
+    /**
+     * @group issue-399
+     * @link  https://github.com/guzzle/guzzle/issues/399
+     */
+    public function testDiscardingUnknownHeaders()
+    {
+        $visitor = new Visitor();
+        $param = new Parameter(array(
+            'location'             => 'header',
+            'name'                 => 'Content-Type',
+            'additionalParameters' => false
+        ));
+        $visitor->visit($this->command, $this->response, $param, $this->value);
+        $this->assertEquals('text/plain', $this->value['Content-Type']);
+        $this->assertArrayNotHasKey('X-Foo', $this->value);
+    }
+
+    /**
+     * @group issue-399
+     * @link  https://github.com/guzzle/guzzle/issues/399
+     */
+    public function testDiscardingUnknownPropertiesWithAliasing()
+    {
+        $visitor = new Visitor();
+        $param = new Parameter(array(
+            'location'             => 'header',
+            'name'                 => 'ContentType',
+            'sentAs'               => 'Content-Type',
+            'additionalParameters' => false
+        ));
+        $visitor->visit($this->command, $this->response, $param, $this->value);
+        $this->assertEquals('text/plain', $this->value['ContentType']);
+        $this->assertArrayNotHasKey('X-Foo', $this->value);
+    }
 }

--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/JsonVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/JsonVisitorTest.php
@@ -87,4 +87,51 @@ class JsonVisitorTest extends AbstractResponseVisitorTest
         $visitor->visit($this->command, $this->response, $param, $this->value);
         $this->assertEquals(array('foo' => 'HELLO', 'bar' => 'there'), $this->value['foo']);
     }
+
+    /**
+     * @group issue-399
+     * @link  https://github.com/guzzle/guzzle/issues/399
+     */
+    public function testDiscardingUnknownProperties()
+    {
+        $visitor = new Visitor();
+        $param = new Parameter(array(
+            'name'                 => 'foo',
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => array(
+                'bar' => array(
+                    'type' => 'string',
+                    'name' => 'bar',
+                ),
+            ),
+        ));
+        $this->value = array('foo' => array('bar' => 15, 'unknown' => 'Unknown'));
+        $visitor->visit($this->command, $this->response, $param, $this->value);
+        $this->assertEquals(array('foo' => array('bar' => 15)), $this->value);
+    }
+
+    /**
+     * @group issue-399
+     * @link  https://github.com/guzzle/guzzle/issues/399
+     */
+    public function testDiscardingUnknownPropertiesWithAliasing()
+    {
+        $visitor = new Visitor();
+        $param = new Parameter(array(
+            'name'                 => 'foo',
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => array(
+                'bar' => array(
+                    'name'   => 'bar',
+                    'sentAs' => 'baz',
+                ),
+            ),
+        ));
+        $this->value = array('foo' => array('baz' => 15, 'unknown' => 'Unknown'));
+        $visitor->visit($this->command, $this->response, $param, $this->value);
+        $this->assertEquals(array('foo' => array('bar' => 15)), $this->value);
+    }
+
 }

--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/XmlVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Response/XmlVisitorTest.php
@@ -366,4 +366,50 @@ class XmlVisitorTest extends AbstractResponseVisitorTest
             )
         ), $value);
     }
+
+    /**
+     * @group issue-399
+     * @link  https://github.com/guzzle/guzzle/issues/399
+     */
+    public function testDiscardingUnknownProperties()
+    {
+        $visitor = new Visitor();
+        $param = new Parameter(array(
+            'name'                 => 'foo',
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => array(
+                'bar' => array(
+                    'type' => 'string',
+                    'name' => 'bar',
+                ),
+            ),
+        ));
+        $this->value = array('foo' => array('bar' => 15, 'unknown' => 'Unknown'));
+        $visitor->visit($this->command, $this->response, $param, $this->value);
+        $this->assertEquals(array('foo' => array('bar' => 15)), $this->value);
+    }
+
+    /**
+     * @group issue-399
+     * @link  https://github.com/guzzle/guzzle/issues/399
+     */
+    public function testDiscardingUnknownPropertiesWithAliasing()
+    {
+        $visitor = new Visitor();
+        $param = new Parameter(array(
+            'name'                 => 'foo',
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => array(
+                'bar' => array(
+                    'name'   => 'bar',
+                    'sentAs' => 'baz',
+                ),
+            ),
+        ));
+        $this->value = array('foo' => array('baz' => 15, 'unknown' => 'Unknown'));
+        $visitor->visit($this->command, $this->response, $param, $this->value);
+        $this->assertEquals(array('foo' => array('bar' => 15)), $this->value);
+    }
 }


### PR DESCRIPTION
This fixes [issue 399](https://github.com/guzzle/guzzle/issues/399)
