### PR TITLE
fixing event handler definition in documentation

### DIFF
--- a/docs/webservice-client/webservice-client.rst
+++ b/docs/webservice-client/webservice-client.rst
@@ -618,7 +618,8 @@ A ``Guzzle\Service\Client`` object emits the following events:
 
     // create an event listener that operates on request objects
     $client->getEventDispatcher()->addListener('command.after_prepare', function (Event $event) {
-        $request = $event->getRequest();
+        $command = $event['command'];
+        $request = $command->getRequest();
         
         // do something with request
     });


### PR DESCRIPTION
oops, needed to pull the command out of the event
