### PR TITLE
Switch Middleware to use exception factory

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -79,22 +79,61 @@ class RequestException extends TransferException
 
         $level = floor($response->getStatusCode() / 100);
         if ($level == '4') {
-            $label = 'Client error response';
+            $label = 'Client Error';
             $className = __NAMESPACE__ . '\\ClientException';
         } elseif ($level == '5') {
-            $label = 'Server error response';
+            $label = 'Server Error';
             $className = __NAMESPACE__ . '\\ServerException';
         } else {
-            $label = 'Unsuccessful response';
+            $label = 'Unsuccessful Request';
             $className = __CLASS__;
         }
 
-        $message = $label . ' [url] ' . $request->getUri()
-            . ' [http method] ' . $request->getMethod()
-            . ' [status code] ' . $response->getStatusCode()
-            . ' [reason phrase] ' . $response->getReasonPhrase();
+        // Server Error: `GET /` resulted in a `404 Not Found` response:
+        // <html> ... (truncated)
+        $message = sprintf(
+            '%s: `%s` resulted in a `%s` response',
+            $label,
+            $request->getMethod() . ' ' . $request->getUri(),
+            $response->getStatusCode() . ' ' . $response->getReasonPhrase()
+        );
+
+        $summary = static::getResponseBodySummary($response);
+
+        if (is_string($summary)) {
+            $message .= ":\n{$summary}\n";
+        }
 
         return new $className($message, $request, $response, $previous, $ctx);
+    }
+
+    /**
+     * Get a short summary of the response
+     *
+     * Will return `null` if the response is not printable.
+     *
+     * @param ResponseInterface $response
+     *
+     * @return string|null
+     */
+    public static function getResponseBodySummary(ResponseInterface $response)
+    {
+        $body = $response->getBody();
+
+        if (!$body->isSeekable()) {
+            return null;
+        }
+
+        $summary = $body->read(120);
+        $body->rewind();
+
+        // Matches any printable character, including unicode characters:
+        // letters, marks, numbers, punctuation, spacing, and separators.
+        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', $summary)) {
+            return null;
+        }
+
+        return $summary;
     }
 
     /**

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -2,9 +2,7 @@
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJarInterface;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
@@ -64,9 +62,7 @@ final class Middleware
                         if ($code < 400) {
                             return $response;
                         }
-                        throw $code > 499
-                            ? new ServerException("Server error: $code", $request, $response)
-                            : new ClientException("Client error: $code", $request, $response);
+                        throw RequestException::create($request, $response);
                     }
                 );
             };

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -193,13 +193,14 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $h = new MockHandler([new Response(404)]);
         $stack = new HandlerStack($h);
         $logger = new Logger();
-        $formatter = new MessageFormatter('"{method} {target} HTTP/{version}\" {code} {error}');
+        $formatter = new MessageFormatter('{code} {error}');
         $stack->push(Middleware::log($logger, $formatter));
         $stack->push(Middleware::httpErrors());
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), ['http_errors' => true]);
         $p->wait(false);
-        $this->assertContains('"PUT / HTTP/1.1\" 404 Client error: 404', $logger->output);
+        $this->assertContains('PUT http://www.google.com', $logger->output);
+        $this->assertContains('404 Not Found', $logger->output);
     }
 }
 


### PR DESCRIPTION
The `RequestException::create` factory was not being used anywhere.
Using it inside of `Middleware::httpErrors` simplifies the code and
allows for simpler changes in the future.

Also updates the message formatting of the exception factory to
provide a more complete status, including the body of the response.