### PR TITLE
Require react/promise:2.2 or above

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/ringphp": "^1.1"
+        "guzzlehttp/ringphp": "^1.1",
+        "react/promise": "^2.2"
     },
     "require-dev": {
         "ext-curl": "*",


### PR DESCRIPTION
We use react/promise but we have never specified it in composer.json. We do currently not support react/promise:2.0 or react/promise:2.1

This will fix https://github.com/guzzle/RingPHP/issues/39