### PR TITLE
Yield key

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -52,11 +52,11 @@ class Pool implements PromisorInterface
 
         $iterable = \GuzzleHttp\Promise\iter_for($requests);
         $requests = function () use ($iterable, $client, $opts) {
-            foreach ($iterable as $rfn) {
+            foreach ($iterable as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {
-                    yield $client->sendAsync($rfn, $opts);
+                    yield $key => $client->sendAsync($rfn, $opts);
                 } elseif (is_callable($rfn)) {
-                    yield $rfn($opts);
+                    yield $key => $rfn($opts);
                 } else {
                     throw new \InvalidArgumentException('Each value yielded by '
                         . 'the iterator must be a Psr7\Http\Message\RequestInterface '

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -135,6 +135,28 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($called);
     }
 
+    public function testUsesYieldedKeyInFulfilledCallback()
+    {
+        $r1 = new Promise(function () use (&$r1) { $r1->resolve(new Response()); });
+        $r2 = new Promise(function () use (&$r2) { $r2->resolve(new Response()); });
+        $r3 = new Promise(function () use (&$r3) { $r3->resolve(new Response()); });
+        $handler = new MockHandler([$r1, $r2, $r3]);
+        $c = new Client(['handler' => $handler]);
+        $keys = [];
+        $requests = [
+            'request_1' => new Request('GET', 'http://example.com'),
+            'request_2' => new Request('GET', 'http://example.com'),
+            'request_3' => new Request('GET', 'http://example.com'),
+        ];
+        $p = new Pool($c, $requests, [
+            'pool_size' => 2,
+            'fulfilled' => function($res, $index) use (&$keys) { $keys[] = $index; }
+        ]);
+        $p->promise()->wait();
+        $this->assertCount(3, $keys);
+        $this->assertSame($keys, array_keys($requests));
+    }
+
     private function getClient($total = 1)
     {
         $queue = [];


### PR DESCRIPTION
Yield the key while iterating requests. 
Can be useful for identifying request/response


``` php
use GuzzleHttp\Client;
use GuzzleHttp\Psr7\Request;
use GuzzleHttp\Pool;

$client = new Client;
$batch = [
    'key_1' => 'http://example.com',
    'key_2' => 'http://example.com',
    'key_3' => 'http://example.com'
];
$requests = function ($batch) {
	foreach ($batch as $key => $url) {
		yield  $key => new Request('GET', $url);
	}
};
$pool = new Pool($client, $requests($batch), [
	'fulfilled' => function ($response, $index) {
		var_dump($index);
	}
]);
$promise = $pool->promise();
$promise->wait();
```

Please let me know if it is utter crap, or you would like anything different