### PR TITLE
Allow "0" (and any other falsy) URI paths

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -181,11 +181,13 @@ class Client implements ClientInterface
         // Use a clone of the client's emitter
         $options['config']['emitter'] = clone $this->getEmitter();
 
-        $request = $this->messageFactory->createRequest(
-            $method,
-            $url ? (string) $this->buildUrl($url) : (string) $this->baseUrl,
-            $options
-        );
+        if ((is_string($url) && strlen($url)) || $url) {
+          $url = $this->buildUrl($url);
+        } else {
+          $url = (string) $this->baseUrl;
+        }
+
+        $request = $this->messageFactory->createRequest($method, $url, $options);
 
         // Merge in default headers
         if ($headers) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -272,6 +272,15 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFalsyPathsAreCombinedWithBaseUrl()
+    {
+        $client = new Client(['base_url' => 'http://www.foo.com/baz?bam=bar']);
+        $this->assertEquals(
+            'http://www.foo.com/0',
+            $client->createRequest('GET', '0')->getUrl()
+        );
+    }
+
     public function testUsesBaseUrlCombinedWithProvidedUrlViaUriTemplate()
     {
         $client = new Client(['base_url' => 'http://www.foo.com/baz?bam=bar']);


### PR DESCRIPTION
Some strings are not converted into proper URLs when Request objects are created through `createRequest`. For example, passing a `string(1) "0"` will fail because [this ternary conditional](https://github.com/guzzle/guzzle/blob/master/src/Client.php#L186) isn't assigning it properly (it refuses to combine any false-like values). But there are a lot of use cases where the before mentioned strings are needed, say doing a `POST` on `http://foo.com/0`. I've added a test case, so hopefully that should explain what I mean.
