### PR TITLE
Prevent concurrent writes

### DIFF
--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -50,7 +50,7 @@ class FileCookieJar extends CookieJar
             }
         }
 
-        if (false === file_put_contents($filename, json_encode($json))) {
+        if (false === file_put_contents($filename, json_encode($json), LOCK_EX)) {
             // @codeCoverageIgnoreStart
             throw new \RuntimeException("Unable to save file {$filename}");
             // @codeCoverageIgnoreEnd


### PR DESCRIPTION
Concurrent writes might lead to invalid JSON being saved in the cookie jar.
Hopefully fixes #1883 .