### PR TITLE
Persing query parameters starting with '&'

### DIFF
--- a/src/Guzzle/Http/QueryString.php
+++ b/src/Guzzle/Http/QueryString.php
@@ -55,6 +55,9 @@ class QueryString extends Collection
         foreach (explode('&', $query) as $kvp) {
             $parts = explode('=', $kvp, 2);
             $key = rawurldecode($parts[0]);
+            if (!strlen($key)) {
+            	continue;
+            }
             if ($paramIsPhpStyleArray = substr($key, -2) == '[]') {
                 $foundPhpStyle = true;
                 $key = substr($key, 0, -2);


### PR DESCRIPTION
Url `/foo?&a=1`

should be equivalent to `/foo?a=1`, not `/foo?=&a=1`.

The current implementation explodes sting using `&`, i've added just a check that looks if key is empty
