### PR TITLE
Include Tests in Autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,11 @@
         },
         "files": ["src/functions.php"]
     },
-
+    "autoload-dev": {
+        "psr-4": {
+            "GuzzleHttp\\Tests\\": "tests/"
+        }
+    },	
     "require-dev": {
         "ext-curl": "*",
         "psr/log": "~1.0",

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -173,15 +173,11 @@ Guzzle ships with a node.js test server that receives requests and returns
 responses from a queue. The test server exposes a simple API that is used to
 enqueue responses and inspect the requests that it has received.
 
-In order to use the web server, you'll need to manually require
-``tests/Server.php``. Any operation on the ``Server`` object will ensure that
+Any operation on the ``Server`` object will ensure that
 the server is running and wait until it is able to receive requests before
 returning.
 
 .. code-block:: php
-
-    // Require the test server (using something like this).
-    require __DIR__ . '/../vendor/guzzlehttp/guzzle/tests/Server.php';
 
     use GuzzleHttp\Client;
     use GuzzleHttp\Tests\Server;


### PR DESCRIPTION
I added the tests namespace to the autoload so the test server could be used using autoload.

I've found two issues, with it not being available via autoload.
1. When including the file manually in a symfony2 application I got file could not be found on both travis-ci and drone.io. (Didn't get this issue locally)
2. It stops me from being fully compliant with PSR-2. In that it causes my test files to have a side effects.
