### PR TITLE
defaultCredentials attribute added.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -113,7 +113,22 @@ class Client implements ClientInterface
 
     public function requestAsync($method, $uri = null, array $options = [])
     {
+        // Remove the option so that they are not doubly-applied.
         $options = $this->prepareDefaults($options);
+        $request = $this->createNewRequest($method, $uri, $options);
+        unset($options['headers'], $options['body'], $options['version']);
+        return $this->transfer($request, $options);
+    }
+
+    /**
+     * Returns a Request object with the provided configuration
+     * @param $method
+     * @param null $uri
+     * @param array $options
+     * @return Psr7\Request
+     */
+    public function createNewRequest($method, $uri = null, array $options = [])
+    {
         // Remove request modifying parameter because it can be done up-front.
         $headers = isset($options['headers']) ? $options['headers'] : [];
         $body = isset($options['body']) ? $options['body'] : null;
@@ -123,11 +138,7 @@ class Client implements ClientInterface
         if (is_array($body)) {
             $this->invalidBody();
         }
-        $request = new Psr7\Request($method, $uri, $headers, $body, $version);
-        // Remove the option so that they are not doubly-applied.
-        unset($options['headers'], $options['body'], $options['version']);
-
-        return $this->transfer($request, $options);
+        return new Psr7\Request($method, $uri, $headers, $body, $version);
     }
 
     public function request($method, $uri = null, array $options = [])

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -615,4 +615,18 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
     }
 
+    public function testBaseDefaultCredentialsAreReadInConstructor()
+    {
+        $client = new Client(['base_uri' => 'http://foo2.com', 'default_credentials' => ['foo', 'bar']]);
+        $this->assertEquals(['foo', 'bar'], $client->getDefaultCredentials());
+    }
+
+    public function testDefaultCredentialsAreSentWithRequest()
+    {
+        $mockHandler = new MockHandler([new Response(200)]);
+        $client = new Client(['default_credentials' => ['foo', 'bar'], 'handler' => $mockHandler]);
+        $request = new Request('GET', '/test', ['Host'=>'foo.com']);
+        $client->send($request);
+        $this->assertArrayHasKey('Authorization', $mockHandler->getLastRequest()->getHeaders());
+    }
 }


### PR DESCRIPTION
If credentials are required for many requests of the same Client instance, it is helpful not to specify them in each request.