### PR TITLE
Update testing docs about History middleware

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -62,14 +62,14 @@ history of the requests that were sent by a client.
     use GuzzleHttp\HandlerStack;
     use GuzzleHttp\Middleware;
 
-    $stack = HandlerStack::create();
-    // Add the history middleware to the handler stack.
-    $stack->append($history);
-
-    $client = new Client(['handler' => $stack]);
-
     $container = [];
     $history = Middleware::history($container);
+    
+    $stack = HandlerStack::create();
+    // Add the history middleware to the handler stack.
+    $stack->push($history);
+
+    $client = new Client(['handler' => $stack]);
 
     $client->get('http://httpbin.org/get');
     $client->head('http://httpbin.org/get');


### PR DESCRIPTION
I think this should be the correct order of instructions in the code. ;) Also, there is `HandlerStack::push`, not `::append`.