### PR TITLE
Updated test Server class to make sure server is started on flush()

### DIFF
--- a/tests/Server.php
+++ b/tests/Server.php
@@ -37,7 +37,9 @@ class Server
      */
     public static function flush()
     {
-        self::$started && self::$client->delete('guzzle-server/requests');
+        self::start();
+
+        return self::$client->delete('guzzle-server/requests');
     }
 
     /**


### PR DESCRIPTION
This should fix #638 by making sure the node server is running for tests where `Server::flush()` is called, but not `Server::enqueue()`.
