### PR TITLE
merge header values in AbstractMessage case insensitively

### DIFF
--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -106,7 +106,18 @@ abstract class AbstractMessage implements MessageInterface
     public function setHeaders(array $headers)
     {
         $this->headers = $this->headerNames = [];
-        foreach ($headers as $key => $value) {
+
+        // Merge headers of differing case; singular setHeader()'s de facto behavior is not to merge so must merge here
+        $mergedHeaders = [];
+        foreach ($headers as $key => &$value) {
+            if (!isset($mergedHeaders[$key])) {
+                $mergedHeaders[$key] = [];
+            }
+
+            $mergedHeaders[$key][] = $value;
+        }
+
+        foreach ($mergedHeaders as $key => $value) {
             $this->setHeader($key, $value);
         }
     }

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -117,4 +117,17 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response->setReasonPhrase('Foo');
         $this->assertEquals('Foo', $response->getReasonPhrase());
     }
+
+    /**
+     * This tests array-like header merging compatibility with errant HTTP servers that return header names of varying
+     * cases within the same request.
+     */
+    public function testMergesHeadersCaseInsensitively()
+    {
+        $response = new Response(200, ['SET-COOKIE' => 'a=1', 'Set-Cookie' => ['b=2', 'c=3'], 'Content-Type' => 'text/plain']);
+        $this->assertEquals([
+            'Set-Cookie' => ['a=1', 'b=2', 'c=3'],
+            'Content-Type' => ['text/plain'],
+        ], $response->getHeaders());
+    }
 }


### PR DESCRIPTION
This code can be reached when an HTTP response is received containing appearance of same header with differing cases. (Believe it or not, I encountered this in a third party production system from Microsoft; presumably headers being added to their responses by multiple layers of disparate code.) Here is a sample of an HTTP response that surfaces the bug:

```
Content-Type: text/plain
Set-Cookie: foo=bar
SET-COOKIE: baz=1
```

Expected result should be header collection like:

```
[
  'Content-Type' => 'text/plain',
  'Set-Cookie' => ['foo=bar', 'baz=1'],
]
```