### PR TITLE
check handler type on construction

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -61,12 +61,10 @@ class Client implements ClientInterface
      */
     public function __construct(array $config = [])
     {
-        if (isset($config['handler'])) {
-            if (!is_callable($config['handler'])) {
-                throw new \InvalidArgumentException('handler must be a callable');
-            }
-        } else {
+        if (!isset($config['handler'])) {
             $config['handler'] = HandlerStack::create();
+        } elseif (!is_callable($config['handler'])) {
+            throw new \InvalidArgumentException('handler must be a callable');
         }
 
         // Convert the base_uri to a UriInterface

--- a/src/Client.php
+++ b/src/Client.php
@@ -61,7 +61,11 @@ class Client implements ClientInterface
      */
     public function __construct(array $config = [])
     {
-        if (!isset($config['handler'])) {
+        if (isset($config['handler'])) {
+            if (!is_callable($config['handler'])) {
+                throw new \InvalidArgumentException('handler must be a callable');
+            }
+        } else {
             $config['handler'] = HandlerStack::create();
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -653,4 +653,13 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             (string) $mockHandler->getLastRequest()->getUri()
         );
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testHandlerIsCallable()
+    {
+        new Client(['handler' => 'not_cllable']);
+    }
+
 }


### PR DESCRIPTION
# Background
`handler` option must be an callable, but there is no type check

# Current behavior

So Fatal Error occurs on request time.

```php
$client = new GuzzleHttp\Client(['handler' => 'x']);
$res = $client->request('get', 'https://example.com/');
```

```
PHP Fatal error:  Uncaught Error: Call to undefined function x() in /Users/DQNEO/src/github.com/DQNEO/guzzle/src/Client.php:275
Stack trace:
#0 /Users/DQNEO/src/github.com/DQNEO/guzzle/src/Client.php(123): GuzzleHttp\Client->transfer(Object(GuzzleHttp\Psr7\Request), Array)
#1 /Users/DQNEO/src/github.com/DQNEO/guzzle/src/Client.php(129): GuzzleHttp\Client->requestAsync('get', Object(GuzzleHttp\Psr7\Uri), Array)
#2 /Users/DQNEO/src/github.com/DQNEO/guzzle/,.php(9): GuzzleHttp\Client->request('get', 'https://httpbin...')
#3 {main}
  thrown in /Users/DQNEO/src/github.com/DQNEO/guzzle/src/Client.php on line 275
```

# New behavior
by this PR, users can see a exception on construction , which is more easier to find the cause.

```
PHP Fatal error:  Uncaught InvalidArgumentException: handler must be a callable in /Users/DQNEO/src/github.com/DQNEO/guzzle/src/Client.php:66
Stack trace:
#0 /Users/DQNEO/src/github.com/DQNEO/guzzle/,.php(7): GuzzleHttp\Client->__construct(Array)
#1 {main}
  thrown in /Users/DQNEO/src/github.com/DQNEO/guzzle/src/Client.php on line 66
```
