### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
-build/*          export-ignore
-docs/*           export-ignore
-tests/*          export-ignore
+build            export-ignore
+docs             export-ignore
+tests            export-ignore
 .editorconfig    export-ignore
 .gitattributes   export-ignore
 .gitignore       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,6 @@ tests/*          export-ignore
 .editorconfig    export-ignore
 .gitattributes   export-ignore
 .gitignore       export-ignore
-.travis          export-ignore
+.travis.yml      export-ignore
 Makefile         export-ignore
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
Before if I exec `composer require guzzlehttp/guzzle` I would have see this:
<img width="193" alt="2016-11-10 16 10 08" src="https://cloud.githubusercontent.com/assets/7838144/20177911/2fe1b486-a760-11e6-8356-c6e35016fefa.png">
So the `.travis.yml` file appears.

This pull request solves it.

I think the appearance of empty directories `build`, `docs` and `tests` also could be fixed.