### PR TITLE
Force lower case URL scheme

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -138,7 +138,7 @@ class Url
         $query = null,
         $fragment = null
     ) {
-        $this->scheme = $scheme;
+        $this->scheme = strtolower($scheme);
         $this->host = $host;
         $this->port = $port;
         $this->username = $username;
@@ -234,7 +234,7 @@ class Url
             $this->port = null;
         }
 
-        $this->scheme = $scheme;
+        $this->scheme = strtolower($scheme);
     }
 
     /**

--- a/tests/Subscriber/RedirectTest.php
+++ b/tests/Subscriber/RedirectTest.php
@@ -267,6 +267,20 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testUpperCaseScheme()
+    {
+        $client = new Client(['base_url' => 'http://www.foo.com']);
+        $client->getEmitter()->attach(new Mock([
+            "HTTP/1.1 301 Moved Permanently\r\nLocation: HTTP://www.bar.com\r\nContent-Length: 0\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+        ]));
+        $response = $client->get('/');
+        $this->assertEquals(
+            'http://www.bar.com',
+            $response->getEffectiveUrl()
+        );
+    }
+
     /**
      * @expectedException \GuzzleHttp\Exception\BadResponseException
      * @expectedExceptionMessage Redirect URL, https://foo.com/redirect2, does not use one of the allowed redirect protocols: http

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -353,4 +353,10 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $url = Url::fromString('http://foo.com/baz%20 bar:boo/baz!');
         $this->assertEquals('/baz%20%20bar:boo/baz!', $url->getPath());
     }
+
+    public function testLowercaseScheme()
+    {
+        $url = Url::fromString('HTTP://foo.com/');
+        $this->assertEquals('http', $url->getScheme());
+    }
 }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -358,5 +358,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         $url = Url::fromString('HTTP://foo.com/');
         $this->assertEquals('http', $url->getScheme());
+        $url->setScheme('HTTPS');
+        $this->assertEquals('https', $url->getScheme());
     }
 }


### PR DESCRIPTION
A user of my RingPHP react handler [ran into an issue](https://github.com/WyriHaximus/ReactGuzzleRing/issues/12) where redirects with an upper case scheme (`HTTPS` e.g. instead of `http`) triggered an error because the allowed scheme check is case sensitive. This PR solves that issue be forcing the scheme to be lower case.