### PR TITLE
Updates Zend package dependencies to prevent deprecation messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,8 @@
         "symfony/class-loader": "*",
         "monolog/monolog": "1.*",
         "psr/log": "1.0.*",
-        "zendframework/zend-cache": "2.0.*",
-        "zendframework/zend-log": "2.0.*",
+        "zendframework/zend-cache": "2.1.*",
+        "zendframework/zend-log": "2.1.*",
         "phpunit/phpunit": "3.7.*"
     },
 


### PR DESCRIPTION
This change updates the `zend/zend-*` packages to more recent versions, primarily to prevent deprecation messages.
- Updated ZendLog to 2.1 series to prevent `Deprecated: Polyfill autoload support` messages
- Updated ZendCache to same series for continuity
