### PR TITLE
Remove URI default value

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -104,7 +104,7 @@ class Client implements ClientInterface
         return $this->sendAsync($request, $options)->wait();
     }
 
-    public function requestAsync($method, $uri, array $options = [])
+    public function requestAsync($method, $uri = '', array $options = [])
     {
         $options = $this->prepareDefaults($options);
         // Remove request modifying parameter because it can be done up-front.
@@ -123,7 +123,7 @@ class Client implements ClientInterface
         return $this->transfer($request, $options);
     }
 
-    public function request($method, $uri, array $options = [])
+    public function request($method, $uri = '', array $options = [])
     {
         $options[RequestOptions::SYNCHRONOUS] = true;
         return $this->requestAsync($method, $uri, $options)->wait();
@@ -142,7 +142,7 @@ class Client implements ClientInterface
             return $uri instanceof UriInterface ? $uri : new Psr7\Uri($uri);
         }
 
-        return Psr7\Uri::resolve($config['base_uri'], $uri);
+        return Psr7\Uri::resolve(Psr7\uri_for($config['base_uri']), $uri);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -104,7 +104,7 @@ class Client implements ClientInterface
         return $this->sendAsync($request, $options)->wait();
     }
 
-    public function requestAsync($method, $uri = null, array $options = [])
+    public function requestAsync($method, $uri, array $options = [])
     {
         $options = $this->prepareDefaults($options);
         // Remove request modifying parameter because it can be done up-front.
@@ -123,7 +123,7 @@ class Client implements ClientInterface
         return $this->transfer($request, $options);
     }
 
-    public function request($method, $uri = null, array $options = [])
+    public function request($method, $uri, array $options = [])
     {
         $options[RequestOptions::SYNCHRONOUS] = true;
         return $this->requestAsync($method, $uri, $options)->wait();

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -44,14 +44,14 @@ interface ClientInterface
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string                   $method  HTTP method.
-     * @param string|UriInterface|null $uri     URI object or string (default null).
-     * @param array                    $options Request options to apply.
+     * @param string              $method  HTTP method.
+     * @param string|UriInterface $uri     URI object or string.
+     * @param array               $options Request options to apply.
      *
      * @return ResponseInterface
      * @throws GuzzleException
      */
-    public function request($method, $uri = null, array $options = []);
+    public function request($method, $uri, array $options = []);
 
     /**
      * Create and send an asynchronous HTTP request.

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -87,7 +87,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testCanMergeOnBaseUriWithRequest()
     {
-        $mock = new MockHandler([new Response()]);
+        $mock = new MockHandler([new Response(), new Response()]);
         $client = new Client([
             'handler'  => $mock,
             'base_uri' => 'http://foo.com/bar/'
@@ -96,6 +96,13 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             'http://foo.com/bar/baz',
             (string) $mock->getLastRequest()->getUri()
+        );
+
+        $client->request('GET', new Uri('baz'), ['base_uri' => 'http://example.com/foo/']);
+        $this->assertEquals(
+            'http://example.com/foo/baz',
+            (string) $mock->getLastRequest()->getUri(),
+            'Can overwrite the base_uri through the request options'
         );
     }
 


### PR DESCRIPTION
The URI default value makes no sense for many reasons:

1. `$client->request('GET')` makes no sense. Where does it get it from?
2. the shortcut methods actually require the URI `$client->get($uri)` (otherwise throw an exception) so this wasn't consistent at all.
3. #1374 only changed `ClientInterface::request` but not `ClientInterface::requestAsync` which is inconsistent
3. Request class also requires the URI: https://github.com/guzzle/psr7/blob/master/src/Request.php#L36