### PR TITLE
Updated docs for query string parameters

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -160,7 +160,7 @@ option.
 
 .. code-block:: php
 
-    $client->get('http://httpbin.org', [
+    $client->get('http://httpbin.org', null, [
         'query' => ['foo' => 'bar']
     ]);
 


### PR DESCRIPTION
The options for the get request method are the third parameter, not the second.
