### PR TITLE
Updating documentation for async requests

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -181,8 +181,12 @@ requests.
         'webp'  => $client->getAsync('/image/webp')
     ];
 
-    // Wait on all of the requests to complete.
+    // Wait on all of the requests to complete. Throws a ConnectException 
+    // if any of the requests fail
     $results = Promise\unwrap($promises);
+    
+    // Wait for the requests to complete, even if some of them fail
+    $results = Promise\settle($promises)->wait();
 
     // You can access each result using the key provided to the unwrap
     // function.


### PR DESCRIPTION
I took me many hours to realize I could use the settle function instead of unwrap if I wanted to get the responses regardless of their status.