### PR TITLE
Create a RequestFactory to generate requests using options arrays

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -27,6 +27,7 @@ class Client implements ClientInterface
     /** @var array Default request options */
     private $config;
 
+
     /**
      * Clients accept an array of constructor parameters.
      *
@@ -67,6 +68,12 @@ class Client implements ClientInterface
             throw new \InvalidArgumentException('handler must be a callable');
         }
 
+        if (!isset($config['factory'])) {
+            $config['factory'] = new RequestFactory;
+        } elseif (!$config['factory'] instanceof RequestFactoryInterface) {
+            throw new \InvalidArgumentException('factory must implement ' . RequestFactoryInterface::class);
+        }
+
         // Convert the base_uri to a UriInterface
         if (isset($config['base_uri'])) {
             $config['base_uri'] = Psr7\uri_for($config['base_uri']);
@@ -74,6 +81,7 @@ class Client implements ClientInterface
 
         $this->configureDefaults($config);
     }
+
 
     public function __call($method, $args)
     {
@@ -89,16 +97,21 @@ class Client implements ClientInterface
             : $this->request($method, $uri, $opts);
     }
 
+
     public function sendAsync(RequestInterface $request, array $options = [])
     {
         // Merge the base URI into the request URI if needed.
         $options = $this->prepareDefaults($options);
 
-        return $this->transfer(
-            $request->withUri($this->buildUri($request->getUri(), $options), $request->hasHeader('Host')),
-            $options
-        );
+        $factory = $options['factory'];
+
+        $request = $request->withUri($factory->createUri($request->getUri(), $options), $request->hasHeader('Host'));
+
+        $request = $factory->applyOptions($request, $options);
+
+        return $this->transfer($request, $options);
     }
+
 
     public function send(RequestInterface $request, array $options = [])
     {
@@ -106,30 +119,33 @@ class Client implements ClientInterface
         return $this->sendAsync($request, $options)->wait();
     }
 
+
     public function requestAsync($method, $uri = '', array $options = [])
     {
         $options = $this->prepareDefaults($options);
-        // Remove request modifying parameter because it can be done up-front.
-        $headers = isset($options['headers']) ? $options['headers'] : [];
-        $body = isset($options['body']) ? $options['body'] : null;
-        $version = isset($options['version']) ? $options['version'] : '1.1';
-        // Merge the URI into the base URI.
-        $uri = $this->buildUri($uri, $options);
-        if (is_array($body)) {
-            $this->invalidBody();
+
+        if (isset($options['body']) && is_array($options['body'])) {
+            throw new \InvalidArgumentException('Passing in the "body" request '
+                . 'option as an array to send a POST request has been deprecated. '
+                . 'Please use the "form_params" request option to send a '
+                . 'application/x-www-form-urlencoded request, or the "multipart" '
+                . 'request option to send a multipart/form-data request.');
         }
-        $request = new Psr7\Request($method, $uri, $headers, $body, $version);
-        // Remove the option so that they are not doubly-applied.
-        unset($options['headers'], $options['body'], $options['version']);
+
+        $factory = $options['factory'];
+
+        $request = $factory->createRequest($method, $uri, $options);
 
         return $this->transfer($request, $options);
     }
+
 
     public function request($method, $uri = '', array $options = [])
     {
         $options[RequestOptions::SYNCHRONOUS] = true;
         return $this->requestAsync($method, $uri, $options)->wait();
     }
+
 
     public function getConfig($option = null)
     {
@@ -138,17 +154,6 @@ class Client implements ClientInterface
             : (isset($this->config[$option]) ? $this->config[$option] : null);
     }
 
-    private function buildUri($uri, array $config)
-    {
-        // for BC we accept null which would otherwise fail in uri_for
-        $uri = Psr7\uri_for($uri === null ? '' : $uri);
-
-        if (isset($config['base_uri'])) {
-            $uri = Psr7\UriResolver::resolve(Psr7\uri_for($config['base_uri']), $uri);
-        }
-
-        return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;
-    }
 
     /**
      * Configures the default options for a client.
@@ -159,10 +164,10 @@ class Client implements ClientInterface
     {
         $defaults = [
             'allow_redirects' => RedirectMiddleware::$defaultSettings,
-            'http_errors'     => true,
-            'decode_content'  => true,
-            'verify'          => true,
-            'cookies'         => false
+            'http_errors' => true,
+            'decode_content' => true,
+            'verify' => true,
+            'cookies' => false
         ];
 
         // Use the standard Linux HTTP_PROXY and HTTPS_PROXY if set.
@@ -202,6 +207,7 @@ class Client implements ClientInterface
             $this->config['headers']['User-Agent'] = default_user_agent();
         }
     }
+
 
     /**
      * Merges default options into the array.
@@ -245,6 +251,7 @@ class Client implements ClientInterface
         return $result;
     }
 
+
     /**
      * Transfers the given request and applies request options.
      *
@@ -252,25 +259,12 @@ class Client implements ClientInterface
      * as-is without merging in default options.
      *
      * @param RequestInterface $request
-     * @param array            $options
+     * @param array $options
      *
      * @return Promise\PromiseInterface
      */
     private function transfer(RequestInterface $request, array $options)
     {
-        // save_to -> sink
-        if (isset($options['save_to'])) {
-            $options['sink'] = $options['save_to'];
-            unset($options['save_to']);
-        }
-
-        // exceptions -> http_errors
-        if (isset($options['exceptions'])) {
-            $options['http_errors'] = $options['exceptions'];
-            unset($options['exceptions']);
-        }
-
-        $request = $this->applyOptions($request, $options);
         $handler = $options['handler'];
 
         try {
@@ -278,145 +272,5 @@ class Client implements ClientInterface
         } catch (\Exception $e) {
             return Promise\rejection_for($e);
         }
-    }
-
-    /**
-     * Applies the array of request options to a request.
-     *
-     * @param RequestInterface $request
-     * @param array            $options
-     *
-     * @return RequestInterface
-     */
-    private function applyOptions(RequestInterface $request, array &$options)
-    {
-        $modify = [
-            'set_headers' => [],
-        ];
-
-        if (isset($options['headers'])) {
-            $modify['set_headers'] = $options['headers'];
-            unset($options['headers']);
-        }
-
-        if (isset($options['form_params'])) {
-            if (isset($options['multipart'])) {
-                throw new \InvalidArgumentException('You cannot use '
-                    . 'form_params and multipart at the same time. Use the '
-                    . 'form_params option if you want to send application/'
-                    . 'x-www-form-urlencoded requests, and the multipart '
-                    . 'option to send multipart/form-data requests.');
-            }
-            $options['body'] = http_build_query($options['form_params'], '', '&');
-            unset($options['form_params']);
-            // Ensure that we don't have the header in different case and set the new value.
-            $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);
-            $options['_conditional']['Content-Type'] = 'application/x-www-form-urlencoded';
-        }
-
-        if (isset($options['multipart'])) {
-            $options['body'] = new Psr7\MultipartStream($options['multipart']);
-            unset($options['multipart']);
-        }
-
-        if (isset($options['json'])) {
-            $options['body'] = \GuzzleHttp\json_encode($options['json']);
-            unset($options['json']);
-            // Ensure that we don't have the header in different case and set the new value.
-            $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);
-            $options['_conditional']['Content-Type'] = 'application/json';
-        }
-
-        if (!empty($options['decode_content'])
-            && $options['decode_content'] !== true
-        ) {
-            // Ensure that we don't have the header in different case and set the new value.
-            $options['_conditional'] = Psr7\_caseless_remove(['Accept-Encoding'], $options['_conditional']);
-            $modify['set_headers']['Accept-Encoding'] = $options['decode_content'];
-        }
-
-        if (isset($options['body'])) {
-            if (is_array($options['body'])) {
-                $this->invalidBody();
-            }
-            $modify['body'] = Psr7\stream_for($options['body']);
-            unset($options['body']);
-        }
-
-        if (!empty($options['auth']) && is_array($options['auth'])) {
-            $value = $options['auth'];
-            $type = isset($value[2]) ? strtolower($value[2]) : 'basic';
-            switch ($type) {
-                case 'basic':
-                    // Ensure that we don't have the header in different case and set the new value.
-                    $modify['set_headers'] = Psr7\_caseless_remove(['Authorization'], $modify['set_headers']);
-                    $modify['set_headers']['Authorization'] = 'Basic '
-                        . base64_encode("$value[0]:$value[1]");
-                    break;
-                case 'digest':
-                    // @todo: Do not rely on curl
-                    $options['curl'][CURLOPT_HTTPAUTH] = CURLAUTH_DIGEST;
-                    $options['curl'][CURLOPT_USERPWD] = "$value[0]:$value[1]";
-                    break;
-                case 'ntlm':
-                    $options['curl'][CURLOPT_HTTPAUTH] = CURLAUTH_NTLM;
-                    $options['curl'][CURLOPT_USERPWD] = "$value[0]:$value[1]";
-                    break;
-            }
-        }
-
-        if (isset($options['query'])) {
-            $value = $options['query'];
-            if (is_array($value)) {
-                $value = http_build_query($value, null, '&', PHP_QUERY_RFC3986);
-            }
-            if (!is_string($value)) {
-                throw new \InvalidArgumentException('query must be a string or array');
-            }
-            $modify['query'] = $value;
-            unset($options['query']);
-        }
-
-        // Ensure that sink is not an invalid value.
-        if (isset($options['sink'])) {
-            // TODO: Add more sink validation?
-            if (is_bool($options['sink'])) {
-                throw new \InvalidArgumentException('sink must not be a boolean');
-            }
-        }
-
-        $request = Psr7\modify_request($request, $modify);
-        if ($request->getBody() instanceof Psr7\MultipartStream) {
-            // Use a multipart/form-data POST if a Content-Type is not set.
-            // Ensure that we don't have the header in different case and set the new value.
-            $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);
-            $options['_conditional']['Content-Type'] = 'multipart/form-data; boundary='
-                . $request->getBody()->getBoundary();
-        }
-
-        // Merge in conditional headers if they are not present.
-        if (isset($options['_conditional'])) {
-            // Build up the changes so it's in a single clone of the message.
-            $modify = [];
-            foreach ($options['_conditional'] as $k => $v) {
-                if (!$request->hasHeader($k)) {
-                    $modify['set_headers'][$k] = $v;
-                }
-            }
-            $request = Psr7\modify_request($request, $modify);
-            // Don't pass this internal value along to middleware/handlers.
-            unset($options['_conditional']);
-        }
-
-        return $request;
-    }
-
-    private function invalidBody()
-    {
-        throw new \InvalidArgumentException('Passing in the "body" request '
-            . 'option as an array to send a POST request has been deprecated. '
-            . 'Please use the "form_params" request option to send a '
-            . 'application/x-www-form-urlencoded request, or the "multipart" '
-            . 'request option to send a multipart/form-data request.');
     }
 }

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace GuzzleHttp;
+
+use Psr\Http\Message\RequestInterface;
+
+class RequestFactory implements RequestFactoryInterface
+{
+
+    public static function create($method, $uri = '', array $options = [])
+    {
+        return (new self)->createRequest($method, $uri, $options);
+    }
+
+
+    public function createUri($uri, array $config)
+    {
+        // for BC we accept null which would otherwise fail in uri_for
+        $uri = Psr7\uri_for($uri === null ? '' : $uri);
+
+        if (isset($config['base_uri'])) {
+            $uri = Psr7\UriResolver::resolve(Psr7\uri_for($config['base_uri']), $uri);
+        }
+
+        return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;
+    }
+
+
+    public function createRequest($method, $uri = '', array &$options = [])
+    {
+        $headers = isset($options['headers']) ? $options['headers'] : [];
+        $body = isset($options['body']) ? $options['body'] : null;
+        $version = isset($options['version']) ? $options['version'] : '1.1';
+
+        $uri = $this->createUri($uri, $options);
+
+        $request = new Psr7\Request($method, $uri, $headers, $body, $version);
+
+        // Remove the option so that they are not doubly-applied.
+        unset($options['headers'], $options['body'], $options['version']);
+
+        $request = $this->applyOptions($request, $options);
+
+        return $request;
+    }
+
+
+    /**
+     * Applies the array of request options to a request.
+     *
+     * @param RequestInterface $request
+     * @param array            $options
+     *
+     * @return RequestInterface
+     */
+    public function applyOptions(RequestInterface $request, array &$options)
+    {
+        $modify = [
+            'set_headers' => [],
+        ];
+
+        // save_to -> sink
+        if (isset($options['save_to'])) {
+            $options['sink'] = $options['save_to'];
+            unset($options['save_to']);
+        }
+
+        // exceptions -> http_errors
+        if (isset($options['exceptions'])) {
+            $options['http_errors'] = $options['exceptions'];
+            unset($options['exceptions']);
+        }
+
+        if (isset($options['headers'])) {
+            $modify['set_headers'] = $options['headers'];
+            unset($options['headers']);
+        }
+
+        $options['_conditional'] = [];
+
+        if (isset($options['form_params'])) {
+            if (isset($options['multipart'])) {
+                throw new \InvalidArgumentException('You cannot use '
+                    . 'form_params and multipart at the same time. Use the '
+                    . 'form_params option if you want to send application/'
+                    . 'x-www-form-urlencoded requests, and the multipart '
+                    . 'option to send multipart/form-data requests.');
+            }
+            $options['body'] = http_build_query($options['form_params'], '', '&');
+            unset($options['form_params']);
+            // Ensure that we don't have the header in different case and set the new value.
+            $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);
+            $options['_conditional']['Content-Type'] = 'application/x-www-form-urlencoded';
+        }
+
+        if (isset($options['multipart'])) {
+            $options['body'] = new Psr7\MultipartStream($options['multipart']);
+            unset($options['multipart']);
+        }
+
+        if (isset($options['json'])) {
+            $options['body'] = \GuzzleHttp\json_encode($options['json']);
+            unset($options['json']);
+            // Ensure that we don't have the header in different case and set the new value.
+            $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);
+            $options['_conditional']['Content-Type'] = 'application/json';
+        }
+
+        if (!empty($options['decode_content'])
+            && $options['decode_content'] !== true
+        ) {
+            // Ensure that we don't have the header in different case and set the new value.
+            $options['_conditional'] = Psr7\_caseless_remove(['Accept-Encoding'], $options['_conditional']);
+            $modify['set_headers']['Accept-Encoding'] = $options['decode_content'];
+        }
+
+        if (isset($options['body'])) {
+            if (is_array($options['body'])) {
+                throw new \InvalidArgumentException('Passing in the "body" request '
+                    . 'option as an array to send a POST request has been deprecated. '
+                    . 'Please use the "form_params" request option to send a '
+                    . 'application/x-www-form-urlencoded request, or the "multipart" '
+                    . 'request option to send a multipart/form-data request.');
+            }
+            $modify['body'] = Psr7\stream_for($options['body']);
+            unset($options['body']);
+        }
+
+        if (!empty($options['auth']) && is_array($options['auth'])) {
+            $value = $options['auth'];
+            $type = isset($value[2]) ? strtolower($value[2]) : 'basic';
+            switch ($type) {
+                case 'basic':
+                    // Ensure that we don't have the header in different case and set the new value.
+                    $modify['set_headers'] = Psr7\_caseless_remove(['Authorization'], $modify['set_headers']);
+                    $modify['set_headers']['Authorization'] = 'Basic '
+                        . base64_encode("$value[0]:$value[1]");
+                    break;
+                case 'digest':
+                    // @todo: Do not rely on curl
+                    $options['curl'][CURLOPT_HTTPAUTH] = CURLAUTH_DIGEST;
+                    $options['curl'][CURLOPT_USERPWD] = "$value[0]:$value[1]";
+                    break;
+                case 'ntlm':
+                    $options['curl'][CURLOPT_HTTPAUTH] = CURLAUTH_NTLM;
+                    $options['curl'][CURLOPT_USERPWD] = "$value[0]:$value[1]";
+                    break;
+            }
+        }
+
+        if (isset($options['query'])) {
+            $value = $options['query'];
+            if (is_array($value)) {
+                $value = http_build_query($value, null, '&', PHP_QUERY_RFC3986);
+            }
+            if (!is_string($value)) {
+                throw new \InvalidArgumentException('query must be a string or array');
+            }
+            $modify['query'] = $value;
+            unset($options['query']);
+        }
+
+        // Ensure that sink is not an invalid value.
+        if (isset($options['sink'])) {
+            // TODO: Add more sink validation?
+            if (is_bool($options['sink'])) {
+                throw new \InvalidArgumentException('sink must not be a boolean');
+            }
+        }
+
+        $request = Psr7\modify_request($request, $modify);
+        if ($request->getBody() instanceof Psr7\MultipartStream) {
+            // Use a multipart/form-data POST if a Content-Type is not set.
+            // Ensure that we don't have the header in different case and set the new value.
+            $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);
+            $options['_conditional']['Content-Type'] = 'multipart/form-data; boundary='
+                . $request->getBody()->getBoundary();
+        }
+
+        // Merge in conditional headers if they are not present.
+        if (isset($options['_conditional'])) {
+            // Build up the changes so it's in a single clone of the message.
+            $modify = [];
+            foreach ($options['_conditional'] as $k => $v) {
+                if (!$request->hasHeader($k)) {
+                    $modify['set_headers'][$k] = $v;
+                }
+            }
+            $request = Psr7\modify_request($request, $modify);
+            // Don't pass this internal value along to middleware/handlers.
+            unset($options['_conditional']);
+        }
+
+        return $request;
+    }
+}

