### PR TITLE
Fixed issue with NET MVC 4 multipart uploads

### DIFF
--- a/src/Post/MultipartBody.php
+++ b/src/Post/MultipartBody.php
@@ -101,13 +101,8 @@ class MultipartBody implements StreamInterface
             $stream->addStream(Stream::factory("\r\n"));
         }
 
-        // Add the trailing boundary
-        $stream->addStream(Stream::factory("--{$this->boundary}--"));
-
-        // .NET's MVC 4 fails to parse multipart uploads which lack a trailing CRLF.
-        // This is safe to add to all multipart requests since it is after the final boundary
-        // which is considered part of the epilogue and is ignored (per RFC1341 section 7.2.1).
-        $stream->addStream(Stream::factory("\r\n"));
+        // Add the trailing boundary with CRLF
+        $stream->addStream(Stream::factory("--{$this->boundary}--\r\n"));
 
         return $stream;
     }


### PR DESCRIPTION
.NET's MVC 4 fails to parse multipart uploads which lack a trailing CRLF. This is safe to add to all multipart requests since it is after the final boundary which is considered part of the epilogue and is ignored (per RFC1341 section 7.2.1).
