### PR TITLE
Updating the resolving of "$ref" attributes in schemas to merge over existing values

### DIFF
--- a/src/Guzzle/Service/Description/Parameter.php
+++ b/src/Guzzle/Service/Description/Parameter.php
@@ -97,12 +97,7 @@ class Parameter
         if ($description) {
             if (isset($data['$ref'])) {
                 if ($model = $description->getModel($data['$ref'])) {
-                    // The name of the original parameter should override the ref name if one is available
-                    $name = empty($data['name']) ? null : $data['name'];
-                    $data = $model->toArray();
-                    if ($name) {
-                        $data['name'] = $name;
-                    }
+                    $data = $model->toArray() + $data;
                 }
             } elseif (isset($data['extends'])) {
                 // If this parameter extends from another parameter then start with the actual data

--- a/tests/Guzzle/Tests/Service/Description/ParameterTest.php
+++ b/tests/Guzzle/Tests/Service/Description/ParameterTest.php
@@ -323,22 +323,17 @@ class ParameterTest extends \Guzzle\Tests\GuzzleTestCase
 
     public function testResolvesRefKeysRecursively()
     {
-        $jarJar = array('type' => 'string', 'default' => 'Mesa address tha senate!');
-        $anakin = array('type' => 'array', 'items' => array('$ref' => 'JarJar'));
         $description = new ServiceDescription(array(
             'models' => array(
-                'JarJar' => $jarJar,
-                'Anakin' => $anakin
+                'JarJar' => array('type' => 'string', 'default' => 'Mesa address tha senate!'),
+                'Anakin' => array('type' => 'array', 'items' => array('$ref' => 'JarJar'))
             )
         ));
-        // description attribute will be removed
-        $p = new Parameter(array('$ref' => 'Anakin', 'description' => 'missing'), $description);
+        $p = new Parameter(array('$ref' => 'Anakin', 'description' => 'added'), $description);
         $this->assertEquals(array(
-            'type'  => 'array',
-            'items' => array(
-                'type'    => 'string',
-                'default' => 'Mesa address tha senate!'
-            )
+            'type' => 'array',
+            'items' => array('type' => 'string', 'default' => 'Mesa address tha senate!'),
+            'description' => 'added'
         ), $p->toArray());
     }
 


### PR DESCRIPTION
The current $ref implementation completely replaces a schema, but I think it should augment a schema and replace any conflicting keys (see https://github.com/justinrainbow/json-schema/blob/master/src/JsonSchema/RefResolver.php#L192).

Closes #501
