### PR TITLE
Fill Content-Type header when multipart body is explicit set

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -297,9 +297,6 @@ class Client implements ClientInterface
             $elements = $options['multipart'];
             unset($options['multipart']);
             $options['body'] = new Psr7\MultipartStream($elements);
-            // Use a multipart/form-data POST if a Content-Type is not set.
-            $options['_conditional']['Content-Type'] = 'multipart/form-data; boundary='
-                . $options['body']->getBoundary();
         }
 
         if (!empty($options['decode_content'])
@@ -363,6 +360,11 @@ class Client implements ClientInterface
         }
 
         $request = Psr7\modify_request($request, $modify);
+        if ($request->getBody() instanceof Psr7\MultipartStream) {
+            // Use a multipart/form-data POST if a Content-Type is not set.
+            $options['_conditional']['Content-Type'] = 'multipart/form-data; boundary='
+                . $request->getBody()->getBoundary();
+        }
 
         // Merge in conditional headers if they are not present.
         if (isset($options['_conditional'])) {


### PR DESCRIPTION
When custom crafted requests are created Content-Type is not automatically filled like was done in multipart option.

Alternative:

```php
$multipartStream = new Psr7\MultipartStream(
    [
        $fieldName => [
            'name' => $fieldName,
            'contents' => $content,
            'filename' => $filename,
        ],
    ]
);

$request = new Psr7\Request('POST', $uri, $headers, $multipartStream);
$request = $request->withHeader(
    'Content-Type',
    'multipart/form-data; boundary='. $multipartStream->getBoundary()
);
```