### PR TITLE
Guzzle v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ php:
 
 before_script:
   - curl --version
-  - pear config-set php_ini ~/.phpenv/versions/`php -r 'echo phpversion();'`/etc/php.ini || echo 'Error modifying PEAR'
-  - pecl install uri_template || echo 'Error installing uri_template'
   - composer self-update
   - composer install --no-interaction --prefer-source --dev
   - ~/.nvm/nvm.sh install v0.6.14
@@ -37,4 +35,4 @@ deploy:
     repo: guzzle/guzzle
     tags: true
     all_branches: true
-    php: 5.4
+    php: 5.5

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,7 @@ tag:
 	git commit -m '$(TAG) release'
 	chag tag
 
-burgomaster:
-	mkdir -p build/artifacts
-	curl -s https://raw.githubusercontent.com/mtdowling/Burgomaster/0.0.2/src/Burgomaster.php > build/artifacts/Burgomaster.php
-
-package: burgomaster
+package:
 	php build/packager.php
 
 .PHONY: docs burgomaster

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,15 @@
-all: clean coverage docs
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  start-server   to start the test server"
+	@echo "  stop-server    to stop the test server"
+	@echo "  test           to perform unit tests.  Provide TEST to perform a specific test."
+	@echo "  coverage       to perform unit tests with code coverage. Provide TEST to perform a specific test."
+	@echo "  coverage-show  to show the code coverage report"
+	@echo "  clean          to remove build artifacts"
+	@echo "  docs           to build the Sphinx docs"
+	@echo "  docs-show      to view the Sphinx docs"
+	@echo "  tag            to modify the version, update changelog, and chag tag"
+	@echo "  package        to build the phar and zip files"
 
 start-server: stop-server
 	node tests/server.js &> /dev/null &
@@ -18,6 +29,8 @@ coverage: start-server
 	vendor/bin/phpunit --coverage-html=build/artifacts/coverage
 	$(MAKE) stop-server
 
+coverage-show: view-coverage
+
 view-coverage:
 	open build/artifacts/coverage/index.html
 
@@ -27,7 +40,7 @@ clean:
 docs:
 	cd docs && make html && cd ..
 
-view-docs:
+docs-show:
 	open docs/_build/html/index.html
 
 tag:
@@ -43,4 +56,4 @@ tag:
 package:
 	php build/packager.php
 
