### PR TITLE
in visit_debug: check $value for true-ish value.

### DIFF
--- a/src/Guzzle/Http/Message/RequestFactory.php
+++ b/src/Guzzle/Http/Message/RequestFactory.php
@@ -304,12 +304,15 @@ class RequestFactory implements RequestFactoryInterface
 
     protected function visit_debug(RequestInterface $request, $value, $flags)
     {
-        if (class_exists('Guzzle\Plugin\Log\LogPlugin')) {
-            $request->addSubscriber(LogPlugin::getDebugPlugin());
-        } else {
-            // @codeCoverageIgnoreStart
-            $request->getCurlOptions()->set(CURLOPT_VERBOSE, true);
-            // @codeCoverageIgnoreEnd
+        // check for true-ish value
+        if($value) {
+            if (class_exists('Guzzle\Plugin\Log\LogPlugin')) {
+                $request->addSubscriber(LogPlugin::getDebugPlugin());
+            } else {
+                // @codeCoverageIgnoreStart
+                $request->getCurlOptions()->set(CURLOPT_VERBOSE, true);
+                // @codeCoverageIgnoreEnd
+            }
         }
     }
 


### PR DESCRIPTION
Hello Michael Dowling,

today I frustratingly found out, that

``` php
  use Guzzle\Http\Client;
  $client = new Client($url, array(Client::REQUEST_OPTIONS => array("debug"=>false)):
  $request = $client->get($suburl);
```

would eventually result in execution of `RequestFactory::visit_debug` and thus the subscription of `LogPlugin::getDebugPlugin()` -- which was not my intention.

Careful consultation of the guzzle documentation revealed that the value of the `debug` option is indeed unspecified, thus setting the value `false` still constitutes "use of the option".
However, I think the intuitivity of guzzle's API would greatly improve if the `debug` option would distinguish between `true` and `false`.

I therefore kindly request you pull into your repository the changes attached to this pull-request and also the connected documentation changes requested in https://github.com/guzzle/guzzle-docs/pull/61.
  Please note, that this change technically constitutes breaking backward compatibility. If you choose to not change the functional behavior, I recommend supplementing the documentation to clarify the issue.

With kind regards,

Max-Julian
