### PR TITLE
Do not attempt to escape cookie values.

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -58,22 +58,10 @@ class CookieJar implements CookieJarInterface
     }
 
     /**
-     * Quote the cookie value if it is not already quoted and it contains
-     * problematic characters.
-     *
-     * @param string $value Value that may or may not need to be quoted
-     *
-     * @return string
+     * @deprecated
      */
     public static function getCookieValue($value)
     {
-        if (substr($value, 0, 1) !== '"' &&
-            substr($value, -1, 1) !== '"' &&
-            strpbrk($value, ';,=')
-        ) {
-            $value = '"' . $value . '"';
-        }
-
         return $value;
     }
 
@@ -248,7 +236,7 @@ class CookieJar implements CookieJarInterface
                 (!$cookie->getSecure() || $scheme == 'https')
             ) {
                 $values[] = $cookie->getName() . '='
-                    . self::getCookieValue($cookie->getValue());
+                    . $cookie->getValue();
             }
         }
 

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -28,14 +28,6 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function testQuotesBadCookieValues()
-    {
-        $this->assertEquals('foo', CookieJar::getCookieValue('foo'));
-        $this->assertEquals('"foo,bar"', CookieJar::getCookieValue('foo,bar'));
-        $this->assertEquals('"foobar="', CookieJar::getCookieValue('foobar='));
-        $this->assertEquals('"foo;bar"', CookieJar::getCookieValue('foo;bar'));
-    }
-
     public function testCreatesFromArray()
     {
         $jar = CookieJar::fromArray([


### PR DESCRIPTION
Trust that the cookie value sent by the server is escaped accordingly,
and do not attempt to escape the cookie by adding quotes around the value.

This is a pull request for: #1405 

I can see others have run into the same issue: http://tricksty.com/coding/remove-double-quotes-from-guzzle-cookies