### PR TITLE
ignore URI fragment when dereferencing

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -284,7 +284,7 @@ class StreamHandler
 
         return $this->createResource(
             function () use ($request, &$http_response_header, $context) {
-                $resource = fopen($request->getUri(), 'r', null, $context);
+                $resource = fopen((string) $request->getUri()->withFragment(''), 'r', null, $context);
                 $this->lastHeaders = $http_response_header;
                 return $resource;
             }
@@ -425,7 +425,7 @@ class StreamHandler
             'bytes_transferred', 'bytes_max'];
 
         $value = \GuzzleHttp\debug_resource($value);
-        $ident = $request->getMethod() . ' ' . $request->getUri();
+        $ident = $request->getMethod() . ' ' . $request->getUri()->withFragment('');
         $this->addNotification(
             $params,
             function () use ($ident, $value, $map, $args) {


### PR DESCRIPTION
The URI fragment should be ignored when dereferencing a URI and is not meant to be sent.

> Fragment identifiers have a special role in information retrieval
   systems as the primary form of client-side indirect referencing,
   allowing an author to specifically identify aspects of an existing
   resource that are only indirectly provided by the resource owner.  As
   such, the fragment identifier is not used in the scheme-specific
   processing of a URI; instead, the fragment identifier is separated
   from the rest of the URI prior to a dereference, and thus the
   identifying information within the **fragment itself is dereferenced
   solely by the user agent, regardless of the URI scheme**.

https://tools.ietf.org/html/rfc3986#section-3.5