### PR TITLE
Update Middleware::history() docblock to note $container type

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -73,7 +73,7 @@ final class Middleware
     /**
      * Middleware that pushes history data to an ArrayAccess container.
      *
-     * @param array $container Container to hold the history (by reference).
+     * @param array|\ArrayAccess $container Container to hold the history (by reference).
      *
      * @return callable Returns a function that accepts the next handler.
      * @throws \InvalidArgumentException if container is not an array or ArrayAccess.


### PR DESCRIPTION
`Middleware::history()` accepts as its single argument an array or an object implementing `\ArrayAccess`.

The docblock for this method currently states the type for the argument as: `@param array $container`. The current docblock lacks the `\ArrayAccess` type.

When passing in an object that implements `\ArrayAccess`, PHPStorm highlights to me that, due to the docblock, the wrong type is being passed. This is due to the docblock being incorrect.

This change updates the docblock for `\Middleware::history()` to correctly reflect the type for the argument.