### PR TITLE
Add `failed to open stream` to ConnectException

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -60,7 +60,7 @@ class StreamHandler
             if (strpos($message, 'getaddrinfo') // DNS lookup failed
                 || strpos($message, 'Connection refused')
                 || strpos($message, "couldn't connect to host") // error on HHVM
-                || strpos($message, "failed to open stream")
+                || strpos($message, "connection attempt failed")
             ) {
                 $e = new ConnectException($e->getMessage(), $request, $e);
             }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -60,6 +60,7 @@ class StreamHandler
             if (strpos($message, 'getaddrinfo') // DNS lookup failed
                 || strpos($message, 'Connection refused')
                 || strpos($message, "couldn't connect to host") // error on HHVM
+                || strpos($message, "failed to open stream")
             ) {
                 $e = new ConnectException($e->getMessage(), $request, $e);
             }


### PR DESCRIPTION
When `connect_timeout` is reached I see the following error but `isConnectionError` is `false`

>Error creating resource: [message] fopen(url): failed to open stream: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.