### PR TITLE
Change port used for unit tests

### DIFF
--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -896,7 +896,7 @@ Pass a string to specify a proxy for all protocols.
 
 .. code-block:: php
 
-    $client->get('/', ['proxy' => 'tcp://localhost:8124']);
+    $client->get('/', ['proxy' => 'tcp://localhost:8125']);
 
 Pass an associative array to specify HTTP proxies for specific URI schemes
 (i.e., "http", "https").
@@ -905,7 +905,7 @@ Pass an associative array to specify HTTP proxies for specific URI schemes
 
     $client->get('/', [
         'proxy' => [
-            'http'  => 'tcp://localhost:8124', // Use this proxy with "http"
+            'http'  => 'tcp://localhost:8125', // Use this proxy with "http"
             'https' => 'tcp://localhost:9124'  // Use this proxy with "https"
         ]
     ]);

--- a/tests/Adapter/StreamAdapterTest.php
+++ b/tests/Adapter/StreamAdapterTest.php
@@ -34,7 +34,7 @@ class StreamAdapterTest extends \PHPUnit_Framework_TestCase
         $sent = Server::received(true)[0];
         $this->assertEquals('GET', $sent->getMethod());
         $this->assertEquals('/', $sent->getResource());
-        $this->assertEquals('127.0.0.1:8124', $sent->getHeader('host'));
+        $this->assertEquals('127.0.0.1:8125', $sent->getHeader('host'));
         $this->assertEquals('Bar', $sent->getHeader('foo'));
         $this->assertTrue($sent->hasHeader('user-agent'));
     }
@@ -134,7 +134,7 @@ class StreamAdapterTest extends \PHPUnit_Framework_TestCase
         $sent = Server::received(true)[0];
         $this->assertEquals('PUT', $sent->getMethod());
         $this->assertEquals('/foo', $sent->getResource());
-        $this->assertEquals('127.0.0.1:8124', $sent->getHeader('host'));
+        $this->assertEquals('127.0.0.1:8125', $sent->getHeader('host'));
         $this->assertEquals('Bar', $sent->getHeader('foo'));
         $this->assertTrue($sent->hasHeader('user-agent'));
     }
@@ -201,7 +201,7 @@ class StreamAdapterTest extends \PHPUnit_Framework_TestCase
             'stream' => true
         ]);
         $body = $response->getBody();
-        $this->assertEquals('compress.zlib://http://127.0.0.1:8124/', $body->getMetadata()['uri']);
+        $this->assertEquals('compress.zlib://http://127.0.0.1:8125/', $body->getMetadata()['uri']);
     }
 
     protected function getStreamFromBody(Stream $body)
@@ -222,9 +222,9 @@ class StreamAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testAddsProxy()
     {
-        $body = $this->getSendResult(['stream' => true, 'proxy' => '127.0.0.1:8124'])->getBody();
+        $body = $this->getSendResult(['stream' => true, 'proxy' => '127.0.0.1:8125'])->getBody();
         $opts = stream_context_get_options($this->getStreamFromBody($body));
-        $this->assertEquals('127.0.0.1:8124', $opts['http']['proxy']);
+        $this->assertEquals('127.0.0.1:8125', $opts['http']['proxy']);
         $this->assertTrue($opts['http']['request_fulluri']);
     }
 
@@ -307,9 +307,9 @@ class StreamAdapterTest extends \PHPUnit_Framework_TestCase
         ob_start();
         $client->get('/', ['debug' => true]);
         $contents = ob_get_clean();
-        $this->assertContains('<http://127.0.0.1:8124/> [CONNECT]', $contents);
-        $this->assertContains('<http://127.0.0.1:8124/> [FILE_SIZE_IS]', $contents);
-        $this->assertContains('<http://127.0.0.1:8124/> [PROGRESS]', $contents);
+        $this->assertContains('<http://127.0.0.1:8125/> [CONNECT]', $contents);
+        $this->assertContains('<http://127.0.0.1:8125/> [FILE_SIZE_IS]', $contents);
+        $this->assertContains('<http://127.0.0.1:8125/> [PROGRESS]', $contents);
     }
 
     public function testDebugAttributeWritesStreamInfoToBuffer()
