### PR TITLE
Catch PHP7 \Throwable

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -268,6 +268,8 @@ class Client implements ClientInterface
             return Promise\promise_for($handler($request, $options));
         } catch (\Exception $e) {
             return Promise\rejection_for($e);
+        } catch (\Throwable $e) {
+            return Promise\rejection_for($e);
         }
     }
 

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -10,10 +10,17 @@ use Psr\Http\Message\RequestInterface;
  */
 class ConnectException extends RequestException
 {
+
+    /**
+     * @param string $message
+     * @param \Psr\Http\Message\RequestInterface $request
+     * @param \Exception|\Throwable $previous
+     * @param mixed[] $handlerContext
+     */
     public function __construct(
         $message,
         RequestInterface $request,
-        \Exception $previous = null,
+        $previous = null,
         array $handlerContext = []
     ) {
         parent::__construct($message, $request, null, $previous, $handlerContext);

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -19,11 +19,18 @@ class RequestException extends TransferException
     /** @var array */
     private $handlerContext;
 
+    /**
+     * @param string $message
+     * @param \Psr\Http\Message\RequestInterface $request
+     * @param \Psr\Http\Message\ResponseInterface $response
+     * @param \Exception|\Throwable $previous
+     * @param mixed[] $handlerContext
+     */
     public function __construct(
         $message,
         RequestInterface $request,
         ResponseInterface $response = null,
-        \Exception $previous = null,
+        $previous = null,
         array $handlerContext = []
     ) {
         // Set the code of the exception if the response is set and not future.

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -520,6 +520,11 @@ class CurlFactory implements CurlFactoryInterface
                         // a curl header write error by returning 0.
                         $easy->onHeadersException = $e;
                         return -1;
+                    } catch (\Throwable $e) {
+                        // Associate the exception with the handle and trigger
+                        // a curl header write error by returning 0.
+                        $easy->onHeadersException = $e;
+                        return -1;
                     }
                 }
             } elseif ($startingResponse) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -68,6 +68,11 @@ class StreamHandler
             $this->invokeStats($options, $request, $startTime, null, $e);
 
             return new RejectedPromise($e);
+        } catch (\Throwable $e) {
+            $e = RequestException::wrapException($request, $e);
+            $this->invokeStats($options, $request, $startTime, null, $e);
+
+            return new RejectedPromise($e);
         }
     }
 
@@ -112,6 +117,10 @@ class StreamHandler
             try {
                 $options['on_headers']($response);
             } catch (\Exception $e) {
+                $msg = 'An error was encountered during the on_headers event';
+                $ex = new RequestException($msg, $request, $response, $e);
+                return new RejectedPromise($ex);
+            } catch (\Throwable $e) {
                 $msg = 'An error was encountered during the on_headers event';
                 $ex = new RequestException($msg, $request, $response, $e);
                 return new RejectedPromise($ex);

--- a/tests/Server.php
+++ b/tests/Server.php
@@ -157,6 +157,8 @@ class Server
             return true;
         } catch (\Exception $e) {
             return false;
+        } catch (\Throwable $e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
There are several "catch all" traps in the code, that catch `\Exception` and they should be catching `\Throwable`.
While it's not possible to simply replace it, since that would break compatibility with PHP 5.6, it still can be fixed pretty easily.

Little worse are the typehints, as I'm not sure how much you wanna typecheck that the object is in fact a exception.