### PR TITLE
Added new PostField class to allow header with simple fields (multipart request fix)

### DIFF
--- a/src/Post/PostBody.php
+++ b/src/Post/PostBody.php
@@ -66,6 +66,20 @@ class PostBody implements PostBodyInterface
         $this->mutate();
     }
 
+    public function addField(PostFieldInterface $field)
+    {
+        $name = $field->getName();
+
+        if (empty($name)) {
+            $this->fields[] = $field;
+            $this->mutate();
+            return;
+        }
+
+        $this->setField($name, $field);
+
+    }
+
     public function replaceFields(array $fields)
     {
         $this->fields = $fields;

--- a/src/Post/PostElementInterface.php
+++ b/src/Post/PostElementInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace GuzzleHttp\Post;
+
+interface PostElementInterface
+{
+    /**
+     * Gets all POST headers of the element.
+     *
+     * The keys represent the header name as it will be sent over the wire, and
+     * each value is a string.
+     *
+     * @return array Returns an associative array of the file's headers.
+     */
+    public function getHeaders();
+
+    /**
+     * Add an header to the post element
+     *
+     * @param string $name
+     * @param string $value
+     * @return self
+     */
+    public function addHeader($name, $value);
+}

--- a/src/Post/PostField.php
+++ b/src/Post/PostField.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace GuzzleHttp\Post;
+
+class PostField implements PostFieldInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @var array
+     */
+    private $headers;
+
+    /**
+     * @param string $value
+     * @param string $name
+     * @param array  $headers
+     */
+    public function __construct($value, $name = null, $headers = [])
+    {
+        $this->name = $name;
+        $this->value = $value;
+        $this->headers = $headers;
+    }
+
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    public function addHeader($name, $value)
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function __toString()
+    {
+        return $this->getValue();
+    }
+}

--- a/src/Post/PostFieldInterface.php
+++ b/src/Post/PostFieldInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace GuzzleHttp\Post;
+
+/**
+ * Interface post field interface
+ */
+interface PostFieldInterface extends PostElementInterface
+{
+    /**
+     * Get the name of the field
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Get the value of the field
+     *
+     * @return string
+     */
+    public function getValue();
+
+    /**
+     * Return the value (alias of getValue)
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/src/Post/PostFile.php
+++ b/src/Post/PostFile.php
@@ -36,6 +36,13 @@ class PostFile implements PostFileInterface
         $this->prepareDefaultHeaders();
     }
 
+    public function addHeader($name, $value)
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
     public function getName()
     {
         return $this->name;

--- a/src/Post/PostFileInterface.php
+++ b/src/Post/PostFileInterface.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Stream\StreamInterface;
 /**
  * Post file upload interface
  */
-interface PostFileInterface
+interface PostFileInterface extends PostElementInterface
 {
     /**
      * Get the name of the form field
@@ -28,14 +28,4 @@ interface PostFileInterface
      * @return StreamInterface
      */
     public function getContent();
-
-    /**
-     * Gets all POST file headers.
-     *
-     * The keys represent the header name as it will be sent over the wire, and
-     * each value is a string.
-     *
-     * @return array Returns an associative array of the file's headers.
-     */
-    public function getHeaders();
 }

--- a/tests/Post/PostBodyTest.php
+++ b/tests/Post/PostBodyTest.php
@@ -3,6 +3,7 @@ namespace GuzzleHttp\Tests\Post;
 
 use GuzzleHttp\Message\Request;
 use GuzzleHttp\Post\PostBody;
+use GuzzleHttp\Post\PostField;
 use GuzzleHttp\Post\PostFile;
 use GuzzleHttp\Query;
 
@@ -122,14 +123,15 @@ class PostBodyTest extends \PHPUnit_Framework_TestCase
     {
         $b = new PostBody();
         $b->setField('foo', 'bar');
+        $b->addField(new PostField('foovalue', 'barname'));
         $b->setField('baz', '123');
-        $this->assertEquals('foo=bar&baz=123', $b);
-        $this->assertEquals(15, $b->getSize());
+        $this->assertEquals('foo=bar&barname=foovalue&baz=123', $b);
+        $this->assertEquals(32, $b->getSize());
         $b->seek(0);
-        $this->assertEquals('foo=bar&baz=123', $b->getContents());
+        $this->assertEquals('foo=bar&barname=foovalue&baz=123', $b->getContents());
         $b->seek(0);
-        $this->assertEquals('foo=bar&baz=123', $b->read(1000));
-        $this->assertEquals(15, $b->tell());
+        $this->assertEquals('foo=bar&barname=foovalue&baz=123', $b->read(1000));
+        $this->assertEquals(32, $b->tell());
     }
 
     public function testCanSpecifyQueryAggregator()
@@ -173,11 +175,13 @@ class PostBodyTest extends \PHPUnit_Framework_TestCase
         $b = new PostBody();
         $b->setField('testing', ['baz', 'bar']);
         $b->setField('other', 'hi');
+        $b->addField(new PostField('{"content": "some random json content"}', null, ['Content-Type' => 'application/json']));
         $b->setField('third', 'there');
         $b->addFile(new PostFile('foo', fopen(__FILE__, 'r')));
         $s = (string) $b;
         $this->assertContains(file_get_contents(__FILE__), $s);
         $this->assertContains('testing=bar', $s);
+        $this->assertContains('Content-Type: application/json', $s);
         $this->assertContains(
             'Content-Disposition: form-data; name="third"',
             $s


### PR DESCRIPTION
Hello,

I had a problem using Guzzle: I needed to make a "classic" multipart request. That means that I didn't want to make a "form post". And for now guzzle can only make multipart request like a form.

With my changes you can now add fields that doesn't have name. It will generate part without "Content-Disposition" header. Also you can add an header for a field, like that you can specify the type of your part or any other header you want.

Actually my changes are not perfect IMO but here are my motivation to change like that:
* Avoid modifying the logic of the current code
* Access of methods to avoid adding potential deprecations needs in the future

I think the test is complete but i'm not sure about that, please check it.

I hope you will like this PR :-) .

> For more info, see here: http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html