### PR TITLE
Fix cache plugin default revalidation

### DIFF
--- a/src/Guzzle/Plugin/Cache/DefaultRevalidation.php
+++ b/src/Guzzle/Plugin/Cache/DefaultRevalidation.php
@@ -60,7 +60,7 @@ class DefaultRevalidation implements RevalidationInterface
             ($resCache && ($resCache->hasDirective('no-cache') || $resCache->hasDirective('must-revalidate')));
 
         // Use the strong ETag validator if available and the response contains no Cache-Control directive
-        if (!$revalidate && !$reqCache && $response->hasHeader('ETag')) {
+        if (!$revalidate && !$resCache && $response->hasHeader('ETag')) {
             $revalidate = true;
         }
 


### PR DESCRIPTION
Default revalidation handler should check the Cache-Control directive on the response, not the request.

At least that's what the code comment suggests and what makes it work for me...
