### PR TITLE
Allow custom log levels for logging middleware.

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Functions used to create and wrap handlers with handler middleware.
@@ -176,17 +177,18 @@ final class Middleware
      *
      * @param LoggerInterface  $logger Logs messages.
      * @param MessageFormatter $formatter Formatter used to create message strings.
+     * @param string           $logLevel Level at which to log requests.
      *
      * @return callable Returns a function that accepts the next handler.
      */
-    public static function log(LoggerInterface $logger, MessageFormatter $formatter)
+    public static function log(LoggerInterface $logger, MessageFormatter $formatter, $logLevel = LogLevel::INFO)
     {
-        return function (callable $handler) use ($logger, $formatter) {
-            return function ($request, array $options) use ($handler, $logger, $formatter) {
+        return function (callable $handler) use ($logger, $formatter, $logLevel) {
+            return function ($request, array $options) use ($handler, $logger, $formatter, $logLevel) {
                 return $handler($request, $options)->then(
-                    function ($response) use ($logger, $request, $formatter) {
+                    function ($response) use ($logger, $request, $formatter, $logLevel) {
                         $message = $formatter->format($request, $response);
-                        $logger->info($message);
+                        $logger->log($logLevel, $message);
                         return $response;
                     },
                     function ($reason) use ($logger, $request, $formatter) {

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -174,6 +174,20 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('"PUT / HTTP/1.1" 200', $logger->output);
     }
 
+    public function testLogsRequestsAndResponsesCustomLevel()
+    {
+        $h = new MockHandler([new Response(200)]);
+        $stack = new HandlerStack($h);
+        $logger = new Logger();
+        $formatter = new MessageFormatter();
+        $stack->push(Middleware::log($logger, $formatter, 'debug'));
+        $comp = $stack->resolve();
+        $p = $comp(new Request('PUT', 'http://www.google.com'), []);
+        $p->wait();
+        $this->assertContains('"PUT / HTTP/1.1" 200', $logger->output);
+        $this->assertContains('[debug]', $logger->output);
+    }
+
     public function testLogsRequestsAndErrors()
     {
         $h = new MockHandler([new Response(404)]);
@@ -199,6 +213,6 @@ class Logger implements LoggerInterface
 
     public function log($level, $message, array $context = [])
     {
-        $this->output .= $message . "\n";
+        $this->output .= "[{$level}] {$message}\n";
     }
 }


### PR DESCRIPTION
This would be great as I generally prefer to log these to debug instead of info. Didn't want to duplicate all that logic for my own middleware, however.