### PR TITLE
SSL Stream Context Options Expanded

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -161,7 +161,7 @@ class Client implements ClientInterface
             'decode_content'	=> true,
             'verify'		=> true,
             'cookies'		=> false,
-            'allow_self_signed'	=> false,
+            'allow_self_signed' => false,
             'verify_peer_name'	=> false,
         ];
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -159,7 +159,7 @@ class Client implements ClientInterface
             'cookies'			=> false,
             'verify'			=> true,
             'allow_self_signed'		=> false,
-            'verify_peer_name'		=> false,
+            'verify_peer_name'		=> true,
         ];
 
         // Use the standard Linux HTTP_PROXY and HTTPS_PROXY if set

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Psr7;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use \InvalidArgumentException as Iae;
 
 /**
  * @method ResponseInterface get($uri, array $options = [])
@@ -150,8 +149,6 @@ class Client implements ClientInterface
      * Configures the default options for a client.
      *
      * @param array $config
-     *
-     * @return array
      */
     private function configureDefaults(array $config)
     {
@@ -159,8 +156,8 @@ class Client implements ClientInterface
             'allow_redirects'		=> RedirectMiddleware::$defaultSettings,
             'http_errors'		=> true,
             'decode_content'		=> true,
-            'verify'			=> true,
             'cookies'			=> false,
+            'verify'			=> true,
             'allow_self_signed'		=> false,
             'verify_peer_name'		=> false,
         ];
@@ -174,6 +171,11 @@ class Client implements ClientInterface
             $defaults['proxy']['https'] = $proxy;
         }
 
+        if ($noProxy = getenv('NO_PROXY')) {
+            $cleanedNoProxy = str_replace(' ', '', $noProxy);
+            $defaults['proxy']['no'] = explode(',', $cleanedNoProxy);
+        }
+        
         $this->config = $config + $defaults;
 
         if (!empty($config['cookies']) && $config['cookies'] === true) {
@@ -284,7 +286,14 @@ class Client implements ClientInterface
         $modify = [];
 
         if (isset($options['form_params'])) {
-            $options['body'] = http_build_query($options['form_params']);
+            if (isset($options['multipart'])) {
+                throw new \InvalidArgumentException('You cannot use '
+                    . 'form_params and multipart at the same time. Use the '
+                    . 'form_params option if you want to send application/'
+                    . 'x-www-form-urlencoded requests, and the multipart '
+                    . 'option to send multipart/form-data requests.');
+            }
+            $options['body'] = http_build_query($options['form_params'], null, '&');
             unset($options['form_params']);
             $options['_conditional']['Content-Type'] = 'application/x-www-form-urlencoded';
         }
@@ -293,9 +302,6 @@ class Client implements ClientInterface
             $elements = $options['multipart'];
             unset($options['multipart']);
             $options['body'] = new Psr7\MultipartStream($elements);
-            // Use a multipart/form-data POST if a Content-Type is not set.
-            $options['_conditional']['Content-Type'] = 'multipart/form-data; boundary='
-                . $options['body']->getBoundary();
         }
 
         if (!empty($options['decode_content'])
@@ -346,7 +352,7 @@ class Client implements ClientInterface
                 $value = http_build_query($value, null, '&', PHP_QUERY_RFC3986);
             }
             if (!is_string($value)) {
-                throw new Iae('query must be a string or array');
+                throw new \InvalidArgumentException('query must be a string or array');
             }
             $modify['query'] = $value;
             unset($options['query']);
@@ -359,6 +365,11 @@ class Client implements ClientInterface
         }
 
         $request = Psr7\modify_request($request, $modify);
+        if ($request->getBody() instanceof Psr7\MultipartStream) {
+            // Use a multipart/form-data POST if a Content-Type is not set.
+            $options['_conditional']['Content-Type'] = 'multipart/form-data; boundary='
+                . $request->getBody()->getBoundary();
+        }
 
         // Merge in conditional headers if they are not present.
         if (isset($options['_conditional'])) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -156,13 +156,13 @@ class Client implements ClientInterface
     private function configureDefaults(array $config)
     {
         $defaults = [
-            'allow_redirects'	=> RedirectMiddleware::$defaultSettings,
-            'http_errors'	=> true,
-            'decode_content'	=> true,
-            'verify'		=> true,
-            'cookies'		=> false,
-            'allow_self_signed' => false,
-            'verify_peer_name'	=> false,
+            'allow_redirects'		=> RedirectMiddleware::$defaultSettings,
+            'http_errors'		=> true,
+            'decode_content'		=> true,
+            'verify'			=> true,
+            'cookies'			=> false,
+            'allow_self_signed'		=> false,
+            'verify_peer_name'		=> false,
         ];
 
         // Use the standard Linux HTTP_PROXY and HTTPS_PROXY if set

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -7,9 +7,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\TransferStats;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -34,24 +32,11 @@ class StreamHandler
             usleep($options['delay'] * 1000);
         }
 
