### PR TITLE
Updates LogPlugin to use Protected for $logAdapter

### DIFF
--- a/src/Guzzle/Plugin/Log/LogPlugin.php
+++ b/src/Guzzle/Plugin/Log/LogPlugin.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class LogPlugin implements EventSubscriberInterface
 {
     /** @var LogAdapterInterface Adapter responsible for writing log data */
-    private $logAdapter;
+    protected $logAdapter;
 
     /** @var MessageFormatter Formatter used to format messages before logging */
     protected $formatter;


### PR DESCRIPTION
Changes $logAdapter in the LogPlugin from private to protected. This
makes it easier for people to extend from LogPlugin to make any needed
customizations and still have access to $logAdapter. Without this
change, if someone wanted to use $logAdapter, they will need to
duplicate the entire class instead of extending.
