### PR TITLE
Throw a BadResponseException when the Location header is empty on 3xx responses

### DIFF
--- a/src/Exception/BadResponseException.php
+++ b/src/Exception/BadResponseException.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * Exception when an HTTP error occurs (4xx or 5xx error)
+ * Exception when an HTTP error occurs (ie 4xx or 5xx error and 3xx redirects without Location header)
  */
 class BadResponseException extends RequestException
 {

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -209,9 +209,23 @@ class RedirectMiddleware
         ResponseInterface $response,
         array $protocols
     ): UriInterface {
+        $locationHeaderLine = $response->getHeaderLine('Location');
+
+        // Avoid TooManyRedirectsException when following empty location headers
+        if (empty($locationHeaderLine)) {
+            throw new BadResponseException(
+                sprintf(
+                    'The server responded with a %d status code, but supplied an empty Location header',
+                    $response->getStatusCode()
+                ),
+                $request,
+                $response
+            );
+        }
+
         $location = Psr7\UriResolver::resolve(
             $request->getUri(),
-            new Psr7\Uri($response->getHeaderLine('Location'))
+            new Psr7\Uri($locationHeaderLine)
         );
 
         // Ensure that the redirect URI is allowed based on the protocols.


### PR DESCRIPTION
This avoids a TooManyRedirectsException, because Guzzle hits the same base uri over and over again