### PR TITLE
Added setConfigProperty to dynamically set configurations

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -400,4 +400,13 @@ class Client implements ClientInterface
             . 'application/x-www-form-urlencoded request, or a the "multipart" '
             . 'request option to send a multipart/form-data request.');
     }
+
+    /**
+     * @param $property
+     * @param $value
+     */
+    public function setConfigProperty($property, $value)
+    {
+        $this->config[$property] = $value;
+    }
 }


### PR DESCRIPTION
this method might be used to dynamically add configurations or to swap/change headers between groups of multiple requests and avoid adding configs to each request.