### PR TITLE
Using a shutdown function rather than a destructor to terminate the test...

### DIFF
--- a/tests/Guzzle/Tests/Http/Server.php
+++ b/tests/Guzzle/Tests/Http/Server.php
@@ -47,16 +47,7 @@ class Server
     {
         $this->port = $port ?: self::DEFAULT_PORT;
         $this->client = new Client($this->getUrl());
-    }
-
-    public function __destruct()
-    {
-        try {
-            $this->stop();
-        } catch (\Exception $e) {
-            // Can't throw exceptions in destructor
-            echo "\n{$e}\n";
-        }
+        register_shutdown_function(array($this, 'stop'));
     }
 
     /**


### PR DESCRIPTION
Using register_shutdown_function rather than relying on __destruct to terminate the test server because it is more reliable than __destruct.
