### PR TITLE
Added an emitter option to the Client

### DIFF
--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -56,6 +56,11 @@ defaults
     default headers (e.g., User-Agent), default query string parameters, SSL
     configurations, and any other supported request options.
 
+emitter
+    Specifies an event emitter (``GuzzleHttp\Event\EmitterInterface``) instance
+    to be used by the client to emit request events. This option is useful if
+    you need to inject an emitter with listeners/subscribers already attached.
+
 Here's an example of creating a client with various options, including using
 a mock adapter that just returns the result of a callable function and a
 base URL that is a URI template with parameters.

--- a/src/Client.php
+++ b/src/Client.php
@@ -69,12 +69,16 @@ class Client implements ClientInterface
      *     - parallel_adapter: Adapter used to transfer requests in parallel
      *     - message_factory: Factory used to create request and response object
      *     - defaults: Default request options to apply to each request
+     *     - emitter: Event emitter used for request events
      */
     public function __construct(array $config = [])
     {
         $this->configureBaseUrl($config);
         $this->configureDefaults($config);
         $this->configureAdapter($config);
+        if (isset($config['emitter'])) {
+            $this->emitter = $config['emitter'];
+        }
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -103,6 +103,19 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->get();
     }
 
+    public function testCanSpecifyEmitter()
+    {
+        $emitter = $this->getMockBuilder('GuzzleHttp\Event\EmitterInterface')
+            ->setMethods(['listeners'])
+            ->getMockForAbstractClass();
+        $emitter->expects($this->once())
+            ->method('listeners')
+            ->will($this->returnValue('foo'));
+
+        $client = new Client(['emitter' => $emitter]);
+        $this->assertEquals('foo', $client->getEmitter()->listeners());
+    }
+
     public function testAddsDefaultUserAgentHeaderWithDefaultOptions()
     {
         $client = new Client(['defaults' => ['allow_redirects' => false]]);


### PR DESCRIPTION
Allows you to inject an emitter to the client, so you can pre-attach listeners and subscribers.

``` php
$emitter = new Emitter();
$emitter->on('before', function($e) {die('BAIL!');});
$client = new Client(['emitter' => $emitter]);
```

This solves the root issue of #639 in a backwards-compatible way.
