### PR TITLE
Make retry with different request possible

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -151,15 +151,17 @@ final class Middleware
     }
 
     /**
-     * Middleware that retries requests based on the boolean result of
-     * invoking the provided "decider" function.
+     * Middleware that retries requests based on the result of invoking
+     * the provided "decider" function.
      *
      * If no delay function is provided, a simple implementation of exponential
      * backoff will be utilized.
      *
      * @param callable $decider Function that accepts the number of retries,
      *                          a request, [response], and [exception] and
-     *                          returns true if the request is to be retried.
+     *                          returns true if previous request is to be retried
+     *                          and returns RequestInterface if RequestInterface
+     *                          is to be retried.
      * @param callable $delay   Function that accepts the number of retries and
      *                          returns the number of milliseconds to delay.
      *

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -6,8 +6,8 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * Middleware that retries requests based on the boolean result of
- * invoking the provided "decider" function.
+ * Middleware that retries requests based on the result of invoking
+ * the provided "decider" function.
  */
 class RetryMiddleware
 {
@@ -18,10 +18,11 @@ class RetryMiddleware
     private $decider;
 
     /**
-     * @param callable $decider     Function that accepts the number of retries,
-     *                              a request, [response], and [exception] and
-     *                              returns true if the request is to be
-     *                              retried.
+     * @param callable $decider Function that accepts the number of retries,
+     *                          a request, [response], and [exception] and
+     *                          returns true if previous request is to be retried
+     *                          and returns RequestInterface if RequestInterface
+     *                          is to be retried.
      * @param callable $nextHandler Next handler to invoke.
      * @param callable $delay       Function that accepts the number of retries
      *                              and [response] and returns the number of
@@ -79,6 +80,7 @@ class RetryMiddleware
                 $value,
                 null
             );
+            // For backward compatibility, use type-casting instead of strict comparison $result===false.
             if (!$result) {
                 return $value;
             }
@@ -99,6 +101,7 @@ class RetryMiddleware
                 null,
                 $reason
             );
+            // For backward compatibility, use type-casting instead of strict comparison $result===false.
             if (!$result) {
                 return \GuzzleHttp\Promise\rejection_for($reason);
             }


### PR DESCRIPTION
It often needs change request a little when retrying a request. For example, `access_token` is expired so request failed. When retrying this request, we need to use new `access_token`.  But `Psr\Http\Message\RequestInterface` is immutable. This PR makes retry with different request possible.
