### PR TITLE
Add boundary to multipart header according RFC1341

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -317,6 +317,8 @@ class Client implements ClientInterface
         if (isset($options['multipart'])) {
             $options['body'] = new Psr7\MultipartStream($options['multipart']);
             unset($options['multipart']);
+            
+            $request = $request->withAddedHeader('content-type', 'boundary=' . $options['body']->getBoundary());
         }
 
         if (isset($options['json'])) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -484,7 +484,11 @@ class ClientTest extends TestCase
 
         $last = $mock->getLastRequest();
         $this->assertContains(
-            'multipart/form-data; boundary=',
+            'multipart/form-data',
+            $last->getHeaderLine('Content-Type')
+        );
+        $this->assertContains(
+            'boundary=',
             $last->getHeaderLine('Content-Type')
         );
 


### PR DESCRIPTION
According [RFC1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) request header should contain one requires parameter, "boundary".
With this error codeception module REST, that I uses, can correctly send files to our server that under development