### PR TITLE
Alias the ring branch to 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0-dev"
+            "dev-ring": "5.0-dev"
         }
     }
 }


### PR DESCRIPTION
This allows people to install guzzle 5 and get this branch. I suggested this change over on your pull request on your command repo.
