### PR TITLE
Fix status code as integer in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $res = $client->request('GET', 'https://api.github.com/user', [
     'auth' => ['user', 'pass']
 ]);
 echo $res->getStatusCode();
-// "200"
+// 200
 echo $res->getHeader('content-type');
 // 'application/json; charset=utf8'
 echo $res->getBody();


### PR DESCRIPTION
The `getStatusCode()` method returns an `integer` status code, not a `string`.