### PR TITLE
Fixed documentation.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -54,7 +54,6 @@ class Client implements ClientInterface
      *              ['version' => '123']
      *          ],
      *         'defaults' => [
-     *             'timeout'         => 10,
      *             'allow_redirects' => false,
      *             'proxy'           => '192.168.16.1:10'
      *         ]


### PR DESCRIPTION
I removed a line from the doc:

```
'timeout'         => 10,
```

This parameter is ignored as a default because 'timeout' is not one of the keys
returned by getDefaultOptions. Thus, it is ignored by the array_replace call.

It is important that this document be correct; otherwise people may think that
they are setting a timeout when in fact their timeout setting is being ignored.
