### PR TITLE
Add a constant holding base_uri config value to RequestOptions

### DIFF
--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -43,6 +43,12 @@ final class RequestOptions
     const AUTH = 'auth';
 
     /**
+     * base_uri: (string|null|UriInterface) Base URI of the client that is
+     * merged into relative URIs.
+     */
+    const BASE_URI = 'base_uri';
+
+    /**
      * body: (string|null|callable|iterator|object) Body to send in the
      * request.
      */


### PR DESCRIPTION
It seems like all possible config options are defined in RequestOptions class. I have been using those constant when defining configs for the client in my code, but felt that the fact base_uri is not defined as constant is inconsistent. 
This PR would help to have less hard coded strings in the code that uses Guzzle