--- a/src/RequestFactoryInterface.php
+++ b/src/RequestFactoryInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace GuzzleHttp;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Interface for generating HTTP requests.
+ */
+interface RequestFactoryInterface
+{
+
+    /**
+     * Applies any URI options to an existing URI to generate a new one.
+     *
+     * @param string $uri
+     * @param array  $config
+     *
+     * @return string
+     */
+    public function createUri($uri, array $config);
+
+
+    /**
+     * Create a new request.
+     *
+     * The $options array is passed by reference so that any
+     * options that are applied to the request are then removed
+     * from the array to avoid them being applied twice.
+     *
+     * @param string $method
+     * @param string $uri
+     * @param array  $options
+     *
+     * @return RequestInterface
+     */
+    public function createRequest($method, $uri = '', array &$options = []);
+
+
+    /**
+     * Applies the array of request options to a request.
+     *
+     * The $options array is passed by reference so that any
+     * options that are applied to the request are then removed
+     * from the array to avoid them being applied twice.
+     *
+     * @param RequestInterface $request
+     * @param array            $options
+     *
+     * @return RequestInterface
+     */
+    public function applyOptions(RequestInterface $request, array &$options);
+}

--- a/tests/RequestFactoryTest.php
+++ b/tests/RequestFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace GuzzleHttp\Tests;
+
+use GuzzleHttp\RequestFactory;
+use PHPUnit\Framework\TestCase;
+
+class RequestFactoryTest extends TestCase
+{
+
+
+    public function testOptionsArrayModified()
+    {
+        $factory = new RequestFactory();
+
+        $options = [
+            'form_params'   =>  ['one' => 1],
+            'sink'          =>  'ok',
+        ];
+        $factory->createRequest('POST', 'http://example.com', $options);
+
+        $expected = [
+            'sink'          =>  'ok',
+        ];
+
+        $this->assertSame($expected, $options);
+    }
+
+
+    public function testOptionsArrayUnmodified()
+    {
+        $options = [
+            'form_params'   =>  ['one' => 1],
+            'sink'          =>  'ok',
+        ];
+        $expected = $options;
+        RequestFactory::create('POST', 'http://example.com', $options);
+
+        $this->assertSame($expected, $options);
+    }
+}


### PR DESCRIPTION
I recently wrote some code using `Client::createRequest()` before realising that this is not present in Guzzle 6, I then found #1886 and this pr is an attempt to allow `RequestInterface`s to be generated using array options.

The only thing I'm not comfortable with is the reference variable (`$options`) used in `make()`. But I've provided the static method `create()` which provides a version that operates on a copy of `$options`.

Let me know what you think