### PR TITLE
Setting a request option to null will ensure it is not set.

### DIFF
--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -227,12 +227,8 @@ class MessageFactory implements MessageFactoryInterface
                 if (!is_array($value)) {
                     throw new Iae('header value must be an array');
                 }
-
-                // Do not overwrite existing headers
                 foreach ($value as $k => $v) {
-                    if (!$request->hasHeader($k)) {
-                        $request->setHeader($k, $v);
-                    }
+                    $request->setHeader($k, $v);
                 }
                 break;
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -245,6 +245,15 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('custom', $request->getHeader('Foo'));
     }
 
+    public function testCanOverrideDefaultOptionWithNull()
+    {
+        $client = new Client(['defaults' => ['proxy' => 'invalid!']]);
+        $request = $client->createRequest('GET', 'http://foo.com?a=b', [
+            'proxy' => null
+        ]);
+        $this->assertFalse($request->getConfig()->hasKey('proxy'));
+    }
+
     public function testDoesNotOverwriteExistingUA()
     {
         $client = new Client(['defaults' => [


### PR DESCRIPTION
This commit makes it so that setting a request option to null will
ensure that the option is not set by the single request or as a result
of merging in default client settings (like being able to override proxy
on a one-off basis).
