### PR TITLE
Non-seekable streams do not work

### DIFF
--- a/src/Adapter/StreamAdapter.php
+++ b/src/Adapter/StreamAdapter.php
@@ -84,7 +84,7 @@ class StreamAdapter implements AdapterInterface
         $response = $this->messageFactory->createResponse(
             $parts[1],
             $this->headersFromLines($headers),
-            null,
+            $stream,
             $options
         );
 


### PR DESCRIPTION
I've followed [documentation](http://guzzle.readthedocs.org/en/latest/streams.html#cachingstream) and used `CachingStream` to work with non-seekable streams for some time now. After upgrading to 4.2.x it stopped working. 

This example works prior 4.2.x. After upgrading the second call to response body is empty. I use guzzles event system and call `->getBody()` multiple times for manipulation.

``` php
class MyMessageFactory extends \GuzzleHttp\Message\MessageFactory {
    public function createResponse($statusCode, array $headers = [], $body = null, array $options = []) {
        if (null !== $body) {
            $body = new \GuzzleHttp\Stream\CachingStream(
                \GuzzleHttp\Stream\Stream::factory($body)
            );
        }

        return new \GuzzleHttp\Message\Response($statusCode, $headers, $body, $options);
    }
}

$client = new \GuzzleHttp\Client([
    'message_factory' => new MyMessageFactory()
]);
$response = $client->get('http://www.google.de', ['stream' => true]);

$body = (string) $response->getBody();
// "<html>...</html"
$body2 = (string) $response->getBody();
// ""
```

With recent changes, argument `$body` of `createResponse` becomes always `null`.
