### PR TITLE
Added ability to define Postname.

### DIFF
--- a/src/Guzzle/Http/Message/EntityEnclosingRequest.php
+++ b/src/Guzzle/Http/Message/EntityEnclosingRequest.php
@@ -181,7 +181,7 @@ class EntityEnclosingRequest extends Request implements EntityEnclosingRequestIn
         return $this;
     }
 
-    public function addPostFile($field, $filename = null, $contentType = null)
+    public function addPostFile($field, $filename = null, $contentType = null, $postname = null)
     {
         $data = null;
 
@@ -197,7 +197,7 @@ class EntityEnclosingRequest extends Request implements EntityEnclosingRequestIn
             throw new RequestException('The path to a file must be a string');
         } elseif (!empty($filename)) {
             // Adding an empty file will cause cURL to error out
-            $data = new PostFile($field, $filename, $contentType);
+            $data = new PostFile($field, $filename, $contentType, $postname);
         }
 
         if ($data) {

--- a/src/Guzzle/Http/Message/EntityEnclosingRequestInterface.php
+++ b/src/Guzzle/Http/Message/EntityEnclosingRequestInterface.php
@@ -106,11 +106,12 @@ interface EntityEnclosingRequestInterface extends RequestInterface
      *
      * @param string $field       POST field to use (e.g. file). Used to reference content from the server.
      * @param string $filename    Full path to the file. Do not include the @ symbol.
+     * @param string $postname    The name of the file, when posted. (e.g. rename the file)
      * @param string $contentType Optional Content-Type to add to the Content-Disposition.
      *                            Default behavior is to guess. Set to false to not specify.
      * @return self
      */
-    public function addPostFile($field, $filename = null, $contentType = null);
+    public function addPostFile($field, $filename = null, $contentType = null, $postname = null);
 
     /**
      * Add POST files to use in the upload

--- a/src/Guzzle/Http/Message/PostFile.php
+++ b/src/Guzzle/Http/Message/PostFile.php
@@ -14,16 +14,19 @@ class PostFile implements PostFileInterface
     protected $fieldName;
     protected $contentType;
     protected $filename;
+    protected $postname;
 
     /**
      * @param string $fieldName   Name of the field
-     * @param string $filename    Path to the file
+     * @param string $filename    Local path to the file
+     * @param string $postname    Remote post file name
      * @param string $contentType Content-Type of the upload
      */
-    public function __construct($fieldName, $filename, $contentType = null)
+    public function __construct($fieldName, $filename, $contentType = null, $postname = null)
     {
         $this->fieldName = $fieldName;
         $this->setFilename($filename);
+        $this->postname = $postname ? $postname : basename($filename);
         $this->contentType = $contentType ?: $this->guessContentType();
     }
 
@@ -55,9 +58,21 @@ class PostFile implements PostFileInterface
         return $this;
     }
 
+    public function setPostname($postname)
+    {
+        $this->postname = $postname;
+
+        return $this;
+    }
+
     public function getFilename()
     {
         return $this->filename;
+    }
+
+    public function getPostname()
+    {
+        return $this->postname;
     }
 
     public function setContentType($type)
@@ -77,11 +92,11 @@ class PostFile implements PostFileInterface
         // PHP 5.5 introduced a CurlFile object that deprecates the old @filename syntax
         // See: https://wiki.php.net/rfc/curl-file-upload
         if (function_exists('curl_file_create')) {
-            return curl_file_create($this->filename, $this->contentType, basename($this->filename));
+            return curl_file_create($this->filename, $this->contentType, $this->postname);
         }
 
         // Use the old style if using an older version of PHP
-        $value = "@{$this->filename};filename=" . basename($this->filename);
+        $value = "@{$this->filename};filename=" . $this->postname;
         if ($this->contentType) {
             $value .= ';type=' . $this->contentType;
         }

--- a/src/Guzzle/Http/Message/PostFileInterface.php
+++ b/src/Guzzle/Http/Message/PostFileInterface.php
@@ -36,11 +36,27 @@ interface PostFileInterface
     public function setFilename($path);
 
     /**
+     * Set the post name of the file
+     *
+     * @param string $name The new name of the file
+     *
+     * @return self
+     */
+    public function setPostname($name);
+
+    /**
      * Get the full path to the file
      *
      * @return string
      */
     public function getFilename();
+
+    /**
+     * Get the post name of the file
+     *
+     * @return string
+     */
+    public function getPostname();
 
     /**
      * Set the Content-Type of the file

--- a/tests/Guzzle/Tests/Http/Message/PostFileTest.php
+++ b/tests/Guzzle/Tests/Http/Message/PostFileTest.php
@@ -13,9 +13,10 @@ class PostFileTest extends \Guzzle\Tests\GuzzleTestCase
 {
     public function testConstructorConfiguresPostFile()
     {
-        $file = new PostFile('foo', __FILE__, 'x-foo');
+        $file = new PostFile('foo', __FILE__, 'x-foo', 'boo');
         $this->assertEquals('foo', $file->getFieldName());
         $this->assertEquals(__FILE__, $file->getFilename());
+        $this->assertEquals('boo', $file->getPostName());
         $this->assertEquals('x-foo', $file->getContentType());
     }
 
@@ -56,6 +57,19 @@ class PostFileTest extends \Guzzle\Tests\GuzzleTestCase
             $c = $file->getCurlValue();
             $this->assertEquals(__FILE__, $c->getFilename());
             $this->assertEquals('PostFileTest.php', $c->getPostFilename());
+            $this->assertContains('text/x-', $c->getMimeType());
+        }
+    }
+
+    public function testReturnsCurlValueStringAndPostname()
+    {
+        $file = new PostFile('foo', __FILE__, null, 'NewPostFileTest.php');
+        if (version_compare(phpversion(), '5.5.0', '<')) {
+            $this->assertContains('@' . __FILE__ . ';filename=NewPostFileTest.php;type=text/x-', $file->getCurlValue());
+        } else {
+            $c = $file->getCurlValue();
+            $this->assertEquals(__FILE__, $c->getFilename());
+            $this->assertEquals('NewPostFileTest.php', $c->getPostFilename());
             $this->assertContains('text/x-', $c->getMimeType());
         }
     }


### PR DESCRIPTION
PHP 5.5 allows a postname to be defined in the CURL request. This pull request adds the ability to define a postname using the "addPostFile()" function. 

To define a postname, use "addPostFile('postField', '@/local/file/path/file.txt', 'newfile.txt')". The receiving resource will see "newfile.txt" instead of "file.txt". 

I set the $postname to null, in the constructor, to ensure backward compatibility. The below will ensure a filename is set, when Guzzle constructs the CURL value string. 

``` php
PostFile.php - 63
$this->postname = $postname ? $postname : basename($this->filename);
```

The below will return the postname, if defined. If not, the basename of the original file. 

``` php
PostFile.php - 95
return curl_file_create($this->filename, $this->contentType, $this->postname);
```

Added a test. Tests pass on Travis-CI. Closes #442.

Reference: http://www.php.net/manual/en/curlfile.construct.php
