### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "^4.0 || ^5.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.7",
         "psr/log": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "^4.8.35 || ^5.7",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4",
         "psr/log": "^1.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./tests/bootstrap.php"
+         backupGlobals="true"
          colors="true">
   <testsuites>
     <testsuite>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -11,8 +11,9 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     public function testUsesDefaultHandler()
     {

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -5,11 +5,12 @@ use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Cookie\CookieJar
  */
-class CookieJarTest extends \PHPUnit_Framework_TestCase
+class CookieJarTest extends TestCase
 {
     /** @var CookieJar */
     private $jar;

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\CookieJar;
 
 use GuzzleHttp\Cookie\FileCookieJar;
 use GuzzleHttp\Cookie\SetCookie;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Cookie\FileCookieJar
  */
-class FileCookieJarTest extends \PHPUnit_Framework_TestCase
+class FileCookieJarTest extends TestCase
 {
     private $file;
 

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\CookieJar;
 
 use GuzzleHttp\Cookie\SessionCookieJar;
 use GuzzleHttp\Cookie\SetCookie;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Cookie\SessionCookieJar
  */
-class SessionCookieJarTest extends \PHPUnit_Framework_TestCase
+class SessionCookieJarTest extends TestCase
 {
     private $sessionVar;
 

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -2,11 +2,12 @@
 namespace GuzzleHttp\Tests\CookieJar;
 
 use GuzzleHttp\Cookie\SetCookie;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Cookie\SetCookie
  */
-class SetCookieTest extends \PHPUnit_Framework_TestCase
+class SetCookieTest extends TestCase
 {
     public function testInitializesDefaultValues()
     {

--- a/tests/Exception/ConnectExceptionTest.php
+++ b/tests/Exception/ConnectExceptionTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\Event;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Exception\ConnectException
  */
-class ConnectExceptionTest extends \PHPUnit_Framework_TestCase
+class ConnectExceptionTest extends TestCase
 {
     public function testHasNoResponse()
     {

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -4,11 +4,12 @@ namespace GuzzleHttp\Tests\Event;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Exception\RequestException
  */
-class RequestExceptionTest extends \PHPUnit_Framework_TestCase
+class RequestExceptionTest extends TestCase
 {
     public function testHasRequestAndResponse()
     {

--- a/tests/Exception/SeekExceptionTest.php
+++ b/tests/Exception/SeekExceptionTest.php
@@ -3,8 +3,9 @@ namespace GuzzleHttp\Tests\Exception;
 
 use GuzzleHttp\Exception\SeekException;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
-class SeekExceptionTest extends \PHPUnit_Framework_TestCase
+class SeekExceptionTest extends TestCase
 {
     public function testHasStream()
     {

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -8,11 +8,12 @@ use GuzzleHttp\Handler;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Handler\CurlFactory
  */
-class CurlFactoryTest extends \PHPUnit_Framework_TestCase
+class CurlFactoryTest extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -7,11 +7,12 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Tests\Server;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Handler\CurlHandler
  */
-class CurlHandlerTest extends \PHPUnit_Framework_TestCase
+class CurlHandlerTest extends TestCase
 {
     protected function getHandler($options = [])
     {

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -5,8 +5,9 @@ use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Tests\Server;
+use PHPUnit\Framework\TestCase;
 
-class CurlMultiHandlerTest extends \PHPUnit_Framework_TestCase
+class CurlMultiHandlerTest extends TestCase
 {
     public function testSendsRequest()
     {

--- a/tests/Handler/EasyHandleTest.php
+++ b/tests/Handler/EasyHandleTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Handler\EasyHandle
  */
-class EasyHandleTest extends \PHPUnit_Framework_TestCase
+class EasyHandleTest extends TestCase
 {
     /**
      * @expectedException \BadMethodCallException

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -6,11 +6,12 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\TransferStats;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Handler\MockHandler
  */
-class MockHandlerTest extends \PHPUnit_Framework_TestCase
+class MockHandlerTest extends TestCase
 {
     public function testReturnsMockResponse()
     {

--- a/tests/Handler/ProxyTest.php
+++ b/tests/Handler/ProxyTest.php
@@ -5,11 +5,12 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Handler\Proxy
  */
-class ProxyTest extends \PHPUnit_Framework_TestCase
+class ProxyTest extends TestCase
 {
     public function testSendsToNonSync()
     {

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -50,7 +50,7 @@ class StreamHandlerTest extends TestCase
     }
 
     /**
-     * @expectedException \GuzzleHttp\Exception\ConnectException
+     * @expectedException \GuzzleHttp\Exception\RequestException
      */
     public function testAddsErrorToResponse()
     {

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -11,11 +11,12 @@ use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Handler\StreamHandler
  */
-class StreamHandlerTest extends \PHPUnit_Framework_TestCase
+class StreamHandlerTest extends TestCase
 {
     private function queueRes()
     {

--- a/tests/HandlerStackTest.php
+++ b/tests/HandlerStackTest.php
@@ -6,8 +6,9 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class HandlerStackTest extends \PHPUnit_Framework_TestCase
+class HandlerStackTest extends TestCase
 {
     public function testSetsHandlerInCtor()
     {

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -6,11 +6,12 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\MessageFormatter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\MessageFormatter
  */
-class MessageFormatterTest extends \PHPUnit_Framework_TestCase
+class MessageFormatterTest extends TestCase
 {
     public function testCreatesWithClfByDefault()
     {

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -16,8 +16,9 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
+use PHPUnit\Framework\TestCase;
 
-class MiddlewareTest extends \PHPUnit_Framework_TestCase
+class MiddlewareTest extends TestCase
 {
     public function testAddsCookiesToRequests()
     {

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -10,8 +10,9 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class PoolTest extends \PHPUnit_Framework_TestCase
+class PoolTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -10,8 +10,9 @@ use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class PrepareBodyMiddlewareTest extends \PHPUnit_Framework_TestCase
+class PrepareBodyMiddlewareTest extends TestCase
 {
 
     public function methodProvider()

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -9,11 +9,12 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RedirectMiddleware;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\RedirectMiddleware
  */
-class RedirectMiddlewareTest extends \PHPUnit_Framework_TestCase
+class RedirectMiddlewareTest extends TestCase
 {
     public function testIgnoresNonRedirects()
     {

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -8,8 +8,9 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RetryMiddleware;
+use PHPUnit\Framework\TestCase;
 
-class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
+class RetryMiddlewareTest extends TestCase
 {
     public function testRetriesWhenDeciderReturnsTrue()
     {

--- a/tests/TransferStatsTest.php
+++ b/tests/TransferStatsTest.php
@@ -3,8 +3,9 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
-class TransferStatsTest extends \PHPUnit_Framework_TestCase
+class TransferStatsTest extends TestCase
 {
     public function testHasData()
     {

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -2,11 +2,12 @@
 namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\UriTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\UriTemplate
  */
-class UriTemplateTest extends \PHPUnit_Framework_TestCase
+class UriTemplateTest extends TestCase
 {
     /**
      * @return array

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -2,8 +2,9 @@
 namespace GuzzleHttp\Test;
 
 use GuzzleHttp;
+use PHPUnit\Framework\TestCase;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase
+class FunctionsTest extends TestCase
 {
     public function testExpandsTemplate()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.