### PR TITLE
Adding AppliesHeadersInterface

### DIFF
--- a/src/Message/AppliesHeadersInterface.php
+++ b/src/Message/AppliesHeadersInterface.php
@@ -1,0 +1,24 @@
+<?php
+namespace GuzzleHttp\Message;
+
+/**
+ * Applies headers to a request.
+ *
+ * This interface can be used with Guzzle streams to apply body specific
+ * headers to a request during the PREPARE_REQUEST priority of the before event
+ *
+ * NOTE: a body that implements this interface will prevent a default
+ * content-type from being added to a request during the before event. If you
+ * want a default content-type to be added, then it will need to be done
+ * manually (e.g., using {@see GuzzleHttp\Mimetypes}).
+ */
+interface AppliesHeadersInterface
+{
+    /**
+     * Apply headers to a request appropriate for the current state of the
+     * object.
+     *
+     * @param RequestInterface $request Request
+     */
+    public function applyRequestHeaders(RequestInterface $request);
+}

--- a/src/Post/PostBodyInterface.php
+++ b/src/Post/PostBodyInterface.php
@@ -1,22 +1,15 @@
 <?php
 namespace GuzzleHttp\Post;
 
-use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Message\AppliesHeadersInterface;
 use GuzzleHttp\Stream\StreamInterface;
 
 /**
  * Represents a POST body that is sent as either a multipart/form-data stream
  * or application/x-www-urlencoded stream.
  */
-interface PostBodyInterface extends StreamInterface, \Countable
+interface PostBodyInterface extends StreamInterface, \Countable, AppliesHeadersInterface
 {
-    /**
-     * Apply headers to the request appropriate for the current state of the object
-     *
-     * @param RequestInterface $request Request
-     */
-    public function applyRequestHeaders(RequestInterface $request);
-
     /**
      * Set a specific field
      *

--- a/src/Subscriber/Prepare.php
+++ b/src/Subscriber/Prepare.php
@@ -4,9 +4,9 @@ namespace GuzzleHttp\Subscriber;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Event\RequestEvents;
 use GuzzleHttp\Event\SubscriberInterface;
+use GuzzleHttp\Message\AppliesHeadersInterface;
 use GuzzleHttp\Message\RequestInterface;
 use GuzzleHttp\Mimetypes;
-use GuzzleHttp\Post\PostBodyInterface;
 use GuzzleHttp\Stream\StreamInterface;
 
 /**
@@ -40,8 +40,8 @@ class Prepare implements SubscriberInterface
 
         $this->addContentLength($request, $body);
 
-        if ($body instanceof PostBodyInterface) {
-            // Synchronize the POST body with the request's headers
+        if ($body instanceof AppliesHeadersInterface) {
+            // Synchronize the body with the request headers
             $body->applyRequestHeaders($request);
         } elseif (!$request->hasHeader('Content-Type')) {
             $this->addContentType($request, $body);


### PR DESCRIPTION
Making it possible to create custom streams that apply request headers during the before event rather than hardcoding it to only look for PostBodyInterface.