### PR TITLE
Correct reference to undefined default handler

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -118,7 +118,7 @@ pairs:
     This option only has an effect if your handler has the
     ``GuzzleHttp\Middleware::redirect`` middleware. This middleware is added
     by default when a client is created with no handler, and is added by
-    default when creating a handler with ``GuzzleHttp\default_handler``.
+    default when creating a handler with ``GuzzleHttp\HandlerStack::create``.
 
 
 auth


### PR DESCRIPTION
The default handler is created with `HandlerStack::create()`.