### PR TITLE
Changed  type hinting from array to ArrayAccess.

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -76,7 +76,7 @@ final class Middleware
      *
      * @return callable Returns a function that accepts the next handler.
      */
-    public static function history(array &$container)
+    public static function history(\ArrayAccess &$container)
     {
         return function (callable $handler) use (&$container) {
             return function ($request, array $options) use ($handler, &$container) {


### PR DESCRIPTION
Because of the type hinting am not able to pass an ArrayObject as a container. 

Passing an array is not possible for me, as i will have to pass it around by reference. 
and laravel IOC while resolving wont pass the paraments  by reference. 

the solution i found is to make the container an object ie: ArrayObject, as it will be passed by reference. 

But the type hinting was preventing me from doing so.