### PR TITLE
Force form_params to use & as fields separator

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -289,7 +289,7 @@ class Client implements ClientInterface
                     . 'x-www-form-urlencoded requests, and the multipart '
                     . 'option to send multipart/form-data requests.');
             }
-            $options['body'] = http_build_query($options['form_params']);
+            $options['body'] = http_build_query($options['form_params'], null, '&');
             unset($options['form_params']);
             $options['_conditional']['Content-Type'] = 'application/x-www-form-urlencoded';
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -410,6 +410,27 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFormParamsEncodedProperly()
+    {
+        $separator = ini_get('arg_separator.output');
+        ini_set('arg_separator.output', '&amp;');
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->post('http://foo.com', [
+            'form_params' => [
+                'foo' => 'bar bam',
+                'baz' => ['boo' => 'qux']
+            ]
+        ]);
+        $last = $mock->getLastRequest();
+        $this->assertEquals(
+            'foo=bar+bam&baz%5Bboo%5D=qux',
+            (string) $last->getBody()
+        );
+
+        ini_set('arg_separator.output', $separator);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
According to w3.org separator [should always be](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) `&`