### PR TITLE
prevent exception when handles is null

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -63,7 +63,7 @@ class CurlFactory implements CurlFactoryInterface
         $resource = $easy->handle;
         unset($easy->handle);
 
-        if (count($this->handles) >= $this->maxHandles) {
+        if ($this->handles != NULL && count($this->handles) >= $this->maxHandles) {
             curl_close($resource);
         } else {
             // Remove all callback functions as they can hold onto references


### PR DESCRIPTION
I ran into a situation where $this->handles was null, but because null is not countable an exception was thrown.  This prevents that I added a check to see if handles is null.