### PR TITLE
Fixed the bug with cached class methods.

### DIFF
--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -28,6 +28,9 @@ class MessageFactory implements MessageFactoryInterface
     /** @var Redirect */
     private $redirectPlugin;
 
+    /** @var array */
+    protected static $classMethods = [];
+
     public function __construct()
     {
         $this->errorPlugin = new HttpError();
@@ -152,10 +155,17 @@ class MessageFactory implements MessageFactoryInterface
         static $configMap = ['connect_timeout' => 1, 'timeout' => 1,
             'verify' => 1, 'ssl_key' => 1, 'cert' => 1, 'proxy' => 1,
             'debug' => 1, 'save_to' => 1, 'stream' => 1, 'expect' => 1];
-        static $methods;
-        if (!$methods) {
-            $methods = array_flip(get_class_methods($this));
+        
+        // Take the class of the instance, not the parent
+        $selfClass = get_class($this);
+
+        // Check if we already took it's class methods and had them saved
+        if (!isset(self::$classMethods[$selfClass])) {
+            self::$classMethods[$selfClass] = array_flip(get_class_methods($this));
         }
+
+        // Take class methods of this particular instance
+        $methods = self::$classMethods[$selfClass];
 
         // Iterate over each key value pair and attempt to apply a config using
         // double dispatch.


### PR DESCRIPTION
When get_class_methods(**CLASS**) was changed to get_class_methods($this), derived classes got a method list from the first instantiated MessageFactory, which could be the parent or a sibling class, so this is fixed now.
