### PR TITLE
Add original content encoding and length to responses

### DIFF
--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -56,8 +56,13 @@ final class EasyHandle
         if (!empty($this->options['decode_content'])
             && isset($normalizedKeys['content-encoding'])
         ) {
+            $headers['x-encoded-content-encoding']
+                = $headers[$normalizedKeys['content-encoding']];
             unset($headers[$normalizedKeys['content-encoding']]);
             if (isset($normalizedKeys['content-length'])) {
+                $headers['x-encoded-content-length']
+                    = $headers[$normalizedKeys['content-length']];
+
                 $bodyLength = (int) $this->sink->getSize();
                 if ($bodyLength) {
                     $headers[$normalizedKeys['content-length']] = $bodyLength;

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -153,10 +153,15 @@ class StreamHandler
                     $stream = new Psr7\InflateStream(
                         Psr7\stream_for($stream)
                     );
+                    $headers['x-encoded-content-encoding']
+                        = $headers[$normalizedKeys['content-encoding']];
                     // Remove content-encoding header
                     unset($headers[$normalizedKeys['content-encoding']]);
                     // Fix content-length header
                     if (isset($normalizedKeys['content-length'])) {
+                        $headers['x-encoded-content-length']
+                            = $headers[$normalizedKeys['content-length']];
+
                         $length = (int) $stream->getSize();
                         if ($length == 0) {
                             unset($headers[$normalizedKeys['content-length']]);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -301,6 +301,23 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($sent->hasHeader('Accept-Encoding'));
     }
 
+    public function testReportsOriginalSizeAndContentEncodingAfterDecoding()
+    {
+        $this->addDecodeResponse();
+        $handler = new Handler\CurlMultiHandler();
+        $request = new Psr7\Request('GET', Server::$url);
+        $response = $handler($request, ['decode_content' => true]);
+        $response = $response->wait();
+        $this->assertSame(
+            'gzip',
+            $response->getHeaderLine('x-encoded-content-encoding')
+        );
+        $this->assertSame(
+            strlen(gzencode('test')),
+            (int) $response->getHeaderLine('x-encoded-content-length')
+        );
+    }
+
     public function testDecodesGzippedResponsesWithHeader()
     {
         $this->addDecodeResponse();


### PR DESCRIPTION
This PR adds new headers to responses that have been decoded. It's a potential resolution to #1397; when content has been decoded, the original Content-Encoding and Content-Length header values will be saved to the 'x-encoded-content-encoding' and 'x-encoded-content-length' headers, respectively.