### PR TITLE
fix milliseconds timeout problem

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -379,6 +379,13 @@ class CurlFactory implements CurlFactoryInterface
             $conf[CURLOPT_CONNECTTIMEOUT_MS] = $options['connect_timeout'] * 1000;
         }
 
+        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+            if (isset($options['timeout']) || isset($options['connect_timeout'])) {
+                $conf[CURLOPT_NOSIGNAL] = 1;
+            }
+        }
+
+
         if (isset($options['proxy'])) {
             if (!is_array($options['proxy'])) {
                 $conf[CURLOPT_PROXY] = $options['proxy'];


### PR DESCRIPTION
"If libcurl is built to use the standard system name resolver, that portion of the transfer will still use full-second resolution for timeouts with a minimum timeout allowed of one second."

The problem is that on (Li|U)nix, when libcurl uses the standard name resolver, a SIGALRM is raised during name resolution which libcurl thinks is the timeout alarm.

The solution is to disable signals using CURLOPT_NOSIGNAL. 
