### PR TITLE
Created more client exceptions

### DIFF
--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (400 error)
+ */
+class BadRequestException extends ClientException  {}

--- a/src/Exception/ConflictException.php
+++ b/src/Exception/ConflictException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (409 error)
+ */
+class ConflictException extends ClientException  {}

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (403 error)
+ */
+class ForbiddenException extends ClientException  {}

--- a/src/Exception/GoneException.php
+++ b/src/Exception/GoneException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (410 error)
+ */
+class GoneException extends ClientException  {}

--- a/src/Exception/MethodNotAllowedException.php
+++ b/src/Exception/MethodNotAllowedException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (405 error)
+ */
+class MethodNotAllowedException extends ClientException  {}

--- a/src/Exception/NotAcceptableException.php
+++ b/src/Exception/NotAcceptableException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (406 error)
+ */
+class NotAcceptableException extends ClientException  {}

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (404 error)
+ */
+class NotFoundException extends ClientException  {}

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -81,10 +81,10 @@ class RequestException extends TransferException
         $level = (int) floor($response->getStatusCode() / 100);
         if ($level === 4) {
             $label = 'Client error';
-            $className = __NAMESPACE__ . '\\ClientException';
+            $className = static::getClientExceptionClass($response->getStatusCode());
         } elseif ($level === 5) {
             $label = 'Server error';
-            $className = __NAMESPACE__ . '\\ServerException';
+            $className = ServerException::class;
         } else {
             $label = 'Unsuccessful request';
             $className = __CLASS__;
@@ -109,6 +109,33 @@ class RequestException extends TransferException
         }
 
         return new $className($message, $request, $response, $previous, $ctx);
+    }
+
+    /**
+     * Returns the instance of the class to load for client exception cases
+     *
+     * @param int $statusCode The int result code of the server's attempt 
+     * @return string The class name of the ClientException
+     */
+    private static function getClientExceptionClass($statusCode)
+    {
+        $classes = [
+            400 => BadRequestException::class,
+            401 => UnauthorizedException::class,
+            403 => ForbiddenException::class,
+            404 => NotFoundException::class,
+            405 => MethodNotAllowedException::class,
+            406 => NotAcceptableException::class,
+            409 => ConflictException::class,
+            410 => GoneException::class,
+            429 => TooManyRequestsException::class,
+        ];
+
+        if (isset($classes[$statusCode])) {
+            return $classes[$statusCode];
+        }
+
+        return ClientException::class;
     }
 
     /**

--- a/src/Exception/TooManyRequestsException.php
+++ b/src/Exception/TooManyRequestsException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (429 error)
+ */
+class TooManyRequestsException extends ClientException  {}

--- a/src/Exception/UnauthorizedException.php
+++ b/src/Exception/UnauthorizedException.php
@@ -1,0 +1,7 @@
+<?php
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when an HTTP error occurs (401 error)
+ */
+class UnauthorizedException extends ClientException  {}

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 
 /**
- * @covers GuzzleHttp\Exception\RequestException
+ * @covers \GuzzleHttp\Exception\RequestException
  */
 class RequestExceptionTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
I have added some more Exceptions for 4xx http errors. I haven't wrote any Tests. If the changes seems fine to you then I will proceed with the unit tests and update any documentation.

More specific I added the following Exceptions

```
 400 = BadRequestException
 401 = UnauthorizedException
 403 = ForbiddenException
 404 = NotFoundException
 405 = MethodNotAllowedException
 406 = NotAcceptableException
 409 = ConflictException
 410 = GoneException
 429 = TooManyRequestsException
```

I believe they are the most common cases.
