### PR TITLE
Fix Typo in FAQ Doc

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -130,7 +130,7 @@ setting the ``expect`` request option to ``false``:
     // Disable the expect header on all client requests
     $client = new GuzzleHttp\Client(['expect' => false]);
 
-How can I track a redirected requests?
+How can I track redirected requests?
 ======================================
 
 You can enable tracking of redirected URIs and status codes via the

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -131,7 +131,7 @@ setting the ``expect`` request option to ``false``:
     $client = new GuzzleHttp\Client(['expect' => false]);
 
 How can I track redirected requests?
-======================================
+====================================
 
 You can enable tracking of redirected URIs and status codes via the
 `track_redirects` option. Each redirected URI and status code will be stored in the


### PR DESCRIPTION
This PR fixes a minor typo in the "Redirected Requests" header of the FAQ document.