### PR TITLE
Allow square brackets in cookie name

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -377,12 +377,12 @@ class SetCookie
 
         // Check if any of the invalid characters are present in the cookie name
         if (preg_match(
-            '/[\x00-\x20\x22\x28-\x29\x2c\x2f\x3a-\x40\x5b-\x5d\x7b\x7d\x7f]/',
+            '/[\x00-\x20\x22\x28-\x29\x2c\x2f\x3a-\x40\x5c\x7b\x7d\x7f]/',
             $name)
         ) {
             return 'Cookie name must not contain invalid characters: ASCII '
                 . 'Control characters (0-31;127), space, tab and the '
-                . 'following characters: ()<>@,;:\"/[]?={}';
+                . 'following characters: ()<>@,;:\"/?={}';
         }
 
         // Value must not be empty, but can be 0

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -291,7 +291,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
-     * @expectedExceptionMessage Invalid cookie: Cookie name must not contain invalid characters: ASCII Control characters (0-31;127), space, tab and the following characters: ()<>@,;:\"/[]?={}
+     * @expectedExceptionMessage Invalid cookie: Cookie name must not contain invalid characters: ASCII Control characters (0-31;127), space, tab and the following characters: ()<>@,;:\"/?={}
      */
     public function testThrowsExceptionWithStrictMode()
     {

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -156,7 +156,7 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
             array('', 'baz', 'bar', 'The cookie name must not be empty'),
             array('foo', '', 'bar', 'The cookie value must not be empty'),
             array('foo', 'baz', '', 'The cookie domain must not be empty'),
-            array("foo\r", 'baz', '0', 'Cookie name must not contain invalid characters: ASCII Control characters (0-31;127), space, tab and the following characters: ()<>@,;:\"/[]?={}'),
+            array("foo\r", 'baz', '0', 'Cookie name must not contain invalid characters: ASCII Control characters (0-31;127), space, tab and the following characters: ()<>@,;:\"/?={}'),
         );
     }
 

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -153,6 +153,7 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
         return array(
             array('foo', 'baz', 'bar', true),
             array('0', '0', '0', true),
+            array('foo[bar]', 'baz', 'bar', true),
             array('', 'baz', 'bar', 'The cookie name must not be empty'),
             array('foo', '', 'bar', 'The cookie value must not be empty'),
             array('foo', 'baz', '', 'The cookie domain must not be empty'),


### PR DESCRIPTION
Allow square brackets in cookie name, because PHP uses them.
http://php.net/setcookie#example-4936

#1205