### PR TITLE
Add annotations for exception methods

### DIFF
--- a/src/Exception/GuzzleException.php
+++ b/src/Exception/GuzzleException.php
@@ -1,4 +1,13 @@
 <?php
 namespace GuzzleHttp\Exception;
 
+/**
+ * @method string getMessage()
+ * @method \Throwable|null getPrevious()
+ * @method mixed getCode()
+ * @method string getFile()
+ * @method int getLine()
+ * @method array getTrace()
+ * @method string getTraceAsString()
+ */
 interface GuzzleException {}


### PR DESCRIPTION
Adds `@method` annotations to `GuzzleException`, as suggested in #1257, in order to help IDEs and static analysis tools.