### PR TITLE
Fix/transfer encoding fix for get method

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -21,6 +21,9 @@ class CurlFactory implements CurlFactoryInterface
     /** @var int Total number of idle handles to keep in cache */
     private $maxHandles;
 
+    /** @var array */
+    private static $skipMethods = ['GET' => true, 'HEAD' => true];
+
     /**
      * @param int $maxHandles Maximum number of idle handles.
      */
@@ -258,7 +261,7 @@ class CurlFactory implements CurlFactoryInterface
             // Don't duplicate the Content-Length header
             $this->removeHeader('Content-Length', $conf);
             $this->removeHeader('Transfer-Encoding', $conf);
-        } else {
+        } elseif (!isset(self::$skipMethods[$request->getMethod()])) {
             $conf[CURLOPT_UPLOAD] = true;
             if ($size !== null) {
                 $conf[CURLOPT_INFILESIZE] = $size;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -261,8 +261,10 @@ class CurlFactory implements CurlFactoryInterface
             // Don't duplicate the Content-Length header
             $this->removeHeader('Content-Length', $conf);
             $this->removeHeader('Transfer-Encoding', $conf);
-        } elseif (!isset(self::$skipMethods[$request->getMethod()])) {
-            $conf[CURLOPT_UPLOAD] = true;
+        } else {
+            if (!isset(self::$skipMethods[$request->getMethod()])) {
+                $conf[CURLOPT_UPLOAD] = true;
+            }
             if ($size !== null) {
                 $conf[CURLOPT_INFILESIZE] = $size;
                 $this->removeHeader('Content-Length', $conf);


### PR DESCRIPTION
When CURLOPT_UPLOAD is sent to curl_setopt method it's resulting with 'Transfer-uncoding: chunked' which rather should not be present in GET or HEAD requests as in section 4.4 of https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html