### PR TITLE
failing test for merging Uris using $client->request

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -79,6 +80,20 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'http://foo.com/bar/baz',
             $mock->getLastRequest()->getUri()
+        );
+    }
+
+    public function testCanMergeOnBaseUriWithRequest()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client([
+            'handler'  => $mock,
+            'base_uri' => 'http://foo.com/bar/'
+        ]);
+        $client->request('GET', new Uri('baz'));
+        $this->assertEquals(
+            'http://bar.com/bar/baz',
+            (string) $mock->getLastRequest()->getUri()
         );
     }
 


### PR DESCRIPTION
Hi!
Just ran into this today. Is this expected behaviour?
What I've found so far is that the `/` prefix gets prepended all the time in https://github.com/guzzle/psr7/blob/master/src/Uri.php#L574 then, since the relative `Uri` starts with a slash, it replaces the `basu_uri`.