### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -sS https://getcomposer.org/installer | php
 Next, run the Composer command to install the latest stable version of Guzzle:
 
 ```bash
-composer require guzzlehttp/guzzle
+composer.phar require guzzlehttp/guzzle
 ```
 
 After installing, you need to require Composer's autoloader:


### PR DESCRIPTION
In the Installing via Composer section:

$ curl -sS https://getcomposer.org/installer | php

results in the following composer file location on OSX: /usr/local/bin/composer.phar

This means the following next step will result in a "command not found" error

$ composer require guzzlehttp/guzzle

Some solutions include:

(1) changing command to composer.phar
(2) renaming / moving composer.phar to composer
(3) creating a link from composer.phar to composer

This request uses the composer.phar name but if this is only for select environments, either of the above or simply a note would be useful.