### PR TITLE
MutableClient first implementation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ use Psr\Http\Message\ResponseInterface;
 class Client implements ClientInterface
 {
     /** @var array Default request options */
-    private $config;
+    protected $config;
 
     /**
      * Clients accept an array of constructor parameters.

--- a/src/MutableClient.php
+++ b/src/MutableClient.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GuzzleHttp;
+
+/**
+ * Class MutableClient
+ * @package GuzzleHttp
+ * This is an extension of the Client class which allows the configuration to be set anytime.
+ */
+class MutableClient extends Client
+{
+    /**
+     * @param $key
+     * @param $value
+     */
+    public function setConfigOption($key, $value)
+    {
+        $this->config[$key] = $value;
+    }
+}

--- a/tests/MutableClientTest.php
+++ b/tests/MutableClientTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GuzzleHttp\Tests;
+
+use GuzzleHttp\MutableClient;
+
+class MutableClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanChangeClientOptions()
+    {
+        $auth = ['username', 'password'];
+        $client = new MutableClient(['auth' => $auth]);
+        $this->assertEquals($client->getConfig('auth'), $auth);
+        $newAuth = ['newsername', 'newword'];
+        $client->setConfigOption('auth', $newAuth);
+        $this->assertEquals($client->getConfig('auth'), $newAuth);
+    }
+}


### PR DESCRIPTION
Referring to the pr #1479.
This is a very simple implementation of a mutable version of the Client, the class extends the Client base class.
By now this class only exposes one public method that does the trick, it can be improved in the future.
The only change in the main class is the visibility of the 'config' attribute, which should be declared protected to allow this.
