### PR TITLE
Conditionally require functions.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr/log": "~1.0"
     },
     "autoload": {
-        "files": ["src/functions.php"],
+        "files": ["src/functions_include.php"],
         "psr-4": {
             "GuzzleHttp\\": "src/"
         }

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,0 +1,6 @@
+<?php
+
+// Don't redefine the functions if included multiple times.
+if (!function_exists('GuzzleHttp\uri_template')) {
+    require __DIR__ . '/functions.php';
+}


### PR DESCRIPTION
Composer unconditionally "autoloads" files using `require` (see composer/composer#3003): this causes problems with globally-installed dependencies or where the composer autoload happens to be called more than once (see guzzle/guzzle#676).

One solution is to guard against function redeclaration using `function_exists()`: this was ruled out as not being done in the wild, but this PR uses this solution based on guzzle/promises and React doing the same thing (see [L4-7 in functions.php](https://github.com/guzzle/promises/blob/master/src/functions.php#L4-L7) and reactphp/promise#25, respectively).

The solution guzzle/promises currently uses does not work: PHP will attempt to load the functions before the conditional is evaluated. I've opted for the React solution, which is to point to a shim `functions_include.php` file that checks for the existence of the first function within `functions.php` before including `functions.php`.