### PR TITLE
Added support for PSR18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": "^7.0",
+        "psr/http-client": "^0.1",
         "guzzlehttp/psr7": "^1.4",
         "guzzlehttp/promises": "^1.0"
     },

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\InvalidRequestException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\UriInterface;
@@ -103,6 +104,15 @@ class Client implements ClientInterface
     public function send(RequestInterface $request, array $options = [])
     {
         $options[RequestOptions::SYNCHRONOUS] = true;
+        return $this->sendAsync($request, $options)->wait();
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $options[RequestOptions::SYNCHRONOUS] = true;
+        $options[RequestOptions::ALLOW_REDIRECTS] = false;
+        $options[RequestOptions::HTTP_ERRORS] = false;
+
         return $this->sendAsync($request, $options)->wait();
     }
 
@@ -371,7 +381,7 @@ class Client implements ClientInterface
                 $value = http_build_query($value, null, '&', PHP_QUERY_RFC3986);
             }
             if (!is_string($value)) {
-                throw new \InvalidArgumentException('query must be a string or array');
+                throw new InvalidRequestException($request, 'query must be a string or array');
             }
             $modify['query'] = $value;
             unset($options['query']);
@@ -381,7 +391,7 @@ class Client implements ClientInterface
         if (isset($options['sink'])) {
             // TODO: Add more sink validation?
             if (is_bool($options['sink'])) {
-                throw new \InvalidArgumentException('sink must not be a boolean');
+                throw new InvalidRequestException($request, 'sink must not be a boolean');
             }
         }
 

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Exception;
 
+use Psr\Http\Client\Exception\NetworkException;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -8,7 +9,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * Note that no response is present for a ConnectException
  */
-class ConnectException extends RequestException
+class ConnectException extends RequestException implements NetworkException
 {
     public function __construct(
         $message,

--- a/src/Exception/InvalidRequestException.php
+++ b/src/Exception/InvalidRequestException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Exception;
+
+use Psr\Http\Message\RequestInterface;
+
+class InvalidRequestException extends \InvalidArgumentException implements \Psr\Http\Client\Exception\RequestException,  GuzzleException
+{
+    private $request;
+    public function __construct(RequestInterface $request, $message)
+    {
+        $this->request = $request;
+        parent::__construct($message);
+    }
+
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+}

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -175,7 +175,7 @@ class RequestException extends TransferException
      *
      * @return RequestInterface
      */
-    public function getRequest()
+    public function getRequest(): RequestInterface
     {
         return $this->request;
     }


### PR DESCRIPTION
I know this PR maybe premature for you and we may not be ready to drop PHP5 support. I'm soon about to open the official vote for PSR-18. And I wanted to show how it will effect Guzzle.

See the specification: https://github.com/php-fig/fig-standards/blob/master/proposed/http-client/http-client.md
Read the blog post: https://medium.com/php-fig/the-http-client-psr-9c2535132980