### PR TITLE
Make MessageFactory options extendable

### DIFF
--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -154,7 +154,7 @@ class MessageFactory implements MessageFactoryInterface
             'debug' => 1, 'save_to' => 1, 'stream' => 1, 'expect' => 1];
         static $methods;
         if (!$methods) {
-            $methods = array_flip(get_class_methods(__CLASS__));
+            $methods = array_flip(get_class_methods($this));
         }
 
         // Iterate over each key value pair and attempt to apply a config using


### PR DESCRIPTION
Currently, the options that get registered are tied to the `MessageFactory` class. If I extend it with `MyMessageFactory`, I should be able to register custom options like `MyMessageFactory::add_my_option`, and `MessageFactory::applyOptions` should recognize it, instead of throwing `[InvalidArgumentException]: "No method is configured to handle the my_option config key"`.
