### PR TITLE
add setRegex method as described in the docs

### DIFF
--- a/src/Guzzle/Parser/UriTemplate/UriTemplate.php
+++ b/src/Guzzle/Parser/UriTemplate/UriTemplate.php
@@ -16,7 +16,7 @@ class UriTemplate implements UriTemplateInterface
     private $variables;
 
     /** @var string Regex used to parse expressions */
-    private static $regex = '/\{([^\}]+)\}/';
+    private $regex = '/\{([^\}]+)\}/';
 
     /** @var array Hash for quick operator lookups */
     private static $operatorHash = array(
@@ -36,15 +36,9 @@ class UriTemplate implements UriTemplateInterface
 
     public function expand($template, array $variables)
     {
-        // Check to ensure that the preg_* function is needed
-        if (false === strpos($template, '{')) {
-            return $template;
-        }
-
         $this->template = $template;
         $this->variables = $variables;
-
-        return preg_replace_callback(self::$regex, array($this, 'expandMatch'), $this->template);
+        return preg_replace_callback($this->regex, array($this, 'expandMatch'), $this->template);
     }
 
     /**
@@ -239,5 +233,15 @@ class UriTemplate implements UriTemplateInterface
     private function decodeReserved($string)
     {
         return str_replace(self::$delimsPct, self::$delims, $string);
+    }
+
+    /**
+     * set the regex patten
+     * 
+     * @param string $regexPattern 
+     */
+    public function setRegex($regexPattern)
+    {
+        $this->regex = $regexPattern;
     }
 }

--- a/tests/Guzzle/Tests/Parser/UriTemplate/UriTemplateTest.php
+++ b/tests/Guzzle/Tests/Parser/UriTemplate/UriTemplateTest.php
@@ -93,4 +93,14 @@ class UriTemplateTest extends AbstractUriTemplateTest
 
         $this->assertEquals('http://example.com/foo/bar/one,two?query=test&more%5B0%5D=fun&more%5B1%5D=ice%20cream&baz%5Bbar%5D=fizz&baz%5Btest%5D=buzz&bam=boo', $result);
     }
+
+    /**
+     * @ticket https://github.com/guzzle/guzzle/issues/426
+     */
+    public function testSetRegex()
+    {
+        $template = new UriTemplate();
+        $template->setRegex('/\<\$(.+)\>/');
+        $this->assertSame('/foo', $template->expand('/<$a>', array('a' => 'foo')));
+    }
 }


### PR DESCRIPTION
#426 Add a public UriTemplate::setRegex() method

@phpnw13 hackathon thought I'd pick off an easy issue after a few drinks. There is of course some performance trade off in having the regex setable as can no longer use strpos to discount obvious bad matches but don't think this will be too great and there is always option of pecl extension for high performance applications.
