### PR TITLE
Deprecate BadResponseException instantiation without a response

### DIFF
--- a/src/Exception/BadResponseException.php
+++ b/src/Exception/BadResponseException.php
@@ -1,7 +1,27 @@
 <?php
 namespace GuzzleHttp\Exception;
 
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Exception when an HTTP error occurs (4xx or 5xx error)
  */
-class BadResponseException extends RequestException {}
+class BadResponseException extends RequestException
+{
+    public function __construct(
+        $message,
+        RequestInterface $request,
+        ResponseInterface $response = null,
+        \Exception $previous = null,
+        array $handlerContext = []
+    ) {
+        if (null === $response) {
+            @trigger_error(
+                'Instantiating the ' . __CLASS__ . ' class without a Response is deprecated since version 6.3 and will be removed in 7.0.',
+                E_USER_DEPRECATED
+            );
+        }
+        parent::__construct($message, $request, $response, $previous, $handlerContext);
+    }
+}


### PR DESCRIPTION
Closes #1631 
I created the PR anyway :smile: 

**Edit**:
I guess this is a Breaking Change? I don't know if it will be accepted but it feels more correct to me this way.