### PR TITLE
A better fix for #1894 - "Undefined offset: 0"

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -35,8 +35,8 @@ class SetCookie
         $data = self::$defaults;
         // Explode the cookie string using a series of semicolons
         $pieces = array_filter(array_map('trim', explode(';', $cookie)));
-        // The name of the cookie (first kvp) must include an equal sign.
-        if (empty($pieces) || !strpos($pieces[0], '=')) {
+        // The name of the cookie (first kvp) must exist and include an equal sign.
+        if (empty($pieces[0]) || !strpos($pieces[0], '=')) {
             return new self($data);
         }
 

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -223,6 +223,7 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
             ),
             array('', []),
             array('foo', []),
+            array('; foo', []),
             array(
                 'foo="bar"',
                 [


### PR DESCRIPTION
There's a bug in `SetCookie::fromString()` which throws an "Undefined offset: 0" error if the inputted `$cookie` string is missing its first key-value pair, but has at least one other pair. For example, it would be triggered with the following (malformed) cookie:

```
; foo
```

Another author submitted a pull request for this (https://github.com/guzzle/guzzle/pull/1894), but the request was rejected due to improper test writing.  However, I don't believe the fix itself is appropriate, as I documented there.

So I am submitting my own pull request.  The change is trivial.  It makes the function return an empty cookie in response to this input, which is the same behavior as this function already has when the first key-value pair is missing the cookie name.