### PR TITLE
Make the Response::json() array conversion optional

### DIFF
--- a/docs/http-client/client.rst
+++ b/docs/http-client/client.rst
@@ -402,7 +402,7 @@ the path to a CA bundle to enable verification using a custom certificate.
 cert
 ~~~~
 
-The `cert` option lets you specify a PEM formatted SSL client certificate to use with servers that require one. If the
+The `cert` option lets you specify a PEM formatted SSL client certificate to use with servers that require one. If the 
 certificate requires a password, provide an array with the password as the second item.
 
 This would typically be used in conjuction with the `ssl_key` option.
@@ -412,15 +412,15 @@ This would typically be used in conjuction with the `ssl_key` option.
     $request = $client->get('https://www.example.com', array(), array(
         'cert' => '/etc/pki/client_certificate.pem'
     )
-
+    
     $request = $client->get('https://www.example.com', array(), array(
         'cert' => array('/etc/pki/client_certificate.pem', 's3cr3tp455w0rd')
     )
-
+    
 ssl_key
 ~~~~~~~
 
-The `ssl_key` option lets you specify a file containing your PEM formatted private key, optionally protected by a password.
+The `ssl_key` option lets you specify a file containing your PEM formatted private key, optionally protected by a password. 
 Note: your password is sensitive, keep the PHP script containing it safe.
 
 This would typically be used in conjuction with the `cert` option.
@@ -430,10 +430,10 @@ This would typically be used in conjuction with the `cert` option.
     $request = $client->get('https://www.example.com', array(), array(
         'ssl_key' => '/etc/pki/private_key.pem'
     )
-
+    
     $request = $client->get('https://www.example.com', array(), array(
         'ssl_key' => array('/etc/pki/private_key.pem', 's3cr3tp455w0rd')
-    )
+    )    
 
 proxy
 ~~~~~

--- a/tests/Guzzle/Tests/Http/Message/ResponseTest.php
+++ b/tests/Guzzle/Tests/Http/Message/ResponseTest.php
@@ -618,10 +618,10 @@ class ResponseTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals(array('foo' => 'bar'), $response->json());
 
         $response = new Response(200, array(), '{"foo": "bar"}');
-        $this->assertTrue($response->json($maintainStructure = true) instanceof stdClass);
+        $this->assertTrue($response->json($asArray = false) instanceof stdClass);
 
         $response = new Response(200, array(), '["foo", "bar"]');
-        $data     = $response->json($maintainStructure = true);
+        $data     = $response->json($asArray = false);
         $this->assertTrue(is_array($data));
         $this->assertEquals('foo', $data[0]);
         $this->assertEquals('bar', $data[1]);


### PR DESCRIPTION
Make the Response::json() function reflect the JSON structure of the
fetched data. By passing TRUE as argument you can force the response
to be converted to only associative arrays.
