### PR TITLE
Fix sleep calculation when waiting for delayed requests

### DIFF
--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -192,6 +192,6 @@ class CurlMultiHandler
             }
         }
 
-        return max(0, $currentTime - $nextTime);
+        return max(0, $nextTime - $currentTime) * 1000000;
     }
 }


### PR DESCRIPTION
`$nextTime` is always set in the future, and `usleep()` takes microseconds as an argument. Currently this function always returns 0 if there are no ongoing requests, clogging the CPU in the `while` loop.