### PR TITLE
Adding more information to ExceptionCollection exceptions

### DIFF
--- a/src/Guzzle/Common/Exception/ExceptionCollection.php
+++ b/src/Guzzle/Common/Exception/ExceptionCollection.php
@@ -10,6 +10,15 @@ class ExceptionCollection extends \Exception implements GuzzleException, \Iterat
     /** @var array Array of Exceptions */
     protected $exceptions = array();
 
+    /** @var string Succinct exception message not including sub-exceptions */
+    private $shortMessage;
+
+    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->shortMessage = $message;
+    }
+
     /**
      * Set all of the exceptions
      *
@@ -36,19 +45,12 @@ class ExceptionCollection extends \Exception implements GuzzleException, \Iterat
      */
     public function add($e)
     {
+        $this->exceptions[] = $e;
         if ($this->message) {
             $this->message .= "\n";
         }
 
-        if ($e instanceof self) {
-            $this->message .= '(' . get_class($e) . ")";
-            foreach (explode("\n", $e->getMessage()) as $message) {
-                $this->message .= "\n    {$message}";
-            }
-        } elseif ($e instanceof \Exception) {
-            $this->exceptions[] = $e;
-            $this->message .= '(' . get_class($e) . ') ' . $e->getMessage();
-        }
+        $this->message .= $this->getExceptionMessage($e, 0);
 
         return $this;
     }
@@ -81,5 +83,26 @@ class ExceptionCollection extends \Exception implements GuzzleException, \Iterat
     public function getFirst()
     {
         return $this->exceptions ? $this->exceptions[0] : null;
+    }
+
+    private function getExceptionMessage(\Exception $e, $depth = 0)
+    {
+        static $sp = '    ';
+        $prefix = $depth ? str_repeat($sp, $depth) : '';
+        $message = "{$prefix}(" . get_class($e) . ') ' . $e->getFile() . ' line ' . $e->getLine() . "\n";
+
+        if ($e instanceof self) {
+            if ($e->shortMessage) {
+                $message .= "\n{$prefix}{$sp}" . str_replace("\n", "\n{$prefix}{$sp}", $e->shortMessage) . "\n";
+            }
+            foreach ($e as $ee) {
+                $message .= "\n" . $this->getExceptionMessage($ee, $depth + 1);
+            }
+        }  else {
+            $message .= "\n{$prefix}{$sp}" . str_replace("\n", "\n{$prefix}{$sp}", $e->getMessage()) . "\n";
+            $message .= "\n{$prefix}{$sp}" . str_replace("\n", "\n{$prefix}{$sp}", $e->getTraceAsString()) . "\n";
+        }
+
+        return str_replace(getcwd(), '.', $message);
     }
 }

--- a/tests/Guzzle/Tests/Common/Exception/ExceptionCollectionTest.php
+++ b/tests/Guzzle/Tests/Common/Exception/ExceptionCollectionTest.php
@@ -20,7 +20,8 @@ class ExceptionCollectionTest extends \Guzzle\Tests\GuzzleTestCase
         $exceptions = $this->getExceptions();
         $e->add($exceptions[0]);
         $e->add($exceptions[1]);
-        $this->assertEquals("(Exception) Test\n(Exception) Testing", $e->getMessage());
+        $this->assertContains("(Exception) ./tests/Guzzle/Tests/Common/Exception/ExceptionCollectionTest.php line ", $e->getMessage());
+        $this->assertContains("    Test\n\n    #0 ./", $e->getMessage());
         $this->assertSame($exceptions[0], $e->getFirst());
     }
 
@@ -53,11 +54,13 @@ class ExceptionCollectionTest extends \Guzzle\Tests\GuzzleTestCase
         $e2->add($e3);
         $e1->add($e2);
         $message = $e1->getMessage();
-        $this->assertEquals("(Exception) Test\n"
-            . "(Guzzle\\Common\\Exception\\ExceptionCollection)\n"
-            . "    Meta description!\n"
-            . "    (Exception) Test 2\n"
-            . "    (Guzzle\\Common\\Exception\\ExceptionCollection)\n"
-            . "        (Exception) Baz", $message);
+        $this->assertContains("(Exception) ./tests/Guzzle/Tests/Common/Exception/ExceptionCollectionTest.php line ", $message);
+        $this->assertContains("\n    Test\n\n    #0 ", $message);
+        $this->assertContains("\n\n(Guzzle\\Common\\Exception\\ExceptionCollection) ./tests/Guzzle/Tests/Common/Exception/ExceptionCollectionTest.php line ", $message);
+        $this->assertContains("\n\n    Meta description!\n\n", $message);
+        $this->assertContains("    (Exception) ./tests/Guzzle/Tests/Common/Exception/ExceptionCollectionTest.php line ", $message);
+        $this->assertContains("\n        Test 2\n\n        #0 ", $message);
+        $this->assertContains("        (Exception) ./tests/Guzzle/Tests/Common/Exception/ExceptionCollectionTest.php line ", $message);
+        $this->assertContains("            Baz\n\n            #0", $message);
     }
 }


### PR DESCRIPTION
Adding more information to ExceptionCollection exceptions so that users have more context, including a stack trace of each sub-exception.

/cc @jeremeamia 
