### PR TITLE
Adding the option to combine URLs using strict RFC 3986 compliance while...

### DIFF
--- a/src/Guzzle/Http/Url.php
+++ b/src/Guzzle/Http/Url.php
@@ -468,13 +468,18 @@ class Url
     /**
      * Combine the URL with another URL. Follows the rules specific in RFC 3986 section 5.4.
      *
-     * @param string $url Relative URL to combine with
-     *
+     * @param string $url          Relative URL to combine with
+     * @param bool   $strictRfc386 Set to true to use strict RFC 3986 compliance when merging paths. When first
+     *                             released, Guzzle used an incorrect algorithm for combining relative URL paths. In
+     *                             order to not break users, we introduced this flag to allow the merging of URLs based
+     *                             on strict RFC 3986 section 5.4.1. This means that "http://a.com/foo/baz" merged with
+     *                             "bar" would become "http://a.com/foo/bar". When this value is set to false, it would
+     *                             become "http://a.com/foo/baz/bar".
      * @return Url
      * @throws InvalidArgumentException
      * @link http://tools.ietf.org/html/rfc3986#section-5.4
      */
-    public function combine($url)
+    public function combine($url, $strictRfc386 = false)
     {
         $url = self::factory($url);
 
@@ -503,6 +508,7 @@ class Url
             $this->username = $url->getUsername();
             $this->password = $url->getPassword();
             $this->path = $url->getPath();
+            $this->query = $url->getQuery();
             $this->fragment = $url->getFragment();
             return $this;
         }
@@ -517,6 +523,8 @@ class Url
         } else {
             if ($path[0] == '/') {
                 $this->path = $path;
+            } elseif ($strictRfc386) {
+                $this->path .= '/../' . $path;
             } else {
                 $this->path .= '/' . $path;
             }

--- a/tests/Guzzle/Tests/Http/UrlTest.php
+++ b/tests/Guzzle/Tests/Http/UrlTest.php
@@ -245,4 +245,45 @@ class UrlTest extends \Guzzle\Tests\GuzzleTestCase
         $url->addPath('?');
         $this->assertEquals('http://foo.com/baz%20bar/%3F?a=b', (string) $url);
     }
+
+    /**
+     * @link http://tools.ietf.org/html/rfc3986#section-5.4.1
+     */
+    public function rfc3986UrlProvider()
+    {
+        return array(
+            array('g', 'http://a/b/c/g'),
+            array('./g', 'http://a/b/c/g'),
+            array('g/', 'http://a/b/c/g/'),
+            array('/g', 'http://a/g'),
+            array('//g', 'http://g'),
+            array('?y', 'http://a/b/c/d;p?y'),
+            array('g?y', 'http://a/b/c/g?y'),
+            array('#s', 'http://a/b/c/d;p?q=#s'),
+            array('g#s', 'http://a/b/c/g#s'),
+            array('g?y#s', 'http://a/b/c/g?y=#s'),
+            array(';x', 'http://a/b/c/;x'),
+            array('g;x', 'http://a/b/c/g;x'),
+            array('g;x?y#s', 'http://a/b/c/g;x?y=#s'),
+            array('', 'http://a/b/c/d;p?q'),
+            array('.', 'http://a/b/c'),
+            array('./', 'http://a/b/c/'),
+            array('..', 'http://a/b'),
+            array('../', 'http://a/b/'),
+            array('../g', 'http://a/b/g'),
+            array('../..', 'http://a/'),
+            array('../../', 'http://a/'),
+            array('../../g', 'http://a/g')
+        );
+    }
+
+    /**
+     * @dataProvider rfc3986UrlProvider
+     */
+    public function testCombinesUrlsUsingRfc3986($relative, $result)
+    {
+        $a = Url::factory('http://a/b/c/d;p?q');
+        $b = Url::factory($relative);
+        $this->assertEquals($result, trim((string) $a->combine($b, true), '='));
+    }
 }


### PR DESCRIPTION
... maintaining backwards compatibility with the erroneous way that Guzzle had previously implemented

This addresses #436 
