### PR TITLE
Fix documentation using the getHeader method

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -159,8 +159,8 @@ together in a single report:
     $response = $client->request('GET', $initialRequest); // Make your request
 
     // Retrieve both Redirect History headers
-    $redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History'); // retrieve Redirect URI history
-    $redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History'); // retrieve Redirect HTTP Status history
+    $redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History')[0]; // retrieve Redirect URI history
+    $redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History')[0]; // retrieve Redirect HTTP Status history
 
     // Add the initial URI requested to the (beginning of) URI history
     array_unshift($redirectUriHistory, $initialRequest);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ trivial to integrate with web services.
     ]);
     echo $res->getStatusCode();
     // "200"
-    echo $res->getHeader('content-type');
+    echo $res->getHeader('content-type')[0];
     // 'application/json; charset=utf8'
     echo $res->getBody();
     // {"type":"User"...'

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -272,7 +272,7 @@ You can retrieve headers from the response:
     }
 
     // Get a header from the response.
-    echo $response->getHeader('Content-Length');
+    echo $response->getHeader('Content-Length')[0];
 
     // Get all of the response headers.
     foreach ($response->getHeaders() as $name => $values) {


### PR DESCRIPTION
Add missing 0 index to documentation making use of the getHeader method.
The getHeader method always returns an array, but it may be empty.
For documentation purpose, we assume that the response object always contains the queried header, thus providing at least one element in the array at index 0.

Fixes #1972.