### PR TITLE
Fix count being called on null

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\RequestInterface;
 class CurlFactory implements CurlFactoryInterface
 {
     /** @var array */
-    private $handles;
+    private $handles = [];
 
     /** @var int Total number of idle handles to keep in cache */
     private $maxHandles;


### PR DESCRIPTION
PHP 7.2 requires arguments to count being an array or an instance of Countable.

This property when not initialized, is neither of these, it's null.