### PR TITLE
Makes Guzzle compatible with TYPO3 Flow Framework out of the box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "psr-0": {
             "Guzzle": "src/",
             "Guzzle\\Tests": "tests/"
-            
         }
     },
 


### PR DESCRIPTION
This small change allow using the guzzle/Guzzle out of the box with TYPO3 Flow.

Unfortunately TYPO3 Flow can not load second entry given in the manifest for autoloading (Source: http://docs.typo3.org/flow/TYPO3FlowDocumentation/stable/TheDefinitiveGuide/PartIII/PackageManagement.html#using-3rd-party-packages )

Only one trick is needed in Flow's Settings.yaml to allow using Guzzle:

:1. excluding annotations
 excluding this package from Object Framework (Note: this makes AOP for Guzzle off)

<pre>
TYPO3:
  Flow:
    object:
      excludeClasses:
        'guzzle.Guzzle': ['Guzzle\\.*']
</pre>

).
