### PR TITLE
Track redirect HTTP status codes

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -131,17 +131,16 @@ setting the ``expect`` request option to ``false``:
     $client = new GuzzleHttp\Client(['expect' => false]);
 
 How can I track a redirected requests HTTP codes?
-============================================
+=================================================
 
-You can enable the `track_redirects` option which will enable Guzzle to track
-any redirected URI and status code. Each redirected URI will be stored in the
-``X-Guzzle-Redirect-History`` header and each Response Code will be stored in
+You can enable tracking of redirected URLs and the status codes via the
+`track_redirects` option. Each redirected URI will be stored in the
+``X-Guzzle-Redirect-History`` header and each status code will be stored in
 the ``X-Guzzle-Redirect-Status-History`` header.
 
-The ``X-Guzzle-Redirect-History`` header will exclude the initial request's URI
-and the ``X-Guzzle-Redirect-Status-History`` header will exclude the final
-response code. With this in mind you should easily be able to track a requests
-full redirect path.
+The URL history header will exclude the initial request's URI and the
+status code history header will exclude the final status code. With this
+in mind you should easily be able to track a request's full redirect path.
 
 For example, let's say you need to track redirects and provide both results
 together in a single report:
@@ -167,13 +166,11 @@ together in a single report:
     $redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History'); // retrieve Redirects URI history
     $redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History'); // retrieve Redirects HTTP Status history
 
-    // Add the initial URI requested to the URI history
-    $reversedUriHistory = array_reverse($redirectUriHistory); // First we reverse the array items
-    array_push($reversedUriHistory, $initialRequest); // then we add the initial URL on the end
-    $redirectUriHistory = array_reverse($reversedUriHistory); // Overwrite original variable with new list
+    // Add the initial URI requested to the (beginning of) URI history
+    array_unshift($reversedUriHistory, $initialRequest); // then we add the initial URL on the end
 
     // Add the final HTTP status code to the HTTP response history
-    array_push($redirectCodeHistory, $response->getStatusCode()); // Add final response status to code array
+    array_push($redirectCodeHistory, $response->getStatusCode()); // Add final status code to code array
 
     // (Optional) Combine the items of each array into a single result set
     $fullRedirectReport = [];

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -130,17 +130,16 @@ setting the ``expect`` request option to ``false``:
     // Disable the expect header on all client requests
     $client = new GuzzleHttp\Client(['expect' => false]);
 
-How can I track a redirected requests HTTP codes?
-=================================================
+How can I track a redirected requests?
+======================================
 
-You can enable tracking of redirected URLs and the status codes via the
-`track_redirects` option. Each redirected URI will be stored in the
-``X-Guzzle-Redirect-History`` header and each status code will be stored in
-the ``X-Guzzle-Redirect-Status-History`` header.
+You can enable tracking of redirected URIs and status codes via the
+`track_redirects` option. Each redirected URI and status code will be stored in the
+``X-Guzzle-Redirect-History`` and the ``X-Guzzle-Redirect-Status-History``
+header respectively.
 
-The URL history header will exclude the initial request's URI and the
-status code history header will exclude the final status code. With this
-in mind you should easily be able to track a request's full redirect path.
+The initial request's URI and the final status code will be excluded from the results.
+With this in mind you should be able to easily track a request's full redirect path.
 
 For example, let's say you need to track redirects and provide both results
 together in a single report:
@@ -149,28 +148,25 @@ together in a single report:
 
     // First you configure Guzzle with redirect tracking and make a request
     $client = new Client([
-                RequestOptions::CONNECT_TIMEOUT => 10,
-                RequestOptions::TIMEOUT => 10,
-                RequestOptions::COOKIES => true,
-                RequestOptions::ALLOW_REDIRECTS => [
-                    'max'             => 10,        // allow at most 10 redirects.
-                    'strict'          => true,      // use "strict" RFC compliant redirects.
-                    'referer'         => true,      // add a Referer header
-                    'track_redirects' => true
-                ]
-            ]);
+        RequestOptions::ALLOW_REDIRECTS => [
+            'max'             => 10,        // allow at most 10 redirects.
+            'strict'          => true,      // use "strict" RFC compliant redirects.
+            'referer'         => true,      // add a Referer header
+            'track_redirects' => true,
+        ],
+    ]);
     $initialRequest = '/redirect/3'; // Store the request URI for later use
     $response = $client->request('GET', $initialRequest); // Make your request
 
     // Retrieve both Redirect History headers
