### PR TITLE
Added 'options' to Response->xml() $config parameter.

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -150,7 +150,7 @@ class Response extends AbstractMessage implements ResponseInterface
             // Allow XML to be retrieved even if there is no response body
             $xml = new \SimpleXMLElement(
                 (string) $this->getBody() ?: '<root />',
-                isset($config['options']) ? $config['options'] : LIBXML_NONET,
+                isset($config['libxml_options']) ? $config['libxml_options'] : LIBXML_NONET,
                 isset($config['ns']) ? $config['ns'] : '',
                 isset($config['ns_is_prefix']) ? $config['ns_is_prefix'] : false
             );

--- a/src/Message/ResponseInterface.php
+++ b/src/Message/ResponseInterface.php
@@ -77,6 +77,9 @@ interface ResponseInterface extends MessageInterface
      *     - ns: Set to a string to represent the namespace prefix or URI
      *     - ns_is_prefix: Set to true to specify that the NS is a prefix rather
      *       than a URI (defaults to false).
+     *     - libxml_options: Bitwise OR of the libxml option constants
+     *       listed at http://php.net/manual/en/libxml.constants.php
+     *       (defaults to LIBXML_NONET)
      *
      * @return \SimpleXMLElement
      * @throws \RuntimeException if the response body is not in XML format


### PR DESCRIPTION
Enables the passing of options to the SimpleXMLElement instance, eg:

`$xml = $response->xml(['options'=>LIBXML_NONET|LIBXML_NOCDATA]);`
