### PR TITLE
Fixed typo in quickstart docs for httpbin

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -95,7 +95,7 @@ ready:
 
     use GuzzleHttp\Psr7\Request;
 
-    $request = new Request('PUT', 'http:/httpbin.org/put');
+    $request = new Request('PUT', 'http://httpbin.org/put');
     $response = $client->send($request, ['timeout' => 2]);
 
 Client objects provide a great deal of flexibility in how request are


### PR DESCRIPTION
Missing slash on http protocol for a httpbin URL.