### PR TITLE
getLastOptions function from mockhandler had a wrong docblock typehint

### DIFF
--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -158,7 +158,7 @@ class MockHandler implements \Countable
     /**
      * Get the last received request options.
      *
-     * @return RequestInterface
+     * @return array
      */
     public function getLastOptions()
     {


### PR DESCRIPTION
Return type of getLastOptions was wrong in MockHandler class.
