### PR TITLE
Add PHP 7.2 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - nightly
   - hhvm
 
 before_script:
@@ -21,6 +22,7 @@ script: make test
 matrix:
   allow_failures:
     - php: hhvm
+    - php: nightly
   fast_finish: true
 
 before_deploy:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "^4.0",
+        "phpunit/phpunit": "^4.0 || ^5.0",
         "psr/log": "^1.0"
     },
     "autoload": {

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class MockHandler implements \Countable
 {
-    private $queue;
+    private $queue = [];
     private $lastRequest;
     private $lastOptions;
     private $onFulfilled;

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -39,7 +39,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
 
     public function testEmptyJarIsCountable()
     {
-        self::assertCount(0, new CookieJar());
+        $this->assertCount(0, new CookieJar());
     }
 
     public function testGetsCookiesByName()

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -37,6 +37,11 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $jar);
     }
 
+    public function testEmptyJarIsCountable()
+    {
+        self::assertCount(0, new CookieJar());
+    }
+
     public function testGetsCookiesByName()
     {
         $cookies = $this->getTestCookies();

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -28,6 +28,11 @@ class MockHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $mock);
     }
 
+    public function testEmptyHandlerIsCountable()
+    {
+        $this->assertCount(0, new MockHandler());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -270,6 +270,7 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
     public function testAddsProxyByProtocol()
     {
         $url = str_replace('http', 'tcp', Server::$url);
+        $url = rtrim($url, '/');
         $res = $this->getSendResult(['proxy' => ['http' => $url]]);
         $opts = stream_context_get_options($res->getBody()->detach());
         $this->assertEquals($url, $opts['http']['proxy']);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -270,6 +270,7 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
     public function testAddsProxyByProtocol()
     {
         $url = str_replace('http', 'tcp', Server::$url);
+        // Workaround until #1823 is fixed properly
         $url = rtrim($url, '/');
         $res = $this->getSendResult(['proxy' => ['http' => $url]]);
         $opts = stream_context_get_options($res->getBody()->detach());


### PR DESCRIPTION
* Include PHP 7.2 to travis matrix
* Fix TCP proxy url (trailing slash parsing fails on PHP 7.2)
* Update to phpunit `^4.0 || ^5.0` (4.0 is no longer supported, but required for testing against PHP 5.5)
* Add tests for countables

At the moment no more failures found for 7.2 and tests are green. Further patches are matter of test coverage

Incorporates #1809 
cc. @sagikazarmark