### PR TITLE
fix phpdoc comment

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -139,7 +139,7 @@ interface ClientInterface extends HasEmitterInterface
      * @param array           $options  Associative array of options
      *     - parallel: (int) Maximum number of requests to send in parallel
      *     - before: (callable|array) Receives a BeforeEvent
-     *     - after: (callable|array) Receives a CompleteEvent
+     *     - complete: (callable|array) Receives a CompleteEvent
      *     - error: (callable|array) Receives a ErrorEvent
      *
      * @throws AdapterException When an error occurs in the HTTP adapter.


### PR DESCRIPTION
Fixed small inaccuracy: in `\GuzzleHttp\Adapter\TransactionIterator` options called `['before', 'complete', 'error']` (http://guzzle.readthedocs.org/en/latest/clients.html#asynchronous-response-handling).

See https://github.com/guzzle/guzzle/blob/4.2.2/src/Adapter/TransactionIterator.php#L34
