### PR TITLE
SchemaValidator not returning correct invalid additionalProperties

### DIFF
--- a/src/Guzzle/Service/Description/SchemaValidator.php
+++ b/src/Guzzle/Service/Description/SchemaValidator.php
@@ -157,8 +157,9 @@ class SchemaValidator implements ValidatorInterface
                             }
                         } else {
                             // if additionalProperties is set to false and there are additionalProperties in the values, then fail
-                            $keys = array_keys($value);
-                            $this->errors[] = sprintf('%s[%s] is not an allowed property', $path, reset($keys));
+                            foreach ($diff as $prop) {
+                                $this->errors[] = sprintf('%s[%s] is not an allowed property', $path, $prop);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I was noticing the SchemaValidator will just return the name of the first property for an object that has invalid additional properties. For example, with the schema snippet:

```
'contact' => [
    'type' => 'object',
    'additionalProperties' => false,
    'location' => 'json',
    'properties' => [
        'email' => [
            'type' => 'string'
        ],
        'name' => [
            'type' => 'string'
        ]
    ]
]
```

Passing in the following parameters:
['email' => 'example@address.com', 'invalidParam' => 'random', 'anotherInvalid' => 'random]

Returns the a ValidationException reporting only 1 validation error for the wrong property:
Validation errors: [contact][email] is not an allowed property.

This pull request should cause the validation errors to be:
[contact][invalidParam] is not an allowed property
[contact][anotherInvalid] is not an allowed property
