### PR TITLE
Fix for PHP Fatal error in MockHandler.php

### DIFF
--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -74,7 +74,7 @@ class MockHandler implements \Countable
         $response = array_shift($this->queue);
 
         if (is_callable($response)) {
-            $response = $response($request, $options);
+            $response = call_user_func($response, $request, $options);
         }
 
         $response = $response instanceof \Exception


### PR DESCRIPTION
The error appears when 'callable' is send as a string to 'queue' argument of MockHandler.
For example:
```php
$mock_handler = new MockHandler([
    '\MyNamespace\MyTest::mockResponse',
]);
```
We get:
PHP Fatal error:  Call to undefined function \MyNamespace\MyTest::mockResponse() in guzzlehttp/guzzle/src/Handler/MockHandler.php on line 77