### PR TITLE
on_headers if isset

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -474,12 +474,14 @@ class CurlFactory implements CurlFactoryInterface
 
     private function createHeaderFn(EasyHandle $easy)
     {
-        if (!isset($easy->options['on_headers'])) {
-            $onHeaders = null;
-        } elseif (!is_callable($easy->options['on_headers'])) {
-            throw new \InvalidArgumentException('on_headers must be callable');
-        } else {
+        $onHeaders = null;
+
+        if (isset($easy->options['on_headers'])) {
             $onHeaders = $easy->options['on_headers'];
+        }
+
+        if (!is_callable($onHeaders)) {
+            throw new \InvalidArgumentException('on_headers must be callable');
         }
 
         return function ($ch, $h) use (


### PR DESCRIPTION
when $easy->options['on_headers'] is set it will not be checked by is_callable