### PR TITLE
Fixing ChunkedIterator example

### DIFF
--- a/docs/iterators/guzzle-iterators.rst
+++ b/docs/iterators/guzzle-iterators.rst
@@ -17,7 +17,7 @@ pulling out chunks of values from the inner iterator.
     use Guzzle\Iterator\ChunkedIterator;
 
     $inner = new ArrayIterator(range(0, 8));
-    $chunkedIterator = new ChunkedIterator($inner, 10);
+    $chunkedIterator = new ChunkedIterator($inner, 2);
 
     foreach ($chunkedIterator as $chunk) {
         echo implode(', ', $chunk) . "\n";


### PR DESCRIPTION
The iterator should be initialized with a chunk size of 2 to match the given example.
