### PR TITLE
don't use eventName as parameter and variable

### DIFF
--- a/src/Event/Emitter.php
+++ b/src/Event/Emitter.php
@@ -44,8 +44,7 @@ class Emitter implements EmitterInterface
     public function once($eventName, callable $listener, $priority = 0)
     {
         $onceListener = function (
-            EventInterface $event,
-            $eventName
+            EventInterface $event
         ) use (&$onceListener, $eventName, $listener, $priority) {
             $this->removeListener($eventName, $onceListener);
             $listener($event, $eventName, $this);


### PR DESCRIPTION
This cherry picks @xabbuh's fix from #1393 to the 4.x branch, thereby avoiding `Fatal error: Cannot use lexical variable $eventName as a parameter name` when running Guzzle 4 on PHP 7.1.
