### PR TITLE
Rewind seekable request bodies before dispatching to cURL

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -265,6 +265,9 @@ class CurlFactory implements CurlFactoryInterface
                 $this->removeHeader('Content-Length', $conf);
             }
             $body = $request->getBody();
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
             $conf[CURLOPT_READFUNCTION] = function ($ch, $fd, $length) use ($body) {
                 return $body->read($length);
             };


### PR DESCRIPTION
This will resolve #1335.

/cc @mtdowling @jeremeamia 