### PR TITLE
Make CookieJar->cookies usable by derivatives

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -11,7 +11,7 @@ use GuzzleHttp\ToArrayInterface;
 class CookieJar implements CookieJarInterface, ToArrayInterface
 {
     /** @var SetCookie[] Loaded cookie data */
-    private $cookies = [];
+    protected $cookies = [];
 
     /** @var bool */
     private $strictMode;

--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -44,7 +44,7 @@ class FileCookieJar extends CookieJar
     public function save($filename)
     {
         $json = [];
-        foreach ($this as $cookie) {
+        foreach ($this->cookies as $cookie) {
             if ($cookie->getExpires() && !$cookie->getDiscard()) {
                 $json[] = $cookie->toArray();
             }

--- a/src/Cookie/SessionCookieJar.php
+++ b/src/Cookie/SessionCookieJar.php
@@ -36,7 +36,7 @@ class SessionCookieJar extends CookieJar
     public function save()
     {
         $json = [];
-        foreach ($this as $cookie) {
+        foreach ($this->cookies as $cookie) {
             if ($cookie->getExpires() && !$cookie->getDiscard()) {
                 $json[] = $cookie->toArray();
             }


### PR DESCRIPTION
Advantages:

* Better performance, since the not needed array_values call
and ArrayIterator construction are skipped
* Static analysis tools now understand the type of $cookie
in the loops

Disadvantage:

* Encapsulation decrease