### PR TITLE
Fix options merge, ensure latter options override

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -46,7 +46,7 @@ class CurlFactory implements CurlFactoryInterface
 
         // Add handler options from the request configuration options
         if (isset($options['curl'])) {
-            $conf = $options['curl'] + $conf;
+            $conf = array_replace($conf, $options['curl']);
         }
 
         $conf[CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);


### PR DESCRIPTION
As shown in [this 3v4l example](https://3v4l.org/Z3Deo), using `+=` does not have the desired result of overriding the matching keys in the left operand with those as the right operand. `array_merge()` will just append duplicate numeric keys as a new entry in the array; `array_replace()` as used here gives the desired behavior.