### PR TITLE
Allows for MessageFactory subscribers to be overridden

### DIFF
--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -20,10 +20,10 @@ use GuzzleHttp\Url;
 class MessageFactory implements MessageFactoryInterface
 {
     /** @var HttpError */
-    private $errorPlugin;
+    protected $errorPlugin;
 
     /** @var Redirect */
-    private $redirectPlugin;
+    protected $redirectPlugin;
 
     public function __construct()
     {


### PR DESCRIPTION
I want to inject my own message factory into the client instantiation process. Because my version differs very slightly from the default `GuzzleHttp\Message\MessageFactory`, instead of rolling my own from scratch I want to inherit and override.

The only difference between mine and the default version is the `HttpError` subscriber (I want to handle exceptions differently) - but because they're private properties I can't override
