### PR TITLE
Fix #1790 proxy should not end with /

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -381,7 +381,7 @@ class StreamHandler
                         $value['no']
                     )
                 ) {
-                    $options['http']['proxy'] = $value[$scheme];
+                    $options['http']['proxy'] = rtrim($value[$scheme], '/');
                 }
             }
         }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -272,7 +272,7 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $url = str_replace('http', 'tcp', Server::$url);
         $res = $this->getSendResult(['proxy' => ['http' => $url]]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertEquals($url, $opts['http']['proxy']);
+        $this->assertEquals(rtrim($url, '/'), $opts['http']['proxy']);
     }
 
     public function testAddsProxyButHonorsNoProxy()


### PR DESCRIPTION
@sgolemon  can you please have a look, related to fix from https://bugs.php.net/74216

Perhaps better to ignore this ending / in php side to avoid BC

But, probably,  fixing here make sense in all case