### PR TITLE
[Iterator] Fix target-dir (composer.json)

### DIFF
--- a/src/Guzzle/Iterator/composer.json
+++ b/src/Guzzle/Iterator/composer.json
@@ -18,7 +18,7 @@
     "autoload": {
         "psr-0": { "Guzzle\\Iterator": "/" }
     },
-    "target-dir": "Guzzle/Log",
+    "target-dir": "Guzzle/Iterator",
     "extra": {
         "branch-alias": {
             "dev-master": "3.7-dev"


### PR DESCRIPTION
Independent usage of `Guzzle/Iterator` is impossible for now. Looks like some copy-paste is detected :)
Other `composer.json` are ok.
