### PR TITLE
MockHandler - Add support to reset internal queue

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -50,9 +50,18 @@ a response or exception by shifting return values off of a queue.
     echo $client->request('GET', '/')->getStatusCode();
     //> 202
 
+    // Reset the queue and queue up a new response
+    $mock->reset();
+    $mock->append(new Response(201));
+
+    // As the mock was reset, the new response is the 201 CREATED,
+    // instead of the previously queued RequestException
+    echo $client->request('GET', '/')->getStatusCode();
+    //> 201
+
+
 When no more responses are in the queue and a request is sent, an
 ``OutOfBoundsException`` is thrown.
-
 
 History Middleware
 ==================
@@ -71,9 +80,9 @@ history of the requests that were sent by a client.
     $container = [];
     $history = Middleware::history($container);
 
-    $handlerStack = HandlerStack::create(); 
+    $handlerStack = HandlerStack::create();
     // or $handlerStack = HandlerStack::create($mock); if using the Mock handler.
-    
+
     // Add the history middleware to the handler stack.
     $handlerStack->push($history);
 

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -175,6 +175,11 @@ class MockHandler implements \Countable
         return count($this->queue);
     }
 
+    public function reset()
+    {
+        $this->queue = [];
+    }
+
     private function invokeStats(
         RequestInterface $request,
         array $options,

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -235,4 +235,16 @@ class MockHandlerTest extends TestCase
         $mock($request, [ 'on_stats' => $onStats, 'transfer_time' => 0.4 ])->wait(false);
         $this->assertEquals(0.4, $stats->getTransferTime());
     }
+
+    public function testResetQueue()
+    {
+        $mock = new MockHandler([new Response(200), new Response(204)]);
+        $this->assertCount(2, $mock);
+
+        $mock->reset();
+        $this->assertEmpty($mock);
+
+        $mock->append(new Response(500));
+        $this->assertCount(1, $mock);
+    }
 }


### PR DESCRIPTION
| Q            | A
| ------------ | ---
| Bug?         | no
| New Feature? | yes
| Version      | 6.3.3


#### Actual Behavior

MockHandler doesn't offer a way of resetting the internal queue. There are testing scenarios where the handler has been initialized in the setUp() method of a test suite, to avoid duplication, and some specific responses are queued up as the default behavior but then you have tests which need to queue up something different (i.e a request error).

In this cases, it is not possible to reuse the handler defined in setUp(), and instad, it is required to re-instantiate and re-wire a handler and the dependencies all over again.

#### Expected Behavior

To avoid having to wire and set up the handler all over again, it would be great to expose a way to reset the internal queue in the MockHandler instance, and then just queue the new response(s).

This PR adds a method to MockHandler to reset the internal queue. Calling `$handler->reset(); ` would reset the internal array and allow the tester to queue up new responses.