### PR TITLE
Updated UPGRADING guide about Mock Subscriber

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -70,7 +70,7 @@ functions that wrap handlers (or are injected into a
   - `GuzzleHttp\Subscriber\History` is now provided by
     `GuzzleHttp\Middleware::history`
   - `GuzzleHttp\Subscriber\Mock` is now provided by
-    `GuzzleHttp\Middleware::mock`
+    `GuzzleHttp\Handler\MockHandler`
   - `GuzzleHttp\Subscriber\Prepare` is now provided by
     `GuzzleHttp\PrepareBodyMiddleware`
   - `GuzzleHttp\Subscriber\Redirect` is now provided by


### PR DESCRIPTION
UPGRADING guide says there is Mock Middleware as a replacement for Mock Subscriber which is incorrect because we have `MockHandler`.