### PR TITLE
Documented throwing an exception in MockHandler

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -27,11 +27,14 @@ a response or exception by shifting return values off of a queue.
     use GuzzleHttp\Handler\MockHandler;
     use GuzzleHttp\HandlerStack;
     use GuzzleHttp\Psr7\Response;
+    use GuzzleHttp\Psr7\Request;
+    use GuzzleHttp\Exception\RequestException;
 
     // Create a mock and queue two responses.
     $mock = new MockHandler([
         new Response(200, ['X-Foo' => 'Bar']),
-        new Response(202, ['Content-Length' => 0])
+        new Response(202, ['Content-Length' => 0]),
+        new RequestException("Error Communicating with Server", new Request('GET', 'test'))
     ]);
 
     $handler = HandlerStack::create($mock);


### PR DESCRIPTION
While exceptions are briefly mentioned in the preceding documentation, it is not immediately clear that exceptions can be thrown in the MockHandler, since my eyes are immediately drawn to the example code rather than the textual pre-amble.

With this, it is immediately clear to anyone that the stack can consist of both Responses and Exceptions.