### PR TITLE
Add Fixture Subscriber

### DIFF
--- a/src/Subscriber/Fixture.php
+++ b/src/Subscriber/Fixture.php
@@ -1,0 +1,124 @@
+<?php
+namespace GuzzleHttp\Subscriber;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Event\BeforeEvent;
+use GuzzleHttp\Event\CompleteEvent;
+use GuzzleHttp\Event\RequestEvents;
+use GuzzleHttp\Event\SubscriberInterface;
+use GuzzleHttp\Message\MessageFactory;
+use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Message\ResponseInterface;
+
+/**
+ * Stores responses in and delivers from local fixture files
+ *
+ * - The name of a fixture file is an MD5 hash of the complete request body.
+ * - Mocked responses are not stored
+ * - If a fixture file is not already present, an actual request is being sent once,
+ *   subsequent requests will be served
+ */
+class Fixture implements SubscriberInterface
+{
+    /** @var string Local fixtures storage path */
+    protected $path;
+
+    /** @var MessageFactory */
+    protected $factory;
+
+    /**
+     * @param string $fixturesPath Location to store the fixtures in
+     */
+    public function __construct($fixturesPath)
+    {
+        $this->factory = new MessageFactory();
+        $this->initFixturesPath($fixturesPath);
+    }
+
+    /**
+     * Create the given fixtures path, if not already there
+     *
+     * @param string $path
+     */
+    protected function initFixturesPath($path)
+    {
+        if (!is_dir($path)) {
+            mkdir($path, 0777, true);
+        }
+
+        $this->path = $path;
+    }
+
+    public function getEvents()
+    {
+        return [
+            'before' => ['onBefore', RequestEvents::SIGN_REQUEST - 20],
+            'complete' => ['onComplete', RequestEvents::EARLY],
+        ];
+    }
+
+    public function onBefore(BeforeEvent $event)
+    {
+        if ($response = $this->getResponseFromFixture($event->getRequest())) {
+            $event->intercept($response);
+        }
+    }
+
+    public function onComplete(CompleteEvent $event)
+    {
+        if ($this->clientHasMockSubscriber($event->getClient())) {
+            // Don't store already mocked responses
+            return;
+        }
+
+        $this->createFixture($event->getRequest(), $event->getResponse());
+    }
+
+    /**
+     * Returns true if the client has a mock subscriber attached
+     *
+     * @param ClientInterface $client
+     * @return bool
+     */
+    protected function clientHasMockSubscriber(ClientInterface $client)
+    {
+        $beforeListeners = $client->getEmitter()->listeners('before');
+        foreach( $beforeListeners as $listener) {
+            if ($listener[0] instanceof Mock) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return \GuzzleHttp\Message\ResponseInterface|null
+     */
+    protected function getResponseFromFixture(RequestInterface $request)
+    {
+        $hash = md5((string) $request);
+        $file = $this->path . DIRECTORY_SEPARATOR . $hash . '.fixture';
+
+        return file_exists($file)
+            ? $this->factory->fromMessage(file_get_contents($file))
+            : null;
+    }
+
+    /**
+     * Writes a response string to a file named after the request
+     *
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
+     * @return bool true on success, false on failure
+     */
+    protected function createFixture(RequestInterface $request, ResponseInterface $response)
+    {
+        $hash = md5((string) $request);
+        $file = $this->path . DIRECTORY_SEPARATOR . $hash . '.fixture';
+        $responseString = (string) $response;
+
+        return file_put_contents($file, $responseString) !== false;
+    }
+} 

--- a/tests/Subscriber/FixtureTest.php
+++ b/tests/Subscriber/FixtureTest.php
@@ -1,0 +1,107 @@
+<?php
+namespace GuzzleHttp\Tests\Subscriber;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Event\BeforeEvent;
+use GuzzleHttp\Event\CompleteEvent;
+use GuzzleHttp\Message\Request;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Subscriber\Fixture;
+use GuzzleHttp\Subscriber\Mock;
+use GuzzleHttp\Transaction;
+
+/**
+ * @covers GuzzleHttp\Subscriber\Fixture
+ */
+class FixtureTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var string */
+    protected $tmpPath;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->tmpPath = '/tmp/' . uniqid('guzzle_fixture', true);
+    }
+
+    public function testCreatesFixturesPath()
+    {
+        $f = new Fixture($this->tmpPath);
+
+        $path = $this->readAttribute($f, 'path');
+        $this->assertEquals($this->tmpPath, $path);
+        $this->assertFileExists($path);
+    }
+
+    public function testDescribesSubscribedEvents()
+    {
+        $f = new Fixture($this->tmpPath);
+        $this->assertInternalType('array', $f->getEvents());
+    }
+
+    public function testDoesNotGetResponseFromFixture()
+    {
+        $t = new Transaction(new Client(), new Request('GET', '/'));
+        $e = new BeforeEvent($t);
+        $f = new Fixture($this->tmpPath);
+        $f->onBefore($e);
+
+        $this->assertFalse($e->isPropagationStopped());
+    }
+
+    public function testGetsResponseFromFixture()
+    {
+        $request = new Request('GET', '/');
+        $response = new Response(200);
+        $responseString = (string) $response;
+
+        mkdir($this->tmpPath, 0777, true);
+        $fileName = $this->tmpPath . '/' . md5((string) $request) . '.fixture';
+        file_put_contents($fileName, $responseString);
+
+        $t = new Transaction(new Client(), $request);
+        $e = new BeforeEvent($t);
+        $f = new Fixture($this->tmpPath);
+        $f->onBefore($e);
+
+        $this->assertTrue($e->isPropagationStopped());
+        $this->assertEquals($response, $t->response);
+        $this->assertEquals((string) $response, (string) $t->response);
+    }
+
+    public function testWritesResponseToFixture()
+    {
+        $request = new Request('GET', '/');
+        $response = new Response(200);
+        $fileName = $this->tmpPath . '/' . md5($request) . '.fixture';
+
+        $t = new Transaction(new Client(), $request);
+        $t->response = $response;
+        $e = new CompleteEvent($t);
+        $f = new Fixture($this->tmpPath);
+        $f->onComplete($e);
+
+        $this->assertFileExists($fileName);
+        $this->assertEquals((string) $response, file_get_contents($fileName));
+    }
+
+    public function testDoesNotWriteFixtureWhenResponseIsMocked()
+    {
+        $client = new Client(['base_url' => 'http://test.com']);
+        $mockedResponse = new Response(200);
+        $mock = new Mock([$mockedResponse]);
+        $f = new Fixture($this->tmpPath);
+        $client->getEmitter()->attach($mock);
+        $client->getEmitter()->attach($f);
+
+        $request = $client->createRequest('GET', '/');
+        $fileName = $this->tmpPath . '/' . md5($request) . '.fixture';
+
+        $response = $client->send($request);
+
+        $this->assertFileNotExists($fileName);
+        $this->assertSame($response, $mockedResponse);
+    }
+}
+ 


