### PR TITLE
[ServiceDescription] Fixed value population check

### DIFF
--- a/src/Guzzle/Service/Description/SchemaValidator.php
+++ b/src/Guzzle/Service/Description/SchemaValidator.php
@@ -136,7 +136,7 @@ class SchemaValidator implements ValidatorInterface
                             $current = null;
                             $this->recursiveProcess($property, $current, $path, $depth + 1);
                             // Only set the value if it was populated with something
-                            if ($current) {
+                            if (null !== $current) {
                                 $value[$name] = $current;
                             }
                         }


### PR DESCRIPTION
Currently, for a given default value of "0" (or any other falsy, actually), the property will be ignored. Just a not null check fixes that.

In this (kind of) example, the inner property `baz` will not be sent:

``` php
return array(
    'name' => 'test',
    'description' => 'Test service',
    'operations' => array(
       'foo' => array(
            'parameters' => array(
                'bar' => array(
                    'location' => 'xml',
                    'type' => 'object',
                    'required' => true,
                    'properties' => array(
                        'baz' => array(
                            'static' => true,
                            'required' => true,
                            'default' => 0
                        )
                    )
                )
            )
        )
    )
)
```
