### PR TITLE
docs/quickstart: add Exception Tree View (#2055)

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -483,6 +483,23 @@ The following example shows that redirects can be disabled.
 Exceptions
 ==========
 
+**Tree View**
+
+The following tree view describes how the Guzzle Exceptions depend
+on eachother.
+
+.. code-block:: none
+
+    . \RuntimeException
+    ├── SeekException (implements GuzzleException)
+    └── TransferException (implements GuzzleException)
+        └── RequestException
+            ├── BadResponseException
+            │   ├── ServerException
+            │   └── ClientException
+            ├── ConnectionException
+            └── TooManyRedirectsException
+ 
 Guzzle throws exceptions for errors that occur during a transfer.
 
 - In the event of a networking error (connection timeout, DNS errors, etc.),


### PR DESCRIPTION
Add a tree view to the quickstart documentation for Exceptions

Closes #2055

GitHub render: https://github.com/Zarthus/guzzle/blob/docs/quickstart-exception-treeview-2055/docs/quickstart.rst#exceptions