-    $redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History'); // retrieve Redirects URI history
-    $redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History'); // retrieve Redirects HTTP Status history
+    $redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History'); // retrieve Redirect URI history
+    $redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History'); // retrieve Redirect HTTP Status history
 
     // Add the initial URI requested to the (beginning of) URI history
-    array_unshift($redirectUriHistory, $initialRequest); // then we add the initial URL on the end
+    array_unshift($redirectUriHistory, $initialRequest);
 
-    // Add the final HTTP status code to the HTTP response history
-    array_push($redirectCodeHistory, $response->getStatusCode()); // Add final status code to code array
+    // Add the final HTTP status code to the end of HTTP response history
+    array_push($redirectCodeHistory, $response->getStatusCode());
 
     // (Optional) Combine the items of each array into a single result set
     $fullRedirectReport = [];

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -167,7 +167,7 @@ together in a single report:
     $redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History'); // retrieve Redirects HTTP Status history
 
     // Add the initial URI requested to the (beginning of) URI history
-    array_unshift($reversedUriHistory, $initialRequest); // then we add the initial URL on the end
+    array_unshift($redirectUriHistory, $initialRequest); // then we add the initial URL on the end
 
     // Add the final HTTP status code to the HTTP response history
     array_push($redirectCodeHistory, $response->getStatusCode()); // Add final status code to code array
@@ -177,3 +177,4 @@ together in a single report:
     foreach ($redirectUriHistory as $key => $value) {
         $fullRedirectReport[$key] = ['location' => $value, 'code' => $redirectCodeHistory[$key]];
     }
+    echo json_encode($fullRedirectReport);

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -70,9 +70,15 @@ pairs:
   is encountered. The callable is invoked with the original request and the
   redirect response that was received. Any return value from the on_redirect
   function is ignored.
-- track_redirects: (bool) When set to ``true``, each redirected URI encountered
-  will be tracked in the ``X-Guzzle-Redirect-History`` header in the order in
-  which the redirects were encountered.
+- track_redirects: (bool) When set to ``true``, each redirected URI and Response
+  Code encountered will be tracked in the ``X-Guzzle-Redirect-History`` and 
+  ``X-Guzzle-Redirect-Status-History`` headers respectively. All URIs and
+  Response Codes will be stored in the order in which the redirects were
+  encountered.
+
+  Note: When tracking redirects the ``X-Guzzle-Redirect-History`` header will
+  exclude the initial request's URI and the ``X-Guzzle-Redirect-Status-History``
+  header will exclude the final response code.
 
 .. code-block:: php
 
@@ -104,6 +110,9 @@ pairs:
 
     echo $res->getHeaderLine('X-Guzzle-Redirect-History');
     // http://first-redirect, http://second-redirect, etc...
+
+    echo $res->getHeaderLine('X-Guzzle-Redirect-Status-History');
+    // 301, 302, etc...
 
 .. warning::
 

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -70,15 +70,14 @@ pairs:
   is encountered. The callable is invoked with the original request and the
   redirect response that was received. Any return value from the on_redirect
   function is ignored.
-- track_redirects: (bool) When set to ``true``, each redirected URI and Response
-  Code encountered will be tracked in the ``X-Guzzle-Redirect-History`` and 
+- track_redirects: (bool) When set to ``true``, each redirected URI and status
+  code encountered will be tracked in the ``X-Guzzle-Redirect-History`` and
   ``X-Guzzle-Redirect-Status-History`` headers respectively. All URIs and
