### PR TITLE
Fix: URLs should probably marked down as such

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,7 @@ Guzzle Upgrade Guide
 
 ## Rewritten Adapter Layer
 
-Guzzle now uses `RingPHP <http://ringphp.readthedocs.org/en/latest/>`_ to send
+Guzzle now uses [RingPHP](http://ringphp.readthedocs.org/en/latest) to send
 HTTP requests. The `adapter` option in a `GuzzleHttp\Client` constructor
 is still supported, but it has now been renamed to `handler`. Instead of
 passing a `GuzzleHttp\Adapter\AdapterInterface`, you must now pass a PHP
@@ -14,7 +14,7 @@ passing a `GuzzleHttp\Adapter\AdapterInterface`, you must now pass a PHP
 
 ## Removed Fluent Interfaces
 
-`Fluent interfaces were removed <http://ocramius.github.io/blog/fluent-interfaces-are-evil/>`_
+[Fluent interfaces were removed](http://ocramius.github.io/blog/fluent-interfaces-are-evil)
 from the following classes:
 
 - `GuzzleHttp\Collection`


### PR DESCRIPTION
This PR

* [x] marks down URLs as actual links 

:bulb: Seems like they should be, no?