### PR TITLE
Fix E_NOTICE on Header::parseParams() with empty text.

### DIFF
--- a/src/Guzzle/Http/Message/Header.php
+++ b/src/Guzzle/Http/Message/Header.php
@@ -132,11 +132,19 @@ class Header implements HeaderInterface
         foreach ($this->normalize()->toArray() as $val) {
             $part = array();
             foreach (preg_split('/;(?=([^"]*"[^"]*")*[^"]*$)/', $val) as $kvp) {
-                preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches);
+                if(!preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches)){
+                    continue;
+                }
+
                 $pieces = array_map($callback, $matches[0]);
+                if(!count($pieces)){
+                    continue;
+                }
                 $part[$pieces[0]] = isset($pieces[1]) ? $pieces[1] : '';
             }
-            $params[] = $part;
+            if(!empty($part)){
+                $params[] = $part;
+            }
         }
 
         return $params;

--- a/tests/Guzzle/Tests/Http/Message/HeaderTest.php
+++ b/tests/Guzzle/Tests/Http/Message/HeaderTest.php
@@ -86,6 +86,7 @@ class HeaderTest extends \Guzzle\Tests\GuzzleTestCase
         $h = new Header('Foo', '');
         $this->assertEquals('', (string) $h);
         $this->assertEquals(1, count($h));
+        $this->assertEquals(1, count($h->normalize()->toArray()));
     }
 
     public function testCanRemoveValues()
@@ -142,6 +143,10 @@ class HeaderTest extends \Guzzle\Tests\GuzzleTestCase
                     array('<http://.../side.jpeg?test=1>' => '', 'rel' => 'side', 'type' => 'image/jpeg'),
                     array('<http://.../side.jpeg?test=2>' => '', 'rel' => 'side', 'type' => 'image/jpeg')
                 )
+            ),
+            array(
+                '',
+                array()
             )
         );
     }


### PR DESCRIPTION
``` php
$h = new Header('X-Whatever', '');
$h->parseParams();
```

```
Notice: Undefined offset: 0 in guzzle/src/Guzzle/Http/Message/Header.php on line 137
```
