### PR TITLE
Fix documentation about default connect_timeout

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -256,9 +256,9 @@ connect_timeout
 ---------------
 
 :Summary: Float describing the number of seconds to wait while trying to connect
-        to a server. Use ``0`` to wait indefinitely (the default behavior).
+        to a server. Use ``0`` to wait indefinitely.
 :Types: float
-:Default: ``0``
+:Default: ``150``
 :Constant: ``GuzzleHttp\RequestOptions::CONNECT_TIMEOUT``
 
 .. code-block:: php


### PR DESCRIPTION
According to [CurlFactory::getDefaultConf()](https://github.com/guzzle/guzzle/blob/master/src/Handler/CurlFactory.php#L200) the default connect timeout is 150s instead of the written 0s.
