### PR TITLE
Update Quickstart.rst to fix syntax issue

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -131,7 +131,7 @@ You can also use the `sendAsync()` and `requestAsync()` methods of a client:
     use GuzzleHttp\Psr7\Request;
 
     // Create a PSR-7 request object to send
-    $headers = ['X-Foo' => 'Bar'];
+    $headers = ['headers' => ['X-Foo' => 'Bar']];
     $body = 'Hello!';
     $request = new Request('HEAD', 'http://httpbin.org/head', $headers, $body);
 


### PR DESCRIPTION
I’m just getting started with Guzzle so I might be wrong about that. I just tried to implement by example and I believe the given syntax from the quickstart example doesn’t work that way. My example didn’t respond as I expected and that change made it work.

`$headers` has to be a nested array otherwise it will be ignored by the request. The example doesn’t read as concise as before but that way it should be correct and work out of the box.

(I’m not sure about $body since I haven’t used that yet, but I suspect the same issue.)