### PR TITLE
Fix save_to for Mock

### DIFF
--- a/src/Subscriber/Mock.php
+++ b/src/Subscriber/Mock.php
@@ -60,6 +60,12 @@ class Mock implements SubscriberInterface, \Countable
             }
         }
 
+        $save_to = $event->getRequest()->getConfig()->get('save_to');
+
+        if ($save_to) {
+            file_put_contents($save_to, $item->getBody());
+        }
+
         $event->intercept($item);
     }
 

--- a/src/Subscriber/Mock.php
+++ b/src/Subscriber/Mock.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Message\MessageFactory;
 use GuzzleHttp\Message\ResponseInterface;
+use GuzzleHttp\Stream\StreamInterface;
 
 /**
  * Queues mock responses or exceptions and delivers mock responses or
@@ -62,8 +63,16 @@ class Mock implements SubscriberInterface, \Countable
 
         $save_to = $event->getRequest()->getConfig()->get('save_to');
 
-        if ($save_to) {
-            file_put_contents($save_to, $item->getBody());
+        if (null !== $save_to) {
+        	$body = $item->getBody();
+
+        	if (is_resource($save_to)) {
+        		fwrite($save_to, $body);
+        	} elseif (is_string($save_to)) {
+	            file_put_contents($save_to, $body);
+        	} elseif ($save_to instanceof StreamInterface) {
+        		$save_to->write($body);
+        	}
         }
 
         $event->intercept($item);

--- a/src/Subscriber/Mock.php
+++ b/src/Subscriber/Mock.php
@@ -64,15 +64,15 @@ class Mock implements SubscriberInterface, \Countable
         $saveTo = $event->getRequest()->getConfig()->get('save_to');
 
         if (null !== $saveTo) {
-        	$body = $item->getBody();
+            $body = $item->getBody();
 
-        	if (is_resource($saveTo)) {
-        		fwrite($saveTo, $body);
-        	} elseif (is_string($saveTo)) {
-	            file_put_contents($saveTo, $body);
-        	} elseif ($saveTo instanceof StreamInterface) {
-        		$saveTo->write($body);
-        	}
+            if (is_resource($saveTo)) {
+                fwrite($saveTo, $body);
+            } elseif (is_string($saveTo)) {
+                file_put_contents($saveTo, $body);
+            } elseif ($saveTo instanceof StreamInterface) {
+                $saveTo->write($body);
+            }
         }
 
         $event->intercept($item);

--- a/src/Subscriber/Mock.php
+++ b/src/Subscriber/Mock.php
@@ -61,17 +61,17 @@ class Mock implements SubscriberInterface, \Countable
             }
         }
 
-        $save_to = $event->getRequest()->getConfig()->get('save_to');
+        $saveTo = $event->getRequest()->getConfig()->get('save_to');
 
-        if (null !== $save_to) {
+        if (null !== $saveTo) {
         	$body = $item->getBody();
 
-        	if (is_resource($save_to)) {
-        		fwrite($save_to, $body);
-        	} elseif (is_string($save_to)) {
-	            file_put_contents($save_to, $body);
-        	} elseif ($save_to instanceof StreamInterface) {
-        		$save_to->write($body);
+        	if (is_resource($saveTo)) {
+        		fwrite($saveTo, $body);
+        	} elseif (is_string($saveTo)) {
+	            file_put_contents($saveTo, $body);
+        	} elseif ($saveTo instanceof StreamInterface) {
+        		$saveTo->write($body);
         	}
         }
 

--- a/tests/Subscriber/MockTest.php
+++ b/tests/Subscriber/MockTest.php
@@ -162,18 +162,35 @@ class MockTest extends \PHPUnit_Framework_TestCase
 
     public function testSaveToFile()
     {
-        $file = sys_get_temp_dir().'/mock_test_'.uniqid();
+        $filename = sys_get_temp_dir().'/mock_test_'.uniqid();
+        $file = tmpfile();
+        $stream = new Stream(tmpfile());
 
-        $m = new Mock([new Response(200, [], Stream::factory('TEST FILE'))]);
+        $m = new Mock([
+        	new Response(200, [], Stream::factory('TEST FILENAME')),
+        	new Response(200, [], Stream::factory('TEST FILE')),
+        	new Response(200, [], Stream::factory('TEST STREAM')),
+        ]);
+
         $client = new Client();
         $client->getEmitter()->attach($m);
 
+        $client->get('/', ['save_to' => $filename]);
         $client->get('/', ['save_to' => $file]);
+        $client->get('/', ['save_to' => $stream]);
 
-        $this->assertFileExists($file);
-        $this->assertEquals('TEST FILE', file_get_contents($file));
+        $this->assertFileExists($filename);
+        $this->assertEquals('TEST FILENAME', file_get_contents($filename));
 
-        unlink($file);
+        $meta = stream_get_meta_data($file);
+
+        $this->assertFileExists($meta['uri']);
+        $this->assertEquals('TEST FILE', file_get_contents($meta['uri']));
+
+        $this->assertFileExists($stream->getMetadata('uri'));
+        $this->assertEquals('TEST STREAM', file_get_contents($stream->getMetadata('uri')));
+
+        unlink($filename);
     }
 
     public function testCanMockFailedFutureResponses()

--- a/tests/Subscriber/MockTest.php
+++ b/tests/Subscriber/MockTest.php
@@ -160,6 +160,22 @@ class MockTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testSaveToFile()
+    {
+        $file = sys_get_temp_dir().'/mock_test_'.uniqid();
+
+        $m = new Mock([new Response(200, [], Stream::factory('TEST FILE'))]);
+        $client = new Client();
+        $client->getEmitter()->attach($m);
+
+        $client->get('/', ['save_to' => $file]);
+
+        $this->assertFileExists($file);
+        $this->assertEquals('TEST FILE', file_get_contents($file));
+
+        unlink($file);
+    }
+
     public function testCanMockFailedFutureResponses()
     {
         $client = new Client(['base_url' => 'http://test.com']);


### PR DESCRIPTION
Great project, just a small fix for an issue I ran into while using your library - one cannot use "save_to" and write proper tests for it at the moment. 

This allows using “save_to” in mocked requests. Now you can write tests for code that uses “save_to” easily.
Test included.