### PR TITLE
Ensuring that '0' paths can be combined into empty URLs

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -548,7 +548,7 @@ class Url
             );
         }
 
-        if (!$parts['path']) {
+        if (!$parts['path'] && $parts['path'] !== '0') {
             // The relative URL has no path, so check if it is just a query
             $path = $this->path ?: '';
             $query = count($parts['query']) ? $parts['query'] : $this->query;

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -162,7 +162,9 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             ['http://www.example.com/path',       'http://u:a@www.example.com/', 'http://u:a@www.example.com/'],
             ['/path?q=2', 'http://www.test.com/', 'http://www.test.com/path?q=2'],
             ['http://api.flickr.com/services/',   'http://www.flickr.com/services/oauth/access_token', 'http://www.flickr.com/services/oauth/access_token'],
-            ['https://www.example.com/path',       '//foo.com/abc', 'https://foo.com/abc'],
+            ['https://www.example.com/path',      '//foo.com/abc', 'https://foo.com/abc'],
+            ['https://www.example.com/0/',        'relative/foo', 'https://www.example.com/0/relative/foo'],
+            ['',                                  '0', '0'],
             // RFC 3986 test cases
             [self::RFC3986_BASE, 'g:h',           'g:h'],
             [self::RFC3986_BASE, 'g',             'http://a/b/c/g'],


### PR DESCRIPTION
When URLs are combined, it checks to see whether the new URL's path is falsey. Unfortunately, this means that URLs with paths of `string(1) "0"` will fail too and won't be combined properly. This PR handles this edge case.

Before: `"" + "0" = ""`

Now: `"" + "0" = "0"`
