### PR TITLE
Fix the empty response body when logging {res_body}

### DIFF
--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -109,7 +109,7 @@ class MessageFormatter
                         $result = $request->getBody();
                         break;
                     case 'res_body':
-                        if(!isset($response)){
+                        if(!$response instanceof ResponseInterface){
                             $result = 'NULL';
                             break;
                         }
@@ -122,7 +122,6 @@ class MessageFormatter
                         }
 
                         $result = $response->getBody()->__toString();
-                        $response->getBody()->rewind();
                         break;
                     case 'ts':
                     case 'date_iso_8601':

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -109,14 +109,14 @@ class MessageFormatter
                         $result = $request->getBody();
                         break;
                     case 'res_body':
-                        if(!$response instanceof ResponseInterface){
+                        if (!$response instanceof ResponseInterface) {
                             $result = 'NULL';
                             break;
                         }
 
                         $body = $response->getBody();
 
-                        if(!$body->isSeekable()){
+                        if (!$body->isSeekable()) {
                             $result = 'RESPONSE_NOT_LOGGEABLE';
                             break;
                         }

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -109,7 +109,20 @@ class MessageFormatter
                         $result = $request->getBody();
                         break;
                     case 'res_body':
-                        $result = $response ? $response->getBody() : 'NULL';
+                        if(!isset($response)){
+                            $result = 'NULL';
+                            break;
+                        }
+
+                        $body = $response->getBody();
+
+                        if(!$body->isSeekable()){
+                            $result = 'RESPONSE_NOT_LOGGEABLE';
+                            break;
+                        }
+
+                        $result = $response->getBody()->__toString();
+                        $response->getBody()->rewind();
                         break;
                     case 'ts':
                     case 'date_iso_8601':


### PR DESCRIPTION
This only fixes the issue with {res_body} variable.

When logging with {res_body} the Stream goes to the eof.

This fix will make to return:
- `NULL` when response is null
- `RESPONSE_NOT_LOGGEABLE` when the Stream is not seekable.
- Body to String and rewind if possible

To fix the {response} I would tackle into Psr7\str class

Also found on the following issues #1262 and  #1582