### PR TITLE
psr/log should be also in suggested packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
             "GuzzleHttp\\Tests\\": "tests/"
         }
     },
+    "suggest": {
+        "psr/log": "This package holds all interfaces/classes/traits related to PSR-3 in order to use Middleware::log()"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "6.2-dev"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     },
     "suggest": {
-        "psr/log": "This package holds all interfaces/classes/traits related to PSR-3 in order to use Middleware::log()"
+        "psr/log": "Required for using the Log middleware"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Since you have a [middleware](https://github.com/guzzle/guzzle/blob/master/src/Middleware.php#L185) in Middleware class that is using the LoggerInterface and this class is bundled with the package and it is not just for testing then I believe that psr/log should not be in require-dev.