### PR TITLE
check exception class

### DIFF
--- a/src/Guzzle/Plugin/Backoff/BackoffPlugin.php
+++ b/src/Guzzle/Plugin/Backoff/BackoffPlugin.php
@@ -8,6 +8,7 @@ use Guzzle\Http\Message\EntityEnclosingRequestInterface;
 use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Http\Message\Response;
 use Guzzle\Http\Curl\CurlMultiInterface;
+use Guzzle\Http\Exception\CurlException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -92,7 +93,7 @@ class BackoffPlugin extends AbstractHasDispatcher implements EventSubscriberInte
             $this->dispatch(self::RETRY_EVENT, array(
                 'request'  => $request,
                 'response' => $response,
-                'handle'   => $exception ? $exception->getCurlHandle() : null,
+                'handle'   => ($exception && $exception instanceof CurlException) ? $exception->getCurlHandle() : null,
                 'retries'  => $retries,
                 'delay'    => $delay
             ));


### PR DESCRIPTION
I got this fatal error today : PHP Fatal error:  Call to undefined method Guzzle\Http\Exception\ServerErrorResponseException::getCurlHandle() in /home/frontoffice/instances/lekino-video_web/shared/vendor/guzzle/guzzle/src/Guzzle/Plugin/Backoff/BackoffPlugin.php on line 95
