### PR TITLE
Allow a single instance of a Response object to be set as the next mocked response

### DIFF
--- a/tests/Guzzle/Tests/GuzzleTestCase.php
+++ b/tests/Guzzle/Tests/GuzzleTestCase.php
@@ -188,6 +188,12 @@ abstract class GuzzleTestCase extends \PHPUnit_Framework_TestCase
             $that->addMockedRequest($event['request']);
         });
 
+        if ($paths instanceof Response) {
+            // A single response instance has been specified, create an array with that instance
+            // as the only element for the following loop to work as expected
+            $paths = array($paths);
+        }
+
         foreach ((array) $paths as $path) {
             $mock->addResponse($this->getMockResponse($path));
         }


### PR DESCRIPTION
The `GuzzleTestCase` class has a `setMockedResponse` method that allows you to do the following:

```
$this->setMockedResponse($client, 'some_response')
```

where `some_response` is a mock response file. The `setMockedResponse` also allows you to specify response object instances, but only when added as an elements to an array:

```
$this->setMockedResponse($client, array(new Guzzle\Http\Message\Response( /* ... */ )));
```

This PR will allow the following for consistency:

```
$this->setMockedResponse($client, new Guzzle\Http\Message\Response( /* ... */ ));
```
