### PR TITLE
Remove redundant instantiation (minor clean-up)

### DIFF
--- a/src/Guzzle/Http/Exception/BadResponseException.php
+++ b/src/Guzzle/Http/Exception/BadResponseException.php
@@ -32,7 +32,6 @@ class BadResponseException extends RequestException
         } else {
             $label = 'Unsuccessful response';
             $class = __CLASS__;
-            $e = new self();
         }
 
         $message = $label . PHP_EOL . implode(PHP_EOL, array(


### PR DESCRIPTION
This removes a redundant instantiation of BadResponseException which is immediately overwritten within this class' factory method.
