### PR TITLE
Handle disabled functions with curl_exec() and curl_multi_exec()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -105,7 +105,12 @@ function choose_handler()
 {
     $handler = null;
     if (extension_loaded('curl')) {
-        $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
+        if (function_exists('curl_multi_exec') && function_exists('curl_exec')) {
+            $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
+        }
+        elseif (function_exists('curl_exec')) {
+            $handler = new CurlHandler();
+        }
     }
 
     if (ini_get('allow_url_fopen')) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -104,13 +104,12 @@ function debug_resource($value = null)
 function choose_handler()
 {
     $handler = null;
-    if (extension_loaded('curl')) {
-        if (function_exists('curl_multi_exec') && function_exists('curl_exec')) {
-            $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
-        }
-        elseif (function_exists('curl_exec')) {
-            $handler = new CurlHandler();
-        }
+    if (function_exists('curl_multi_exec') && function_exists('curl_exec')) {
+        $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
+    } elseif (function_exists('curl_exec')) {
+        $handler = new CurlMultiHandler();
+    } elseif (function_exists('curl_multi_exec')) {
+        $handler = new CurlHandler();
     }
 
     if (ini_get('allow_url_fopen')) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -107,9 +107,9 @@ function choose_handler()
     if (function_exists('curl_multi_exec') && function_exists('curl_exec')) {
         $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
     } elseif (function_exists('curl_exec')) {
-        $handler = new CurlMultiHandler();
-    } elseif (function_exists('curl_multi_exec')) {
         $handler = new CurlHandler();
+    } elseif (function_exists('curl_multi_exec')) {
+        $handler = new CurlMultiHandler();
     }
 
     if (ini_get('allow_url_fopen')) {


### PR DESCRIPTION
On shared hosting providers disable curl_exec() and curl_multi_exec() so the choose_handler() function
has to take that into account.