-.PHONY: docs burgomaster
+.PHONY: docs burgomaster coverage-show view-coverage

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,13 +5,21 @@ Guzzle Upgrade Guide
 ----------
 
 Guzzle now uses [PSR-7](http://www.php-fig.org/psr/psr-7/) for HTTP messages.
-Due to the fact that these messages are immutable, this prompted a
-re-architecting of Guzzle to use a middleware based system rather than an
-event system. Any HTTP message interaction (e.g., `GuzzleHttp\Message\Request`)
-need to be updated to work with the new immutable PSR-7 request and response
-objects. Any event listeners or subscribers need to be updated to become
-middleware functions that wrap handlers (or are injected into a
-`GuzzleHttp\HandlerStack`.
+Due to the fact that these messages are immutable, this prompted a refactoring
+of Guzzle to use a middleware based system rather than an event system. Any
+HTTP message interaction (e.g., `GuzzleHttp\Message\Request`) need to be
+updated to work with the new immutable PSR-7 request and response objects. Any
+event listeners or subscribers need to be updated to become middleware
+functions that wrap handlers (or are injected into a
+`GuzzleHttp\HandlerStack`).
+
+The change to PSR-7 unfortunately required significant refactoring to Guzzle
+due to the fact that PSR-7 messages are immutable. Guzzle 5 relied on an event
+system from plugins. The event system relied on mutability of HTTP messages and
+side effects in order to work. With immutable messages, you have to change your
+workflow to become more about either returning a value (e.g., functional
+middlewares) or setting a value on an object. Guzzle v6 has chosen the
+functional middleware approach.
 
 - Removed `GuzzleHttp\BatchResults`
 - Removed `GuzzleHttp\Collection`
@@ -29,9 +37,10 @@ middleware functions that wrap handlers (or are injected into a
      Note: there has been movement in the React project to modify promises to
      no longer utilize recursion.
   2. Guzzle needs to have the ability to synchronously block on a promise to
-     wait for a result. Guzzle promises allows this functionality.
+     wait for a result. Guzzle promises allows this functionality (and does
+     not require the use of recursion).
   3. Because we need to be able to wait on a result, doing so using React
-     promises requiring wrapping react promises with RingPHP futures. This
+     promises requires wrapping react promises with RingPHP futures. This
      overhead is no longer needed, reducing stack sizes, reducing complexity,
      and improving performance.
 - `GuzzleHttp\Mimetypes` has been moved to a function in

--- a/build/Burgomaster.php
+++ b/build/Burgomaster.php
@@ -1,0 +1,384 @@
+<?php
+
+/**
+ * Packages the zip and phar file using a staging directory.
+ *
+ * @license MIT, Michael Dowling https://github.com/mtdowling
+ * @license https://github.com/mtdowling/Burgomaster/LICENSE
+ */
+class Burgomaster
+{
+    /** @var string Base staging directory of the project */
+    public $stageDir;
+
+    /** @var string Root directory of the project */
+    public $projectRoot;
+
+    /** @var array stack of sections */
+    private $sections = array();
+
+    /**
+     * @param string $stageDir    Staging base directory where your packaging
+     *                            takes place. This folder will be created for
+     *                            you if it does not exist. If it exists, it
+     *                            will be deleted and recreated to start fresh.
+     * @param string $projectRoot Root directory of the project.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     */
+    public function __construct($stageDir, $projectRoot = null)
+    {
+        $this->startSection('setting_up');
+        $this->stageDir = $stageDir;
+        $this->projectRoot = $projectRoot;
+
+        if (!$this->stageDir || $this->stageDir == '/') {
+            throw new \InvalidArgumentException('Invalid base directory');
+        }
+
+        if (is_dir($this->stageDir)) {
+            $this->debug("Removing existing directory: $this->stageDir");
+            echo $this->exec("rm -rf $this->stageDir");
+        }
+
+        $this->debug("Creating staging directory: $this->stageDir");
+
+        if (!mkdir($this->stageDir, 0777, true)) {
+            throw new \RuntimeException("Could not create {$this->stageDir}");
+        }
+
+        $this->stageDir = realpath($this->stageDir);
+        $this->debug("Creating staging directory at: {$this->stageDir}");
+
+        if (!is_dir($this->projectRoot)) {
+            throw new \InvalidArgumentException(
+                "Project root not found: $this->projectRoot"
+            );
+        }
+
+        $this->endSection();
+        $this->startSection('staging');
+
+        chdir($this->projectRoot);
+    }
+
+    /**
+     * Cleanup if the last section was not already closed.
+     */
+    public function __destruct()
+    {
+        if ($this->sections) {
+            $this->endSection();
+        }
+    }
+
+    /**
+     * Call this method when starting a specific section of the packager.
+     *
+     * This makes the debug messages used in your script more meaningful and
+     * adds context when things go wrong. Be sure to call endSection() when
+     * you have finished a section of your packaging script.
+     *
+     * @param string $section Part of the packager that is running
+     */
+    public function startSection($section)
+    {
+        $this->sections[] = $section;
+        $this->debug('Starting');
+    }
+
+    /**
+     * Call this method when leaving the last pushed section of the packager.
+     */
+    public function endSection()
+    {
+        if ($this->sections) {
+            $this->debug('Completed');
+            array_pop($this->sections);
+        }
+    }
+
+    /**
+     * Prints a debug message to STDERR bound to the current section.
+     *
+     * @param string $message Message to echo to STDERR
+     */
+    public function debug($message)
+    {
+        $prefix = date('c') . ': ';
+
+        if ($this->sections) {
+            $prefix .= '[' . end($this->sections) . '] ';
+        }
+
+        fwrite(STDERR, $prefix . $message . "\n");
+    }
+
+    /**
+     * Copies a file and creates the destination directory if needed.
+     *
+     * @param string $from File to copy
+     * @param string $to   Destination to copy the file to, relative to the
+     *                     base staging directory.
+     * @throws \InvalidArgumentException if the file cannot be found
+     * @throws \RuntimeException if the directory cannot be created.
+     * @throws \RuntimeException if the file cannot be copied.
+     */
+    public function deepCopy($from, $to)
+    {
+        if (!is_file($from)) {
+            throw new \InvalidArgumentException("File not found: {$from}");
+        }
+
+        $to = str_replace('//', '/', $this->stageDir . '/' . $to);
+        $dir = dirname($to);
+
+        if (!is_dir($dir)) {
+            if (!mkdir($dir, 0777, true)) {
+                throw new \RuntimeException("Unable to create directory: $dir");
+            }
+        }
+
+        if (!copy($from, $to)) {
+            throw new \RuntimeException("Unable to copy $from to $to");
+        }
+    }
+
+    /**
+     * Recursively copy one folder to another.
+     *
+     * Any LICENSE file is automatically copied.
+     *
+     * @param string $sourceDir  Source directory to copy from
+     * @param string $destDir    Directory to copy the files to that is relative
+     *                           to the the stage base directory.
+     * @param array  $extensions File extensions to copy from the $sourceDir.
+     *                           Defaults to "php" files only (e.g., ['php']).
+     * @throws \InvalidArgumentException if the source directory is invalid.
+     */
+    function recursiveCopy(
+        $sourceDir,
+        $destDir,
+        $extensions = array('php')
+    ) {
+        if (!realpath($sourceDir)) {
+            throw new \InvalidArgumentException("$sourceDir not found");
+        }
+
+        if (!$extensions) {
+            throw new \InvalidArgumentException('$extensions is empty!');
+        }
+
+        $sourceDir = realpath($sourceDir);
+        $exts = array_fill_keys($extensions, true);
+        $iter = new \RecursiveDirectoryIterator($sourceDir);
+        $iter = new \RecursiveIteratorIterator($iter);
+        $total = 0;
+
+        $this->startSection('copy');
+        $this->debug("Starting to copy files from $sourceDir");
+
+        foreach ($iter as $file) {
+            if (isset($exts[$file->getExtension()])
+                || $file->getBaseName() == 'LICENSE'
+            ) {
+                // Remove the source directory from the destination path
+                $toPath = str_replace($sourceDir, '', (string) $file);
+                $toPath = $destDir . '/' . $toPath;
+                $toPath = str_replace('//', '/', $toPath);
+                $this->deepCopy((string) $file, $toPath);
+                $total++;
+            }
+        }
+
+        $this->debug("Copied $total files from $sourceDir");
+        $this->endSection();
+    }
+
+    /**
+     * Execute a command and throw an exception if the return code is not 0.
+     *
+     * @param string $command Command to execute
+     *
+     * @return string Returns the output of the command as a string
+     * @throws \RuntimeException on error.
+     */
+    public function exec($command)
+    {
+        $this->debug("Executing: $command");
+        $output = $returnValue = null;
+        exec($command, $output, $returnValue);
+
+        if ($returnValue != 0) {
+            throw new \RuntimeException('Error executing command: '
+                . $command . ' : ' . implode("\n", $output));
+        }
+
+        return implode("\n", $output);
+    }
+
+    /**
+     * Creates a class-map autoloader to the staging directory in a file
+     * named autoloader.php
+     *
+     * @param array $files Files to explicitly require in the autoloader. This
+     *                     is similar to Composer's "files" "autoload" section.
+     * @param string $filename Name of the autoloader file.
+     * @throws \RuntimeException if the file cannot be written
+     */
+    function createAutoloader($files = array(), $filename = 'autoloader.php') {
+        $sourceDir = realpath($this->stageDir);
+        $iter = new \RecursiveDirectoryIterator($sourceDir);
+        $iter = new \RecursiveIteratorIterator($iter);
+
+        $this->startSection('autoloader');
+        $this->debug('Creating classmap autoloader');
+        $this->debug("Collecting valid PHP files from {$this->stageDir}");
+
+        $classMap = array();
+        foreach ($iter as $file) {
+            if ($file->getExtension() == 'php') {
+                $location = str_replace($this->stageDir . '/', '', (string) $file);
+                $className = str_replace('/', '\\', $location);
+                $className = substr($className, 0, -4);
+
+                // Remove "src\" or "lib\"
+                if (strpos($className, 'src\\') === 0
+                    || strpos($className, 'lib\\') === 0
+                ) {
+                    $className = substr($className, 4);
+                }
+
+                $classMap[$className] = "__DIR__ . '/$location'";
+                $this->debug("Found $className");
+            }
+        }
+
+        $destFile = $this->stageDir . '/' . $filename;
+        $this->debug("Writing autoloader to {$destFile}");
+
+        if (!($h = fopen($destFile, 'w'))) {
+            throw new \RuntimeException('Unable to open file for writing');
+        }
+
+        $this->debug('Writing classmap files');
+        fwrite($h, "<?php\n\n");
+        fwrite($h, "\$mapping = array(\n");
+        foreach ($classMap as $c => $f) {
+            fwrite($h, "    '$c' => $f,\n");
+        }
+        fwrite($h, ");\n\n");
+        fwrite($h, <<<EOT
+spl_autoload_register(function (\$class) use (\$mapping) {
+    if (isset(\$mapping[\$class])) {
+        require \$mapping[\$class];
+    }
+}, true);
+
+EOT
+        );
+
+        fwrite($h, "\n");
+
+        $this->debug('Writing automatically included files');
+        foreach ($files as $file) {
+            fwrite($h, "require __DIR__ . '/$file';\n");
+        }
+
+        fclose($h);
+
+        $this->endSection();
+    }
+
+    /**
+     * Creates a default stub for the phar that includeds the generated
+     * autoloader.
+     *
+     * This phar also registers a constant that can be used to check if you
+     * are running the phar. The constant is the basename of the $dest variable
+     * without the extension, with "_PHAR" appended, then converted to all
+     * caps (e.g., "/foo/guzzle.phar" gets a contant defined as GUZZLE_PHAR.
+     *
+     * @param $dest
+     * @param string $autoloaderFilename Name of the autoloader file.
+     *
+     * @return string
+     */
+    private function createStub($dest, $autoloaderFilename = 'autoloader.php')
+    {
+        $this->startSection('stub');
+        $this->debug("Creating phar stub at $dest");
+
+        $alias = basename($dest);
+        $constName = str_replace('.phar', '', strtoupper($alias)) . '_PHAR';
+        $stub  = "<?php\n";
+        $stub .= "define('$constName', true);\n";
+        $stub .= "require 'phar://$alias/{$autoloaderFilename}';\n";
+        $stub .= "__HALT_COMPILER();\n";
+        $this->endSection();
+
+        return $stub;
+    }
+
+    /**
+     * Creates a phar that automatically registers an autoloader.
+     *
+     * Call this only after your staging directory is built.
+     *
+     * @param string $dest Where to save the file. The basename of the file
+     *     is also used as the alias name in the phar
+     *     (e.g., /path/to/guzzle.phar => guzzle.phar).
+     * @param string|bool|null $stub The path to the phar stub file. Pass or
+     *      leave null to automatically have one created for you. Pass false
+     *      to no use a stub in the generated phar.
+     * @param string $autoloaderFilename Name of the autolaoder filename.
+     */
+    public function createPhar(
+        $dest,
+        $stub = null,
+        $autoloaderFilename = 'autoloader.php'
+    ) {
+        $this->startSection('phar');
+        $this->debug("Creating phar file at $dest");
+        $this->createDirIfNeeded(dirname($dest));
+        $phar = new \Phar($dest, 0, basename($dest));
+        $phar->buildFromDirectory($this->stageDir);
+
+        if ($stub !== false) {
+            if (!$stub) {
+                $stub = $this->createStub($dest, $autoloaderFilename);
+            }
+            $phar->setStub($stub);
+        }
+
+        $this->debug("Created phar at $dest");
+        $this->endSection();
+    }
+
+    /**
+     * Creates a zip file containing the staged files of your project.
+     *
+     * Call this only after your staging directory is built.
+     *
+     * @param string $dest Where to save the zip file
+     */
+    public function createZip($dest)
+    {
+        $this->startSection('zip');
+        $this->debug("Creating a zip file at $dest");
+        $this->createDirIfNeeded(dirname($dest));
+        chdir($this->stageDir);
+        $this->exec("zip -r $dest ./");
+        $this->debug("  > Created at $dest");
+        chdir(__DIR__);
+        $this->endSection();
+    }
+
+    private function createDirIfNeeded($dir)
+    {
+        if (!is_dir($dir) && !mkdir($dir, 0755, true)) {
+            throw new \RuntimeException("Could not create dir: $dir");
+        }
+    }
+}

--- a/build/packager.php
+++ b/build/packager.php
@@ -1,5 +1,5 @@
 <?php
-require __DIR__ . '/artifacts/Burgomaster.php';
+require __DIR__ . '/Burgomaster.php';
 
 $stageDirectory = __DIR__ . '/artifacts/staging';
 $projectRoot = __DIR__ . '/../';

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "6.0-dev",
-            "dev-v5": "5.0-dev"
+            "dev-v5": "5.3-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0-dev",
-            "dev-v6": "6.0-dev"
+            "dev-master": "6.0-dev",
+            "dev-v5": "5.0-dev"
         }
     }
 }

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -386,30 +386,23 @@ Cookies
 =======
 
 Guzzle can maintain a cookie session for you if instructed using the
