### PR TITLE
Don't include summary in exception message when body is empty

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -129,6 +129,11 @@ class RequestException extends TransferException
         }
 
         $size = $body->getSize();
+
+        if ($size === 0) {
+            return null;
+        }
+
         $summary = $body->read(120);
         $body->rewind();
 

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -109,6 +109,12 @@ class RequestExceptionTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($expected, $e->getMessage());
     }
 
+    public function testExceptionMessageIgnoresEmptyBody()
+    {
+        $e = RequestException::create(new Request('GET', '/'), new Response(500));
+        $this->assertStringEndsWith('response', $e->getMessage());
+    }
+
     public function testCreatesExceptionWithoutPrintableBody()
     {
         $response = new Response(
@@ -124,7 +130,8 @@ class RequestExceptionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
     }
 
-    public function testHasStatusCodeAsExceptionCode() {
+    public function testHasStatusCodeAsExceptionCode()
+    {
         $e = RequestException::create(new Request('GET', '/'), new Response(442));
         $this->assertEquals(442, $e->getCode());
     }


### PR DESCRIPTION
Exception messages end with `:\n\n` when there is no response body.