### PR TITLE
Error with malformed domain that contains a "/" character

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -348,7 +348,7 @@ class SetCookie
             return false;
         }
 
-        return (bool) preg_match('/\.' . preg_quote($cookieDomain) . '$/', $domain);
+        return (bool) preg_match('/\.' . preg_quote($cookieDomain, '/') . '$/', $domain);
     }
 
     /**

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -35,8 +35,8 @@ class SetCookie
         $data = self::$defaults;
         // Explode the cookie string using a series of semicolons
         $pieces = array_filter(array_map('trim', explode(';', $cookie)));
-        // The name of the cookie (first kvp) must include an equal sign.
-        if (empty($pieces) || !strpos($pieces[0], '=')) {
+        // The name of the cookie (first kvp) must exist and include an equal sign.
+        if (empty($pieces[0]) || !strpos($pieces[0], '=')) {
             return new self($data);
         }
 

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -223,6 +223,7 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
             ),
             array('', []),
             array('foo', []),
+            array('; foo', []),
             array(
                 'foo="bar"',
                 [

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -115,6 +115,9 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
 
         $cookie->setDomain('.local');
         $this->assertTrue($cookie->matchesDomain('example.local'));
+
+        $cookie->setDomain('example.com/'); // malformed domain
+        $this->assertFalse($cookie->matchesDomain('example.com'));
     }
 
     public function pathMatchProvider()


### PR DESCRIPTION
Cookies where the domain contains a "/" character are triggering an exception with `SetCookie::matchesDomain()`.  The issue is that the call to `preg_quote()` inside this function does not specify the regex delimiter being used, and so this character isn't getting escaped, which leads to a malformed pattern going into `preg_match()`. This can be triggered for example if the cookie improperly contains a URL, or if it appends a path after the hostname, such as in the following examples:

```
foo=bar; domain=example.com/
```
```
foo=bar; domain=http://www.example.com
```
