### PR TITLE
Fix headers with same field name

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -287,9 +287,12 @@ class CurlFactory implements CurlFactoryInterface
     private function applyHeaders(EasyHandle $easy, array &$conf)
     {
         foreach ($conf['_headers'] as $name => $values) {
-            foreach ($values as $value) {
-                $conf[CURLOPT_HTTPHEADER][] = "$name: $value";
+            if (count($values) >= 2) {
+                $value = "$name: " . implode(",", array_values($values));
+            } else {
+                $value = "$name: $values[0]";
             }
+            $conf[CURLOPT_HTTPHEADER][] = $value;
         }
 
         // Remove the Accept header if one was not set


### PR DESCRIPTION
When I try to send a request like this (as described in http://docs.guzzlephp.org/en/latest/request-options.html#headers)

```php
$client->request('GET', '/get', [
    'headers' => [
        'User-Agent' => 'testing/1.0',
        'Accept'     => 'application/json',
        'X-Foo'      => ['Bar', 'Baz']
    ]
]);
```

Guzzle will send a request with following headers:

```
User-Agent: testing/1.0
Accept: application/json
X-FOO: BAR
X-FOO: Baz
```

When I try to read these headers (using, for example, [getallheaders](http://br.php.net/getallheaders) or `print_r($_SERVER)`), I got this:

```
...
"HTTP_USER_AGENT": "GuzzleHttp/6.2.1 curl/7.51.0 PHP/7.1.5",
"HTTP_X_FOO": "Bar",
...
```

https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

> Multiple message-header fields with the same field-name MAY be present in a message if and only if the entire field-value for that header field is defined as a comma-separated list [i.e., #(values)]. It MUST be possible to combine the multiple header fields into one "field-name: field-value" pair, without changing the semantics of the message, by appending each subsequent field-value to the first, each separated by a comma. The order in which header fields with the same field-name are received is therefore significant to the interpretation of the combined field value, and thus a proxy MUST NOT change the order of these field values when a message is forwarded.


This PR put everything in the same field name (if has more than one value for the same key) without changing field value order.

Guzzle will send: `"X-Foo: Bar, Baz"`