### PR DESCRIPTION
If you're writing tests for an application that consumes a remote API, it can be quite tedious to craft the mocks for each possible response manually, especially when the responses contain complex data that has to be used for further tests.

The Fixture Subscriber enables you to actually hit your remote API when you execute your tests for the first time (preferably on your local machine), and only then. It will store the responses into files and use those on subsequent test runs and never hit the real API again.

Here is an example of how it works:

``` php
use GuzzleHttp\Client;
use GuzzleHttp\Subscriber\Fixture;
use GuzzleHttp\Message\Response;

$client = new Client(['base_url' => 'http://httpstat.us']);
$fixture = new Fixture(__DIR__ . '/_fixtures');
$client->getEmitter()->attach($fixture);

$response = $this->client->get('/200');
```

The first run of this snippet will trigger an actual call to the remote API and store the response string to a file named `c950f693fb16b7d5672de736d6db462e.fixture` in the `_fixtures` directory.

When you run the snippet again, the response will be taken from this file instead of the actual remote endpoint.

When all your tests have run through, you can commit the fixture files to your code base, so that test runs on CI systems (Travis CI, Jenkins, etc.) without hitting the actual remote API.

When the remote API changes, just delete all the fixture files and restart.
### Notes
- The file names are MD5 hashes of the complete request string, which enables you to test the same URL with different variables
- Responses mocked with the Mock Subscriber will not be handled by the Fixture Subscriber, so that you can continue to use manually created mocks without duplicating them on the file system.

I also thought about extending the documentation, too, but without knowing if you would consider integrating this Subscriber into Guzzle, I preferred to wait with that. In addition to that, you certainly already have noticed that I am not a native speaker :).

Cheers
:octocat: Jérôme
