### PR TITLE
Test cookie handling when cookie path is empty.

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -216,9 +216,39 @@ class CookieJar implements CookieJarInterface
                 if (!$sc->getDomain()) {
                     $sc->setDomain($request->getUri()->getHost());
                 }
+                if (0 !== strpos($sc->getPath(), '/')) {
+                    $sc->setPath($this->getCookiePathFromRequest($request));
+                }
                 $this->setCookie($sc);
             }
         }
+    }
+
+    /**
+     * Computes cookie path following RFC 6265 section 5.1.4
+     *
+     * @link https://tools.ietf.org/html/rfc6265#section-5.1.4
+     *
+     * @param RequestInterface $request
+     * @return string
+     */
+    private function getCookiePathFromRequest(RequestInterface $request)
+    {
+        $uriPath = $request->getUri()->getPath();
+        if (''  === $uriPath) {
+            return '/';
+        }
+        if (0 !== strpos($uriPath, '/')) {
+            return '/';
+        }
+        if ('/' === $uriPath) {
+            return '/';
+        }
+        if (0 === $lastSlashPos = strrpos($uriPath, '/')) {
+            return '/';
+        }
+
+        return substr($uriPath, 0, $lastSlashPos);
     }
 
     public function withCookieHeader(RequestInterface $request)

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -343,4 +343,45 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(3, $newCookieJar);
         $this->assertSame($jar->toArray(), $newCookieJar->toArray());
     }
+
+    public function testAddsCookiesWithEmptyPathFromResponse()
+    {
+        $response = new Response(200, array(
+            'Set-Cookie' => "fpc=foobar; expires=Fri, 02-Mar-2019 02:17:40 GMT; path=;"
+        ));
+        $request = new Request('GET', 'http://www.example.com');
+        $this->jar->extractCookies($request, $response);
+        $newRequest = $this->jar->withCookieHeader(new Request('GET','http://www.example.com/foo'));
+        $this->assertTrue($newRequest->hasHeader('Cookie'));
+    }
+
+    public function getCookiePathsDataProvider()
+    {
+        return [
+            ['', '/'],
+            ['/', '/'],
+            ['/foo', '/'],
+            ['/foo/bar', '/foo'],
+            ['/foo/bar/', '/foo/bar'],
+            ['foo', '/'],
+            ['foo/bar', '/'],
+            ['foo/bar/', '/'],
+        ];
+    }
+
+    /**
+     * @dataProvider getCookiePathsDataProvider
+     */
+    public function testCookiePathWithEmptySetCookiePath($uriPath, $cookiePath)
+    {
+        $response = (new Response(200))
+            ->withAddedHeader('Set-Cookie', "foo=bar; expires=Fri, 02-Mar-2019 02:17:40 GMT; domain=www.example.com; path=;")
+            ->withAddedHeader('Set-Cookie', "bar=foo; expires=Fri, 02-Mar-2019 02:17:40 GMT; domain=www.example.com; path=foobar;")
+        ;
+        $request = (new Request('GET', $uriPath))->withHeader('Host', 'www.example.com');
+        $this->jar->extractCookies($request, $response);
+
+        $this->assertEquals($cookiePath, $this->jar->toArray()[0]['Path']);
+        $this->assertEquals($cookiePath, $this->jar->toArray()[1]['Path']);
+    }
 }


### PR DESCRIPTION
Using CookieJar class I have detected that matchesPath method on SetCookie class sometimes fails when withCookieHeader method is called. 
The reason is that the cookie path attribute sent from the upstream server is an empty string.

I have created a test to check different cookie path possibilities according to the https://tools.ietf.org/html/rfc6265#section-5.1.4
