### PR TITLE
Add content-length header to outgoing requests if not supplied

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -35,6 +35,17 @@ class StreamHandler
         try {
             // Does not support the expect header.
             $request = $request->withoutHeader('Expect');
+
+            // Append a content-length header if body size is known and greater
+            // than zero. cURL appends this header automatically.
+            if ($request->getBody()->getSize()
+                && '' === $request->getHeaderLine('Content-Length')
+            ) {
+                $request = $request->withHeader('Content-Length',
+                    $request->getBody()->getSize()
+                );
+            }
+
             $stream = $this->createStream($request, $options);
             return $this->createResponse($request, $options, $stream);
         } catch (\InvalidArgumentException $e) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -36,14 +36,10 @@ class StreamHandler
             // Does not support the expect header.
             $request = $request->withoutHeader('Expect');
 
-            // Append a content-length header if body size is known and greater
-            // than zero. cURL appends this header automatically.
-            if ($request->getBody()->getSize()
-                && '' === $request->getHeaderLine('Content-Length')
-            ) {
-                $request = $request->withHeader('Content-Length',
-                    $request->getBody()->getSize()
-                );
+            // Append a content-length header if body size is zero to match
+            // cURL's behavior.
+            if (0 === $request->getBody()->getSize()) {
+                $request = $request->withHeader('Content-Length', 0);
             }
 
             $stream = $this->createStream($request, $options);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -379,6 +379,16 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $req->getHeaderLine('Content-Length'));
     }
 
+    public function testAddsContentLengthEvenWhenEmpty()
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('PUT', Server::$url, [], '');
+        $handler($request, []);
+        $req = Server::received()[0];
+        $this->assertEquals(0, $req->getHeaderLine('Content-Length'));
+    }
+
     public function testSupports100Continue()
     {
         Server::flush();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -369,6 +369,16 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $req->getHeaderLine('Content-Length'));
     }
 
+    public function testAddsContentLengthByDefault()
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('PUT', Server::$url, [], 'foo');
+        $handler($request, []);
+        $req = Server::received()[0];
+        $this->assertEquals(3, $req->getHeaderLine('Content-Length'));
+    }
+
     public function testSupports100Continue()
     {
         Server::flush();


### PR DESCRIPTION
Curl will assign a content-length header of '0' when it's missing from a request, but the StreamHandler will not. This appeared to be the cause of [an issue on the AWS SDK](https://github.com/aws/aws-sdk-php/issues/701).