-  Response Codes will be stored in the order in which the redirects were
-  encountered.
+  status codes will be stored in the order which the redirects were encountered.
 
   Note: When tracking redirects the ``X-Guzzle-Redirect-History`` header will
   exclude the initial request's URI and the ``X-Guzzle-Redirect-Status-History``
-  header will exclude the final response code.
+  header will exclude the final status code.
 
 .. code-block:: php
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -111,7 +111,7 @@ class RedirectMiddleware
             return $this->withTracking(
                 $promise,
                 (string) $nextRequest->getUri(),
-                (int) $response->getStatusCode()
+                (string) $response->getStatusCode()
             );
         }
 
@@ -129,7 +129,8 @@ class RedirectMiddleware
                 $statusHeader = $response->getHeader(self::STATUS_HISTORY_HEADER);
                 array_unshift($historyHeader, $uri);
                 array_unshift($statusHeader, $statusCode);
-                return $response->withHeader(self::HISTORY_HEADER, $historyHeader)->withHeader(self::STATUS_HISTORY_HEADER, $statusHeader);
+                return $response->withHeader(self::HISTORY_HEADER, $historyHeader)
+                                ->withHeader(self::STATUS_HISTORY_HEADER, $statusHeader);
             }
         );
     }

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -111,7 +111,7 @@ class RedirectMiddleware
             return $this->withTracking(
                 $promise,
                 (string) $nextRequest->getUri(),
-                (string) $response->getStatusCode()
+                $response->getStatusCode()
             );
         }
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -110,24 +110,25 @@ class RedirectMiddleware
         if (!empty($options['allow_redirects']['track_redirects'])) {
             return $this->withTracking(
                 $promise,
-                (string) $nextRequest->getUri()
+                (string) $nextRequest->getUri(),
+                (int) $response->getStatusCode()
             );
         }
 
         return $promise;
     }
 
-    private function withTracking(PromiseInterface $promise, $uri)
+    private function withTracking(PromiseInterface $promise, $uri, $statusCode)
     {
         return $promise->then(
-            function (ResponseInterface $response) use ($uri) {
+            function (ResponseInterface $response) use ($uri, $statusCode) {
                 // Note that we are pushing to the front of the list as this
                 // would be an earlier response than what is currently present
                 // in the history header.
                 $historyHeader = $response->getHeader(self::HISTORY_HEADER);
                 $statusHeader = $response->getHeader(self::STATUS_HISTORY_HEADER);
                 array_unshift($historyHeader, $uri);
-                array_unshift($statusHeader, $response->getStatusCode());
+                array_unshift($statusHeader, $statusCode);
                 return $response->withHeader(self::HISTORY_HEADER, $historyHeader)->withHeader(self::STATUS_HISTORY_HEADER, $statusHeader);
             }
         );

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -19,6 +19,8 @@ class RedirectMiddleware
 {
     const HISTORY_HEADER = 'X-Guzzle-Redirect-History';
 
+    const STATUS_HISTORY_HEADER = 'X-Guzzle-Redirect-Status-History';
+
     public static $defaultSettings = [
         'max'             => 5,
         'protocols'       => ['http', 'https'],
@@ -122,9 +124,11 @@ class RedirectMiddleware
                 // Note that we are pushing to the front of the list as this
                 // would be an earlier response than what is currently present
                 // in the history header.
-                $header = $response->getHeader(self::HISTORY_HEADER);
-                array_unshift($header, $uri);
-                return $response->withHeader(self::HISTORY_HEADER, $header);
+                $historyHeader = $response->getHeader(self::HISTORY_HEADER);
+                $statusHeader = $response->getHeader(self::STATUS_HISTORY_HEADER);
+                array_unshift($historyHeader, $uri);
+                array_unshift($statusHeader, $response->getStatusCode());
+                return $response->withHeader(self::HISTORY_HEADER, $historyHeader)->withHeader(self::STATUS_HISTORY_HEADER, $statusHeader);
             }
         );
     }


### PR DESCRIPTION
Using a similar technique to the current Redirect History feature this PR adds support for tracking the HTTP status codes in a new: 'X-Guzzle-Redirect-Status-History' header.

This PR was created in response to #1710 