### PR TITLE
Fixes a regression in URL resolution

### DIFF
--- a/src/Guzzle/Http/Url.php
+++ b/src/Guzzle/Http/Url.php
@@ -518,7 +518,7 @@ class Url
 
         if (!$path) {
             if (count($query)) {
-                $this->query = $query;
+                $this->addQuery($query, $strictRfc386);
             }
         } else {
             if ($path[0] == '/') {
@@ -529,11 +529,24 @@ class Url
                 $this->path .= '/' . $path;
             }
             $this->normalizePath();
-            $this->query = $query;
+            $this->addQuery($query, $strictRfc386);
         }
 
         $this->fragment = $url->getFragment();
 
         return $this;
+    }
+
+    private function addQuery(QueryString $new, $strictRfc386)
+    {
+        if ($strictRfc386) {
+            $this->query = $new;
+
+            return;
+        }
+
+        foreach ($new as $k => $v) {
+            $this->query->add($k, $v);
+        }
     }
 }

--- a/tests/Guzzle/Tests/Http/ClientTest.php
+++ b/tests/Guzzle/Tests/Http/ClientTest.php
@@ -244,9 +244,9 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
             array($u, 'relative/path/to/resource?a=b&c=d', $u . 'relative/path/to/resource?a=b&c=d'),
             array($u, '/absolute/path/to/resource', $this->getServer()->getUrl() . 'absolute/path/to/resource'),
             array($u, '/absolute/path/to/resource?a=b&c=d', $this->getServer()->getUrl() . 'absolute/path/to/resource?a=b&c=d'),
-            array($u2, '/absolute/path/to/resource?a=b&c=d', $this->getServer()->getUrl()  . 'absolute/path/to/resource?a=b&c=d'),
-            array($u2, 'relative/path/to/resource', $this->getServer()->getUrl() . 'base/relative/path/to/resource'),
-            array($u2, 'relative/path/to/resource?another=query', $this->getServer()->getUrl() . 'base/relative/path/to/resource?another=query')
+            array($u2, '/absolute/path/to/resource?a=b&c=d', $this->getServer()->getUrl()  . 'absolute/path/to/resource?z=1&a=b&c=d'),
+            array($u2, 'relative/path/to/resource', $this->getServer()->getUrl() . 'base/relative/path/to/resource?z=1'),
+            array($u2, 'relative/path/to/resource?another=query', $this->getServer()->getUrl() . 'base/relative/path/to/resource?z=1&another=query')
         );
     }
 

--- a/tests/Guzzle/Tests/Http/UrlTest.php
+++ b/tests/Guzzle/Tests/Http/UrlTest.php
@@ -154,7 +154,9 @@ class UrlTest extends \Guzzle\Tests\GuzzleTestCase
             array('http://u:a@www.example.com/path', 'test', 'http://u:a@www.example.com/path/test'),
             array('http://www.example.com/path', 'http://u:a@www.example.com/', 'http://u:a@www.example.com/'),
             array('/path?q=2', 'http://www.test.com/', 'http://www.test.com/path?q=2'),
-            array('http://api.flickr.com/services/', 'http://www.flickr.com/services/oauth/access_token', 'http://www.flickr.com/services/oauth/access_token')
+            array('http://api.flickr.com/services/', 'http://www.flickr.com/services/oauth/access_token', 'http://www.flickr.com/services/oauth/access_token'),
+            array('http://www.example.com/?foo=bar', 'some/path', 'http://www.example.com/some/path?foo=bar'),
+            array('http://www.example.com/?foo=bar', 'some/path?boo=moo', 'http://www.example.com/some/path?foo=bar&boo=moo'),
         );
     }
 


### PR DESCRIPTION
This fixes a regression which was introduced when rewriting parsing according to RFC 386.

This feature was quite useful for example when communicating with an API f.e. with a base URL of `https://api.github.com/{?access_token}` subsequent calls to `->get()` etc. did not need to specify the access token again.

I've made the fix for non-strict mode only.