-``cookies`` request option.
-
-- Set to ``true`` to use a shared cookie session associated with the client.
-- Pass an associative array containing cookies to send in the request and start
-  a new cookie session.
-- Set to a ``GuzzleHttp\Subscriber\CookieJar\CookieJarInterface`` object to use
-  an existing cookie jar.
+``cookies`` request option. When sending a request, the ``cookies`` option
+must be set an an instance of ``GuzzleHttp\Subscriber\CookieJar\CookieJarInterface``.
 
 .. code-block:: php
-
-    // Use a shared client cookie jar
-    $r = $client->get('http://httpbin.org/cookies', ['cookies' => true]);
-
-    // Use an array of cookies
-    $r = $client->get('http://httpbin.org/cookies', [
-        'cookies' => [
-            'foo' => 'bar',
-            'baz' => 'qux',
-        ]
-    ]);
 
     // Use a specific cookie jar
     $jar = new \GuzzleHttp\Cookie\CookieJar;
     $r = $client->get('http://httpbin.org/cookies', ['cookies' => $jar]);
+
+You can set ``cookies`` to ``true`` in a client constructor if you would like
+to use a shared cookie jar for all requests.
+
+.. code-block:: php
+
+    // Use a shared client cookie jar
+    $client = new \GuzzleHttp\Client(['cookies' => true]);
+    $r = $client->get('http://httpbin.org/cookies');
 
 
 Redirects

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -190,16 +190,12 @@ cookies
 
 :Summary: Specifies whether or not cookies are used in a request or what cookie
         jar to use or what cookies to send.
