### PR TITLE
More flexible history containers

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -75,9 +75,14 @@ final class Middleware
      * @param array $container Container to hold the history (by reference).
      *
      * @return callable Returns a function that accepts the next handler.
+     * @throws \InvalidArgumentException if container is not an array or ArrayAccess.
      */
-    public static function history(array &$container)
+    public static function history(&$container)
     {
+        if (!is_array($container) && !$container instanceof \ArrayAccess) {
+            throw new \InvalidArgumentException('history container must be an array or object implementing ArrayAccess');
+        }
+
         return function (callable $handler) use (&$container) {
             return function ($request, array $options) use ($handler, &$container) {
                 return $handler($request, $options)->then(

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -69,9 +69,11 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('rejected', $p->getState());
     }
 
-    public function testTracksHistory()
+    /**
+     * @dataProvider getHistoryUseCases
+     */
+    public function testTracksHistory($container)
     {
-        $container = [];
         $m = Middleware::history($container);
         $h = new MockHandler([new Response(200), new Response(201)]);
         $f = $m($h);
@@ -86,6 +88,14 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('HEAD', $container[1]['request']->getMethod());
         $this->assertEquals('bar', $container[0]['options']['headers']['foo']);
         $this->assertEquals('baz', $container[1]['options']['headers']['foo']);
+    }
+
+    public function getHistoryUseCases()
+    {
+        return [
+            [[]],                // 1. Container is an array
+            [new \ArrayObject()] // 2. Container is an ArrayObject
+        ];
     }
 
     public function testTracksHistoryForFailures()


### PR DESCRIPTION
Alternative to #1372.

Allows an array or array-accessible object to be used as the history container for the history middleware.