### PR TITLE
Added option to encode url via RFC 1738

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -160,7 +160,8 @@ class Client implements ClientInterface
             'http_errors'     => true,
             'decode_content'  => true,
             'verify'          => true,
-            'cookies'         => false
+            'cookies'         => false,
+            'enc_type'        => PHP_QUERY_RFC3986
         ];
 
         // Use the standard Linux HTTP_PROXY and HTTPS_PROXY if set
@@ -348,7 +349,17 @@ class Client implements ClientInterface
         if (isset($options['query'])) {
             $value = $options['query'];
             if (is_array($value)) {
-                $value = http_build_query($value, null, '&', PHP_QUERY_RFC3986);
+
+	            // Check to see if the constant for enc_type is valid.
+	            if ($options['enc_type'] !== PHP_QUERY_RFC1738
+		            && $options['enc_type'] !== PHP_QUERY_RFC3986) {
+		            throw new \InvalidArgumentException(
+			            'The enc_type given is not a valid constant. You must'
+			            . ' specify either PHP_QUERY_RFC1738 or PHP_QUERY_RFC3986.'
+		            );
+	            }
+
+                $value = http_build_query($value, null, '&', $options['enc_type']);
             }
             if (!is_string($value)) {
                 throw new Iae('query must be a string or array');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -321,8 +321,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $request = new Request('PUT', 'http://foo.com');
-        $client->send($request, ['query' => ['foo' => 'bar baz']]);
-        $this->assertEquals('foo=bar%20baz', $mock->getLastRequest()->getUri()->getQuery());
+	    $client->send($request, ['query' => ['foo' => 'bar', 'john' => 'doe']]);
+	    $this->assertEquals('foo=bar&john=doe', $mock->getLastRequest()->getUri()->getQuery());
     }
 
     public function testCanAddJsonData()
@@ -533,12 +533,21 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testProperlyBuildsQuery()
+    public function testProperlyBuildsQueryWithRFC3986()
     {
         $mock = new MockHandler([new Response(200)]);
-        $client = new Client(['handler' => $mock]);
+        $client = new Client(['handler' => $mock, 'enc_type' => PHP_QUERY_RFC3986]);
         $request = new Request('PUT', 'http://foo.com');
-        $client->send($request, ['query' => ['foo' => 'bar', 'john' => 'doe']]);
-        $this->assertEquals('foo=bar&john=doe', $mock->getLastRequest()->getUri()->getQuery());
+        $client->send($request, ['query' => ['foo' => 'bar baz', 'john' => 'doe']]);
+	    $this->assertEquals('foo=bar%20baz&john=doe', $mock->getLastRequest()->getUri()->getQuery());
     }
+
+	public function testProperlyBuildsQueryWithRFC1738()
+	{
+		$mock = new MockHandler([new Response(200)]);
+		$client = new Client(['handler' => $mock, 'enc_type' => PHP_QUERY_RFC1738]);
+		$request = new Request('PUT', 'http://foo.com');
+		$client->send($request, ['query' => ['foo' => 'bar baz', 'john' => 'doe']]);
+		$this->assertEquals('foo=bar+baz&john=doe', $mock->getLastRequest()->getUri()->getQuery());
+	}
 }


### PR DESCRIPTION
You can now add the option to encode using PHP_RFC_1738 by passing ['enc_type' => PHP_RFC_1738] as an option to the guzzle client.

fixes issue: #1208