### PR TITLE
fix sample code in literal to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ trivial to integrate with web services.
 
 ```php
 $client = new \GuzzleHttp\Client();
-$res = $client->request('GET', 'https://api.github.com/user', [
-    'auth' => ['user', 'pass']
-]);
+$res = $client->request('GET', 'https://api.github.com/repos/guzzle/guzzle');
 echo $res->getStatusCode();
 // 200
 echo $res->getHeaderLine('content-type');
 // 'application/json; charset=utf8'
 echo $res->getBody();
-// {"type":"User"...'
+// '{"id": 1420053, "name": "guzzle", ...}'
 
 // Send an asynchronous request.
 $request = new \GuzzleHttp\Psr7\Request('GET', 'http://httpbin.org');


### PR DESCRIPTION
I know it is just a sample code and  the parameters `['user', 'pass']` are dummy.

But it is fact that this code does not work as it is.

```
PHP Fatal error:  Uncaught GuzzleHttp\Exception\ClientException: Client error: `GET https://api.github.com/user` resulted in a `401 Unauthorized` response:
{
  "message": "Bad credentials",
  "documentation_url": "https://developer.github.com/v3"
}
```

this PR fix the problem.

I think it is very important to show codes which work fine as it is, especially for beginners.


