### PR TITLE
Fix bug parsing 0 epoch expiry times

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -333,7 +333,7 @@ class SetCookie implements ToArrayInterface
      */
     public function isExpired()
     {
-        return $this->getExpires() && time() > $this->getExpires();
+        return $this->getExpires() !== null && time() > $this->getExpires();
     }
 
     /**

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -361,4 +361,45 @@ class SetCookieTest extends \PHPUnit_Framework_TestCase
             }
         }
     }
+
+    /**
+     * Provides the data for testing isExpired
+     *
+     * @return array
+     */
+    public function isExpiredProvider() {
+        return array(
+            array(
+                'FOO=bar; expires=Thu, 01 Jan 1970 00:00:00 GMT;',
+                true,
+            ),
+            array(
+                'FOO=bar; expires=Thu, 01 Jan 1970 00:00:01 GMT;',
+                true,
+            ),
+            array(
+                'FOO=bar; expires='.date(\DateTime::RFC1123, time()+10).';',
+                false,
+            ),
+            array(
+                'FOO=bar; expires='.date(\DateTime::RFC1123, time()-10).';',
+                true,
+            ),
+            array(
+                'FOO=bar;',
+                false,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider isExpiredProvider
+     */
+    public function testIsExpired($cookie, $expired)
+    {
+        $this->assertEquals(
+            $expired,
+            SetCookie::fromString($cookie)->isExpired()
+        );
+    }
 }


### PR DESCRIPTION
As per https://github.com/guzzle/guzzle/issues/1952 expiry times
specified as "Thu, 01 Jan 1970 00:00:00 GMT" should be treated as
expired, but they weren't because 0 was implicitly casting to a bool in
SetCookie::isExpired().

5.3 specific PR as per https://github.com/guzzle/guzzle/issues/1952#issuecomment-376133950