### PR TITLE
Allow emitter be overwrited

### DIFF
--- a/src/Event/HasEmitterTrait.php
+++ b/src/Event/HasEmitterTrait.php
@@ -7,7 +7,7 @@ namespace GuzzleHttp\Event;
 trait HasEmitterTrait
 {
     /** @var EmitterInterface */
-    private $emitter;
+    protected $emitter;
 
     public function getEmitter()
     {


### PR DESCRIPTION
Hi Guys

I am working on a OAuth project which based on guzzle https://github.com/AlloVince/EvaOAuth

In my project, I want to extend GuzzleHttp\Client and replace emitter into mine own.

Currently the emitter of  GuzzleHttp\Client is private and not allow to overwrite, please consider my pull request, I think a replaceable is better.

Best regards
