### PR TITLE
Workaround for large integers in JSON decoding

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -138,7 +138,8 @@ final class Utils
             JSON_ERROR_SYNTAX => 'JSON_ERROR_SYNTAX - Syntax error, malformed JSON',
             JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded'
         ];
-
+		
+		$json = preg_replace ('/:\s?(\d{14,})/', ': "${1}"', $json);		
         $data = \json_decode($json, $assoc, $depth, $options);
 
         if (JSON_ERROR_NONE !== json_last_error()) {


### PR DESCRIPTION
Quick workaround of problem with large integers in JSON, instead of giving
json_decode(): integer overflow detected.

Demo int: 18425396933527319036

Problem:
![image](https://cloud.githubusercontent.com/assets/128443/7343870/4320adb0-eccf-11e4-936f-75220881013f.png)
"Solution":
![image](https://cloud.githubusercontent.com/assets/128443/7343864/336af524-eccf-11e4-8a7d-515debb87d56.png)
