### PR TITLE
support set default handler

### DIFF
--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -18,6 +18,9 @@ class HandlerStack
     /** @var callable|null */
     private $cached;
 
+    /** @var string|callable|null */
+    private static $defaultHandler;
+
     /**
      * Creates a default handler stack that can be used by clients.
      *
@@ -270,4 +273,28 @@ class HandlerStack
 
         return 'callable(' . spl_object_hash($fn) . ')';
     }
+
+    /**
+     * Set a default handler
+     *
+     * @param string|callable|null $handler class name or callable. If value is null, that has no default handler
+     * @return void
+     */
+    public static function setDefaultHandler($handler)
+    {
+        static::$defaultHandler = $handler;
+    }
+
+    /**
+     * Get default handler
+     * 
+     * If return null, that has no default handler
+     *
+     * @return string|callable|null
+     */
+    public static function getDefaultHandler()
+    {
+        return static::$defaultHandler ?: null;
+    }
+
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -103,7 +103,12 @@ function debug_resource($value = null)
 function choose_handler()
 {
     $handler = null;
-    if (function_exists('curl_multi_exec') && function_exists('curl_exec')) {
+    $defaultHandler = get_default_handler();
+    if(is_string($defaultHandler)) {
+        $handler = new $defaultHandler;
+    } elseif (is_callable($defaultHandler)) {
+        $handler = $defaultHandler();
+    } elseif (function_exists('curl_multi_exec') && function_exists('curl_exec')) {
         $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
     } elseif (function_exists('curl_exec')) {
         $handler = new CurlHandler();
@@ -121,6 +126,33 @@ function choose_handler()
     }
 
     return $handler;
+}
+
+/**
+ * Set a default handler
+ *
+ * @param string|callable|null $handler class name or callable. If value is null, that has no default handler
+ * @return void
+ */
+function set_default_handler($handler)
+{
+    $GLOBALS['guzzle_default_handler'] = $handler;
+}
+
+/**
+ * Get default handler
+ * 
+ * If return null, that has no default handler
+ *
+ * @return string|callable|null
+ */
+function get_default_handler()
+{
+    if(isset($GLOBALS['guzzle_default_handler'])) {
+        return $GLOBALS['guzzle_default_handler'];
+    } else {
+        return null;
+    }
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -103,7 +103,7 @@ function debug_resource($value = null)
 function choose_handler()
 {
     $handler = null;
-    $defaultHandler = get_default_handler();
+    $defaultHandler = HandlerStack::getDefaultHandler();
     if(is_string($defaultHandler)) {
         $handler = new $defaultHandler;
     } elseif (is_callable($defaultHandler)) {
@@ -126,33 +126,6 @@ function choose_handler()
     }
 
     return $handler;
-}
-
-/**
- * Set a default handler
- *
- * @param string|callable|null $handler class name or callable. If value is null, that has no default handler
- * @return void
- */
-function set_default_handler($handler)
-{
-    $GLOBALS['guzzle_default_handler'] = $handler;
-}
-
-/**
- * Get default handler
- * 
- * If return null, that has no default handler
- *
- * @return string|callable|null
- */
-function get_default_handler()
-{
-    if(isset($GLOBALS['guzzle_default_handler'])) {
-        return $GLOBALS['guzzle_default_handler'];
-    } else {
-        return null;
-    }
 }
 
 /**


### PR DESCRIPTION
We want to be able to manually set the default handler to let the guzzle-based project use the handler by default.

For example, we want to let the guzzle support the swoole coroutine by setting the default handler.