### PR TITLE
Add a method to get a cookie by cookie name

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -252,7 +252,9 @@ class CookieJar implements CookieJarInterface
         return $this->cookies[
             array_search(
                 $name,
-                array_column($cookiesArray, 'Name')
+                array_map(function ($element) {
+                    return $element['Name'];
+                }, $cookiesArray)
             )
         ];
     }

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -245,6 +245,18 @@ class CookieJar implements CookieJarInterface
             : $request;
     }
 
+    public function getCookieByName($name)
+    {
+        $cookiesArray = $this->toArray();
+
+        return $this->cookies[
+            array_search(
+                $name,
+                array_column($cookiesArray, 'Name')
+            )
+        ];
+    }
+
     /**
      * If a cookie already exists and the server asks to set it again with a
      * null value, the cookie must be deleted.

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -248,15 +248,18 @@ class CookieJar implements CookieJarInterface
     public function getCookieByName($name)
     {
         $cookiesArray = $this->toArray();
+        $key = array_search(
+            $name,
+            array_map(function ($element) {
+                return $element['Name'];
+            }, $cookiesArray)
+        );
 
-        return $this->cookies[
-            array_search(
-                $name,
-                array_map(function ($element) {
-                    return $element['Name'];
-                }, $cookiesArray)
-            )
-        ];
+        if ($key === false) {
+            return null;
+        }
+
+        return $this->cookies[$key];
     }
 
     /**

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -343,4 +343,16 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(3, $newCookieJar);
         $this->assertSame($jar->toArray(), $newCookieJar->toArray());
     }
+
+    public function testGetCookieByName()
+    {
+        $cookies = $this->getTestCookies();
+        foreach ($cookies as $cookie) {
+            $this->jar->setCookie($cookie);
+        }
+
+        $this->assertTrue($this->jar->getCookieByName('foo')->getName() === 'foo');
+        $this->assertTrue($this->jar->getCookieByName('test')->getName() === 'test');
+        $this->assertTrue($this->jar->getCookieByName('you')->getName() === 'you');
+    }
 }

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -354,5 +354,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->jar->getCookieByName('foo')->getName() === 'foo');
         $this->assertTrue($this->jar->getCookieByName('test')->getName() === 'test');
         $this->assertTrue($this->jar->getCookieByName('you')->getName() === 'you');
+        $this->assertTrue($this->jar->getCookieByName(null) === null);
+        $this->assertTrue($this->jar->getCookieByName('notexist') === null);
     }
 }


### PR DESCRIPTION
I added a method to simply get it from the `CookieJar` by the name of the cookie.