### PR TITLE
Add support for Restful APIs with params in uri

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\UriInterface;
  */
 interface ClientInterface
 {
-    const VERSION = '6.2.1';
+    const VERSION = '6.2.3';
 
     /**
      * Send an HTTP request.

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -3,8 +3,6 @@ namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -136,6 +134,18 @@ final class Middleware
                 }
                 return $response;
             };
+        };
+    }
+
+    /**
+     * Middleware that support Restful API with placeholders in uri.
+     *
+     * @return callable Returns a function that accepts the next handler.
+     */
+    public static function restful()
+    {
+        return function (callable $handler) {
+            return new RestfulApiMiddleware($handler);
         };
     }
 

--- a/src/RestfulApiMiddleware.php
+++ b/src/RestfulApiMiddleware.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Frost Wong <frostwong@gmail.com>
- * Date: 2018/6/26
- * Time: 22:59
- */
-
 namespace GuzzleHttp;
 
 
@@ -15,6 +8,9 @@ use Psr\Http\Message\RequestInterface;
 
 /**
  * Pre-process URIs which contains attributes with values provided by $options['attributes']
+ *
+ * Apply this middleware like other middleware using
+ * {@see GuzzleHttp\Middleware::redirect()}.
  */
 class RestfulApiMiddleware
 {

--- a/src/RestfulApiMiddleware.php
+++ b/src/RestfulApiMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Frost Wong <frostwong@gmail.com>
+ * Date: 2018/6/26
+ * Time: 22:59
+ */
+
+namespace GuzzleHttp;
+
+
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\RequestInterface;
+
+
+/**
+ * Pre-process URIs which contains attributes with values provided by $options['attributes']
+ */
+class RestfulApiMiddleware
+{
+
+    private $nextHandler;
+
+    public function __construct(callable $nextHandler)
+    {
+        $this->nextHandler = $nextHandler;
+    }
+
+    public function __invoke(RequestInterface $request, array $options)
+    {
+        $fn = $this->nextHandler;
+
+        // Don't do any thing if attributes is not set
+        if (!isset($options['attributes'])) {
+            return $fn($request, $options);
+        }
+
+        $attributes = $options['attributes'];
+        $uri = (string)$request->getUri();
+
+        $translatedUri = $this->interpolate($uri, $attributes);
+
+        $request = $request->withUri(new Uri($translatedUri), true);
+
+        return $fn($request, $options);
+    }
+
+    /**
+     * Translate placeholders with context.
+     *
+     * @param $message
+     * @param array $context
+     * @return string
+     */
+    private function interpolate($message, array $context = [])
+    {
+        $placeholders = [];
+
+        foreach ($context as $key => $val) {
+            if (! is_array($val) && (! is_object($val) || method_exists($val, '__toString'))) {
+                $placeholders['{' . $key . '}'] = $val;
+            }
+        }
+
+        return strtr(urldecode($message), $placeholders);
+    }
+}


### PR DESCRIPTION
Support Restful APIs with parameters in uri, like `/user/{user_id}`, with this middleware, you can call this API like this:

```php
$client = new Client(['base_uri' => 'https://example.com']);
$stack = HandlerStack::create();
$stack->push(Middleware::restful());
$client->request('GET', '/user/{user_id}', [
    'attributes' => [
        'user_id' => 100000,
    ],
]);