### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -123,7 +123,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
 
     public function testDoesNotAddIncompleteCookies()
     {
-        $this->assertEquals(false, $this->jar->setCookie(new SetCookie()));
+        $this->assertFalse($this->jar->setCookie(new SetCookie()));
         $this->assertFalse($this->jar->setCookie(new SetCookie(array(
             'Name' => 'foo'
         ))));
@@ -195,7 +195,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($this->jar));
 
         $c = $this->jar->getIterator()->getArrayCopy();
-        $this->assertEquals(false, $c[0]->getDiscard());
+        $this->assertFalse($c[0]->getDiscard());
 
         // Make sure it doesn't duplicate the cookie
         $this->jar->setCookie(new SetCookie($data));

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -217,7 +217,7 @@ class MockHandlerTest extends \PHPUnit_Framework_TestCase
         };
         $mock($request, ['on_stats' => $onStats])->wait(false);
         $this->assertSame($e, $stats->getHandlerErrorData());
-        $this->assertSame(null, $stats->getResponse());
+        $this->assertNull($stats->getResponse());
         $this->assertSame($request, $stats->getRequest());
     }
 }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -323,10 +323,10 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $path = $path = \GuzzleHttp\default_ca_bundle();
         $res = $this->getSendResult(['verify' => $path]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertEquals(true, $opts['ssl']['verify_peer']);
-        $this->assertEquals(true, $opts['ssl']['verify_peer_name']);
+        $this->assertTrue($opts['ssl']['verify_peer']);
+        $this->assertTrue($opts['ssl']['verify_peer_name']);
         $this->assertEquals($path, $opts['ssl']['cafile']);
-        $this->assertTrue(file_exists($opts['ssl']['cafile']));
+        $this->assertFileExists($opts['ssl']['cafile']);
     }
 
     public function testUsesSystemDefaultBundle()

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -117,7 +117,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
 
     public function testDecodesJson()
     {
-        $this->assertSame(true, \GuzzleHttp\json_decode('true'));
+        $this->assertTrue(\GuzzleHttp\json_decode('true'));
     }
 
     /**


### PR DESCRIPTION
I've refactored some tests with [`assertFileExists`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileExists), [`assertFalse`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFalse), [`assertTrue`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertTrue) and [`assertNull`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.null) methods.