### PR TITLE
Retain safe request method when following redirects

### DIFF
--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -169,7 +169,10 @@ class RedirectMiddleware
         if ($statusCode == 303 ||
             ($statusCode <= 302 && !$options['allow_redirects']['strict'])
         ) {
-            $modify['method'] = 'GET';
+            $safeMethods = ['GET', 'HEAD', 'OPTIONS'];
+            $requestMethod = $request->getMethod();
+
+            $modify['method'] = in_array($requestMethod, $safeMethods) ? $requestMethod : 'GET';
             $modify['body'] = '';
         }
 

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -11,7 +11,6 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RedirectMiddleware;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * @covers \GuzzleHttp\RedirectMiddleware
@@ -285,14 +284,13 @@ class RedirectMiddlewareTest extends TestCase
      *
      * @dataProvider modifyRequestFollowRequyestMethodAndBodyProvider
      *
-     * @param RequestInterface $request
      * @param string $expectedFollowRequestMethod
      */
     public function testModifyRequestFollowRequestMethodAndBody(
         RequestInterface $request,
         $expectedFollowRequestMethod
     ) {
-        $redirectMiddleware = new RedirectMiddleware(function () {
+        $redirectMiddleware = new RedirectMiddleware(static function () {
         });
 
         $options = [
@@ -305,8 +303,8 @@ class RedirectMiddlewareTest extends TestCase
 
         $modifiedRequest = $redirectMiddleware->modifyRequest($request, $options, new Response());
 
-        $this->assertEquals($expectedFollowRequestMethod, $modifiedRequest->getMethod());
-        $this->assertEquals(0, $modifiedRequest->getBody()->getSize());
+        self::assertEquals($expectedFollowRequestMethod, $modifiedRequest->getMethod());
+        self::assertEquals(0, $modifiedRequest->getBody()->getSize());
     }
 
     /**


### PR DESCRIPTION
**TLDR**
A solution to #2046, ensures HEAD request method is retained when following 301 redirects.

**Overview**
`RetryMiddleware::modifyRequest()` modifies the method when following 301 redirects. In most cases, the method is changed to GET.

Safe methods (GET, HEAD, OPTIONS) can be retained safely when following redirects. 

This change ensures that requests issued when following 301 redirects will retain the original request method if that method is safe.