### PR TITLE
Lots of fixes to multipart/form-data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.4.0",
         "ext-json": "*",
-        "guzzlehttp/streams": "~1.0"
+        "guzzlehttp/streams": "~1.3"
     },
 
     "suggest": {
@@ -34,7 +34,7 @@
         "psr-4": {
             "GuzzleHttp\\Tests\\": "tests/"
         }
-    },	
+    },
     "require-dev": {
         "ext-curl": "*",
         "psr/log": "~1.0",

--- a/src/Post/PostBody.php
+++ b/src/Post/PostBody.php
@@ -253,15 +253,19 @@ class PostBody implements PostBodyInterface
     private function createMultipart()
     {
         // Flatten the nested query string values using the correct aggregator
-        $query = (string) (new Query($this->fields))
-            ->setEncodingType(false)
-            ->setAggregator($this->getAggregator());
+        if (!$this->fields) {
+            $fields = [];
+        } else {
+            $query = (string) (new Query($this->fields))
+                ->setEncodingType(false)
+                ->setAggregator($this->getAggregator());
 
-        // Convert the flattened query string back into an array
-        $fields = [];
-        foreach (explode('&', $query, 2) as $kvp) {
-            $parts = explode('=', $kvp);
-            $fields[$parts[0]] = isset($parts[1]) ? $parts[1] : null;
+            // Convert the flattened query string back into an array
+            $fields = [];
+            foreach (explode('&', $query, 2) as $kvp) {
+                $parts = explode('=', $kvp);
+                $fields[$parts[0]] = isset($parts[1]) ? $parts[1] : null;
+            }
         }
 
         return new MultipartBody($fields, $this->files);

--- a/tests/Post/MultipartBodyTest.php
+++ b/tests/Post/MultipartBodyTest.php
@@ -70,42 +70,21 @@ class MultipartBodyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', (string) $b);
     }
 
-    public function testCanOnlySeekTo0()
-    {
-        $b = new MultipartBody();
-        $this->assertFalse($b->seek(10));
-    }
-
     public function testIsSeekableReturnsTrueIfAllAreSeekable()
     {
         $s = $this->getMockBuilder('GuzzleHttp\Stream\StreamInterface')
-            ->setMethods(['isSeekable'])
+            ->setMethods(['isSeekable', 'isReadable'])
             ->getMockForAbstractClass();
         $s->expects($this->once())
             ->method('isSeekable')
             ->will($this->returnValue(false));
+        $s->expects($this->once())
+            ->method('isReadable')
+            ->will($this->returnValue(true));
         $p = new PostFile('foo', $s, 'foo.php');
         $b = new MultipartBody([], [$p]);
         $this->assertFalse($b->isSeekable());
         $this->assertFalse($b->seek(10));
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testThrowsExceptionWhenStreamFailsToRewind()
-    {
-        $s = $this->getMockBuilder('GuzzleHttp\Stream\StreamInterface')
-            ->setMethods(['seek', 'isSeekable'])
-            ->getMockForAbstractClass();
-        $s->expects($this->once())
-            ->method('isSeekable')
-            ->will($this->returnValue(true));
-        $s->expects($this->once())
-            ->method('seek')
-            ->will($this->returnValue(false));
-        $b = new MultipartBody([], [new PostFile('foo', $s, 'foo.php')]);
-        $b->seek(0);
     }
 
     public function testGetContentsCanCap()
@@ -136,11 +115,14 @@ class MultipartBodyTest extends \PHPUnit_Framework_TestCase
     public function testCalculatesSizeAndReturnsNullForUnknown()
     {
         $s = $this->getMockBuilder('GuzzleHttp\Stream\StreamInterface')
-            ->setMethods(['getSize'])
+            ->setMethods(['getSize', 'isReadable'])
             ->getMockForAbstractClass();
         $s->expects($this->once())
             ->method('getSize')
             ->will($this->returnValue(null));
+        $s->expects($this->once())
+            ->method('isReadable')
+            ->will($this->returnValue(true));
         $b = new MultipartBody([], [new PostFile('foo', $s, 'foo.php')]);
         $this->assertNull($b->getSize());
     }


### PR DESCRIPTION
Using the AppendStream to vastly clean up how a multipart POST is created.
This changes also cleans up how the body is sent over the wire, eliminating
some bugs I discovered when fields are sent before files.
