### PR TITLE
Use ::class in tests where it was possible

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -5,10 +5,12 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\ResponseInterface;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,7 +38,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         Server::flush();
         Server::enqueue([new Response(200, ['Content-Length' => 2], 'hi')]);
         $p = $client->getAsync(Server::$url, ['query' => ['test' => 'foo']]);
-        $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $p);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
         $this->assertEquals(200, $p->wait()->getStatusCode());
         $received = Server::received(true);
         $this->assertCount(1, $received);
@@ -48,7 +50,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client = new Client(['handler' => new MockHandler([new Response()])]);
         $request = new Request('GET', 'http://example.com');
         $r = $client->send($request);
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $r);
+        $this->assertInstanceOf(ResponseInterface::class, $r);
         $this->assertEquals(200, $r->getStatusCode());
     }
 
@@ -62,7 +64,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         ]);
         $base = $client->getConfig('base_uri');
         $this->assertEquals('http://foo.com', (string) $base);
-        $this->assertInstanceOf('GuzzleHttp\Psr7\Uri', $base);
+        $this->assertInstanceOf(Uri::class, $base);
         $this->assertNotNull($client->getConfig('handler'));
         $this->assertEquals(2, $client->getConfig('timeout'));
         $this->assertArrayHasKey('timeout', $client->getConfig());

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace GuzzleHttp\Test\Handler;
 
+use GuzzleHttp\Handler\CurlFactory;
+use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Tests\Server;
 use GuzzleHttp\Handler;
 use GuzzleHttp\Psr7;
@@ -40,7 +42,7 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
         ], 'testing');
         $f = new Handler\CurlFactory(3);
         $result = $f->create($request, ['sink' => $stream]);
-        $this->assertInstanceOf('GuzzleHttp\Handler\EasyHandle', $result);
+        $this->assertInstanceOf(EasyHandle::class, $result);
         $this->assertInternalType('resource', $result->handle);
         $this->assertInternalType('array', $result->headers);
         $this->assertSame($stream, $result->sink);
@@ -502,7 +504,7 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreatesConnectException()
     {
-        $m = new \ReflectionMethod('GuzzleHttp\Handler\CurlFactory', 'finishError');
+        $m = new \ReflectionMethod(CurlFactory::class, 'finishError');
         $m->setAccessible(true);
         $factory = new Handler\CurlFactory(1);
         $easy = $factory->create(new Psr7\Request('GET', Server::$url), []);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Test\Handler;
 
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\StreamHandler;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -539,7 +540,7 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertInternalType('float', $gotStats->getTransferTime());
         $this->assertInstanceOf(
-            'GuzzleHttp\Exception\ConnectException',
+            ConnectException::class,
             $gotStats->getHandlerErrorData()
         );
     }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -98,7 +98,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $f($request, [])->wait(false);
         $this->assertCount(1, $container);
         $this->assertEquals('GET', $container[0]['request']->getMethod());
-        $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $container[0]['error']);
+        $this->assertInstanceOf(RequestException::class, $container[0]['error']);
     }
 
     public function testTapsBeforeAndAfter()
@@ -127,7 +127,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $comp = $b->resolve();
         $p = $comp(new Request('GET', 'http://foo.com'), []);
         $this->assertEquals('123', implode('', $calls));
-        $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $p);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
         $this->assertEquals(200, $p->wait()->getStatusCode());
     }
 
@@ -145,7 +145,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         }));
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);
-        $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $p);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
     }
 
     public function testMapsResponse()

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests;
 
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Pool;
@@ -113,7 +114,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $results[0]->getStatusCode());
         $this->assertEquals(201, $results[1]->getStatusCode());
         $this->assertEquals(202, $results[2]->getStatusCode());
-        $this->assertInstanceOf('GuzzleHttp\Exception\ClientException', $results[3]);
+        $this->assertInstanceOf(ClientException::class, $results[3]);
     }
 
     public function testBatchesResultsWithCallbacks()

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Request;
@@ -25,7 +26,7 @@ class PrepareBodyMiddlewareTest extends \PHPUnit_Framework_TestCase
         $stack->push($m);
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com', [], '123'), []);
-        $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $p);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -47,7 +48,7 @@ class PrepareBodyMiddlewareTest extends \PHPUnit_Framework_TestCase
         $stack->push($m);
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com', [], $body), []);
-        $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $p);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -67,7 +68,7 @@ class PrepareBodyMiddlewareTest extends \PHPUnit_Framework_TestCase
         $stack->push($m);
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com', [], $bd), []);
-        $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $p);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -103,7 +104,7 @@ class PrepareBodyMiddlewareTest extends \PHPUnit_Framework_TestCase
         $p = $comp(new Request('PUT', 'http://www.google.com', [], $bd), [
             'expect' => $value
         ]);
-        $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $p);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
         $this->assertEquals(200, $response->getStatusCode());
     }
@@ -126,7 +127,7 @@ class PrepareBodyMiddlewareTest extends \PHPUnit_Framework_TestCase
             new Request('PUT', 'http://www.google.com', ['Expect' => 'Foo'], $bd),
             ['expect' => true]
         );
-        $this->assertInstanceOf('GuzzleHttp\Promise\PromiseInterface', $p);
+        $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
         $this->assertEquals(200, $response->getStatusCode());
     }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -62,7 +62,7 @@ class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($calls[0][2]);
         $this->assertInstanceOf('Exception', $calls[0][3]);
         $this->assertEquals(1, $calls[1][0]);
-        $this->assertInstanceOf('GuzzleHttp\Psr7\Response', $calls[1][2]);
+        $this->assertInstanceOf(Response::class, $calls[1][2]);
         $this->assertNull($calls[1][3]);
     }
 


### PR DESCRIPTION
As guzzle depends on PHP 5.5  we can use ::class in some tests and make the code a bit easier
to browser in IDEs etc.