-:Types:
-        - bool
-        - ``GuzzleHttp\Cookie\CookieJarInterface``
+:Types: ``GuzzleHttp\Cookie\CookieJarInterface``
 :Default: None
 :Constant: ``GuzzleHttp\RequestOptions::COOKIES``
 
-When creating a client, you can set the default cookie option to ``true``
-to use a shared cookie session associated with the client. Othewise, you
-must specify the cookies option as a ``GuzzleHttp\Cookie\CookieJarInterface``
-or ``false``.
+You must specify the cookies option as a
+``GuzzleHttp\Cookie\CookieJarInterface`` or ``false``.
 
 .. code-block:: php
 
@@ -212,6 +208,11 @@ or ``false``.
     ``GuzzleHttp\Middleware::cookies`` middleware. This middleware is added
     by default when a client is created with no handler, and is added by
     default when creating a handler with ``GuzzleHttp\default_handler``.
+
+.. tip::
+
+    When creating a client, you can set the default cookie option to ``true``
+    to use a shared cookie session associated with the client.
 
 
 .. _connect_timeout-option:

--- a/src/Client.php
+++ b/src/Client.php
@@ -31,9 +31,8 @@ class Client implements ClientInterface
     /**
      * Clients accept an array of constructor parameters.
      *
-     * Here's an example of creating a client using an URI template for the
-     * client's base_uri and an array of default request options to apply
-     * to each request:
+     * Here's an example of creating a client using a base_uri and an array of
+     * default request options to apply to each request:
      *
      *     $client = new Client([
      *         'base_uri'        => 'http://www.foo.com/1.0/',
@@ -58,6 +57,7 @@ class Client implements ClientInterface
      * - **: any request option
      *
      * @param array $config Client configuration settings.
+     *
      * @see \GuzzleHttp\RequestOptions for a list of available request options.
      */
     public function __construct(array $config = [])

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -40,16 +40,15 @@ interface ClientInterface
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
-     * @param string                    $method  HTTP method
-     * @param string|array|UriInterface $uri     URI or URI template
-     * @param array                     $options Request options to apply.
+     * @param string              $method  HTTP method
+     * @param string|UriInterface $uri     URI object or string.
+     * @param array               $options Request options to apply.
      *
      * @return ResponseInterface
      */
-    public function request($method, $uri = null, array $options = []);
+    public function request($method, $uri, array $options = []);
 
     /**
      * Create and send an asynchronous HTTP request.
@@ -59,13 +58,13 @@ interface ClientInterface
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string                    $method  HTTP method
-     * @param string|array|UriInterface $uri     URI or URI template
-     * @param array                     $options Request options to apply.
+     * @param string              $method  HTTP method
+     * @param string|UriInterface $uri     URI object or string.
+     * @param array               $options Request options to apply.
      *
      * @return ResponseInterface
      */
-    public function requestAsync($method, $uri = null, array $options = []);
+    public function requestAsync($method, $uri, array $options = []);
 
     /**
      * Get a client configuration option.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\UriInterface;
  */
 interface ClientInterface
 {
-    const VERSION = '6.0.0-beta.1';
+    const VERSION = '6.0.0';
 
     /**
      * Send an HTTP request.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp;
 
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -21,6 +22,7 @@ interface ClientInterface
      *                                  request and to the transfer.
      *
      * @return ResponseInterface
+     * @throws GuzzleException
      */
     public function send(RequestInterface $request, array $options = []);
 
@@ -47,6 +49,7 @@ interface ClientInterface
      * @param array               $options Request options to apply.
      *
      * @return ResponseInterface
+     * @throws GuzzleException
      */
     public function request($method, $uri, array $options = []);
 

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -1,4 +1,37 @@
 <?php
 namespace GuzzleHttp\Exception;
 
-class ConnectException extends RequestException {}
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Exception thrown when a connection cannot be established.
+ *
+ * Note that no response is present for a ConnectException
+ */
+class ConnectException extends RequestException
+{
+    public function __construct(
+        $message,
+        RequestInterface $request,
+        \Exception $previous = null,
+        array $handlerContext = []
+    ) {
+        parent::__construct($message, $request, null, $previous, $handlerContext);
+    }
+
+    /**
+     * @return null
+     */
+    public function getResponse()
+    {
+        return null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasResponse()
+    {
+        return false;
+    }
+}

--- a/src/Exception/GuzzleException.php
+++ b/src/Exception/GuzzleException.php
@@ -1,0 +1,4 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+interface GuzzleException {}

--- a/src/Exception/SeekException.php
+++ b/src/Exception/SeekException.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\StreamInterface;
 /**
  * Exception thrown when a seek fails on a stream.
  */
-class SeekException extends \RuntimeException
+class SeekException extends \RuntimeException implements GuzzleException
 {
     private $stream;
 

--- a/src/Exception/TransferException.php
+++ b/src/Exception/TransferException.php
@@ -1,4 +1,4 @@
 <?php
 namespace GuzzleHttp\Exception;
 
-class TransferException extends \RuntimeException {}
+class TransferException extends \RuntimeException implements GuzzleException {}

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -158,7 +158,7 @@ class CurlFactory implements CurlFactoryInterface
 
         // Create a connection exception if it was a specific error code.
         $error = isset($connectionErrors[$easy->errno])
-            ? new ConnectException($message, $easy->request, null, null, $ctx)
+            ? new ConnectException($message, $easy->request, null, $ctx)
             : new RequestException($message, $easy->request, $easy->response, null, $ctx);
 
         return new RejectedPromise($error);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -46,7 +46,7 @@ class StreamHandler
             if (strpos($message, 'getaddrinfo') // DNS lookup failed
                 || strpos($message, 'Connection refused')
             ) {
-                $e = new ConnectException($e->getMessage(), $request, null, $e);
+                $e = new ConnectException($e->getMessage(), $request, $e);
             }
             return new RejectedPromise(
                 RequestException::wrapException($request, $e)

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -34,9 +34,9 @@ final class RequestOptions
     const BODY = 'body';
 
     /**
-     * cert: (array) Set to a string to specify the path to a file containing
-     * a PEM formatted SSL client side certificate. If a password is
-     * required, then set cert to an array containing the path to the PEM
+     * cert: (string|array) Set to a string to specify the path to a file
+     * containing a PEM formatted SSL client side certificate. If a password
+     * is required, then set cert to an array containing the path to the PEM
      * file in the first array element followed by the certificate password
      * in the second array element.
      */
@@ -46,7 +46,8 @@ final class RequestOptions
      * cookies: (bool|GuzzleHttp\Cookie\CookieJarInterface, default=false)
      * Specifies whether or not cookies are used in a request or what cookie
      * jar to use or what cookies to send. This option only works if your
-     * handler has the `cookie` middleware.
+     * handler has the `cookie` middleware. Valid values are `false` and
+     * an instance of {@see GuzzleHttp\Cookie\CookieJarInterface}.
      */
     const COOKIES = 'cookies';
 
@@ -80,8 +81,8 @@ final class RequestOptions
      * expect: (bool|integer) Controls the behavior of the
      * "Expect: 100-Continue" header.
      *
-     * Set to ``true`` to enable the "Expect: 100-Continue" header for all
-     * requests that sends a body. Set to ``false`` to disable the
+     * Set to `true` to enable the "Expect: 100-Continue" header for all
+     * requests that sends a body. Set to `false` to disable the
      * "Expect: 100-Continue" header for all requests. Set to a number so that
      * the size of the payload must be greater than the number in order to send
      * the Expect header. Setting to a number will send the Expect header for
@@ -97,7 +98,8 @@ final class RequestOptions
     /**
      * form_params: (array) Associative array of form field names to values
      * where each value is a string or array of strings. Sets the Content-Type
-     * header to application/x-www-form-urlencoded when the header is not set.
+     * header to application/x-www-form-urlencoded when no Content-Type header
+     * is already present.
      */
     const FORM_PARAMS = 'form_params';
 
@@ -125,10 +127,11 @@ final class RequestOptions
     /**
      * multipart: (array) Array of associative arrays, each containing a
      * required "name" key mapping to the form field, name, a required
-     * "contents" key mapping to a StreamInterface/resource/string, an
+     * "contents" key mapping to a StreamInterface|resource|string, an
      * optional "headers" associative array of custom headers, and an
      * optional "filename" key mapping to a string to send as the filename in
-     * the part.
+     * the part. If no "filename" key is present, then no "filename" attribute
+     * will be added to the part.
      */
     const MULTIPART = 'multipart';
 
@@ -143,7 +146,8 @@ final class RequestOptions
 
     /**
      * proxy: (string|array) Pass a string to specify an HTTP proxy, or an
-     * array to specify different proxies for different protocols.
+     * array to specify different proxies for different protocols (where the
+     * key is the protocol and the value is a proxy string).
      */
     const PROXY = 'proxy';
 
@@ -164,13 +168,15 @@ final class RequestOptions
 
     /**
      * synchronous: (bool) Set to true to inform HTTP handlers that you intend
-     * on waiting on the response. This can be useful for optimizations.
+     * on waiting on the response. This can be useful for optimizations. Note
+     * that a promise is still returned if you are using one of the async
+     * client methods.
      */
     const SYNCHRONOUS = 'synchronous';
 
     /**
-     * ssl_key: (array) Specify the path to a file containing a private SSL
-     * key in PEM format. If a password is required, then set to an array
+     * ssl_key: (array|string) Specify the path to a file containing a private
+     * SSL key in PEM format. If a password is required, then set to an array
      * containing the path to the SSL key in the first array element followed
      * by the password required for the certificate in the second element.
      */

--- a/tests/Exception/ConnectExceptionTest.php
+++ b/tests/Exception/ConnectExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace GuzzleHttp\Tests\Event;
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+
+/**
+ * @covers GuzzleHttp\Exception\ConnectException
+ */
+class ConnectExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHasNoResponse()
+    {
+        $req = new Request('GET', '/');
+        $prev = new \Exception();
+        $e = new ConnectException('foo', $req, $prev, ['foo' => 'bar']);
+        $this->assertSame($req, $e->getRequest());
+        $this->assertNull($e->getResponse());
+        $this->assertFalse($e->hasResponse());
+        $this->assertEquals('foo', $e->getMessage());
+        $this->assertEquals('bar', $e->getHandlerContext()['foo']);
+        $this->assertSame($prev, $e->getPrevious());
+    }
+}


### PR DESCRIPTION
Guzzle now uses [PSR-7](http://www.php-fig.org/psr/psr-7/) for HTTP messages.
Due to the fact that these messages are immutable, this prompted a
re-architecting of Guzzle to use a middleware based system rather than an
event system. Any HTTP message interaction (e.g., `GuzzleHttp\Message\Request`)
need to be updated to work with the new immutable PSR-7 request and response
objects. Any event listeners or subscribers need to be updated to become
middleware functions that wrap handlers (or are injected into a
`GuzzleHttp\HandlerStack`.

- Removed `GuzzleHttp\BatchResults`
- Removed `GuzzleHttp\Collection`
- Removed `GuzzleHttp\HasDataTrait`
- Removed `GuzzleHttp\ToArrayInterface`
- The `guzzlehttp/streams` dependency has been removed. Stream functionality
  is now present in the `GuzzleHttp\Psr7` namespace provided by the
  `guzzlehttp/psr7` package.
- Guzzle no longer uses ReactPHP promises and now uses the
  `guzzlehttp/promises` library. We use a custom promise library for three
  significant reasons:
  1. React promises (at the time of writing this) are recursive. Promise
     chaining and promise resolution will eventually blow the stack. Guzzle
     promises are not recursive as they use a sort of trampolining technique.
     Note: there has been movement in the React project to modify promises to
     no longer utilize recursion.
  2. Guzzle needs to have the ability to synchronously block on a promise to
     wait for a result. Guzzle promises allows this functionality.
  3. Because we need to be able to wait on a result, doing so using React
     promises requiring wrapping react promises with RingPHP futures. This
     overhead is no longer needed, reducing stack sizes, reducing complexity,
     and improving performance.
- `GuzzleHttp\Mimetypes` has been moved to a function in
  `GuzzleHttp\Psr7\mimetype_from_extension` and
  `GuzzleHttp\Psr7\mimetype_from_filename`.
- `GuzzleHttp\Query` and `GuzzleHttp\QueryParser` have been removed. Query
  strings must now be passed into request objects as strings, or provided to
  the `query` request option when creating requests with clients. The `query`
  option uses PHP's `http_build_query` to convert an array to a string. If you
  need a different serialization technique, you will need to pass the query
  string in as a string. There are a couple helper functions that will make
  working with query strings easier: `GuzzleHttp\Psr7\parse_query` and
  `GuzzleHttp\Psr7\build_query`.
- Guzzle no longer has a dependency on RingPHP. Due to the use of a middleware
  system based on PSR-7, using RingPHP and it's middleware system as well adds
  more complexity than the benefits it provides. All HTTP handlers that were
  present in RingPHP have been modified to work directly with PSR-7 messages
  and placed in the `GuzzleHttp\Handler` namespace. This significantly reduces
  complexity in Guzzle, removes a dependency, and improves performance. RingPHP
  will be maintained for Guzzle 5 support, but will no longer be a part of
  Guzzle 6.
- As Guzzle now uses a middleware based systems the event system and RingPHP
  integration has been removed. Note: while the event system has been removed,
  if there is sufficient demand, it would be possible that a package could be
  created that adds event support into the middleware system.
  - Removed the `Event` namespace.
  - Removed the `Subscriber` namespace.
  - Removed `Transaction` class
  - Removed `RequestFsm`
  - Removed `RingBridge`
  - `GuzzleHttp\Subscriber\Cookie` is now provided by
    `GuzzleHttp\Middleware::cookies`
  - `GuzzleHttp\Subscriber\HttpError` is now provided by
    `GuzzleHttp\Middleware::httpError`
  - `GuzzleHttp\Subscriber\History` is now provided by
    `GuzzleHttp\Middleware::history`
  - `GuzzleHttp\Subscriber\Mock` is now provided by
    `GuzzleHttp\Middleware::mock`
  - `GuzzleHttp\Subscriber\Prepare` is now provided by
    `GuzzleHttp\PrepareBodyMiddleware`
  - `GuzzleHttp\Subscriber\Redirect` is now provided by
    `GuzzleHttp\RedirectMiddleware`
- Guzzle now uses `Psr\Http\Message\UriInterface` (implements in
  `GuzzleHttp\Psr7\Uri`) for URI support. `GuzzleHttp\Url` is now gone.
- Static functions in `GuzzleHttp\Utils` have been moved to namespaced
  functions under the `GuzzleHttp` namespace. This requires either a Composer
  based autoloader or you to include functions.php.