### PR TITLE
Update clients.rst

### DIFF
--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -70,7 +70,7 @@ base URL that is a URI template with parameters.
     use GuzzleHttp\Client;
 
     $client = new Client([
-        'base_url' => ['https://api.twitter.com/{version}', ['version' => 'v1.1']],
+        'base_url' => ['https://api.twitter.com/{version}/', ['version' => 'v1.1']],
         'defaults' => [
             'headers' => ['Foo' => 'Bar'],
             'query'   => ['testing' => '123'],


### PR DESCRIPTION
The path component of the base URL must end with a slash; otherwise, the effective URL of `$client->get('example-request')` is `https://api.twitter.com/example-request` instead of `https://api.twitter.com/v1.1/example-request`.
