### PR TITLE
Changed the reason phrase casting from int to string 

### DIFF
--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -73,7 +73,7 @@ final class EasyHandle
             $headers,
             $this->sink,
             substr($startLine[0], 5),
-            isset($startLine[2]) ? (int) $startLine[2] : null
+            isset($startLine[2]) ? (string) $startLine[2] : null
         );
     }
 


### PR DESCRIPTION
int casting of reason phrase was converting legitimate string response header message to 0. e.g. If api send res `header("HTTP/1.1 401 Some message");` , "Some message" was resulted in 0 because of int casting and hence could not be fetched with `getReasonPhrase()` method. Instead default matching message from `$phrases` message map from `Response` class was returned. I looked in docs for reason behind int casting but could not find it. 