### PR TITLE
Fix incorrect equal sign in cookie value

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -69,7 +69,7 @@ class CookieJar implements CookieJarInterface
     {
         if (substr($value, 0, 1) !== '"' &&
             substr($value, -1, 1) !== '"' &&
-            strpbrk($value, ';,')
+            strpbrk($value, ';,=')
         ) {
             $value = '"' . $value . '"';
         }

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -32,6 +32,8 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('foo', CookieJar::getCookieValue('foo'));
         $this->assertEquals('"foo,bar"', CookieJar::getCookieValue('foo,bar'));
+        $this->assertEquals('"foobar="', CookieJar::getCookieValue('foobar='));
+        $this->assertEquals('"foo;bar"', CookieJar::getCookieValue('foo;bar'));
     }
 
     public function testCreatesFromArray()


### PR DESCRIPTION
Sometimes ago I meet with problem, that equal sign is breaking cookies using guzzle while I make parser. 

For example 
Browser Cookie:
```Cookie: SHOE="GS8lnoqTZSPD5YcY42WwNsGr84o="```

Guzzle Cookie:
```Cookie: SHOE=GS8lnoqTZSPD5YcY42WwNsGr84o=```

And session was lost by Guzzle with this cookie