### PR TITLE
Fixed incorrect variable in async request example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ trivial to integrate with web services.
 
     // Send an asynchronous request.
     $request = new \GuzzleHttp\Psr7\Request('GET', 'http://httpbin.org');
-    $promise = $client->sendAsync($req)->then(function ($response) {
+    $promise = $client->sendAsync($request)->then(function ($response) {
         echo 'I completed! ' . $response;
     });
     $promise->wait();


### PR DESCRIPTION
Was being assigned to `$request`, but using `$req` in the next part of the example