### PR TITLE
RequestException - check if readable before access

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -126,7 +126,7 @@ class RequestException extends TransferException
     {
         $body = $response->getBody();
 
-        if (!$body->isSeekable()) {
+        if (!$body->isSeekable() || !$body->isReadable()) {
             return null;
         }
 

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -178,10 +178,7 @@ class RequestExceptionTest extends TestCase
 
     public function testGetResponseBodySummaryOfNonReadableStream()
     {
-        $stream = new ReadSeekOnlyStream();
-        $stream->detach();
-        $response = new Response(500, [], $stream);
-        $this->assertNull(RequestException::getResponseBodySummary($response));
+        $this->assertNull(RequestException::getResponseBodySummary(new Response(500, [], new ReadSeekOnlyStream())));
     }
 }
 

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -6,8 +6,6 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamInterface;
 
 /**
  * @covers GuzzleHttp\Exception\RequestException

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -180,21 +180,27 @@ class RequestExceptionTest extends TestCase
 
     public function testGetResponseBodySummaryOfNonReadableStream()
     {
-        $stream = fopen('php://memory', 'wb');
-        $stream = new class($stream) extends Stream {
-            public function isSeekable()
-            {
-                return true;
-            }
-
-            public function isReadable()
-            {
-                return false;
-            }
-        };
-
+        $stream = new ReadSeekOnlyStream();
         $stream->detach();
         $response = new Response(500, [], $stream);
         $this->assertNull(RequestException::getResponseBodySummary($response));
+    }
+}
+
+final class ReadSeekOnlyStream extends Stream
+{
+    public function __construct()
+    {
+        parent::__construct(fopen('php://memory', 'wb'));
+    }
+
+    public function isSeekable()
+    {
+        return true;
+    }
+
+    public function isReadable()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
Hi all!

Thanks for the great package :)
First time PR so please bear with me ;)

I target master here because the issue is not on 5.x or lower it seems.
In my project I attempted to do download file by doing something like:

```php
<?php

require_once __DIR__.'/vendor/autoload.php';

$client = new \GuzzleHttp\Client();
$resource = fopen(__DIR__.'/tmp.txt', 'wb');
$response = $client->request(
    'GET',
    'https://github.com/guzzle/guzzle/tree/5.3_DOES_NOT_EXISTS',
    ['sink' => $resource]
);

```

currently this results in

```bash
$ php tmp.php 
PHP Fatal error:  Uncaught RuntimeException: Cannot read from non-readable stream in /home/possum/work/guzzle/vendor/guzzlehttp/psr7/src/Stream.php:208
Stack trace:
#0 /home/possum/work/guzzle/src/Exception/RequestException.php(139): GuzzleHttp\Psr7\Stream->read(120)
#1 /home/possum/work/guzzle/src/Exception/RequestException.php(107): GuzzleHttp\Exception\RequestException::getResponseBodySummary(Object(GuzzleHttp\Psr7\Response))
#2 /home/possum/work/guzzle/src/Middleware.php(66): GuzzleHttp\Exception\RequestException::create(Object(GuzzleHttp\Psr7\Request), Object(GuzzleHttp\Psr7\Response))
#3 /home/possum/work/guzzle/vendor/guzzlehttp/promises/src/Promise.php(203): GuzzleHttp\Middleware::GuzzleHttp\{closure}(Object(GuzzleHttp\Psr7\Response))
#4 /home/possum/work/guzzle/vendor/guzzlehttp/promises/src/Promise.php(156): GuzzleHttp\Promise\Promise::callHandler(1, Object(GuzzleHttp\Psr7\Response), Array)
#5 /home/possum/work/guzzle/vendor/guzzlehttp/promises/src/TaskQueue.php(47): GuzzleHttp\Promise\Promise::GuzzleHttp\Promise\{cl in /home/possum/work/guzzle/vendor/guzzlehttp/psr7/src/Stream.php on line 208
```

with this patch:

```bash
$ php tmp.php 
PHP Fatal error:  Uncaught GuzzleHttp\Exception\ClientException: Client error: `GET https://github.com/guzzle/guzzle/tree/5.3_DOES_NOT_EXISTS` resulted in a `404 Not Found` response in /home/possum/work/guzzle/src/Exception/RequestException.php:113
Stack trace:
#0 /home/possum/work/guzzle/src/Middleware.php(66): GuzzleHttp\Exception\RequestException::create(Object(GuzzleHttp\Psr7\Request), Object(GuzzleHttp\Psr7\Response))
#1 /home/possum/work/guzzle/vendor/guzzlehttp/promises/src/Promise.php(203): GuzzleHttp\Middleware::GuzzleHttp\{closure}(Object(GuzzleHttp\Psr7\Response))
#2 /home/possum/work/guzzle/vendor/guzzlehttp/promises/src/Promise.php(156): GuzzleHttp\Promise\Promise::callHandler(1, Object(GuzzleHttp\Psr7\Response), Array)
#3 /home/possum/work/guzzle/vendor/guzzlehttp/promises/src/TaskQueue.php(47): GuzzleHttp\Promise\Promise::GuzzleHttp\Promise\{closure}()
#4 /home/possum/work/guzzle/vendor/guzzlehttp/promises/src/Promise.php(246): GuzzleHttp\Promise\TaskQueue->run(true)
#5 /home/possum/work/guzzle/vendor/guzzlehttp in /home/possum/work/guzzle/src/Exception/RequestException.php on line 113
```

I haven't made a unit test yet because I'm wondering if the proposed solution is the correct one. I've my doubts that is OK if a `Stream` `isSeekable` but yet not `isReadable`. So maybe this needs to be solved within the `Stream` class itself (`isSeekable` always returns `false` if not `isReadable`) or maybe the `Stream` is not created correctly?

Some meta data;
```bash
$ php -v
PHP 7.2.5-1+ubuntu16.04.1+deb.sury.org+1 (cli) (built: May  5 2018 04:59:13) ( NTS )
```

let me know what you guys think :)



