### PR TITLE
Fix uri without scheme fallback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "guzzlehttp/psr7": "~1.1",
-        "guzzlehttp/promises": "~1.0"
+        "php": ">=5.5",
+        "guzzlehttp/psr7": "^1.3.1",
+        "guzzlehttp/promises": "^1.0"
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "~4.0",
-        "psr/log": "~1.0"
+        "phpunit/phpunit": "^4.0",
+        "psr/log": "^1.0"
     },
     "autoload": {
         "files": ["src/functions_include.php"],

--- a/src/Client.php
+++ b/src/Client.php
@@ -138,11 +138,14 @@ class Client implements ClientInterface
 
     private function buildUri($uri, array $config)
     {
-        if (!isset($config['base_uri'])) {
-            return $uri instanceof UriInterface ? $uri : new Psr7\Uri($uri);
+        // for BC we accept null which would otherwise fail in uri_for
+        $uri = Psr7\uri_for($uri === null ? '' : $uri);
+
+        if (isset($config['base_uri'])) {
+            $uri = Psr7\Uri::resolve(Psr7\uri_for($config['base_uri']), $uri);
         }
 
-        return Psr7\Uri::resolve(Psr7\uri_for($config['base_uri']), $uri);
+        return $uri->getScheme() === '' ? $uri->withScheme('http') : $uri;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -593,7 +593,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testProperlyBuildsQuery()
     {
-        $mock = new MockHandler([new Response(200)]);
+        $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['query' => ['foo' => 'bar', 'john' => 'doe']]);
@@ -602,8 +602,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testSendSendsWithIpAddressAndPortAndHostHeaderInRequestTheHostShouldBePreserved()
     {
-        $mockHandler = new MockHandler([new Response(200)]);
-        $client = new Client(['base_uri' => '127.0.0.1:8585', 'handler' => $mockHandler]);
+        $mockHandler = new MockHandler([new Response()]);
+        $client = new Client(['base_uri' => 'http://127.0.0.1:8585', 'handler' => $mockHandler]);
         $request = new Request('GET', '/test', ['Host'=>'foo.com']);
 
         $client->send($request);
@@ -613,7 +613,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testSendSendsWithDomainAndHostHeaderInRequestTheHostShouldBePreserved()
     {
-        $mockHandler = new MockHandler([new Response(200)]);
+        $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['base_uri' => 'http://foo2.com', 'handler' => $mockHandler]);
         $request = new Request('GET', '/test', ['Host'=>'foo.com']);
 
@@ -627,8 +627,18 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidatesSink()
     {
-        $mockHandler = new MockHandler([new Response(200)]);
+        $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
         $client->get('http://test.com', ['sink' => true]);
+    }
+
+    public function testHttpDefaultSchemeIfUriHasNone()
+    {
+        $mockHandler = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mockHandler]);
+
+        $client->request('GET', '//example.org/test');
+
+        $this->assertSame('http://example.org/test', (string) $mockHandler->getLastRequest()->getUri());
     }
 }


### PR DESCRIPTION
Fixes guzzle/psr7#102

When URI has no scheme use http by default.

curl usually also uses http when no scheme is given. see https://curl.haxx.se/libcurl/c/CURLOPT_URL.html
but curl requires network-path URIs without a scheme to not start with 2 starting slashes which is actually wrong (probably done for user-friendliness, so called suffix references, see https://tools.ietf.org/html/rfc3986#section-4.5). so the fixes in psr7 1.3.1 actually broke curl handler for URIs without scheme. we solve this problem by applying the http default scheme to the URI beforehand. this also ensures that the stream handler works the same way. fopen() requires a scheme and has no fallback logic. so there was an inconsistency.