### PR TITLE
Allow PHPStan to match with `@throws` phpdoc

### DIFF
--- a/src/Exception/GuzzleException.php
+++ b/src/Exception/GuzzleException.php
@@ -1,13 +1,4 @@
 <?php
 namespace GuzzleHttp\Exception;
 
-/**
- * @method string getMessage()
- * @method \Throwable|null getPrevious()
- * @method mixed getCode()
- * @method string getFile()
- * @method int getLine()
- * @method array getTrace()
- * @method string getTraceAsString()
- */
-interface GuzzleException {}
+interface GuzzleException extends \Throwable {}


### PR DESCRIPTION
[PHPStan `0.10` was released last Weekend](https://github.com/phpstan/phpstan/releases/tag/0.10) 🎉 , and will throw the following exception starting from level 2:

> PHPDoc tag @throws with type GuzzleHttp\Exception\GuzzleException is not subtype of Throwable

As all exceptions eventually extend `\RuntimeException`, and as we in userland want to rely on the interface, letting  `GuzzleException` interface extend `\Throwable` would be preferable.

also see #1971 