### PR TITLE
Adding PHPDoc to GuzzleHTTP/Client::send() to fix type warning detection...

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -186,6 +186,13 @@ class Client implements ClientInterface
         return $this->send($this->createRequest('OPTIONS', $url, $options));
     }
 
+    /**
+     * Sends the request.
+     * @param Message\RequestInterface $request
+     * @return Message\ResponseInterface
+     * @throws Exception\RequestException
+     * @throws \Exception
+     */
     public function send(RequestInterface $request)
     {
         $transaction = new Transaction($this, $request);


### PR DESCRIPTION
This was causing problems in PHPStorm code inspection - it read the send() code as returning a void, which clearly is not the case.
