### PR TITLE
Fix RetryMiddleware default exponential delay

### DIFF
--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -47,7 +47,7 @@ class RetryMiddleware
      *
      * @param int $retries
      *
-     * @return int
+     * @return int milliseconds.
      */
     public static function exponentialDelay($retries)
     {

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -51,7 +51,7 @@ class RetryMiddleware
      */
     public static function exponentialDelay($retries)
     {
-        return (int) pow(2, $retries - 1);
+        return (int) (pow(2, $retries - 1) * 1000);
     }
 
     /**

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -51,7 +51,7 @@ class RetryMiddleware
      */
     public static function exponentialDelay($retries)
     {
-        return (int) (pow(2, $retries - 1) * 1000);
+        return (int) pow(2, $retries - 1) * 1000;
     }
 
     /**

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -73,9 +73,9 @@ class RetryMiddlewareTest extends TestCase
     public function testBackoffCalculateDelay()
     {
         self::assertSame(0, RetryMiddleware::exponentialDelay(0));
-        self::assertSame(1, RetryMiddleware::exponentialDelay(1));
-        self::assertSame(2, RetryMiddleware::exponentialDelay(2));
-        self::assertSame(4, RetryMiddleware::exponentialDelay(3));
-        self::assertSame(8, RetryMiddleware::exponentialDelay(4));
+        self::assertSame(1000, RetryMiddleware::exponentialDelay(1));
+        self::assertSame(2000, RetryMiddleware::exponentialDelay(2));
+        self::assertSame(4000, RetryMiddleware::exponentialDelay(3));
+        self::assertSame(8000, RetryMiddleware::exponentialDelay(4));
     }
 }


### PR DESCRIPTION
`RetryMiddleware::exponentialDelay` was previously returning an integer (good) representing SECONDS of delay. The `RetryMiddleware` was putting that value directly into the `delay` option for the retried request. However, the [docs say](http://docs.guzzlephp.org/en/latest/request-options.html#delay) that the `delay` option should be in milliseconds.

If the `RetryMiddleware` was used without a custom delay function, the `RetryMiddleware::exponentialDelay` is used, meaning that the delay was going to be minimal by default.