### PR TITLE
Set response status code to 0 if status-code is missing in status line

### DIFF
--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -74,7 +74,7 @@ final class EasyHandle
 
         // Attach a response to the easy handle with the parsed headers.
         $this->response = new Response(
-            $startLine[1],
+            isset($startLine[1]) ? $startLine[1] : 0,
             $headers,
             $this->sink,
             substr($startLine[0], 5),

--- a/tests/Handler/EasyHandleTest.php
+++ b/tests/Handler/EasyHandleTest.php
@@ -20,4 +20,19 @@ class EasyHandleTest extends TestCase
         unset($easy->handle);
         $easy->handle;
     }
+
+    public function testZeroStatusCodeIfStatusCodeMissingInHeaders()
+    {
+        $easy = new EasyHandle();
+        $headers = [
+            "HTTP/1.0",
+            "Server: Quick 'n Easy Web Server",
+            "Connection: Keep-Alive",
+            "Content-Length: 0",
+        ];
+        $easy->headers = $headers;
+        $easy->createResponse();
+        $easy->response;
+        $this->assertEquals(0, $easy->response->getStatusCode());
+    }
 }


### PR DESCRIPTION
This avoids undefined offset if status code is missing ([issue](https://github.com/guzzle/guzzle/issues/1909))