### PR TITLE
[WIP] Fix stream size after decoding content

### DIFF
--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -329,6 +329,7 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
         $sent = Server::received()[0];
         $this->assertEquals('gzip', $sent->getHeaderLine('Accept-Encoding'));
         $this->assertEquals('test', (string) $response->getBody());
+        $this->assertTrue(null === $response->getBody()->getSize() || 4 === $response->getBody()->getSize());
         $this->assertFalse($response->hasHeader('content-encoding'));
         $this->assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == $response->getBody()->getSize());
     }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -194,6 +194,7 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => true])->wait();
         $this->assertEquals('test', (string) $response->getBody());
+        $this->assertTrue(null === $response->getBody()->getSize() || 4 === $response->getBody()->getSize());
         $this->assertFalse($response->hasHeader('content-encoding'));
         $this->assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == $response->getBody()->getSize());
     }


### PR DESCRIPTION
When curl decodes the original body contents, the returned response stream has a fixed size of `0`, but it should be `null` or the real body size.
