### PR TITLE
Bug: root XML attributes are not serialized

### DIFF
--- a/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/XmlVisitorTest.php
+++ b/tests/Guzzle/Tests/Service/Command/LocationVisitor/Request/XmlVisitorTest.php
@@ -49,6 +49,22 @@ class XmlVisitorTest extends AbstractVisitorTestCase
                 array('Foo' => 'test', 'Baz' => 'bar'),
                 '<test Foo="test"/>'
             ),
+            // Test adding root node attributes after nodes
+            array(
+                array(
+                    'data' => array(
+                        'xmlRoot' => array(
+                            'name' => 'test'
+                        )
+                    ),
+                    'parameters' => array(
+                        'Foo' => array('location' => 'xml', 'type' => 'string'),
+                        'Baz' => array('location' => 'xml', 'type' => 'string', 'data' => array('xmlAttribute' => true))
+                    )
+                ),
+                array('Foo' => 'test', 'Baz' => 'bar'),
+                '<test Baz="bar"><Foo>test</Foo></test>'
+            ),
             // Test adding with an array
             array(
                 array(


### PR DESCRIPTION
Command parameters can not be serialized as attributes of root XML node.
Versions 3.7.1-3.8.0 are affected (since request XmlVisitor rewrite).
