### PR TITLE
Reworked options keys to be used from RequestOptions capsule.

### DIFF
--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Psr7;
+use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -32,8 +33,8 @@ class CurlHandler
 
     public function __invoke(RequestInterface $request, array $options)
     {
-        if (isset($options['delay'])) {
-            usleep($options['delay'] * 1000);
+        if (isset($options[RequestOptions::DELAY])) {
+            usleep($options[RequestOptions::DELAY] * 1000);
         }
 
         $easy = $this->factory->create($request, $options);

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -129,10 +130,10 @@ class CurlMultiHandler
         $easy = $entry['easy'];
         $id = (int) $easy->handle;
         $this->handles[$id] = $entry;
-        if (empty($easy->options['delay'])) {
+        if (empty($easy->options[RequestOptions::DELAY])) {
             curl_multi_add_handle($this->_mh, $easy->handle);
         } else {
-            $this->delays[$id] = microtime(true) + ($easy->options['delay'] / 1000);
+            $this->delays[$id] = microtime(true) + ($easy->options[RequestOptions::DELAY] / 1000);
         }
     }
 

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -53,7 +54,7 @@ final class EasyHandle
         $headers = \GuzzleHttp\headers_from_lines($this->headers);
         $normalizedKeys = \GuzzleHttp\normalize_header_keys($headers);
 
-        if (!empty($this->options['decode_content'])
+        if (!empty($this->options[RequestOptions::DECODE_CONTENT])
             && isset($normalizedKeys['content-encoding'])
         ) {
             unset($headers[$normalizedKeys['content-encoding']]);

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -65,8 +66,8 @@ class MockHandler implements \Countable
             throw new \OutOfBoundsException('Mock queue is empty');
         }
 
-        if (isset($options['delay'])) {
-            usleep($options['delay'] * 1000);
+        if (isset($options[RequestOptions::DELAY])) {
+            usleep($options[RequestOptions::DELAY] * 1000);
         }
 
         $this->lastRequest = $request;
@@ -87,9 +88,9 @@ class MockHandler implements \Countable
                 if ($this->onFulfilled) {
                     call_user_func($this->onFulfilled, $value);
                 }
-                if (isset($options['sink'])) {
+                if (isset($options[RequestOptions::SINK])) {
                     $contents = (string) $value->getBody();
-                    $sink = $options['sink'];
+                    $sink = $options[RequestOptions::SINK];
 
                     if (is_resource($sink)) {
                         fwrite($sink, $contents);
@@ -168,9 +169,9 @@ class MockHandler implements \Countable
         ResponseInterface $response = null,
         $reason = null
     ) {
-        if (isset($options['on_stats'])) {
+        if (isset($options[RequestOptions::ON_STATS])) {
             $stats = new TransferStats($request, $response, 0, $reason);
-            call_user_func($options['on_stats'], $stats);
+            call_user_func($options[RequestOptions::ON_STATS], $stats);
         }
     }
 }

--- a/src/Handler/Proxy.php
+++ b/src/Handler/Proxy.php
@@ -47,7 +47,7 @@ class Proxy
         callable $streaming
     ) {
         return function (RequestInterface $request, array $options) use ($default, $streaming) {
-            return empty($options['stream'])
+            return empty($options[RequestOptions::STREAM])
                 ? $default($request, $options)
                 : $streaming($request, $options);
         };

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -5,6 +5,7 @@ use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -26,12 +27,12 @@ final class Middleware
     {
         return function (callable $handler) {
             return function ($request, array $options) use ($handler) {
-                if (empty($options['cookies'])) {
+                if (empty($options[RequestOptions::COOKIES])) {
                     return $handler($request, $options);
-                } elseif (!($options['cookies'] instanceof CookieJarInterface)) {
+                } elseif (!($options[RequestOptions::COOKIES] instanceof CookieJarInterface)) {
                     throw new \InvalidArgumentException('cookies must be an instance of GuzzleHttp\Cookie\CookieJarInterface');
                 }
-                $cookieJar = $options['cookies'];
+                $cookieJar = $options[RequestOptions::COOKIES];
                 $request = $cookieJar->withCookieHeader($request);
                 return $handler($request, $options)
                     ->then(function ($response) use ($cookieJar, $request) {
@@ -53,7 +54,7 @@ final class Middleware
     {
         return function (callable $handler) {
             return function ($request, array $options) use ($handler) {
-                if (empty($options['http_errors'])) {
+                if (empty($options[RequestOptions::HTTP_ERRORS])) {
                     return $handler($request, $options);
                 }
                 return $handler($request, $options)->then(

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -82,7 +82,7 @@ class PrepareBodyMiddleware
             return;
         }
 
-        $expect = isset($options['expect']) ? $options['expect'] : null;
+        $expect = isset($options[RequestOptions::EXPECT]) ? $options[RequestOptions::EXPECT] : null;
 
         // Return if disabled or if you're not using HTTP/1.1 or HTTP/2.0
         if ($expect === false || $request->getProtocolVersion() < 1.1) {

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -151,6 +151,14 @@ final class RequestOptions
     const MULTIPART = 'multipart';
 
     /**
+     * on_redirect: (callable) PHP callable that is invoked when a redirect
+     * is encountered. The callable is invoked with the request, the redirect
+     * response that was received, and the effective URI. Any return value
+     * from the on_redirect function is ignored.
+     */
+    const ON_REDIRECT = 'on_redirect';
+
+    /**
      * on_headers: (callable) A callable that is invoked when the HTTP headers
      * of the response have been received but the body has not yet begun to
      * download.

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -93,6 +93,11 @@ final class RequestOptions
     const DELAY = 'delay';
 
     /**
+     * retries: (int) The amount of retries per request(?) if request is rejected.
+     */
+    const RETRIES = 'retries';
+
+    /**
      * expect: (bool|integer) Controls the behavior of the
      * "Expect: 100-Continue" header.
      *

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -3,6 +3,7 @@ namespace GuzzleHttp;
 
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 
@@ -58,8 +59,8 @@ class RetryMiddleware
      */
     public function __invoke(RequestInterface $request, array $options)
     {
-        if (!isset($options['retries'])) {
-            $options['retries'] = 0;
+        if (!isset($options[RequestOptions::RETRIES])) {
+            $options[RequestOptions::RETRIES] = 0;
         }
 
         $fn = $this->nextHandler;
@@ -75,7 +76,7 @@ class RetryMiddleware
         return function ($value) use ($req, $options) {
             if (!call_user_func(
                 $this->decider,
-                $options['retries'],
+                $options[RequestOptions::RETRIES],
                 $req,
                 $value,
                 null
@@ -91,7 +92,7 @@ class RetryMiddleware
         return function ($reason) use ($req, $options) {
             if (!call_user_func(
                 $this->decider,
-                $options['retries'],
+                $options[RequestOptions::RETRIES],
                 $req,
                 null,
                 $reason
@@ -104,7 +105,7 @@ class RetryMiddleware
 
     private function doRetry(RequestInterface $request, array $options)
     {
-        $options['delay'] = call_user_func($this->delay, ++$options['retries']);
+        $options[RequestOptions::DELAY] = call_user_func($this->delay, ++$options[RequestOptions::RETRIES]);
 
         return $this($request, $options);
     }


### PR DESCRIPTION
Changed the Client and other classes who used $options with hard coded strings as keys to use RequestOptions constants as keys, as they are equal and explained in documentation, but the constants itself almost never used in code, for example !empty($option['headers']) became !empty(RequestOptions::HEADERS), etc.
Thank You.