### PR TITLE
Moved GuzzleHttp\Tests autoload from autoload-dev to autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,11 @@
 
     "autoload": {
         "psr-4": {
-            "GuzzleHttp\\": "src/"
+            "GuzzleHttp\\": "src/",
+            "GuzzleHttp\\Tests\\": "tests/"
         },
         "files": ["src/functions.php"]
     },
-    "autoload-dev": {
-        "psr-4": {
-            "GuzzleHttp\\Tests\\": "tests/"
-        }
-    },	
     "require-dev": {
         "ext-curl": "*",
         "psr/log": "~1.0",


### PR DESCRIPTION
Currently autoload-dev only works for root projects therefore it needs defined in the main autoload.

This time I actually tested it worked in my project. 
