### PR TITLE
Update Python2 URL to Python3

### DIFF
--- a/src/Cookie/CookieJarInterface.php
+++ b/src/Cookie/CookieJarInterface.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
  * necessary. Subclasses are also responsible for storing and retrieving
  * cookies from a file, database, etc.
  *
- * @link http://docs.python.org/2/library/cookielib.html Inspiration
+ * @link https://docs.python.org/3/library/http.cookiejar.html Inspiration
  */
 interface CookieJarInterface extends \Countable, \IteratorAggregate
 {


### PR DESCRIPTION
Python 3 docs are more actively maintained and are the future of the Python project.