-        $startTime = isset($options['on_stats']) ? microtime(true) : null;
-
         try {
             // Does not support the expect header.
             $request = $request->withoutHeader('Expect');
-
-            // Append a content-length header if body size is zero to match
-            // cURL's behavior.
-            if (0 === $request->getBody()->getSize()) {
-                $request = $request->withHeader('Content-Length', 0);
-            }
-
-            return $this->createResponse(
-                $request,
-                $options,
-                $this->createStream($request, $options),
-                $startTime
-            );
+            $stream = $this->createStream($request, $options);
+            return $this->createResponse($request, $options, $stream);
         } catch (\InvalidArgumentException $e) {
             throw $e;
         } catch (\Exception $e) {
@@ -60,41 +45,19 @@ class StreamHandler
             // This list can probably get more comprehensive.
             if (strpos($message, 'getaddrinfo') // DNS lookup failed
                 || strpos($message, 'Connection refused')
-                || strpos($message, "couldn't connect to host") // error on HHVM
             ) {
                 $e = new ConnectException($e->getMessage(), $request, $e);
             }
-            $e = RequestException::wrapException($request, $e);
-            $this->invokeStats($options, $request, $startTime, null, $e);
-
-            return new RejectedPromise($e);
-        }
-    }
-
-    private function invokeStats(
-        array $options,
-        RequestInterface $request,
-        $startTime,
-        ResponseInterface $response = null,
-        $error = null
-    ) {
-        if (isset($options['on_stats'])) {
-            $stats = new TransferStats(
-                $request,
-                $response,
-                microtime(true) - $startTime,
-                $error,
-                []
+            return new RejectedPromise(
+                RequestException::wrapException($request, $e)
             );
-            call_user_func($options['on_stats'], $stats);
         }
     }
 
     private function createResponse(
         RequestInterface $request,
         array $options,
-        $stream,
-        $startTime
+        $stream
     ) {
         $hdrs = $this->lastHeaders;
         $this->lastHeaders = [];
@@ -103,8 +66,7 @@ class StreamHandler
         $status = $parts[1];
         $reason = isset($parts[2]) ? $parts[2] : null;
         $headers = \GuzzleHttp\headers_from_lines($hdrs);
-        list ($stream, $headers) = $this->checkDecode($options, $headers, $stream);
-        $stream = Psr7\stream_for($stream);
+        $stream = Psr7\stream_for($this->checkDecode($options, $headers, $stream));
         $sink = $this->createSink($stream, $options);
         $response = new Psr7\Response($status, $headers, $sink, $ver, $reason);
 
@@ -121,8 +83,6 @@ class StreamHandler
         if ($sink !== $stream) {
             $this->drain($stream, $sink);
         }
-
-        $this->invokeStats($options, $request, $startTime, $response, null);
 
         return new FulfilledPromise($response);
     }
@@ -146,29 +106,18 @@ class StreamHandler
     {
         // Automatically decode responses when instructed.
         if (!empty($options['decode_content'])) {
-            $normalizedKeys = \GuzzleHttp\normalize_header_keys($headers);
-            if (isset($normalizedKeys['content-encoding'])) {
-                $encoding = $headers[$normalizedKeys['content-encoding']];
-                if ($encoding[0] == 'gzip' || $encoding[0] == 'deflate') {
-                    $stream = new Psr7\InflateStream(
-                        Psr7\stream_for($stream)
-                    );
-                    // Remove content-encoding header
-                    unset($headers[$normalizedKeys['content-encoding']]);
-                    // Fix content-length header
-                    if (isset($normalizedKeys['content-length'])) {
-                        $length = (int) $stream->getSize();
-                        if ($length == 0) {
-                            unset($headers[$normalizedKeys['content-length']]);
-                        } else {
-                            $headers[$normalizedKeys['content-length']] = [$length];
-                        }
+            foreach ($headers as $key => $value) {
+                if (strtolower($key) == 'content-encoding') {
+                    if ($value[0] == 'gzip' || $value[0] == 'deflate') {
+                        return new Psr7\InflateStream(
+                            Psr7\stream_for($stream)
+                        );
                     }
                 }
             }
         }
 
-        return [$stream, $headers];
+        return $stream;
     }
 
     /**
@@ -327,14 +276,7 @@ class StreamHandler
         } else {
             $scheme = $request->getUri()->getScheme();
             if (isset($value[$scheme])) {
-                if (!isset($value['no'])
-                    || !\GuzzleHttp\is_host_in_noproxy(
-                        $request->getUri()->getHost(),
-                        $value['no']
-                    )
-                ) {
-                    $options['http']['proxy'] = $value[$scheme];
-                }
+                $options['http']['proxy'] = $value[$scheme];
             }
         }
     }
@@ -360,12 +302,19 @@ class StreamHandler
         } elseif ($value === false) {
             $options['ssl']['verify_peer'] = false;
             return;
-        } else {
-            throw new \InvalidArgumentException('Invalid verify request option');
         }
+        
+        throw new \InvalidArgumentException('Invalid verify request option');
+    }
 
-        $options['ssl']['verify_peer'] = true;
-        $options['ssl']['allow_self_signed'] = false;
+    private function add_allow_self_signed(RequestInterface $request, &$options, $value, &$params)
+    {
+        $options['ssl']['allow_self_signed'] = ($value ? true : false);
+    }
+
+    private function add_verify_peer_name(RequestInterface $request, &$options, $value, &$params)
+    {
+        $options['ssl']['verify_peer_name'] = ($value ? true : false);
     }
 
     private function add_cert(RequestInterface $request, &$options, $value, &$params)

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -360,9 +360,9 @@ class StreamHandler
         } elseif ($value === false) {
             $options['ssl']['verify_peer'] = false;
             return;
+        } else {
+            throw new \InvalidArgumentException('Invalid verify request option');
         }
-        
-        throw new \InvalidArgumentException('Invalid verify request option');
     }
 
     private function add_allow_self_signed(RequestInterface $request, &$options, $value, &$params)

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -296,6 +296,11 @@ class StreamHandler
         }
 
         $context = [
+            'ssl' => [
+                'verify_peer'		=> true,
+                'verify_peer_name'	=> true,
+                'allow_self_signed'	=> false,
+            ],
             'http' => [
                 'method'           => $request->getMethod(),
                 'header'           => $headers,

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -230,6 +230,16 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $this->getSendResult(['verify' => false]);
     }
 
+    public function testVerifyPeerNameCanBeDisabled()
+    {
+        $this->getSendResult(['verify_peer_name' => false]);
+    }
+
+    public function testAllowSelfSignedCanBeEnabled()
+    {
+        $this->getSendResult(['allow_self_signed' => true]);
+    }
+
     /**
      * @expectedException \GuzzleHttp\Exception\RequestException
      * @expectedExceptionMessage SSL certificate not found: /does/not/exist

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -255,6 +255,8 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $res = $this->getSendResult(['verify' => $path]);
         $opts = stream_context_get_options($res->getBody()->detach());
         $this->assertEquals(true, $opts['ssl']['verify_peer']);
+        $this->assertEquals(true, $opts['ssl']['verify_peer_name']);
+        $this->assertEquals(false, $opts['ssl']['allow_self_signed']);
         $this->assertEquals($path, $opts['ssl']['cafile']);
         $this->assertTrue(file_exists($opts['ssl']['cafile']));
     }


### PR DESCRIPTION
* Added support for SSL Stream Context Options 'allow_self_signed' & 'verify_peer_name' via options array
* Added StreamHandler::add_allow_self_signed() & StreamHandler::add_verify_peer_name()
* Cleaned up StreamHandler::add_verify() as some code was unreachable

Example usage:

```
// Allow self signed certificates & dont verify the peer name
$client = new GuzzleHttp\Client(['allow_self_signed' => true, 'verify_peer_name' => false]);
```