### PR TITLE
Add certificate path for google app engine

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -166,6 +166,8 @@ function default_ca_bundle()
         '/usr/local/share/certs/ca-root-nss.crt',
         // OS X provided by homebrew (using the default path)
         '/usr/local/etc/openssl/cert.pem',
+        // Google app engine
+        '/etc/ca-certificates.crt',
         // Windows?
         'C:\\windows\\system32\\curl-ca-bundle.crt',
         'C:\\windows\\curl-ca-bundle.crt',


### PR DESCRIPTION
See this comment by @sjlangley on Stack Overflow: http://stackoverflow.com/questions/31631596/curl-error-7-during-guzzle-request-on-google-app-engine?noredirect=1#comment51770582_31631596

Closes #1191.