### PR TITLE
Drop support for legacy PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - nightly
@@ -16,7 +12,7 @@ before_script:
   - composer install --no-interaction --prefer-source --dev
   - ~/.nvm/nvm.sh install v0.6.14
   - ~/.nvm/nvm.sh run v0.6.14
-  - if [[ "$TRAVIS_PHP_VERSION" != "7.0" || "$TRAVIS_PHP_VERSION" != "7.1" ]]; then echo "xdebug.overload_var_dump = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini || true; fi
+  - echo "xdebug.overload_var_dump = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini || true
 
 script: make test
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": "^7.2",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.4"
     },


### PR DESCRIPTION
Hi,

it's end of Q2 2018 and current PHP version is 7.2, with 7.3 knocking on the door.

Guzzle still supports legacy PHP versions as far as 5.5.

5.5 was released 5 years ago and is dead for 2 years already.
5.6 was released almost 4 years ago and is in security-only mode for 18 months already, to be EOL'd in 5 months.
7.0 was released 2 and half years ago and is in security-only mode for 6 months already, to be EOL'd in 6 months.
7.1 was released 18 months ago and is still maintained, scheduled to enter security.only mode in 5 months.

Reference: https://secure.php.net/supported-versions.php

It's time to move on and leave relics behind.

_Targets v7.0._