### PR TITLE
Add backwards compatibility for older curl

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -372,7 +372,11 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (isset($options['timeout'])) {
-            $conf[CURLOPT_TIMEOUT_MS] = $options['timeout'] * 1000;
+            if (defined('CURLOPT_TIMEOUT_MS')) {
+                $conf[CURLOPT_TIMEOUT_MS] = $options['timeout'] * 1000;
+            } else {
+                $conf[CURLOPT_TIMEOUT] = $options['timeout'] * 1000;
+            }
         }
 
         if (isset($options['connect_timeout'])) {


### PR DESCRIPTION
Even knowing that we have set minimum versions for PHP and curl, this simple fix will allow a bunch of older versions of curl library also work with Guzzle. I faced this issue myself (on a shared hosting) and this change made everything work.

By the way, CURLOPT_TIMEOUT_MS was "Added in cURL 7.16.2. Available since PHP 5.2.3.". 
See: http://php.net/manual/en/function.curl-setopt.php