### PR TITLE
Fixing typos in the FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -97,7 +97,7 @@ exception.
 
 .. code-block:: php
 
-    $request = $client->createRequest('GET', ['future' => true']);
+    $request = $client->createRequest('GET', ['future' => true]);
     $client->send($request)->then(function ($response) {
         echo 'Got a response! ' . $response;
     });
@@ -107,7 +107,7 @@ of a response.
 
 .. code-block:: php
 
-    $request = $client->createRequest('GET', ['future' => true']);
+    $request = $client->createRequest('GET', ['future' => true]);
     $futureResponse = $client->send($request);
     $futureResponse->wait();
 


### PR DESCRIPTION
The extra trailing quote marks are unnecessary/invalid, and break the syntax highlighting in the example (and would cause a syntax error in actual code).
