### PR TITLE
If-Modified-Since should set only when server have return Last Modified ...

### DIFF
--- a/src/Guzzle/Plugin/Cache/DefaultRevalidation.php
+++ b/src/Guzzle/Plugin/Cache/DefaultRevalidation.php
@@ -95,9 +95,11 @@ class DefaultRevalidation implements RevalidationInterface
     protected function createRevalidationRequest(RequestInterface $request, Response $response)
     {
         $revalidate = clone $request;
-        $revalidate->removeHeader('Pragma')
-            ->removeHeader('Cache-Control')
-            ->setHeader('If-Modified-Since', $response->getLastModified() ?: $response->getDate());
+        $revalidate->removeHeader('Pragma')->removeHeader('Cache-Control');
+
+        if ($response->getLastModified()) {
+            $revalidate->setHeader('If-Modified-Since', $response->getLastModified());
+        }
 
         if ($response->getEtag()) {
             $revalidate->setHeader('If-None-Match', $response->getEtag());


### PR DESCRIPTION
1. By the default in a browser, when server haven't response back the **Last-Modified**, then the browser never need to append **If-Modified-Since** to the next request. 
2. Some application may defined only Etag and need only validate only Etag parameter, to force it set by **Date**, it also force server to revalidate on this parameter and it will match only Etag parameter, while, **If-Modified-Since** force the server to get new data instead.
