### PR TITLE
Adding method to abstract command to return validation errors

### DIFF
--- a/src/Guzzle/Service/Command/AbstractCommand.php
+++ b/src/Guzzle/Service/Command/AbstractCommand.php
@@ -375,4 +375,17 @@ abstract class AbstractCommand extends Collection implements CommandInterface
 
         return $this->validator;
     }
+
+    /**
+     * Get array of any validation errors
+     * If no validator has been set then return false
+     */
+    public function getValidationErrors()
+    {
+        if (!$this->validator) {
+            return false;
+        }
+
+        return $this->validator->getErrors();
+    }
 }

--- a/tests/Guzzle/Tests/Service/Command/CommandTest.php
+++ b/tests/Guzzle/Tests/Service/Command/CommandTest.php
@@ -408,6 +408,23 @@ class CommandTest extends AbstractCommandTest
         $command->prepare();
     }
 
+    public function testCanAccessValidationErrorsFromCommand()
+    {
+        $validationErrors = array('[Foo] Baz', '[Bar] Boo');
+        $command = new MockCommand();
+        $command->setClient(new \Guzzle\Service\Client());
+
+        $this->assertFalse($command->getValidationErrors());
+
+        $v = $this->getMockBuilder('Guzzle\Service\Description\SchemaValidator')
+            ->setMethods(array('validate', 'getErrors'))
+            ->getMock();
+        $v->expects($this->any())->method('getErrors')->will($this->returnValue($validationErrors));
+        $command->setValidator($v);
+
+        $this->assertEquals($validationErrors, $command->getValidationErrors());
+    }
+
     public function testCanChangeResponseBody()
     {
         $body = EntityBody::factory();


### PR DESCRIPTION
New public method to return validation errors from the validator attached to a command.

Provides the simplest workaround solution for #449, so that it is at least possible to tell which command threw the validation exception as part of the batch preparation process
