### PR TITLE
Obfuscates URI if there is an username and a password present

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Exception;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * HTTP Request exception
@@ -89,12 +90,15 @@ class RequestException extends TransferException
             $className = __CLASS__;
         }
 
+        $uri = $request->getUri();
+        $uri = static::obfuscateUri($uri);
+
         // Server Error: `GET /` resulted in a `404 Not Found` response:
         // <html> ... (truncated)
         $message = sprintf(
             '%s: `%s` resulted in a `%s` response',
             $label,
-            $request->getMethod() . ' ' . $request->getUri(),
+            $request->getMethod() . ' ' . $uri,
             $response->getStatusCode() . ' ' . $response->getReasonPhrase()
         );
 
@@ -139,6 +143,24 @@ class RequestException extends TransferException
         }
 
         return $summary;
+    }
+
+    /**
+     * Obfuscates URI if there is an username and a password present
+     *
+     * @param UriInterface $uri
+     *
+     * @return UriInterface
+     */
+    public static function obfuscateUri($uri)
+    {
+        $userInfo = $uri->getUserInfo();
+
+        if (false !== ($pos = strpos($userInfo, ':'))) {
+            return $uri->withUserInfo(substr($userInfo, 0, $pos), '***');
+        }
+
+        return $uri;
     }
 
     /**

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -152,7 +152,7 @@ class RequestException extends TransferException
      *
      * @return UriInterface
      */
-    public static function obfuscateUri($uri)
+    private static function obfuscateUri($uri)
     {
         $userInfo = $uri->getUserInfo();
 

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -152,4 +152,19 @@ class RequestExceptionTest extends \PHPUnit_Framework_TestCase
         $e = new RequestException('foo', $r, null, null, ['bar' => 'baz']);
         $this->assertEquals(['bar' => 'baz'], $e->getHandlerContext());
     }
+
+    public function testObfuscateUrlWithUsername()
+    {
+        $r = new Request('GET', 'http://username@www.oo.com');
+        $e = RequestException::create($r, new Response(500));
+        $this->assertContains('username@', $e->getMessage());
+    }
+
+    public function testObfuscateUrlWithUsernameAndPassword()
+    {
+        $r = new Request('GET', 'http://user:password@www.oo.com');
+        $e = RequestException::create($r, new Response(500));
+        $this->assertNotContains('user:password', $e->getMessage());
+        $this->assertContains('user:***', $e->getMessage());
+    }
 }

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -157,14 +157,13 @@ class RequestExceptionTest extends \PHPUnit_Framework_TestCase
     {
         $r = new Request('GET', 'http://username@www.oo.com');
         $e = RequestException::create($r, new Response(500));
-        $this->assertContains('username@', $e->getMessage());
+        $this->assertContains('http://username@www.oo.com', $e->getMessage());
     }
 
     public function testObfuscateUrlWithUsernameAndPassword()
     {
         $r = new Request('GET', 'http://user:password@www.oo.com');
         $e = RequestException::create($r, new Response(500));
-        $this->assertNotContains('user:password', $e->getMessage());
-        $this->assertContains('user:***', $e->getMessage());
+        $this->assertContains('http://user:***@www.oo.com', $e->getMessage());
     }
 }


### PR DESCRIPTION
Lets assume that you include username and password into the URI. Currently, if the exception accrued the error message looks like so:

```
Client error: `POST http://username:secrect@hostname.com/somePath` resulted in a `400 Bad Request` response: ......,  (truncated...)
```

It lead to security issue because password is shown like it is.

This commit will hide the password (replace it with `***`).