### PR TITLE
Fix a docblock of BadResponseException

### DIFF
--- a/src/Exception/BadResponseException.php
+++ b/src/Exception/BadResponseException.php
@@ -6,6 +6,8 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * Exception when an HTTP error occurs (4xx or 5xx error)
+ * 
+ * @method ResponseInterface getResponse()
  */
 class BadResponseException extends RequestException
 {


### PR DESCRIPTION
Since BadResponseException should not be initialized with an empty response it makes sense the get response not to return null.

This helps autocompletion/inspections and tools like PHPStan not to detect it as a possible error.

for Instanche if you had a code like:

``` php
try{
 $client->get('/');
} catch (BadResponseException $e){
   $e->getResponse()->getStatusCode();
}
```

PHPStan was detecting the above as a possible error.