### PR TITLE
Adding the json request option

### DIFF
--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -432,6 +432,33 @@ This setting can be set to any of the following types:
       $stream = GuzzleHttp\Stream\Stream::factory('contents...');
       $client->post('/post', ['body' => $stream]);
 
+json
+----
+
+:Summary: The ``json`` option is used to easily upload JSON encoded data as the
+    body of a request. A Content-Type header of ``application/json`` will be
+    added if no Content-Type header is already present on the message.
+:Types:
+    Any PHP type that can be operated on by PHP's ``json_encode()`` function.
+:Default: None
+
+.. code-block:: php
+
+    $request = $client->createRequest('/put', ['json' => ['foo' => 'bar']]);
+    echo $request->getHeader('Content-Type');
+    // application/json
+    echo $request->getBody();
+    // {"foo":"bar"}
+
+.. note::
+
+    This request option does not support customizing the Content-Type header
+    or any of the options from PHP's `json_encode() <http://www.php.net/manual/en/function.json-encode.php>`_
+    function. If you need to customize these settings, then you must pass the
+    JSON encoded data into the request yourself using the ``body`` request
+    option and you must specify the correct Content-Type header using the
+    ``headers`` request option.
+
 query
 -----
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -276,19 +276,33 @@ or response object.
     echo $request->getHeader('X-Foo');
     // Echoes an empty string: ''
 
-POST Requests
-=============
+Uploading Data
+==============
 
-You can send POST requests that contain a raw POST body by passing a
-string, resource returned from ``fopen``, or a
-``GuzzleHttp\Stream\StreamInterface`` object to the ``body`` request option.
+Guzzle provides several methods of uploading data.
+
+You can send requests that contain a stream of data by passing a string,
+resource returned from ``fopen``, or a ``GuzzleHttp\Stream\StreamInterface``
+object to the ``body`` request option.
 
 .. code-block:: php
 
     $r = $client->post('http://httpbin.org/post', ['body' => 'raw data']);
 
+You can easily upload JSON data using the ``json`` request option.
+
+.. code-block:: php
+
+    $r = $client->put('http://httpbin.org/put', ['json' => ['foo' => 'bar']]);
+
+POST Requests
+-------------
+
+In addition to specifying the raw data of a request using the ``body`` request
+option, Guzzle provides helpful abstractions over sending POST data.
+
 Sending POST Fields
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 Sending ``application/x-www-form-urlencoded`` POST requests requires that you
 specify the body of a POST request as an array.
@@ -321,7 +335,7 @@ You can also build up POST requests before sending them.
     $response = $client->send($request);
 
 Sending POST Files
-------------------
+~~~~~~~~~~~~~~~~~~
 
 Sending ``multipart/form-data`` POST requests (POST requests that contain
 files) is the same as sending ``application/x-www-form-urlencoded``, except

--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -320,4 +320,13 @@ class MessageFactory implements MessageFactoryInterface
             $emitter->attach($subscribers);
         }
     }
+
+    private function add_json(RequestInterface $request, $value)
+    {
+        if (!$request->hasHeader('Content-Type')) {
+            $request->setHeader('Content-Type', 'application/json');
+        }
+
+        $request->setBody(Stream\create(json_encode($value)));
+    }
 }

--- a/src/Message/MessageFactoryInterface.php
+++ b/src/Message/MessageFactoryInterface.php
@@ -39,6 +39,7 @@ interface MessageFactoryInterface
      *
      * - headers: Associative array of headers to add to the request
      * - body: string|resource|array|StreamInterface request body to send
+     * - json: mixed Uploads JSON encoded data using an application/json Content-Type header.
      * - query: Associative array of query string values to add to the request
      * - auth: array|string HTTP auth settings (user, pass[, type="basic"])
      * - version: The HTTP protocol version to use with the request

--- a/tests/Message/MessageFactoryTest.php
+++ b/tests/Message/MessageFactoryTest.php
@@ -472,7 +472,29 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCanSetProtocolVersion()
     {
-        $request = (new MessageFactory())->createRequest('GET', 'http://test.com', ['version' => 1.0]);
+        $request = (new MessageFactory())->createRequest('GET', 'http://t.com', ['version' => 1.0]);
         $this->assertEquals(1.0, $request->getProtocolVersion());
+    }
+
+    public function testCanAddJsonData()
+    {
+        $request = (new MessageFactory)->createRequest('PUT', 'http://f.com', [
+            'json' => ['foo' => 'bar']
+        ]);
+        $this->assertEquals(
+            'application/json',
+            $request->getHeader('Content-Type')
+        );
+        $this->assertEquals('{"foo":"bar"}', (string) $request->getBody());
+    }
+
+    public function testCanAddJsonDataAndNotOverwriteContentType()
+    {
+        $request = (new MessageFactory)->createRequest('PUT', 'http://f.com', [
+            'headers' => ['Content-Type' => 'foo'],
+            'json' => null
+        ]);
+        $this->assertEquals('foo', $request->getHeader('Content-Type'));
+        $this->assertEquals('null', (string) $request->getBody());
     }
 }


### PR DESCRIPTION
- Adding the json request option to provide better symmetry
  between request and response APIs.
- Updating the quickstart guide and documentation.
- Closes #674
