### PR TITLE
Updated TransactionIterator::rewind()

### DIFF
--- a/src/Adapter/TransactionIterator.php
+++ b/src/Adapter/TransactionIterator.php
@@ -69,5 +69,10 @@ class TransactionIterator implements \Iterator
         return $this->source->valid();
     }
 
-    public function rewind() {}
+    public function rewind()
+    {
+        if (!($this->source instanceof \Generator)) {
+            $this->source->rewind();
+        }
+    }
 }


### PR DESCRIPTION
Updated `TransactionIterator::rewind()` to call the `rewind()` of the inner iterator. This resolves problems that might arise if the inner iterator requires rewinding in order to yield items (e.g., anything that is `instanceof IteratorIterator`).
