### PR TITLE
Add 'read_timeout' option

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -787,6 +787,30 @@ values supplied in the URI of a request.
     // Send a GET request to /get?foo=bar
     $client->request('GET', '/get?abc=123', ['query' => ['foo' => 'bar']]);
 
+read_timeout
+------------
+
+:Summary: Float describing the timeout to use when reading a streamed body
+:Types: float
+:Default: Defaults to the value of the ``default_socket_timeout`` PHP ini setting
+:Constant: ``GuzzleHttp\RequestOptions::READ_TIMEOUT``
+
+The timeout applies to individual read operations on a streamed body (when the ``stream`` option is enabled).
+
+.. code-block:: php
+
+    $response = $client->request('GET', '/stream', [
+        'stream' => true,
+        'read_timeout' => 10,
+    ]);
+
+    $body = $response->getBody();
+
+    // Returns false on timeout
+    $data = $body->read(1024);
+
+    // Returns false on timeout
+    $line = fgets($body->detach());
 
 .. _sink-option:
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -308,9 +308,17 @@ class StreamHandler
         );
 
         return $this->createResource(
-            function () use ($request, &$http_response_header, $context) {
+            function () use ($request, &$http_response_header, $context, $options) {
                 $resource = fopen((string) $request->getUri()->withFragment(''), 'r', null, $context);
                 $this->lastHeaders = $http_response_header;
+
+                if (isset($options['read_timeout'])) {
+                    $readTimeout = $options['read_timeout'];
+                    $sec = (int) $readTimeout;
+                    $usec = ($readTimeout - $sec) * 100000;
+                    stream_set_timeout($resource, $sec, $usec);
+                }
+
                 return $resource;
             }
         );

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -238,6 +238,12 @@ final class RequestOptions
     const TIMEOUT = 'timeout';
 
     /**
+     * read_timeout: (float, default=default_socket_timeout ini setting) Float describing
+     * the body read timeout, for stream requests.
+     */
+    const READ_TIMEOUT = 'read_timeout';
+
+    /**
      * version: (float) Specifies the HTTP protocol version to attempt to use.
      */
     const VERSION = 'version';

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\FnStream;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\ResponseInterface;
@@ -653,5 +654,27 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $stream = $body->detach();
         $this->assertEquals('hi there... This has a lot of data!', stream_get_contents($stream));
         fclose($stream);
+    }
+
+    public function testHonorsReadTimeout()
+    {
+        Server::flush();
+        $handler = new StreamHandler();
+        $response = $handler(
+            new Request('GET', Server::$url . 'guzzle-server/read-timeout'),
+            [
+                RequestOptions::READ_TIMEOUT => 1,
+                RequestOptions::STREAM => true,
+            ]
+        )->wait();
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('OK', $response->getReasonPhrase());
+        $body = $response->getBody()->detach();
+        $line = fgets($body);
+        $this->assertEquals("sleeping 60 seconds ...\n", $line);
+        $line = fgets($body);
+        $this->assertFalse($line);
+        $this->assertTrue(stream_get_meta_data($body)['timed_out']);
+        $this->assertFalse(feof($body));
     }
 }

--- a/tests/server.js
+++ b/tests/server.js
@@ -155,6 +155,15 @@ var GuzzleServer = function(port, log) {
         var body = JSON.stringify(that.requests);
         res.writeHead(200, 'OK', { 'Content-Length': body.length });
         res.end(body);
+      } else if (req.url == '/guzzle-server/read-timeout') {
+        if (that.log) {
+          console.log('Sleeping');
+        }
+        res.writeHead(200, 'OK');
+        res.write("sleeping 60 seconds ...\n");
+        setTimeout(function () {
+          res.end("slept 60 seconds\n");
+        }, 60*1000);
       }
     } else if (req.method == 'PUT' && req.url == '/guzzle-server/responses') {
       if (that.log) {


### PR DESCRIPTION
This adds a 'read_timeout' option, allowing the user to specify a read timeout for reads on the body of streamed requests.

Support is added only to the StreamHandler, since only this handler seems to support stream requests.

This fixes #1516 
