### PR TITLE
Allowing PostBody to support multipart/form-data with base64 encoded string

### DIFF
--- a/src/Post/PostBody.php
+++ b/src/Post/PostBody.php
@@ -260,7 +260,7 @@ class PostBody implements PostBodyInterface
         // Convert the flattened query string back into an array
         $fields = [];
         foreach (explode('&', $query, 2) as $kvp) {
-            $parts = explode('=', $kvp);
+            $parts = explode('=', $kvp, 2);
             $fields[$parts[0]] = isset($parts[1]) ? $parts[1] : null;
         }
 

--- a/tests/Post/PostBodyTest.php
+++ b/tests/Post/PostBodyTest.php
@@ -152,4 +152,19 @@ class PostBodyTest extends \PHPUnit_Framework_TestCase
         $this->assertContains(file_get_contents(__FILE__), $s);
         $this->assertContains('testing=bar', $s);
     }
+
+    public function testMultipartWithBase64Fields()
+    {
+      $b = new PostBody();
+      $b->setField('foo64', '/xA2JhWEqPcgyLRDdir9WSRi/khpb2Lh3ooqv+5VYoc=');
+      $b->forceMultipartUpload(true);
+      $this->assertEquals(['foo64' => '/xA2JhWEqPcgyLRDdir9WSRi/khpb2Lh3ooqv+5VYoc='], $b->getFields());
+      $m = new Request('POST', '/');
+      $b->applyRequestHeaders($m);
+      $this->assertContains('multipart/form-data', (string) $m->getHeader('Content-Type'));
+      $this->assertTrue($m->hasHeader('Content-Length'));
+      $contents = $b->getContents();
+      $this->assertContains('name="foo64"', $contents);
+      $this->assertContains('/xA2JhWEqPcgyLRDdir9WSRi/khpb2Lh3ooqv+5VYoc=', $contents);
+    }
 }


### PR DESCRIPTION
The explode function was not properly getting the key/value from the string.

For example the base64 encoded string "/xA2JhWEqPcgyLRDdir9WSRi/khpb2Lh3ooqv+5VYoc=" was missing the trailing "=" character.

Running the new unit test PostBodyTest::testMultipartWithBase64Fields() without applying the change results in the following error:

```
There was 1 failure:

1) GuzzleHttp\Tests\Post\PostBodyTest::testMultipartWithBase64Fields
Failed asserting that '--53c5c5b905f14
Content-Disposition: form-data; name="foo64"

/xA2JhWEqPcgyLRDdir9WSRi/khpb2Lh3ooqv+5VYoc
' contains "/xA2JhWEqPcgyLRDdir9WSRi/khpb2Lh3ooqv+5VYoc=".

/Users/jamie/ji/guzzle/tests/Post/PostBodyTest.php:168
```
