### PR TITLE
Retry-After Header in Guzzle 6

### DIFF
--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -5,6 +5,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Middleware that retries requests based on the boolean result of
@@ -25,8 +26,8 @@ class RetryMiddleware
      *                              retried.
      * @param callable $nextHandler Next handler to invoke.
      * @param callable $delay       Function that accepts the number of retries
-     *                              and returns the number of milliseconds to
-     *                              delay.
+     *                              and [response] and returns the number of
+     *                              milliseconds to delay.
      */
     public function __construct(
         callable $decider,
@@ -82,7 +83,7 @@ class RetryMiddleware
             )) {
                 return $value;
             }
-            return $this->doRetry($req, $options);
+            return $this->doRetry($req, $options, $value);
         };
     }
 
@@ -102,9 +103,9 @@ class RetryMiddleware
         };
     }
 
-    private function doRetry(RequestInterface $request, array $options)
+    private function doRetry(RequestInterface $request, array $options, ResponseInterface $response = null)
     {
-        $options['delay'] = call_user_func($this->delay, ++$options['retries']);
+        $options['delay'] = call_user_func($this->delay, ++$options['retries'], $response);
 
         return $this($request, $options);
     }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -19,9 +19,10 @@ class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
             $calls[] = func_get_args();
             return count($calls) < 3;
         };
-        $delay = function ($retries) use (&$delayCalls) {
+        $delay = function ($retries, $response) use (&$delayCalls) {
             $delayCalls++;
             $this->assertEquals($retries, $delayCalls);
+            $this->assertInstanceOf(Response::class, $response);
             return 1;
         };
         $m = Middleware::retry($decider, $delay);


### PR DESCRIPTION
I'm currently migrating a project from Guzzle 5 to 6. In 5 i was using https://github.com/guzzle/retry-subscriber, which was able to read the Retry-After header from the response and delay the retry accordingly. Now with Guzzle 6 middleware, I don't have access to the Response in the delay function.

What's the proposed solution to do retries which respect the Retry-After header? Am I missing something?