### PR TITLE
Adding integration tests for Digest authentication

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -131,6 +131,13 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             if ($e->hasResponse()) {
                 $response = $e->getResponse();
             }
+        } catch(\GuzzleHttp\Exception\ServerException $e) {
+            // 501 Exceptions are thrown when our test server is incomplete. Let us tell the user.
+            if ($e->getCode() == 501) {
+                $this->markTestSkipped('Cannot currently test HTTP Auth; please run an \'npm install http-auth\' to cover this case');
+                return;
+            }
+            throw $e;
         }
         $this->assertEquals(401, $response->getStatusCode());
     }
@@ -141,7 +148,16 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         // Digest has a way to prevent replay attacks by requiring a nonce to be incremented at each request. Ensure we pass multiple successive requests.
         for ($i = 3; --$i >= 0;) {
             Server::enqueue([new Response(200)]);
-            $response = $c->get(Server::$url . 'secure/by-digest/anything', ['auth' => ['me', 'test', 'digest']]); // @todo Someday there should be autodetection of the authentification type, based on the return headers to the first rejected query.
+            try {
+                $response = $c->get(Server::$url . 'secure/by-digest/anything', ['auth' => ['me', 'test', 'digest']]); // @todo Someday there should be autodetection of the authentification type, based on the return headers to the first rejected query.
+            } catch(\GuzzleHttp\Exception\ServerException $e) {
+                // 501 Exceptions are thrown when our test server is incomplete. Let us tell the user.
+                if ($e->getCode() == 501) {
+                    $this->markTestSkipped('Cannot currently test HTTP Auth; please run an \'npm install http-auth\' to cover this case');
+                    break;
+                }
+                throw $e;
+            }
             $this->assertEquals(200, $response->getStatusCode());
         }
     }


### PR DESCRIPTION
(continuation of https://github.com/guzzle/guzzle/pull/918, that was marked unmodifiable by GitHub)

This intends to prepare Digest implementation, to prevent regressing from the current (cURL) implementation.
