### PR TITLE
Oauth plugin: Add query string method to request a Service Provider

### DIFF
--- a/src/Guzzle/Plugin/Oauth/Exception/InvalidMethodException.php
+++ b/src/Guzzle/Plugin/Oauth/Exception/InvalidMethodException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Guzzle\Plugin\Oauth\Exception;
+
+use Guzzle\Common\Exception\BadMethodCallException;
+
+class InvalidMethodException extends BadMethodCallException
+{
+}

--- a/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
+++ b/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
@@ -265,6 +265,26 @@ class OauthPluginTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals($totalLength, strlen($queryString), 'Query string has extra characters i.e. contains extra elements compared to stringsToCheck.');
     }
 
+    public function testInvalidMethodException()
+    {
+        $this->setExpectedException(
+            'Guzzle\Plugin\Oauth\Exception\InvalidMethodException'
+        );
+
+        $config = array_merge(
+            $this->config,
+            ['request_method' => 'FakeMethod']
+        );
+
+        $p = new OauthPlugin($config);
+        $event = new Event(array(
+            'request' => $this->getRequest(),
+            'timestamp' => self::TIMESTAMP
+        ));
+
+        $params = $p->onRequestBeforeSend($event);
+    }
+
     public function testDoesNotAddFalseyValuesToAuthorization()
     {
         unset($this->config['token']);


### PR DESCRIPTION
Hi guys. This is my first guzzle contribution so be indulgent if I did something wrong :)

I am working on a project which use an api protected with Oauth. I wanted to use guzzle but the thing is that api only accept request with Oauth parameters in the query string. It wasn't possible with the actual Oauth plugin so here is the PR!

As you can see [here](http://oauth.net/core/1.0/#consumer_req_param) it's the third authorized method to request a Service Provider.

What do you think?
