### PR TITLE
Allow dynamic pool sizing.

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -63,7 +63,10 @@ class Pool implements FutureInterface
      * @param ClientInterface $client   Client used to send the requests.
      * @param array|\Iterator $requests Requests to send in parallel
      * @param array           $options  Associative array of options
-     *     - pool_size: (int) Maximum number of requests to send concurrently
+     *     - pool_size: (callable|int)   Maximum number of requests to send
+     *                                   concurrently, or a callback that receives
+     *                                   the current queue size and returns the
+     *                                   number of new requests to send
      *     - before:    (callable|array) Receives a BeforeEvent
      *     - complete:  (callable|array) Receives a CompleteEvent
      *     - error:     (callable|array) Receives a ErrorEvent
@@ -146,6 +149,26 @@ class Pool implements FutureInterface
         (new self($client, $requests, $options))->wait();
     }
 
+    private function getPoolSize()
+    {
+        return is_callable($this->poolSize)
+            ? call_user_func($this->poolSize, count($this->waitQueue))
+            : $this->poolSize;
+    }
+
+    /**
+     * Add as many requests as possible up to the current pool limit.
+     */
+    private function addNextRequests()
+    {
+        $limit = max($this->getPoolSize() - count($this->waitQueue), 0);
+        while ($limit--) {
+            if (!$this->addNextRequest()) {
+                break;
+            }
+        }
+    }
+
     public function wait()
     {
         if ($this->isRealized) {
@@ -153,11 +176,7 @@ class Pool implements FutureInterface
         }
 
         // Seed the pool with N number of requests.
-        for ($i = 0; $i < $this->poolSize; $i++) {
-            if (!$this->addNextRequest()) {
-                break;
-            }
-        }
+        $this->addNextRequests();
 
         // Stop if the pool was cancelled while transferring requests.
         if ($this->isRealized) {
@@ -284,7 +303,7 @@ class Pool implements FutureInterface
         // Use this function for both resolution and rejection.
         $thenFn = function ($value) use ($request, $hash) {
             $this->finishResponse($request, $value, $hash);
-            $this->addNextRequest();
+            $this->addNextRequests();
         };
 
         $promise->then($thenFn, $thenFn);

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -154,6 +154,64 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($responses[3], $result[2]->getResponse());
     }
 
+    public function testBatchesRequestsWithDynamicPoolSize()
+    {
+        $client = new Client(['handler' => function () {
+            throw new \RuntimeException('No network access');
+        }]);
+
+        $responses = [
+            new Response(301, ['Location' => 'http://foo.com/bar']),
+            new Response(200),
+            new Response(200),
+            new Response(404)
+        ];
+
+        $client->getEmitter()->attach(new Mock($responses));
+        $requests = [
+            $client->createRequest('GET', 'http://foo.com/baz'),
+            $client->createRequest('HEAD', 'http://httpbin.org/get'),
+            $client->createRequest('PUT', 'http://httpbin.org/put'),
+        ];
+
+        $a = $b = $c = $d = 0;
+        $result = Pool::batch($client, $requests, [
+            'before'    => function (BeforeEvent $e) use (&$a) { $a++; },
+            'complete'  => function (CompleteEvent $e) use (&$b) { $b++; },
+            'error'     => function (ErrorEvent $e) use (&$c) { $c++; },
+            'end'       => function (EndEvent $e) use (&$d) { $d++; },
+            'pool_size' => function ($queueSize) {
+                static $options = [1, 2, 1];
+                static $queued  = 0;
+
+                $this->assertEquals(
+                    $queued,
+                    $queueSize,
+                    'The number of queued requests should be equal to the sum of pool sizes so far.'
+                );
+
+                $next    = array_shift($options);
+                $queued += $next;
+
+                return $next;
+            }
+        ]);
+
+        $this->assertEquals(4, $a);
+        $this->assertEquals(2, $b);
+        $this->assertEquals(1, $c);
+        $this->assertEquals(3, $d);
+        $this->assertCount(3, $result);
+        $this->assertInstanceOf('GuzzleHttp\BatchResults', $result);
+
+        // The first result is actually the second (redirect) response.
+        $this->assertSame($responses[1], $result[0]);
+        // The second result is a 1:1 request:response map
+        $this->assertSame($responses[2], $result[1]);
+        // The third entry is the 404 RequestException
+        $this->assertSame($responses[3], $result[2]->getResponse());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Each event listener must be a callable or


### PR DESCRIPTION
Allows the number of requests allowed in a pool to vary over time by
retrieving the current pool size from a callback instead of a single
constant number.

This allows us to amend the number of requests ongoing according to our
needs, e.g. by responding to rate limiting information provided by an
upstream API.

Changes are
- Allow a callback to be passed in to specify the pool size instead of a
  constant pool size.
- As each request returns, add enough new requests to the queue to fill
  up to the current pool size limit.
