### PR TITLE
Post-body will reset when using json-data

### DIFF
--- a/tests/Message/MessageFactoryTest.php
+++ b/tests/Message/MessageFactoryTest.php
@@ -488,6 +488,21 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"foo":"bar"}', (string) $request->getBody());
     }
 
+    /**
+     * @group failing_test
+     */
+    public function testCanAddJsonDataToAPostRequest()
+    {
+        $request = (new MessageFactory)->createRequest('POST', 'http://f.com', [
+            'json' => ['foo' => 'bar']
+        ]);
+        $this->assertEquals(
+            'application/json',
+            $request->getHeader('Content-Type')
+        );
+        $this->assertEquals('{"foo":"bar"}', (string) $request->getBody());
+    }
+
     public function testCanAddJsonDataAndNotOverwriteContentType()
     {
         $request = (new MessageFactory)->createRequest('PUT', 'http://f.com', [


### PR DESCRIPTION
When I create a Post-Request with Json-Data, then the post-body will reset.

How to create a Json-Request is described [here](http://guzzle.readthedocs.org/en/latest/clients.html?highlight=options#json). I used `post` as first parameter instead of `put`.

I have attached a failing test to verify this behavior.
