### PR TITLE
fix when curl set time less than one second causes libcurl to timeout…

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -370,9 +370,9 @@ class CurlFactory implements CurlFactoryInterface
             $conf[CURLOPT_FILE] = fopen('php://temp', 'w+');
             $easy->sink = Psr7\stream_for($conf[CURLOPT_FILE]);
         }
-        $lessThan1s = false;
+        $timeoutRequiresNoSignal = false;
         if (isset($options['timeout'])) {
-            $options['timeout'] < 1 && $lessThan1s = true;
+            $options['timeout'] < 1 && $timeoutRequiresNoSignal = true;
             $conf[CURLOPT_TIMEOUT_MS] = $options['timeout'] * 1000;
         }
 
@@ -386,11 +386,12 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (isset($options['connect_timeout'])) {
-            $options['connect_timeout'] < 1 && $lessThan1s = true;
+            $options['connect_timeout'] < 1 && $timeoutRequiresNoSignal = true;
             $conf[CURLOPT_CONNECTTIMEOUT_MS] = $options['connect_timeout'] * 1000;
         }
-        if ($lessThan1s) {
-            $conf[CURLOPT_NOSIGNAL] = 1;
+
+        if ($timeoutRequiresNoSignal) {
+            $conf[CURLOPT_NOSIGNAL] = true;
         }
 
         if (isset($options['proxy'])) {

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -390,7 +390,7 @@ class CurlFactory implements CurlFactoryInterface
             $conf[CURLOPT_CONNECTTIMEOUT_MS] = $options['connect_timeout'] * 1000;
         }
 
-        if ($timeoutRequiresNoSignal) {
+        if ($timeoutRequiresNoSignal && strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
             $conf[CURLOPT_NOSIGNAL] = true;
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -372,7 +372,7 @@ class CurlFactory implements CurlFactoryInterface
         }
         $timeoutRequiresNoSignal = false;
         if (isset($options['timeout'])) {
-            $options['timeout'] < 1 && $timeoutRequiresNoSignal = true;
+            $timeoutRequiresNoSignal |= $options['timeout'] < 1;
             $conf[CURLOPT_TIMEOUT_MS] = $options['timeout'] * 1000;
         }
 
@@ -386,7 +386,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (isset($options['connect_timeout'])) {
-            $options['connect_timeout'] < 1 && $timeoutRequiresNoSignal = true;
+            $timeoutRequiresNoSignal |= $options['connect_timeout'] < 1;
             $conf[CURLOPT_CONNECTTIMEOUT_MS] = $options['connect_timeout'] * 1000;
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -370,8 +370,9 @@ class CurlFactory implements CurlFactoryInterface
             $conf[CURLOPT_FILE] = fopen('php://temp', 'w+');
             $easy->sink = Psr7\stream_for($conf[CURLOPT_FILE]);
         }
-
+        $lessThan1s = false;
         if (isset($options['timeout'])) {
+            $options['timeout'] < 1 && $lessThan1s = true;
             $conf[CURLOPT_TIMEOUT_MS] = $options['timeout'] * 1000;
         }
 
@@ -385,7 +386,11 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (isset($options['connect_timeout'])) {
+            $options['connect_timeout'] < 1 && $lessThan1s = true;
             $conf[CURLOPT_CONNECTTIMEOUT_MS] = $options['connect_timeout'] * 1000;
+        }
+        if ($lessThan1s) {
+            $conf[CURLOPT_NOSIGNAL] = 1;
         }
 
         if (isset($options['proxy'])) {


### PR DESCRIPTION
http://php.net/manual/en/function.curl-setopt.php


>If you want cURL to timeout in less than one second, you can use CURLOPT_TIMEOUT_MS, although >there is a bug/"feature"  on "Unix-like systems" that causes libcurl to timeout immediately if the value is >< 1000 ms with the error "cURL Error (28): Timeout was reached".  The explanation for this behavior is:
