### PR TITLE
Ignore zeroed timeout with StreamHandler to use PHP default instead

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -346,7 +346,9 @@ class StreamHandler
 
     private function add_timeout(RequestInterface $request, &$options, $value, &$params)
     {
-        $options['http']['timeout'] = $value;
+        if ($value > 0) {
+            $options['http']['timeout'] = $value;
+        }
     }
 
     private function add_verify(RequestInterface $request, &$options, $value, &$params)

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -584,4 +584,19 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
             $gotStats->getHandlerErrorData()
         );
     }
+
+    public function testStreamIgnoresZeroTimeout()
+    {
+        Server::flush();
+        Server::enqueue([new Psr7\Response(200)]);
+        $req = new Psr7\Request('GET', Server::$url);
+        $gotStats = null;
+        $handler = new StreamHandler();
+        $promise = $handler($req, [
+            'connect_timeout' => 10,
+            'timeout' => 0
+        ]);
+        $response = $promise->wait();
+        $this->assertEquals(200, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
Using \GuzzleHttp\Client without cURL being installed falls back to the
StreamHandler. As documented, guzzle uses a `timeout => 0` setting by
default, if that setting isn't explicitly passed as option. This value
is passed to the context of the stream, causing every request to fail
instantly as `timeout => 0` has a different meaning for streams.

Fixes #1487