### PR TITLE
Make sure path leading slashes aren't added for empty hosts

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -92,7 +92,7 @@ class Url
         if (isset($parts['path']) && strlen($parts['path'])) {
             // Always ensure that the path begins with '/' if set and something
             // is before the path
-            if (isset($parts['host']) && $parts['path'][0] != '/') {
+            if (!empty($parts['host']) && $parts['path'][0] != '/') {
                 $url .= '/';
             }
             $url .= $parts['path'];

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -78,6 +78,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
         $url = Url::buildUrl(['path' => '0']);
         $this->assertSame('0', $url);
+
+        $url = Url::buildUrl(['host' => '', 'path' => '0']);
+        $this->assertSame('0', $url);
     }
 
     public function testUrlStoresParts()


### PR DESCRIPTION
`Url::buildUrl` accepts an array of parts. When it sets the path, it looks to see whether the hostname has been specified, and if it has - it prepends a `/` to the path. However, it's implementing this check with `isset` - so it's just seeing whether the array key exists, not the value. So it unnecessarily prepends a slash if an array contains a `host` key but no value.

This is affecting a bunch of upstream methods, since `buildUrl` is used by `__toString`. 
