### PR TITLE
Quickstart: note that HTTP_PROXY only works on CLI

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -551,7 +551,7 @@ behavior of the library.
 ``HTTP_PROXY``
     Defines the proxy to use when sending requests using the "http" protocol.
     
-    Note: this only works using the CLI SAPI.
+    Note: because the HTTP_PROXY variable may contain arbitrary user input on some (CGI) environments, the variable is only used on the CLI SAPI. See https://httpoxy.org for more information.
 ``HTTPS_PROXY``
     Defines the proxy to use when sending requests using the "https" protocol.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -550,6 +550,8 @@ behavior of the library.
     the timeout.
 ``HTTP_PROXY``
     Defines the proxy to use when sending requests using the "http" protocol.
+    
+    Note: this only works using the CLI SAPI.
 ``HTTPS_PROXY``
     Defines the proxy to use when sending requests using the "https" protocol.
 


### PR DESCRIPTION
Due to "httpoxy" the environment variable HTTP_PROXY is not trusted on non-cli processes. This should be mentioned in the quickstart guide.