### PR TITLE
Fix bug in Mock Handler section of testing docs

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -35,7 +35,7 @@ a response or exception by shifting return values off of a queue.
     ]);
 
     $handler = HandlerStack::create($mock);
-    $client = new Client(['handler' => $mock]);
+    $client = new Client(['handler' => $handler]);
 
     // The first request is intercepted with the first response.
     echo $client->get('/')->getStatusCode();


### PR DESCRIPTION
Based on the handler docs [here](https://github.com/guzzle/guzzle/blob/master/docs/handlers-and-middleware.rst#handlers), I'm pretty sure you mean to pass the `$handler` variable to the Client constructor.