### PR TITLE
rewind the stream after logging

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -175,6 +175,8 @@ final class Middleware
      * Middleware that logs requests, responses, and errors using a message
      * formatter.
      *
+     * If the stream of the request or response has consumed, rewinds the stream.
+     *
      * @param LoggerInterface  $logger Logs messages.
      * @param MessageFormatter $formatter Formatter used to create message strings.
      * @param string           $logLevel Level at which to log requests.
@@ -189,6 +191,8 @@ final class Middleware
                     function ($response) use ($logger, $request, $formatter, $logLevel) {
                         $message = $formatter->format($request, $response);
                         $logger->log($logLevel, $message);
+                        $request->getBody()->eof() && $request->getBody()->rewind();
+                        $response->getBody()->eof() && $response->getBody()->rewind();
                         return $response;
                     },
                     function ($reason) use ($logger, $request, $formatter) {

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -174,6 +174,36 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('"PUT / HTTP/1.1" 200', $logger->output);
     }
 
+    public function testRewindStreamAfterLogsRequestsAndResponses()
+    {
+        $h = new MockHandler([new Response(200, [], 'bar')]);
+        $stack = new HandlerStack($h);
+        $logger = new Logger();
+        $formatter = new MessageFormatter(MessageFormatter::DEBUG);
+        $stack->push(Middleware::log($logger, $formatter));
+        $comp = $stack->resolve();
+        $p = $comp(new Request('GET', 'http://www.google.com', [], 'foo=bar'), []);
+        $response = $p->wait();
+        $this->assertContains('bar', $logger->output);
+        $this->assertContains('foo', $h->getLastRequest()->getBody()->getContents());
+        $this->assertContains('bar', $response->getBody()->getContents());
+    }
+
+    public function testLogDoesNotRewindStreamWhenRequestsAndResponsesNotUsed()
+    {
+        $h = new MockHandler([new Response(200)]);
+        $stack = new HandlerStack($h);
+        $logger = new Logger();
+        $formatter = new MessageFormatter();
+        $stack->push(Middleware::log($logger, $formatter));
+        $comp = $stack->resolve();
+        $p = $comp(new Request('GET', 'http://www.google.com'), []);
+        $response = $p->wait();
+        $this->assertContains('"GET / HTTP/1.1" 200', $logger->output);
+        $this->assertFalse($h->getLastRequest()->getBody()->eof());
+        $this->assertFalse($response->getBody()->eof());
+    }
+
     public function testLogsRequestsAndResponsesCustomLevel()
     {
         $h = new MockHandler([new Response(200)]);


### PR DESCRIPTION
Purpose of the change is rewinding the stream after using the response in log middleware
