### PR TITLE
Add Travis-CI check for PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:
@@ -20,6 +21,7 @@ script: make test
 matrix:
   allow_failures:
     - php: hhvm
+    - php: 7.0
   fast_finish: true
 
 before_deploy:


### PR DESCRIPTION
Added Travis-CI check for PHP 7.0 since that's [gonna be thing soon](https://wiki.php.net/rfc/php7timeline#proposal). I've got `allow_failures` on so it won't cause the whole build to fail. Spoiler-alert: [the 7.0 build fails](https://travis-ci.org/facebook/facebook-php-sdk-v4/jobs/53147975#L187). :) I inadvertently discovered this about Guzzle when [checking against PHP 7.0 in the Facebook PHP SDK](https://github.com/facebook/facebook-php-sdk-v4/pull/375).