### PR TITLE
Cache adapter, which store data in memory.

### DIFF
--- a/src/Guzzle/Cache/MemoryCacheAdapter.php
+++ b/src/Guzzle/Cache/MemoryCacheAdapter.php
@@ -13,12 +13,12 @@ class MemoryCacheAdapter implements CacheAdapterInterface
             return false;
         }
         
-        // fount end expiration not reached
+        // cache found and expiration not reached
         if(!$this->_cache[$id]['expire'] || time() < $this->_cache[$id]['expire']) {
             return $this->_cache[$id]['value'];
         }
         
-        // expiration reached - return not found
+        // expiration reached - return false
         unset($this->_cache[$id]);
         return false;
     }

--- a/tests/Guzzle/Tests/Cache/MemoryCacheAdapterTest.php
+++ b/tests/Guzzle/Tests/Cache/MemoryCacheAdapterTest.php
@@ -4,6 +4,9 @@ namespace Guzzle\Tests\Cache;
 
 use Guzzle\Cache\MemoryCacheAdapter;
 
+/**
+ * @covers Guzzle\Cache\MemoryCacheAdapter
+ */
 class MemoryCacheAdapterTest extends \Guzzle\Tests\GuzzleTestCase
 {
     private $_cache = array();


### PR DESCRIPTION
Cache adapter, which store data in memory. This may be useful in unit testing for mocking real cache storages, while two or more requests executed and HTTP Cache plugin used
