### PR TITLE
Fixed response header case sensitivity

### DIFF
--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -107,7 +107,7 @@ abstract class AbstractMessage implements MessageInterface
     {
         $this->headers = $this->headerNames = [];
         foreach ($headers as $key => $value) {
-            $this->setHeader($key, $value);
+            $this->addHeader($key, $value);
         }
     }
 

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -29,6 +29,18 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ntest", (string) $response);
     }
 
+    public function testConstructorInitializesMessageWithMixedCaseHeaders()
+    {
+        $r = new Response(200, [
+            'Set-Cookie' => 'foo=bar, baz=bam',
+            'Set-cookie' => 'hi=there',
+            'other' => ['1', '2']
+        ]);
+
+        $this->assertEquals('foo=bar, baz=bam, hi=there', $r->getHeader('Set-Cookie'));
+        $this->assertEquals('1, 2', $r->getHeader('other'));
+    }
+
     public function testConvertsToStringAndSeeksToByteZero()
     {
         $response = new Response(200);


### PR DESCRIPTION
This is similar to issue #1058 but in Response.

If there are two headers with the same name but one is lower case, only last header will be used. This PR is fixing this and both will be added.

Sample response:
```
< HTTP/1.0 302 Moved Temporarily
< Server: Sun-Java-System/Application-Server
< Date: Tue, 02 Jun 2015 21:59:18 GMT
< Set-cookie: cookie1=abc; Expires=Thu, 01-Jan-2016 00:00:10 GMT; Domain=.example.org; Path=/
< Set-Cookie: cookie2=abc; Expires=Thu, 01-Jan-2016 00:00:10 GMT; domain=.example.org; Path=/
< Content-Length: 0
< Connection: close
< Location: https://example.org/
```