### PR TITLE
I think before excecute retryMiddleware  rewind request Body will be …

### DIFF
--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -106,7 +106,9 @@ class RetryMiddleware
     private function doRetry(RequestInterface $request, array $options, ResponseInterface $response = null)
     {
         $options['delay'] = call_user_func($this->delay, ++$options['retries'], $response);
-
+        if ($request->getBody()->isSeekable()){
+            $request->getBody()->rewind();
+        }
         return $this($request, $options);
     }
 }


### PR DESCRIPTION
I think rewind the request Body before excecute retryMiddleware  in library will be a good choice, otherwise it will take a bunch time for user to realise should rewind request body in the retryMW ... 