### PR TITLE
Merging one URL onto another when not using strict RFC 3986 compliance

### DIFF
--- a/src/Guzzle/Http/Url.php
+++ b/src/Guzzle/Http/Url.php
@@ -539,10 +539,10 @@ class Url
 
     private function addQuery(QueryString $new, $strictRfc386)
     {
-        if ($strictRfc386) {
-            $this->query = $new;
-        } else {
-            $this->query->merge($new);
+        if (!$strictRfc386) {
+            $new->merge($this->query);
         }
+
+        $this->query = $new;
     }
 }

--- a/tests/Guzzle/Tests/Http/ClientTest.php
+++ b/tests/Guzzle/Tests/Http/ClientTest.php
@@ -244,9 +244,9 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
             array($u, 'relative/path/to/resource?a=b&c=d', $u . 'relative/path/to/resource?a=b&c=d'),
             array($u, '/absolute/path/to/resource', $this->getServer()->getUrl() . 'absolute/path/to/resource'),
             array($u, '/absolute/path/to/resource?a=b&c=d', $this->getServer()->getUrl() . 'absolute/path/to/resource?a=b&c=d'),
-            array($u2, '/absolute/path/to/resource?a=b&c=d', $this->getServer()->getUrl()  . 'absolute/path/to/resource?z=1&a=b&c=d'),
+            array($u2, '/absolute/path/to/resource?a=b&c=d', $this->getServer()->getUrl()  . 'absolute/path/to/resource?a=b&c=d&z=1'),
             array($u2, 'relative/path/to/resource', $this->getServer()->getUrl() . 'base/relative/path/to/resource?z=1'),
-            array($u2, 'relative/path/to/resource?another=query', $this->getServer()->getUrl() . 'base/relative/path/to/resource?z=1&another=query')
+            array($u2, 'relative/path/to/resource?another=query', $this->getServer()->getUrl() . 'base/relative/path/to/resource?another=query&z=1')
         );
     }
 
@@ -256,7 +256,7 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
     public function testBuildsRelativeUrls($baseUrl, $url, $result)
     {
         $client = new Client($baseUrl);
-        $this->assertEquals($client->get($url)->getUrl(), $result);
+        $this->assertEquals($result, $client->get($url)->getUrl());
     }
 
     public function testAllowsConfigsToBeChangedAndInjectedInBaseUrl()

--- a/tests/Guzzle/Tests/Http/UrlTest.php
+++ b/tests/Guzzle/Tests/Http/UrlTest.php
@@ -156,7 +156,8 @@ class UrlTest extends \Guzzle\Tests\GuzzleTestCase
             array('/path?q=2', 'http://www.test.com/', 'http://www.test.com/path?q=2'),
             array('http://api.flickr.com/services/', 'http://www.flickr.com/services/oauth/access_token', 'http://www.flickr.com/services/oauth/access_token'),
             array('http://www.example.com/?foo=bar', 'some/path', 'http://www.example.com/some/path?foo=bar'),
-            array('http://www.example.com/?foo=bar', 'some/path?boo=moo', 'http://www.example.com/some/path?foo=bar&boo=moo'),
+            array('http://www.example.com/?foo=bar', 'some/path?boo=moo', 'http://www.example.com/some/path?boo=moo&foo=bar'),
+            array('http://www.example.com/some/', 'path?foo=bar&foo=baz', 'http://www.example.com/some/path?foo=bar&foo=baz'),
         );
     }
 


### PR DESCRIPTION
will now replace the current query string of the URL with the merged in
query string, causing query aggregators to be replaced.
Closes #489. Closes #511.
