### PR TITLE
Fix typo in docblock

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -34,7 +34,7 @@ class RequestException extends TransferException
     }
 
     /**
-     * Wrap non-RequesExceptions with a RequestException
+     * Wrap non-RequestExceptions with a RequestException
      *
      * @param RequestInterface $request
      * @param \Exception       $e


### PR DESCRIPTION
This is just a small fix, because a `t` was missing in the Docblock