### PR TITLE
allows '0' to be the request body

### DIFF
--- a/src/Guzzle/Http/Message/RequestFactory.php
+++ b/src/Guzzle/Http/Message/RequestFactory.php
@@ -88,7 +88,7 @@ class RequestFactory implements RequestFactoryInterface
         if ($method == 'GET' || $method == 'HEAD' || $method == 'TRACE' || $method == 'OPTIONS') {
             // Handle non-entity-enclosing request methods
             $request = new $this->requestClass($method, $url, $headers);
-            if ($body) {
+            if (isset($body)) {
                 // The body is where the response body will be stored
                 $type = gettype($body);
                 if ($type == 'string' || $type == 'resource' || $type == 'object') {


### PR DESCRIPTION
Since PHP treats '0' as false, therefore, we will skip setting the body value if $body=='0'.

I suppose this is not the intended behavior as the request body can theoretically be '0'.

Changed condition to be not null.
