### PR TITLE
Fix describe_type()'s test when Xdebug is loaded

### DIFF
--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -51,10 +51,12 @@ class FunctionsTest extends TestCase
             ini_set('xdebug.overload_var_dump', 0);
         }
 
-        self::assertSame($output, GuzzleHttp\describe_type($input));
-
-        if (extension_loaded('xdebug')) {
-            ini_set('xdebug.overload_var_dump', $originalOverload);
+        try {
+            self::assertSame($output, GuzzleHttp\describe_type($input));
+        } finally {
+            if (extension_loaded('xdebug')) {
+                ini_set('xdebug.overload_var_dump', $originalOverload);
+            }
         }
     }
 

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -41,7 +41,21 @@ class FunctionsTest extends TestCase
      */
     public function testDescribesType($input, $output)
     {
+        /**
+         * Output may not match if Xdebug is loaded and overloading var_dump().
+         *
+         * @see https://xdebug.org/docs/display#overload_var_dump
+         */
+        if (extension_loaded('xdebug')) {
+            $originalOverload =  ini_get('xdebug.overload_var_dump');
+            ini_set('xdebug.overload_var_dump', 0);
+        }
+
         self::assertSame($output, GuzzleHttp\describe_type($input));
+
+        if (extension_loaded('xdebug')) {
+            ini_set('xdebug.overload_var_dump', $originalOverload);
+        }
     }
 
     public function testParsesHeadersFromLines()


### PR DESCRIPTION
Xdebug's overloaded `var_dump()` may generate different output from the built-in `var_dump()`, causing this test to fail. Temporarily disable Xdebug's `var_dump()` during the test.

I ran into this while working on #1842. I usually avoid extension specific logic branches, but Xdebug may be common enough in development environments to warrant it here. Thanks!