### PR TITLE
Prevent crushes on parsing an incorrect HTTP request

### DIFF
--- a/src/Message/MessageParser.php
+++ b/src/Message/MessageParser.php
@@ -38,7 +38,8 @@ class MessageParser
             'body'     => $parts['body']
         ];
 
-        $parsed['request_url'] = $this->getUrlPartsFromMessage($parts['start_line'][1], $parsed);
+        $parsed['request_url'] = $this->getUrlPartsFromMessage(
+            (isset($parts['start_line'][1]) ? $parts['start_line'][1] : ''), $parsed);
 
         return $parsed;
     }


### PR DESCRIPTION
Steps to reproduce crush:
1. Start http-server (like in Ratchet's Hello World (http://socketo.me/docs/hello-world)).
2. Connect to it with telnet (instead of browser), and send any text followed by '\n\n'.
Http-server will crush with "PHP Notice:  Undefined offset: 1 in .../Guzzle/Parser/Message/MessageParser.php on line 36" (ratchet currently uses v.3.7-dev)
