### PR TITLE
Revert "Bumped the minor version"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "4.3-dev"
+            "dev-master": "4.2-dev"
         }
     }
 }


### PR DESCRIPTION
This is not needed since the proposed breaking changes were cancelled and moved to 5.0.
