### PR TITLE
Refactored tests

### DIFF
--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -81,8 +81,8 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($this->jar->setCookie($cookie));
         }
 
-        $this->assertEquals(3, count($this->jar));
-        $this->assertEquals(3, count($this->jar->getIterator()));
+        $this->assertCount(3, $this->jar);
+        $this->assertCount(3, $this->jar->getIterator());
         $this->assertEquals($cookies, $this->jar->getIterator()->getArrayCopy());
     }
 
@@ -107,18 +107,18 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
 
         // Remove foo.com cookies
         $this->jar->clear('foo.com');
-        $this->assertEquals(2, count($this->jar));
+        $this->assertCount(2, $this->jar);
         // Try again, removing no further cookies
         $this->jar->clear('foo.com');
-        $this->assertEquals(2, count($this->jar));
+        $this->assertCount(2, $this->jar);
 
         // Remove bar.com cookies with path of /boo
         $this->jar->clear('bar.com', '/boo');
-        $this->assertEquals(1, count($this->jar));
+        $this->assertCount(1, $this->jar);
 
         // Remove cookie by name
         $this->jar->clear(null, null, 'test');
-        $this->assertEquals(0, count($this->jar));
+        $this->assertCount(0, $this->jar);
     }
 
     public function testDoesNotAddIncompleteCookies()
@@ -188,23 +188,23 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
 
         // Make sure that the discard cookie is overridden with the non-discard
         $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertEquals(1, count($this->jar));
+        $this->assertCount(1, $this->jar);
 
         $data['Discard'] = false;
         $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertEquals(1, count($this->jar));
+        $this->assertCount(1, $this->jar);
 
         $c = $this->jar->getIterator()->getArrayCopy();
         $this->assertFalse($c[0]->getDiscard());
 
         // Make sure it doesn't duplicate the cookie
         $this->jar->setCookie(new SetCookie($data));
-        $this->assertEquals(1, count($this->jar));
+        $this->assertCount(1, $this->jar);
 
         // Make sure the more future-ful expiration date supersede the other
         $data['Expires'] = time() + 2000;
         $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertEquals(1, count($this->jar));
+        $this->assertCount(1, $this->jar);
         $c = $this->jar->getIterator()->getArrayCopy();
         $this->assertNotEquals($t, $c[0]->getExpires());
     }
@@ -228,13 +228,13 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
 
         $data['Value'] = 'boo';
         $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertEquals(1, count($this->jar));
+        $this->assertCount(1, $this->jar);
 
         // Changing the value plus a parameter also must overwrite the existing one
         $data['Value'] = 'zoo';
         $data['Secure'] = false;
         $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertEquals(1, count($this->jar));
+        $this->assertCount(1, $this->jar);
 
         $c = $this->jar->getIterator()->getArrayCopy();
         $this->assertEquals('zoo', $c[0]->getValue());
@@ -247,7 +247,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         ));
         $request = new Request('GET', 'http://www.example.com');
         $this->jar->extractCookies($request, $response);
-        $this->assertEquals(1, count($this->jar));
+        $this->assertCount(1, $this->jar);
     }
 
     public function getMatchingCookiesDataProvider()

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -56,7 +56,7 @@ class FileCookieJarTest extends \PHPUnit_Framework_TestCase
             'Domain'  => 'foo.com',
         ]));
 
-        $this->assertEquals(3, count($jar));
+        $this->assertCount(3, $jar);
         unset($jar);
 
         // Make sure it wrote to the file
@@ -67,10 +67,10 @@ class FileCookieJarTest extends \PHPUnit_Framework_TestCase
         $jar = new FileCookieJar($this->file);
 
         if ($testSaveSessionCookie) {
-            $this->assertEquals(3, count($jar));
+            $this->assertCount(3, $jar);
         } else {
             // Weeds out temporary and session cookies
-            $this->assertEquals(2, count($jar));
+            $this->assertCount(2, $jar);
         }
 
         unset($jar);

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -60,7 +60,7 @@ class SessionCookieJarTest extends \PHPUnit_Framework_TestCase
             'Domain'  => 'foo.com',
         ]));
 
-        $this->assertEquals(3, count($jar));
+        $this->assertCount(3, $jar);
         unset($jar);
 
         // Make sure it wrote to the sessionVar in $_SESSION
@@ -71,10 +71,10 @@ class SessionCookieJarTest extends \PHPUnit_Framework_TestCase
         $jar = new SessionCookieJar($this->sessionVar);
 
         if ($testSaveSessionCookie) {
-            $this->assertEquals(3, count($jar));
+            $this->assertCount(3, $jar);
         } else {
             // Weeds out temporary and session cookies
-            $this->assertEquals(2, count($jar));
+            $this->assertCount(2, $jar);
         }
 
         unset($jar);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -404,7 +404,7 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
             'sink'           => $tmpfile,
         ]);
         $response->wait();
-        $this->assertEquals('test', file_get_contents($tmpfile));
+        $this->assertStringEqualsFile($tmpfile, 'test');
         unlink($tmpfile);
     }
 
@@ -556,7 +556,7 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
         $request = new Psr7\Request('PUT', Server::$url, [], $bd);
         $f->create($request, []);
         $this->assertEquals(1, $_SERVER['_curl'][CURLOPT_UPLOAD]);
-        $this->assertTrue(is_callable($_SERVER['_curl'][CURLOPT_READFUNCTION]));
+        $this->assertInternalType('callable', $_SERVER['_curl'][CURLOPT_READFUNCTION]);
     }
 
     /**

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -77,7 +77,7 @@ class MockHandlerTest extends \PHPUnit_Framework_TestCase
         $p->wait();
 
         $this->assertFileExists($filename);
-        $this->assertEquals('TEST CONTENT', file_get_contents($filename));
+        $this->assertStringEqualsFile($filename, 'TEST CONTENT');
 
         unlink($filename);
     }
@@ -93,7 +93,7 @@ class MockHandlerTest extends \PHPUnit_Framework_TestCase
         $p->wait();
 
         $this->assertFileExists($meta['uri']);
-        $this->assertEquals('TEST CONTENT', file_get_contents($meta['uri']));
+        $this->assertStringEqualsFile($meta['uri'], 'TEST CONTENT');
     }
 
     public function testSinkStream()
@@ -106,7 +106,7 @@ class MockHandlerTest extends \PHPUnit_Framework_TestCase
         $p->wait();
 
         $this->assertFileExists($stream->getMetadata('uri'));
-        $this->assertEquals('TEST CONTENT', file_get_contents($stream->getMetadata('uri')));
+        $this->assertStringEqualsFile($stream->getMetadata('uri'), 'TEST CONTENT');
     }
 
     public function testCanEnqueueCallables()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -76,7 +76,7 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('8', $response->getHeaderLine('Content-Length'));
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertTrue(is_resource($stream));
+        $this->assertInternalType('resource', $stream);
         $this->assertEquals('http', stream_get_meta_data($stream)['wrapper_type']);
         $this->assertEquals('hi there', stream_get_contents($stream));
         fclose($stream);

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -63,7 +63,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
 
     public function testReturnsDebugResource()
     {
-        $this->assertTrue(is_resource(GuzzleHttp\debug_resource()));
+        $this->assertInternalType('resource' , GuzzleHttp\debug_resource());
     }
 
     public function testProvidesDefaultCaBundler()


### PR DESCRIPTION
Continuing to refactored tests, like #1964, using:
- `assertInternalType` instead of `is_*` PHP methods;
- `assertCount` instead of `count` PHP method;
- `assertStringEqualsFile` when comparing `string` and files.