### PR TITLE
Fixed a typo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "5.0-dev",
-            "dev-6": "6.0-dev"
+            "dev-v6": "6.0-dev"
         }
     }
 }


### PR DESCRIPTION
Also, I'm not sure if you're even allowed to alias branches that are already valid versions. Maybe name this branch "6.0" and ditch the alias to avoid this issue?