### PR TITLE
Changes empty query string value serialization

### DIFF
--- a/tests/Guzzle/Tests/Http/QueryStringTest.php
+++ b/tests/Guzzle/Tests/Http/QueryStringTest.php
@@ -92,13 +92,13 @@ class QueryStringTest extends \Guzzle\Tests\GuzzleTestCase
             'test4'  => null,
         );
         $this->q->replace($params);
-        $this->assertEquals('test=value&test%202=this%20is%20a%20test%3F&test3%5B0%5D=v1&test3%5B1%5D=v2&test3%5B2%5D=v3&test4=', $this->q->__toString());
+        $this->assertEquals('test=value&test%202=this%20is%20a%20test%3F&test3%5B0%5D=v1&test3%5B1%5D=v2&test3%5B2%5D=v3&test4', $this->q->__toString());
         $this->q->useUrlEncoding(false);
-        $this->assertEquals('test=value&test 2=this is a test?&test3[0]=v1&test3[1]=v2&test3[2]=v3&test4=', $this->q->__toString());
+        $this->assertEquals('test=value&test 2=this is a test?&test3[0]=v1&test3[1]=v2&test3[2]=v3&test4', $this->q->__toString());
 
         // Use an alternative aggregator
         $this->q->setAggregator(new CommaAggregator());
-        $this->assertEquals('test=value&test 2=this is a test?&test3=v1,v2,v3&test4=', $this->q->__toString());
+        $this->assertEquals('test=value&test 2=this is a test?&test3=v1,v2,v3&test4', $this->q->__toString());
     }
 
     public function testAllowsMultipleValuesPerKey()
@@ -147,7 +147,7 @@ class QueryStringTest extends \Guzzle\Tests\GuzzleTestCase
             // Ensure that query string values are percent decoded
             array('q%20a=a%20b', array('q a' => 'a b')),
             // Ensure null values can be added
-            array('q&a', array('q' => QueryString::BLANK, 'a' => QueryString::BLANK)),
+            array('q&a', array('q' => false, 'a' => false)),
         );
     }
 
@@ -207,9 +207,10 @@ class QueryStringTest extends \Guzzle\Tests\GuzzleTestCase
             'foo' => 0,
             'baz' => '0',
             'bar' => null,
-            'boo' => false
+            'boo' => false,
+            'bam' => ''
         ));
-        $this->assertEquals('foo=0&baz=0&bar=&boo=', (string) $query);
+        $this->assertEquals('foo=0&baz=0&bar&boo&bam=', (string) $query);
     }
 
     public function testFromStringDoesntStripTrailingEquals()


### PR DESCRIPTION
Previously, the only way to se empty query string variables that had no value (e.g., "foo" rather than "foo=") was to use the magic `"_guzzle_blank_"` variable. This variable was then added in 3.8.1 to query string values when parsing a query string so that when the query string is again cast to a string it would not include the "=" sign. This works, but introduces pain points when working with these parsed query strings because the data contained in the query string object now needs special handling (you must check if the value is `"_guzzle_blank_"` to see if it should actually be empty). This change introduced an asymmetry between how a query string is serialized vs how it is inspected.

The `"_guzzle_blank_"` logic was introduced due to #96. I believe the change introduced as a result was the wrong decision and this commit hopes to address it.

This change now makes `false`, `null`, and `"_guzzle_blank_"` all act as query string fields that contain no value (meaning no trailing equal sign). This change marked the use of `"_guzzle_blank_"` as deprecated. If you still wish for an emtpy query string value that includes a trailing "=", then use an empty string (i.e., `""`).

Here's an example of how the proposed change will affect query string serialization:

Given a `Guzzle\Http\QueryString` object `$q`, adding the values on left will serialize to the string on the right:
- `$q->set('foo', null)` => `"foo"` (previously `"foo="`)
- `$q->set('foo', false)` => `"foo"` (previously `"foo="`)
- `$q->set('foo', '_guzzle_blank_')` => `"foo"` (unchanged)
- `$q->set('foo', '')` => `"foo="` (unchanged)
