### PR TITLE
Add Support for setAuth (for Request)

### DIFF
--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -213,4 +213,8 @@ class Request extends AbstractMessage implements RequestInterface
             }
         }
     }
+    public function setAuth($username, $password){
+        $this->url->setUsername($username)->setPassword($password);
+        return $this;
+    }
 }

--- a/src/Message/RequestInterface.php
+++ b/src/Message/RequestInterface.php
@@ -147,4 +147,14 @@ interface RequestInterface extends MessageInterface, HasEmitterInterface
      * @return \GuzzleHttp\Collection
      */
     public function getConfig();
+
+    /**
+     * Sets auth data for current url.
+     * 
+     * @param String $username
+     * @param String $password
+     *
+     * @return self
+     */
+    public function setAuth($username,$password);
 }


### PR DESCRIPTION
Right now it's not possible to set Auth data for object Request (Url is private, and getUrl returns string representation of object URL) 
