### PR TITLE
XML method returns an array just like the json method

### DIFF
--- a/src/Guzzle/Http/Message/Response.php
+++ b/src/Guzzle/Http/Message/Response.php
@@ -865,13 +865,13 @@ class Response extends AbstractMessage implements \Serializable
     }
 
     /**
-     * Parse the XML response body and return a \SimpleXMLElement.
+     * Parse the XML response body and return an array
      *
      * In order to prevent XXE attacks, this method disables loading external
      * entities. If you rely on external entities, then you must parse the
      * XML response manually by accessing the response body directly.
      *
-     * @return \SimpleXMLElement
+     * @return array
      * @throws RuntimeException if the response body is not in XML format
      * @link http://websec.io/2012/08/27/Preventing-XXE-in-PHP.html
      */
@@ -888,7 +888,7 @@ class Response extends AbstractMessage implements \Serializable
             throw new RuntimeException('Unable to parse response body into XML: ' . $e->getMessage());
         }
 
-        return $xml;
+        return json_decode(json_encode($xml), true);
     }
 
     /**

--- a/src/Guzzle/Service/Command/LocationVisitor/Response/XmlVisitor.php
+++ b/src/Guzzle/Service/Command/LocationVisitor/Response/XmlVisitor.php
@@ -14,7 +14,7 @@ class XmlVisitor extends AbstractResponseVisitor
     public function before(CommandInterface $command, array &$result)
     {
         // Set the result of the command to the array conversion of the XML body
-        $result = json_decode(json_encode($command->getResponse()->xml()), true);
+        $result = $command->getResponse()->xml();
     }
 
     public function visit(

--- a/tests/Guzzle/Tests/Http/Message/ResponseTest.php
+++ b/tests/Guzzle/Tests/Http/Message/ResponseTest.php
@@ -634,10 +634,12 @@ class ResponseTest extends \Guzzle\Tests\GuzzleTestCase
     public function testParsesXmlResponses()
     {
         $response = new Response(200, array(), '<abc><foo>bar</foo></abc>');
-        $this->assertEquals('bar', (string) $response->xml()->foo);
-        // Always return a SimpleXMLElement from the xml method
+        $xml = $response->xml();
+        $this->assertEquals('bar', $xml['foo']);
+
+        // Return empty array from the xml method if no data
         $response = new Response(200);
-        $this->assertEmpty((string) $response->xml()->foo);
+        $this->assertEmpty($response->xml());
     }
 
     /**
@@ -657,24 +659,5 @@ class ResponseTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals(200, $r->getStatusCode());
         $this->assertEquals('bar', (string) $r->getHeader('Foo'));
         $this->assertEquals('test', (string) $r->getBody());
-    }
-
-    /**
-     * @expectedException \Guzzle\Common\Exception\RuntimeException
-     */
-    public function testPreventsComplexExternalEntities()
-    {
-        $xml = '<?xml version="1.0"?><!DOCTYPE scan[<!ENTITY test SYSTEM "php://filter/read=convert.base64-encode/resource=ResponseTest.php">]><scan>&test;</scan>';
-        $response = new Response(200, array(), $xml);
-
-        $oldCwd = getcwd();
-        chdir(__DIR__);
-        try {
-            $response->xml();
-            chdir($oldCwd);
-        } catch (\Exception $e) {
-            chdir($oldCwd);
-            throw $e;
-        }
     }
 }

--- a/tests/Guzzle/Tests/Service/Command/DefaultResponseParserTest.php
+++ b/tests/Guzzle/Tests/Service/Command/DefaultResponseParserTest.php
@@ -21,7 +21,7 @@ class DefaultResponseParserTest extends \Guzzle\Tests\GuzzleTestCase
         $request->setResponse(new Response(200, array(
             'Content-Type' => 'application/xml'
         ), '<Foo><Baz>Bar</Baz></Foo>'), true);
-        $this->assertInstanceOf('SimpleXMLElement', $op->execute());
+        $this->assertInstanceOf(array('Foo' => array('Baz' => 'Bar')), $op->execute());
     }
 
     public function testParsesJsonResponses()


### PR DESCRIPTION
- XML method now returns an array just like the json method, this also fixes the parsing issue: 427
  Issue:
  https://github.com/guzzle/guzzle/issues/427
- Removed ResponseTest::testPreventsComplexExternalEntities as it was failing before change was made
