### PR TITLE
Test ampersand in multipart field value

### DIFF
--- a/tests/Post/PostBodyTest.php
+++ b/tests/Post/PostBodyTest.php
@@ -177,4 +177,19 @@ class PostBodyTest extends \PHPUnit_Framework_TestCase
       $this->assertContains('name="foo64"', $contents);
       $this->assertContains('/xA2JhWEqPcgyLRDdir9WSRi/khpb2Lh3ooqv+5VYoc=', $contents);
     }
+
+    public function testMultipartWithAmpersandInValue()
+    {
+        $b = new PostBody();
+        $b->setField('a', 'b&c=d');
+        $b->forceMultipartUpload(true);
+        $this->assertEquals(['a' => 'b&c=d'], $b->getFields());
+        $m = new Request('POST', '/');
+        $b->applyRequestHeaders($m);
+        $this->assertContains('multipart/form-data', (string) $m->getHeader('Content-Type'));
+        $this->assertTrue($m->hasHeader('Content-Length'));
+        $contents = $b->getContents();
+        $this->assertContains('name="a"', $contents);
+        $this->assertContains('b&c=d', $contents);
+    }
 }


### PR DESCRIPTION
Using Guzzle 4.1.2, I was POSTing some key/values and files (ie. multipart), and received a Bad Request response stating a date was formatted incorrectly. The original date string was `2013-12-20T09:52:49+0100`, but it is posted as `2013-12-20T09:52:49 0100`. Note that the plus sign was replaced by a space.

This is fixed by 14f08734, but this doesn't fully address the issue. In the PR you'll find a failing test. My question is: why not encode and decode the query string? AFAIK this prevents data loss.

My suggestion is to apply the below patch. I encoded according to RFC3986, as this is used by `rawurl*code()`.

``` diff
diff --git a/src/Post/PostBody.php b/src/Post/PostBody.php
index 2848db6..2c4a50e 100644
--- a/src/Post/PostBody.php
+++ b/src/Post/PostBody.php
@@ -257,14 +257,14 @@ class PostBody implements PostBodyInterface
             $fields = [];
         } else {
             $query = (string) (new Query($this->fields))
-                ->setEncodingType(false)
+                ->setEncodingType(Query::RFC3986)
                 ->setAggregator($this->getAggregator());

             // Convert the flattened query string back into an array
             $fields = [];
             foreach (explode('&', $query) as $kvp) {
                 $parts = explode('=', $kvp, 2);
-                $fields[$parts[0]] = isset($parts[1]) ? $parts[1] : null;
+                $fields[rawurldecode($parts[0])] = isset($parts[1]) ? rawurldecode($parts[1]) : null;
             }
         }
```
