### PR TITLE
don't use eventName as parameter and variable

### DIFF
--- a/src/Event/Emitter.php
+++ b/src/Event/Emitter.php
@@ -43,8 +43,7 @@ class Emitter implements EmitterInterface
     public function once($eventName, callable $listener, $priority = 0)
     {
         $onceListener = function (
-            EventInterface $event,
-            $eventName
+            EventInterface $event
         ) use (&$onceListener, $eventName, $listener, $priority) {
             $this->removeListener($eventName, $onceListener);
             $listener($event, $eventName);


### PR DESCRIPTION
Using `$eventName` for both as function parameter and in the `use` statement will fail on PHP 7.1 with a message like "Cannot use lexical variable $eventName as a parameter name" (see symfony/symfony-installer#237).

There also is a test in the test suite for PHP 7.1 ensuring that such a fatal error is triggered: https://github.com/php/php-src/blob/master/Zend/tests/closure_use_parameter_name.phpt