### PR TITLE
Add newly set ServiceDescription objects to CompositeFactory (#565).

### DIFF
--- a/src/Guzzle/Service/Client.php
+++ b/src/Guzzle/Service/Client.php
@@ -147,6 +147,10 @@ class Client extends HttpClient implements ClientInterface
     {
         $this->serviceDescription = $service;
 
+        if ($this->getCommandFactory() && $this->getCommandFactory() instanceof CompositeFactory) {
+            $this->commandFactory->add(new Command\Factory\ServiceDescriptionFactory($service));
+        }
+
         // If a baseUrl was set on the description, then update the client
         if ($baseUrl = $service->getBaseUrl()) {
             $this->setBaseUrl($baseUrl);

--- a/tests/Guzzle/Tests/Service/ClientTest.php
+++ b/tests/Guzzle/Tests/Service/ClientTest.php
@@ -304,4 +304,17 @@ class ClientTest extends \Guzzle\Tests\GuzzleTestCase
             }
         }
     }
+
+    public function testGetCommandAfterTwoSetDescriptions()
+    {
+        $service1 = ServiceDescription::factory(__DIR__ . '/../TestData/test_service.json');
+        $service2 = ServiceDescription::factory(__DIR__ . '/../TestData/test_service_3.json');
+
+        $client = new Mock\MockClient();
+
+        $client->setDescription($service1);
+        $client->getCommand('foo_bar');
+        $client->setDescription($service2);
+        $client->getCommand('baz_qux');
+    }
 }

--- a/tests/Guzzle/Tests/TestData/test_service_3.json
+++ b/tests/Guzzle/Tests/TestData/test_service_3.json
@@ -1,0 +1,40 @@
+{
+    "includes": [ "test_service2.json" ],
+    "operations": {
+        "test": {
+            "uri": "/path"
+        },
+        "concrete": {
+            "extends": "abstract"
+        },
+        "baz_qux": {
+            "uri": "/testing",
+            "parameters": {
+                "other": {
+                    "location": "json",
+                    "location_key": "Other"
+                },
+                "test": {
+                    "type": "object",
+                    "location": "json",
+                    "properties": {
+                        "baz": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "bar": {
+                            "type": "string",
+                            "filters": [
+                                {
+                                    "method": "strtolower",
+                                    "args": ["test", "@value"]
+                                },
+                                "strtoupper"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes bug #565, allowing `Guzzle\Service\Client` to get commands created after setting a different `ServiceDescription`.
