### PR TITLE
Fix deprecations with guzzle/psr7 version 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/psr7": "^1.3.1",
+        "guzzlehttp/psr7": "^1.4",
         "guzzlehttp/promises": "^1.0"
     },
     "require-dev": {

--- a/docs/psr7.rst
+++ b/docs/psr7.rst
@@ -234,7 +234,7 @@ scheme can be set to "http" or "https".
 
     $request = new Request('GET', 'http://httpbin.org');
     echo $request->getUri()->getScheme(); // http
-    echo $request->getUri(); // http://httpbin.org/get
+    echo $request->getUri(); // http://httpbin.org
 
 
 Host

--- a/src/Client.php
+++ b/src/Client.php
@@ -142,7 +142,7 @@ class Client implements ClientInterface
         $uri = Psr7\uri_for($uri === null ? '' : $uri);
 
         if (isset($config['base_uri'])) {
-            $uri = Psr7\Uri::resolve(Psr7\uri_for($config['base_uri']), $uri);
+            $uri = Psr7\UriResolver::resolve(Psr7\uri_for($config['base_uri']), $uri);
         }
 
         return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -208,9 +208,9 @@ class RedirectMiddleware
         ResponseInterface $response,
         array $protocols
     ) {
-        $location = Psr7\Uri::resolve(
+        $location = Psr7\UriResolver::resolve(
             $request->getUri(),
-            $response->getHeaderLine('Location')
+            new Psr7\Uri($response->getHeaderLine('Location'))
         );
 
         // Ensure that the redirect URI is allowed based on the protocols.

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -43,8 +43,8 @@ final class RequestOptions
     const AUTH = 'auth';
 
     /**
-     * body: (string|null|callable|iterator|object) Body to send in the
-     * request.
+     * body: (resource|string|null|int|float|StreamInterface|callable|\Iterator)
+     * Body to send in the request.
      */
     const BODY = 'body';
 


### PR DESCRIPTION
Cherry picked #1753 to an earlier version of guzzle so it can be tagged as a patch version, also merged into the latest master. Did it so we can immediately release it (6.3 is no blocker).

@Tobion can you please review?