### PR TITLE
Makes the HandlerStack more reusable

### DIFF
--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -62,11 +62,8 @@ class HandlerStack
      */
     public function __invoke(RequestInterface $request, array $options)
     {
-        if (!$this->cached) {
-            $this->cached = $this->resolve();
-        }
+        $handler = $this->resolve();
 
-        $handler = $this->cached;
         return $handler($request, $options);
     }
 
@@ -193,15 +190,19 @@ class HandlerStack
      */
     public function resolve()
     {
-        if (!($prev = $this->handler)) {
-            throw new \LogicException('No handler has been specified');
+        if (!$this->cached) {
+            if (!($prev = $this->handler)) {
+                throw new \LogicException('No handler has been specified');
+            }
+
+            foreach (array_reverse($this->stack) as $fn) {
+                $prev = $fn[0]($prev);
+            }
+
+            $this->cached = $prev;
         }
 
-        foreach (array_reverse($this->stack) as $fn) {
-            $prev = $fn[0]($prev);
-        }
-
-        return $prev;
+        return $this->cached;
     }
 
     /**


### PR DESCRIPTION
Fixes #1263. Makes the HandlerStack more reusable (without BC) by moving the "cached" logic from __invoke() to resolve().