### PR TITLE
fix for issue #1938, cURL handler is overwritten if allow_url_fopen is set

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -109,9 +109,7 @@ function choose_handler()
         $handler = new CurlHandler();
     } elseif (function_exists('curl_multi_exec')) {
         $handler = new CurlMultiHandler();
-    }
-
-    if (ini_get('allow_url_fopen')) {
+    } elseif (ini_get('allow_url_fopen')) {
         $handler = $handler
             ? Proxy::wrapStreaming($handler, new StreamHandler())
             : new StreamHandler();


### PR DESCRIPTION
See https://github.com/guzzle/guzzle/issues/1938