### PR TITLE
LSB (self -> static) in Url::factory() for creating Url instances

### DIFF
--- a/src/Guzzle/Http/Url.php
+++ b/src/Guzzle/Http/Url.php
@@ -45,7 +45,7 @@ class Url
             $parts['query'] = QueryString::fromString($parts['query']);
         }
 
-        return new self($parts['scheme'], $parts['host'], $parts['user'],
+        return new static($parts['scheme'], $parts['host'], $parts['user'],
             $parts['pass'], $parts['port'], $parts['path'], $parts['query'],
             $parts['fragment']);
     }


### PR DESCRIPTION
Switching from self:: to static:: when constructing Url in its factory method, thus using late static bindings which will enable easier subclassing of the Url class, in the case that someone wants to use the Url class, but extend it with more specific behaviour.
