### PR TITLE
Fixing CookieJar cookie-string per RFC 6265

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -225,7 +225,7 @@ class CookieJar implements CookieJarInterface, ToArrayInterface
         }
 
         if ($values) {
-            $request->setHeader('Cookie', implode(';', $values));
+            $request->setHeader('Cookie', implode('; ', $values));
         }
     }
 

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -228,10 +228,10 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
     public function getMatchingCookiesDataProvider()
     {
         return array(
-            array('https://example.com', 'foo=bar;baz=foobar'),
+            array('https://example.com', 'foo=bar; baz=foobar'),
             array('http://example.com', ''),
-            array('https://example.com:8912', 'foo=bar;baz=foobar'),
-            array('https://foo.example.com', 'foo=bar;baz=foobar'),
+            array('https://example.com:8912', 'foo=bar; baz=foobar'),
+            array('https://foo.example.com', 'foo=bar; baz=foobar'),
             array('http://foo.example.com/test/acme/', 'googoo=gaga')
         );
     }


### PR DESCRIPTION
Cookie-string format is now: 

```
foo=bar; bizz=buzz
```

instead of: 

```
foo=bar;fizz=buzz
```

Fixes #822
