### PR TITLE
Use a LazyOpenStream instead of try_fopen r+

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -138,7 +138,7 @@ class StreamHandler
             : fopen('php://temp', 'r+');
 
         return is_string($sink)
-            ? new Psr7\Stream(Psr7\try_fopen($sink, 'r+'))
+            ? new Psr7\LazyOpenStream($sink, 'w+')
             : Psr7\stream_for($sink);
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -127,6 +127,21 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         unlink($tmpfname);
     }
 
+    public function testDrainsResponseIntoSaveToBodyAtNonExistentPath()
+    {
+        $tmpfname = tempnam('/tmp', 'save_to_path');
+        unlink($tmpfname);
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $response = $handler($request, ['sink' => $tmpfname])->wait();
+        $body = $response->getBody();
+        $this->assertEquals($tmpfname, $body->getMetadata('uri'));
+        $this->assertEquals('hi', $body->read(2));
+        $body->close();
+        unlink($tmpfname);
+    }
+
     public function testAutomaticallyDecompressGzip()
     {
         Server::flush();


### PR DESCRIPTION
It looks like the stream handler [will immediately open a stream with an 'r+' flag](https://github.com/guzzle/guzzle/blob/5c12b74e9405c50fb0fd6ab831dd6e9df5560b1f/src/Handler/StreamHandler.php#L141), while the curl handler [will create a `LazyOpenStream` with a 'w+' flag](https://github.com/guzzle/guzzle/blob/5c12b74e9405c50fb0fd6ab831dd6e9df5560b1f/src/Handler/CurlFactory.php#L359). This will resolve #1375.

/cc @mtdowling @jeremeamia 