### PR TITLE
Implement "sink" for MockHandler

### DIFF
--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -87,6 +87,19 @@ class MockHandler implements \Countable
                 if ($this->onFulfilled) {
                     call_user_func($this->onFulfilled, $value);
                 }
+                if (isset($options['sink'])) {
+                    $contents = (string) $value->getBody();
+                    $sink = $options['sink'];
+
+                    if (is_resource($sink)) {
+                        fwrite($sink, $contents);
+                    } elseif (is_string($sink)) {
+                        file_put_contents($sink, $contents);
+                    } elseif ($sink instanceof \Psr\Http\Message\StreamInterface) {
+                        $sink->write($contents);
+                    }
+                }
+
                 return $value;
             },
             function ($reason) use ($request, $options) {


### PR DESCRIPTION
This is a reimplementation of my previous pull request https://github.com/guzzle/guzzle/pull/1020 which regressed with the 6.0 rewrite

Fingers crossed for 7.0, maybe I can make one of those too :)