### PR TITLE
Remove default message in RequestException

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -23,7 +23,7 @@ class RequestException extends TransferException
     private $throwImmediately = false;
 
     public function __construct(
-        $message = '',
+        $message,
         RequestInterface $request,
         ResponseInterface $response = null,
         \Exception $previous = null


### PR DESCRIPTION
The default message value in RequestException could never be used as a result of the requirement for a request. This fix removes the default value of '' from the constructor to improve clarity.

Fixes #844.
