### PR TITLE
Add test coverage for RFC3986 merge algorithm in base_url.

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -339,6 +339,34 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * Test that base URLs ending with a slash are resolved as per RFC3986.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-5.2.3
+     */
+    public function testMultipleSubdirectoryWithSlash()
+    {
+        $client = new Client(['base_url' => 'http://www.foo.com/bar/bam/']);
+        $this->assertEquals(
+          'http://www.foo.com/bar/bam/httpfoo',
+          $client->createRequest('GET', 'httpfoo')->getUrl()
+        );
+    }
+
+    /**
+     * Test that base URLs ending without a slash are resolved as per RFC3986.
+     *
+     * @link http://tools.ietf.org/html/rfc3986#section-5.2.3
+     */
+    public function testMultipleSubdirectoryNoSlash()
+    {
+        $client = new Client(['base_url' => 'http://www.foo.com/bar/bam']);
+        $this->assertEquals(
+          'http://www.foo.com/bar/httpfoo',
+          $client->createRequest('GET', 'httpfoo')->getUrl()
+        );
+    }
+
     public function testClientSendsRequests()
     {
         $mock = new MockHandler(['status' => 200, 'headers' => []]);


### PR DESCRIPTION
I was debugging some Guzzle client code that was setting base_url without a trailing slash. In other HTTP clients, they tend to do a raw concatenation of the base URL and request URL, so the slash can live in either place. At first I thought this was a bug in Guzzle, but once I got to the RFC I realized Guzzle is working just fine.

It would have saved me a ton of time to have these examples in the tests, so here they are.