### PR TITLE
Setting CURLOPT_SSL_VERIFYHOST to 0 when certificateAuthority is false t...

### DIFF
--- a/src/Guzzle/Http/Client.php
+++ b/src/Guzzle/Http/Client.php
@@ -141,7 +141,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
         } elseif ($certificateAuthority === false) {
             unset($opts[CURLOPT_CAINFO]);
             $opts[CURLOPT_SSL_VERIFYPEER] = false;
-            $opts[CURLOPT_SSL_VERIFYHOST] = 2;
+            $opts[CURLOPT_SSL_VERIFYHOST] = 0;
         } elseif ($verifyPeer !== true && $verifyPeer !== false && $verifyPeer !== 1 && $verifyPeer !== 0) {
             throw new InvalidArgumentException('verifyPeer must be 1, 0 or boolean');
         } elseif ($verifyHost !== 0 && $verifyHost !== 1 && $verifyHost !== 2) {

--- a/tests/Guzzle/Tests/Http/ClientTest.php
+++ b/tests/Guzzle/Tests/Http/ClientTest.php
@@ -155,7 +155,7 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
         $options = $client->getConfig('curl.options');
         $this->assertArrayNotHasKey(CURLOPT_CAINFO, $options);
         $this->assertSame(false, $options[CURLOPT_SSL_VERIFYPEER]);
-        $this->assertSame(2, $options[CURLOPT_SSL_VERIFYHOST]);
+        $this->assertSame(0, $options[CURLOPT_SSL_VERIFYHOST]);
     }
 
     public function testClientAllowsUnsafeOperationIfRequested()


### PR DESCRIPTION
...o match documentation

When $certificateAuthority is False,
the documentation for setSslVerification() in the Interface, at:
https://github.com/guzzle/guzzle/blob/master/src/Guzzle/Http/ClientInterface.php
says:
"Setting $certificateAuthority to FALSE will turn off peer verification, unset the bundled cacert.pem, and disable host verification."

This allows to have:
curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0);
curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, 0); 
which can be good for testing or troubleshooting. See this, work example.
http://ademar.name/blog/2006/04/curl-ssl-certificate-problem-v.html
