### PR TITLE
[Doc] typehint Pool's 'fulfilled' and 'rejected' callbacks

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -201,9 +201,11 @@ amount of requests you wish to send.
 
 .. code-block:: php
 
-    use GuzzleHttp\Pool;
     use GuzzleHttp\Client;
+    use GuzzleHttp\Exception\RequestException;
+    use GuzzleHttp\Pool;
     use GuzzleHttp\Psr7\Request;
+    use GuzzleHttp\Psr7\Response;
 
     $client = new Client();
 
@@ -216,10 +218,10 @@ amount of requests you wish to send.
 
     $pool = new Pool($client, $requests(100), [
         'concurrency' => 5,
-        'fulfilled' => function ($response, $index) {
+        'fulfilled' => function (Response $response, $index) {
             // this is delivered each successful response
         },
-        'rejected' => function ($reason, $index) {
+        'rejected' => function (RequestException $reason, $index) {
             // this is delivered each failed request
         },
     ]);
@@ -481,7 +483,7 @@ which returns a ``GuzzleHttp\Cookie\SetCookie`` instance.
     $cookie->getExpires(); // expiration date as a Unix timestamp
 
 The cookies can be also fetched into an array thanks to the `toArray()` method.
-The ``GuzzleHttp\Cookie\CookieJarInterface`` interface extends 
+The ``GuzzleHttp\Cookie\CookieJarInterface`` interface extends
 ``Traversable`` so it can be iterated in a foreach loop.
 
 


### PR DESCRIPTION
Add typehints to the `Pool`'s `fulfilled` and `rejected` callbacks in the doc.