### PR TITLE
ClientInterface::request did not accept null

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -44,8 +44,8 @@ interface ClientInterface
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string                   $method  HTTP method
-     * @param string|UriInterface|null $uri     URI object or string.
+     * @param string                   $method  HTTP method.
+     * @param string|UriInterface|null $uri     URI object or string (default null).
      * @param array                    $options Request options to apply.
      *
      * @return ResponseInterface


### PR DESCRIPTION
I found a difference between the ClientInterface and the Client Implementation Request Method.
The `$uri` is required in the Interface, however in the Implementation it is allowed to be null.
See:
https://github.com/guzzle/guzzle/blob/c6851d6e48f63b69357cbfa55bca116448140e0c/src/Client.php#L126 and https://github.com/guzzle/guzzle/blob/c6851d6e48f63b69357cbfa55bca116448140e0c/src/ClientInterface.php#L54

To fix this difference, i changed the `$uri` Parameter in the Interface to default Value `null`