### PR TITLE
Waiting on deep futuress when necessary to deal with retries.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -234,11 +234,12 @@ class Client implements ClientInterface
 
     public function send(RequestInterface $request)
     {
-        $trans = new Transaction($this, $request);
+        $isFuture = $request->getConfig()->get('future');
+        $trans = new Transaction($this, $request, $isFuture);
         $fn = $this->fsm;
 
         // Ensure a future response is returned if one was requested.
-        if ($request->getConfig()->get('future')) {
+        if ($isFuture) {
             try {
                 $fn($trans);
                 // Turn the normal response into a future if needed.

--- a/src/Event/AbstractRetryableEvent.php
+++ b/src/Event/AbstractRetryableEvent.php
@@ -27,9 +27,9 @@ class AbstractRetryableEvent extends AbstractTransferEvent
      */
     public function retry($afterDelay = 0)
     {
-        $this->transaction->response = null;
-        $this->transaction->exception = null;
-        $this->transaction->state = 'before';
+        // Setting the transition state to 'retry' will cause the next state
+        // transition of the transaction to retry the request.
+        $this->transaction->state = 'retry';
 
         if ($afterDelay) {
             $this->transaction->request->getConfig()->set('delay', $afterDelay);

--- a/src/Event/AbstractTransferEvent.php
+++ b/src/Event/AbstractTransferEvent.php
@@ -20,11 +20,23 @@ abstract class AbstractTransferEvent extends AbstractRequestEvent
      */
     public function getTransferInfo($name = null)
     {
-        return !$name
-            ? $this->transaction->transferInfo
-            : (isset($this->transaction->transferInfo[$name])
-                ? $this->transaction->transferInfo[$name]
-                : null);
+        if (!$name) {
+            return $this->transaction->transferInfo;
+        }
+
+        return isset($this->transaction->transferInfo[$name])
+            ? $this->transaction->transferInfo[$name]
+            : null;
+    }
+
+    /**
+     * Get the number of transaction retries.
+     *
+     * @return int
+     */
+    public function getRetryCount()
+    {
+        return $this->transaction->retries;
     }
 
     /**

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -56,30 +56,48 @@ class Transaction
     public $transferInfo = [];
 
     /**
-     * The transaction's state.
+     * The number of transaction retries.
+     *
+     * @var int
+     */
+    public $retries = 0;
+
+    /**
+     * The transaction's current state.
      *
      * @var string
      */
     public $state;
 
     /**
-     * The number of state transitions that this transactions has been through.
+     * Whether or not this is a future transaction. This value should not be
+     * changed after the future is constructed.
+     *
+     * @var bool
+     */
+    public $future;
+
+    /**
+     * The number of state transitions that this transaction has been through.
      *
      * @var int
      * @internal This is for internal use only. If you modify this, then you
      *           are asking for trouble.
      */
-    public $_transitionCount;
+    public $_transitionCount = 0;
 
     /**
      * @param ClientInterface  $client  Client that is used to send the requests
      * @param RequestInterface $request Request to send
+     * @param bool             $future  Whether or not this is a future request.
      */
     public function __construct(
         ClientInterface $client,
-        RequestInterface $request
+        RequestInterface $request,
+        $future = false
     ) {
         $this->client = $client;
         $this->request = $request;
+        $this->_future = $future;
     }
 }

--- a/tests/Event/AbstractRetryableEventTest.php
+++ b/tests/Event/AbstractRetryableEventTest.php
@@ -19,7 +19,7 @@ class AbstractRetryableEventTest extends \PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
         $e->retry();
         $this->assertTrue($e->isPropagationStopped());
-        $this->assertEquals('before', $t->state);
+        $this->assertEquals('retry', $t->state);
     }
 
     public function testCanRetryAfterDelay()
@@ -31,7 +31,7 @@ class AbstractRetryableEventTest extends \PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
         $e->retry(10);
         $this->assertTrue($e->isPropagationStopped());
-        $this->assertEquals('before', $t->state);
+        $this->assertEquals('retry', $t->state);
         $this->assertEquals(10, $t->request->getConfig()->get('delay'));
     }
 }

--- a/tests/Event/AbstractTransferEventTest.php
+++ b/tests/Event/AbstractTransferEventTest.php
@@ -46,4 +46,14 @@ class AbstractTransferEventTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($t->response, $e->getResponse());
         $this->assertTrue($e->isPropagationStopped());
     }
+
+    public function testReturnsNumberOfRetries()
+    {
+        $t = new Transaction(new Client(), new Request('GET', '/'));
+        $t->retries = 2;
+        $e = $this->getMockBuilder('GuzzleHttp\Event\AbstractTransferEvent')
+            ->setConstructorArgs([$t])
+            ->getMockForAbstractClass();
+        $this->assertEquals(2, $e->getRetryCount());
+    }
 }


### PR DESCRIPTION
This commit updates the request FSM to resolve deep futures to
ensure that retried synchronous requests are waited on correctly
and produce side-effects when expected. Previously the results of a
retried request were not being properly brought up to the outermost
layer when a client was attempting to dereference a future because the
request was not a future request.
