### PR TITLE
Update quickstart.rst adding part about usage of closures in pools.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -222,7 +222,24 @@ amount of requests you wish to send.
 
     // Force the pool of requests to complete.
     $promise->wait();
+    
+Or using a closure that will return a promise once the pool calls the closure.
 
+.. code-block:: php
+
+    $client = new Client();
+
+    $requests = function ($total) use ($client) {
+        $uri = 'http://127.0.0.1:8126/guzzle-server/perf';
+        for ($i = 0; $i < $total; $i++) {
+            yield function() use ($client, $uri) {
+                return $client->getAsync($uri);
+            };
+        }
+    };
+
+    $pool = new Pool($client, $requests(100));
+        
 
 Using Responses
 ===============


### PR DESCRIPTION
Add documentation about Pools being able to resolve closures also with a little example that builds upon the example directly above.

Thought this might be nice as I was confused by this before: #1390 