### PR TITLE
Fixed error with promise results

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -193,8 +193,8 @@ requests.
 
     // You can access each result using the key provided to the unwrap
     // function.
-    echo $results['image']['value']->getHeader('Content-Length')[0]
-    echo $results['png']['value']->getHeader('Content-Length')[0]
+    echo $results['image']->getHeader('Content-Length')[0]
+    echo $results['png']->getHeader('Content-Length')[0]
 
 You can use the ``GuzzleHttp\Pool`` object when you have an indeterminate
 amount of requests you wish to send.


### PR DESCRIPTION
With `$results['image']['value']` I was getting:

> Cannot use object of type GuzzleHttp\Psr7\Response as array