### PR TITLE
Equal to identical

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -233,7 +233,7 @@ class CookieJar implements CookieJarInterface
             if ($cookie->matchesPath($path) &&
                 $cookie->matchesDomain($host) &&
                 !$cookie->isExpired() &&
-                (!$cookie->getSecure() || $scheme == 'https')
+                (!$cookie->getSecure() || $scheme === 'https')
             ) {
                 $values[] = $cookie->getName() . '='
                     . $cookie->getValue();

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -86,8 +86,8 @@ class SetCookie
     {
         $str = $this->data['Name'] . '=' . $this->data['Value'] . '; ';
         foreach ($this->data as $k => $v) {
-            if ($k != 'Name' && $k != 'Value' && $v !== null && $v !== false) {
-                if ($k == 'Expires') {
+            if ($k !== 'Name' && $k !== 'Value' && $v !== null && $v !== false) {
+                if ($k === 'Expires') {
                     $str .= 'Expires=' . gmdate('D, d M Y H:i:s \G\M\T', $v) . '; ';
                 } else {
                     $str .= ($v === true ? $k : "{$k}={$v}") . '; ';
@@ -307,7 +307,7 @@ class SetCookie
         $cookiePath = $this->getPath();
 
         // Match on exact matches or when path is the default empty "/"
-        if ($cookiePath == '/' || $cookiePath == $requestPath) {
+        if ($cookiePath === '/' || $cookiePath == $requestPath) {
             return true;
         }
 
@@ -317,12 +317,12 @@ class SetCookie
         }
 
         // Match if the last character of the cookie-path is "/"
-        if (substr($cookiePath, -1, 1) == '/') {
+        if (substr($cookiePath, -1, 1) === '/') {
             return true;
         }
 
         // Match if the first character not included in cookie path is "/"
-        return substr($requestPath, strlen($cookiePath), 1) == '/';
+        return substr($requestPath, strlen($cookiePath), 1) === '/';
     }
 
     /**

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -77,7 +77,7 @@ class RequestException extends TransferException
             );
         }
 
-        $level = (int) ($response->getStatusCode() / 100);
+        $level = (int) floor($response->getStatusCode() / 100);
         if ($level === 4) {
             $label = 'Client error';
             $className = __NAMESPACE__ . '\\ClientException';

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -77,11 +77,11 @@ class RequestException extends TransferException
             );
         }
 
-        $level = floor($response->getStatusCode() / 100);
-        if ($level == '4') {
+        $level = (int) ($response->getStatusCode() / 100);
+        if ($level === 4) {
             $label = 'Client error';
             $className = __NAMESPACE__ . '\\ClientException';
-        } elseif ($level == '5') {
+        } elseif ($level === 5) {
             $label = 'Server error';
             $className = __NAMESPACE__ . '\\ServerException';
         } else {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -163,7 +163,7 @@ class StreamHandler
                             = $headers[$normalizedKeys['content-length']];
 
                         $length = (int) $stream->getSize();
-                        if ($length == 0) {
+                        if ($length === 0) {
                             unset($headers[$normalizedKeys['content-length']]);
                         } else {
                             $headers[$normalizedKeys['content-length']] = [$length];

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -149,7 +149,7 @@ class StreamHandler
             $normalizedKeys = \GuzzleHttp\normalize_header_keys($headers);
             if (isset($normalizedKeys['content-encoding'])) {
                 $encoding = $headers[$normalizedKeys['content-encoding']];
-                if ($encoding[0] == 'gzip' || $encoding[0] == 'deflate') {
+                if ($encoding[0] === 'gzip' || $encoding[0] === 'deflate') {
                     $stream = new Psr7\InflateStream(
                         Psr7\stream_for($stream)
                     );

--- a/src/UriTemplate.php
+++ b/src/UriTemplate.php
@@ -76,7 +76,7 @@ class UriTemplate
                 $varspec['value'] = substr($value, 0, $colonPos);
                 $varspec['modifier'] = ':';
                 $varspec['position'] = (int) substr($value, $colonPos + 1);
-            } elseif (substr($value, -1) == '*') {
+            } elseif (substr($value, -1) === '*') {
                 $varspec['modifier'] = '*';
                 $varspec['value'] = substr($value, 0, -1);
             } else {
@@ -131,14 +131,14 @@ class UriTemplate
 
                     if (!$isNestedArray) {
                         $var = rawurlencode($var);
-                        if ($parsed['operator'] == '+' ||
-                            $parsed['operator'] == '#'
+                        if ($parsed['operator'] === '+' ||
+                            $parsed['operator'] === '#'
                         ) {
                             $var = $this->decodeReserved($var);
                         }
                     }
 
-                    if ($value['modifier'] == '*') {
+                    if ($value['modifier'] === '*') {
                         if ($isAssoc) {
                             if ($isNestedArray) {
                                 // Nested arrays must allow for deeply nested
@@ -160,7 +160,7 @@ class UriTemplate
 
                 if (empty($variable)) {
                     $actuallyUseQuery = false;
-                } elseif ($value['modifier'] == '*') {
+                } elseif ($value['modifier'] === '*') {
                     $expanded = implode($joiner, $kvp);
                     if ($isAssoc) {
                         // Don't prepend the value name when using the explode
@@ -181,17 +181,17 @@ class UriTemplate
                 }
 
             } else {
-                if ($value['modifier'] == ':') {
+                if ($value['modifier'] === ':') {
                     $variable = substr($variable, 0, $value['position']);
                 }
                 $expanded = rawurlencode($variable);
-                if ($parsed['operator'] == '+' || $parsed['operator'] == '#') {
+                if ($parsed['operator'] === '+' || $parsed['operator'] === '#') {
                     $expanded = $this->decodeReserved($expanded);
                 }
             }
 
             if ($actuallyUseQuery) {
-                if (!$expanded && $joiner != '&') {
+                if (!$expanded && $joiner !== '&') {
                     $expanded = $value['value'];
                 } else {
                     $expanded = $value['value'] . '=' . $expanded;


### PR DESCRIPTION
In PHP any string, that does not started from number is equal (==) 0.
Example:
```php
var_dump(0 == '+'); // true
var_dump(0 == '*'); // true
var_dump(0 == '&'); // true
var_dump(0 == 'foo'); // true

var_dump(0 != '&'); // false
```
To avoid this behavior is better to use identical operator (===)
Also, === is faster than ==