### PR TITLE
fixed php 7.2  Warning: count(): Parameter must be an array or an obj…

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -63,7 +63,7 @@ class CurlFactory implements CurlFactoryInterface
         $resource = $easy->handle;
         unset($easy->handle);
 
-        if (count($this->handles) >= $this->maxHandles) {
+        if (is_array($this-handles) && count($this->handles) >= $this->maxHandles) {
             curl_close($resource);
         } else {
             // Remove all callback functions as they can hold onto references


### PR DESCRIPTION
…ect that implements Countable

fixed php 7.2 ,Warning: count(): Parameter must be an array or an object that implements Countable