### PR TITLE
Allow 0 as a value in command arguments.

### DIFF
--- a/src/Guzzle/Service/Description/Parameter.php
+++ b/src/Guzzle/Service/Description/Parameter.php
@@ -189,7 +189,7 @@ class Parameter
      */
     public function getValue($value)
     {
-        return $this->static || ($this->default !== null && !$value && ($this->type != 'boolean' || $value !== false))
+        return $this->static || ($this->default !== null && $value === null && ($this->type != 'boolean' || $value !== false))
             ? $this->default
             : $value;
     }

--- a/tests/Guzzle/Tests/Service/Description/ParameterTest.php
+++ b/tests/Guzzle/Tests/Service/Description/ParameterTest.php
@@ -71,6 +71,15 @@ class ParameterTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals('foo', $p->getValue('foo'));
     }
 
+    public function testZeroValueDoesNotCauseDefaultToBeReturned()
+    {
+        $d = $this->data;
+        $d['default'] = '1';
+        $d['static'] = null;
+        $p = new Parameter($d);
+        $this->assertEquals('0', $p->getValue('0'));
+    }
+
     public function testFiltersValues()
     {
         $d = $this->data;


### PR DESCRIPTION
We're using the Guzzle service description. Some of our querystring parameters can be 0 or 1. Without this fix, we're unable to send through 0 as a value. It would always fallback to the default.

Perhaps there's a better way of achieving this? I couldn't find it.
