### PR TITLE
handle drain case where content-length is the literal string zero

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -210,7 +210,7 @@ class StreamHandler
         Psr7\copy_to_stream(
             $source,
             $sink,
-            strlen($contentLength) > 0 ? (int) $contentLength : -1
+            (strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1
         );
 
         $sink->seek(0);


### PR DESCRIPTION
# What

Fixes issue https://github.com/guzzle/guzzle/issues/1539

```
PHP Warning:  fread(): Length parameter must be greater than 0
```

If the Content-Length header is zero (`0`) a PHP Warning will be generated because the string length of `0` is 1, which ends up passing the integer `0` to `fread`. The intention should be passing `-1` to `fread` -- reading the entire stream.

I added a unit test for this case, which if you copy the unit test to master you'll see that the test suite will fail. With this small fix, the unit test suite passes and no PHP Warning is generated.

# Why

A `Content-Length: 0` header could happen, such as with Amazon AWS. 

# Test

Run the test suite: `vendor/bin/phpunit tests/` and everything should pass.