### PR TITLE
[PrepareBodyMiddleware] Always include the Content-Length if there's a body

### DIFF
--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -14,9 +14,6 @@ class PrepareBodyMiddleware
     /** @var callable  */
     private $nextHandler;
 
-    /** @var array */
-    private static $skipMethods = ['GET' => true, 'HEAD' => true];
-
     /**
      * @param callable $nextHandler Next handler to invoke.
      */
@@ -36,9 +33,7 @@ class PrepareBodyMiddleware
         $fn = $this->nextHandler;
 
         // Don't do anything if the request has no body.
-        if (isset(self::$skipMethods[$request->getMethod()])
-            || $request->getBody()->getSize() === 0
-        ) {
+        if ($request->getBody()->getSize() === 0) {
             return $fn($request, $options);
         }
 
@@ -54,8 +49,7 @@ class PrepareBodyMiddleware
         }
 
         // Add a default content-length or transfer-encoding header.
-        if (!isset(self::$skipMethods[$request->getMethod()])
-            && !$request->hasHeader('Content-Length')
+        if (!$request->hasHeader('Content-Length')
             && !$request->hasHeader('Transfer-Encoding')
         ) {
             $size = $request->getBody()->getSize();


### PR DESCRIPTION
I've been working with a web service provider and their server was returning status `500` for all requests, this is because they accept a body with a `GET` request, but require the `Content-Length` header.

While this is a violation of the HTTP spec, it took a long time to notice the issue.
Once I realised the cause I thought about having Guzzle throw an exception when a body is provided with `GET`, but that would prevent Guzzle from being used with some web services, so I then thought about this approach