### PR TITLE
Fix Content-Encoding and Content-Length headers when the response body is decoded

### DIFF
--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -51,10 +51,24 @@ final class EasyHandle
         // HTTP-version SP status-code SP reason-phrase
         $startLine = explode(' ', array_shift($this->headers), 3);
 
+        $headers = \GuzzleHttp\headers_from_lines($this->headers);
+        $normalizedKeys = array_combine(array_map('strtolower', array_keys($headers)), array_keys($headers));
+        if (!empty($this->options['decode_content']) && isset($normalizedKeys['content-encoding'])) {
+            unset($headers[$normalizedKeys['content-encoding']]);
+            if (isset($normalizedKeys['content-length'])) {
+                $bodyLength = (int) $this->sink->getSize();
+                if ($bodyLength) {
+                    $headers[$normalizedKeys['content-length']] = $bodyLength;
+                } else {
+                    unset($headers[$normalizedKeys['content-length']]);
+                }
+            }
+        }
+
         // Attach a response to the easy handle with the parsed headers.
         $this->response = new Response(
             $startLine[1],
-            \GuzzleHttp\headers_from_lines($this->headers),
+            $headers,
             $this->sink,
             substr($startLine[0], 5),
             isset($startLine[2]) ? (int) $startLine[2] : null

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -66,7 +66,8 @@ class StreamHandler
         $status = $parts[1];
         $reason = isset($parts[2]) ? $parts[2] : null;
         $headers = \GuzzleHttp\headers_from_lines($hdrs);
-        $stream = Psr7\stream_for($this->checkDecode($options, $headers, $stream));
+        list ($stream, $headers) = $this->checkDecode($options, $headers, $stream);
+        $stream = Psr7\stream_for($stream);
         $sink = $this->createSink($stream, $options);
         $response = new Psr7\Response($status, $headers, $sink, $ver, $reason);
 
@@ -106,18 +107,30 @@ class StreamHandler
     {
         // Automatically decode responses when instructed.
         if (!empty($options['decode_content'])) {
-            foreach ($headers as $key => $value) {
-                if (strtolower($key) == 'content-encoding') {
-                    if ($value[0] == 'gzip' || $value[0] == 'deflate') {
-                        return new Psr7\InflateStream(
-                            Psr7\stream_for($stream)
-                        );
+            $normalizedKeys = array_combine(array_map('strtolower', array_keys($headers)), array_keys($headers));
+
+            if (isset($normalizedKeys['content-encoding'])) {
+                $encoding = $headers[$normalizedKeys['content-encoding']];
+                if ($encoding[0] == 'gzip' || $encoding[0] == 'deflate') {
+                    $stream = new Psr7\InflateStream(
+                        Psr7\stream_for($stream)
+                    );
+                    // Remove content-encoding header
+                    unset($headers[$normalizedKeys['content-encoding']]);
+                    // Fix content-length header
+                    if (isset($normalizedKeys['content-length'])) {
+                        $length = (int) $stream->getSize();
+                        if ($length == 0) {
+                            unset($headers[$normalizedKeys['content-length']]);
+                        } else {
+                            $headers[$normalizedKeys['content-length']] = array($length);
+                        }
                     }
                 }
             }
         }
 
-        return $stream;
+        return array($stream, $headers);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -276,6 +276,8 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
         $sent = Server::received()[0];
         $this->assertEquals('gzip', $sent->getHeaderLine('Accept-Encoding'));
         $this->assertEquals('test', (string) $response->getBody());
+        $this->assertFalse($response->hasHeader('content-encoding'));
+        $this->assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == $response->getBody()->getSize());
     }
 
     public function testDoesNotForceDecode()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -139,6 +139,8 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => true])->wait();
         $this->assertEquals('test', (string) $response->getBody());
+        $this->assertFalse($response->hasHeader('content-encoding'));
+        $this->assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == $response->getBody()->getSize());
     }
 
     public function testDoesNotForceGzipDecode()
@@ -155,6 +157,8 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => false])->wait();
         $this->assertSame($content, (string) $response->getBody());
+        $this->assertEquals('gzip', $response->getHeaderLine('content-encoding'));
+        $this->assertEquals(strlen($content), $response->getHeaderLine('content-length'));
     }
 
     public function testProtocolVersion()


### PR DESCRIPTION
When the response body is decoded, the `Content-Length` of the returned response must be equal to the decoded body length, or removed if not known and the `Content-Encoding` header must be absent.

See #1075 