@@ -329,10 +329,10 @@ class StreamAdapterTest extends \PHPUnit_Framework_TestCase
         $client->get('/', ['debug' => $buffer]);
         fseek($buffer, 0);
         $contents = stream_get_contents($buffer);
-        $this->assertContains('<http://127.0.0.1:8124/> [CONNECT]', $contents);
-        $this->assertContains('<http://127.0.0.1:8124/> [FILE_SIZE_IS] message: "Content-Length: 8"', $contents);
-        $this->assertContains('<http://127.0.0.1:8124/> [PROGRESS] bytes_max: "8"', $contents);
-        $this->assertContains('<http://127.0.0.1:8124/> [MIME_TYPE_IS] message: "text/plain"', $contents);
+        $this->assertContains('<http://127.0.0.1:8125/> [CONNECT]', $contents);
+        $this->assertContains('<http://127.0.0.1:8125/> [FILE_SIZE_IS] message: "Content-Length: 8"', $contents);
+        $this->assertContains('<http://127.0.0.1:8125/> [PROGRESS] bytes_max: "8"', $contents);
+        $this->assertContains('<http://127.0.0.1:8125/> [MIME_TYPE_IS] message: "text/plain"', $contents);
     }
 
     public function testAddsProxyByProtocol()

--- a/tests/Server.php
+++ b/tests/Server.php
@@ -28,8 +28,8 @@ class Server
     private static $client;
 
     public static $started;
-    public static $url = 'http://127.0.0.1:8124/';
-    public static $port = 8124;
+    public static $url = 'http://127.0.0.1:8125/';
+    public static $port = 8125;
 
     /**
      * Flush the received requests from the server

--- a/tests/server.js
+++ b/tests/server.js
@@ -5,21 +5,21 @@
  *
  * - Delete all requests that have been received:
  *      DELETE /guzzle-server/requests
- *      Host: 127.0.0.1:8124
+ *      Host: 127.0.0.1:8125
  *
  *  - Enqueue responses
  *      PUT /guzzle-server/responses
- *      Host: 127.0.0.1:8124
+ *      Host: 127.0.0.1:8125
  *
  *      [{ "statusCode": 200, "reasonPhrase": "OK", "headers": {}, "body": "" }]
  *
  *  - Get the received requests
  *      GET /guzzle-server/requests
- *      Host: 127.0.0.1:8124
+ *      Host: 127.0.0.1:8125
  *
  *  - Shutdown the server
  *      DELETE /guzzle-server
- *      Host: 127.0.0.1:8124
+ *      Host: 127.0.0.1:8125
  *
  * @package Guzzle PHP <http://www.guzzlephp.org>
  * @license See the LICENSE file that was distributed with this source code.
@@ -132,13 +132,13 @@ var GuzzleServer = function(port, log) {
         that.server.listen(port, "127.0.0.1");
 
         if (this.log) {
-            console.log("Server running at http://127.0.0.1:8124/");
+            console.log("Server running at http://127.0.0.1:8125/");
         }
     };
 };
 
 // Get the port from the arguments
-port = process.argv.length >= 3 ? process.argv[2] : 8124;
+port = process.argv.length >= 3 ? process.argv[2] : 8125;
 log = process.argv.length >= 4 ? process.argv[3] : false;
 
 // Start the server


### PR DESCRIPTION
The purpose here is to allow running guzzle3 and guzzle4 tests at the
same time, on the same machine. This is needed for
http://hhvm.com/frameworks/ to work correctly. Ideally we'll make these
more isolated in the future, but this should be an unobtrusive
short-term fix.
