### PR TITLE
FilterIterator expects Iterator not Traversable

### DIFF
--- a/src/Guzzle/Iterator/FilterIterator.php
+++ b/src/Guzzle/Iterator/FilterIterator.php
@@ -15,12 +15,12 @@ class FilterIterator extends \FilterIterator
     protected $callback;
 
     /**
-     * @param \Traversable   $iterator Traversable iterator
+     * @param \Iterator      $iterator Traversable iterator
      * @param array|\Closure $callback Callback used for filtering. Return true to keep or false to filter.
      *
      * @throws InvalidArgumentException if the callback if not callable
      */
-    public function __construct(\Traversable $iterator, $callback)
+    public function __construct(\Iterator $iterator, $callback)
     {
         parent::__construct($iterator);
         if (!is_callable($callback)) {


### PR DESCRIPTION
As outlined in https://github.com/guzzle/iterator/pull/2 and https://github.com/guzzle/iterator/commit/eb743f5622252ac3c3441bab203e3e3f9268f581#commitcomment-4009637 there is a problem with input types.

As this was reported against the wrong repository, here reported against the right repository first introducing the regression test showing the code currently fails.

This PR has been split, the parts about ChunkedIterator are move into #417 
