### PR TITLE
Fixed incorrect documentation on the return type of getHeader()

### DIFF
--- a/docs/psr7.rst
+++ b/docs/psr7.rst
@@ -65,14 +65,15 @@ You can check if a request or response has a specific header using the
         echo 'It is there';
     }
 
-You can retrieve a header value as a string using ``getHeader()``.
+You can retrieve all the header values as an array of strings using
+``getHeader()``.
 
 .. code-block:: php
 
-    echo $request->getHeader('X-Foo'); // bar
+    $request->getHeader('X-Foo'); // ['bar']
 
-    // Retrieving a missing header returns an empty string.
-    echo $request->getHeader('X-Bar') // outputs nothing
+    // Retrieving a missing header returns an empty array.
+    $request->getHeader('X-Bar'); // []
 
 You can iterate over the headers of a message using the ``getHeaders()``
 method.


### PR DESCRIPTION
Minor fix to the documentation on ``getHeader()``: it incorrectly states the method returns a string, whereas it returns an array.