### PR TITLE
Bumped branch alias to 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.1-dev"
+            "dev-master": "6.2-dev"
         }
     }
 }


### PR DESCRIPTION
Not sure if you want this, because the 6.1.1 release should have really been 6.2.0 already if you are following semver since it contained new features.