### PR TITLE
Replacing github example with httpbin

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -50,7 +50,7 @@ then you'll need to use a ``GuzzleHttp\ClientInterface`` object.
     use GuzzleHttp\Client;
 
     $client = new Client();
-    $response = $client->get('https://github.com/timeline.json');
+    $response = $client->get('http://httpbin.org/get');
 
     // You can use the same methods you saw in the procedural API
     $response = $client->delete('http://httpbin.org/delete');
@@ -120,9 +120,9 @@ response.
 
 .. code-block:: php
 
-    $response = $client->get('https://github.com/timeline.json');
+    $response = $client->get('http://httpbin.org/get');
     $json = $response->json();
-    var_dump($json[0]['repository']);
+    var_dump($json[0]['origin']);
 
 Guzzle internally uses PHP's ``json_decode()`` function to parse responses. If
 Guzzle is unable to parse the JSON response body, then a


### PR DESCRIPTION
This is a follow up of a question by lokapujya from the IRC channel who was wondering why the example from the quickstart docs didn't work for him.

https://github.com/timeline.json has been removed and delivers a JSON message with a 410 HTTP Status code. The change to http://httpbin.org/get follows the other request examples.

Cheers!
:octocat: Jérôme
