### PR TITLE
Add invalid argument exception

### DIFF
--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,4 +2,4 @@
 
 namespace GuzzleHttp\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException implements GuzzleException {}
+final class InvalidArgumentException extends \InvalidArgumentException implements GuzzleException {}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace GuzzleHttp\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements GuzzleException {}

--- a/src/functions.php
+++ b/src/functions.php
@@ -294,14 +294,14 @@ function is_host_in_noproxy($host, array $noProxyArray)
  * @param int    $options Bitmask of JSON decode options.
  *
  * @return mixed
- * @throws \InvalidArgumentException if the JSON cannot be decoded.
+ * @throws Exception\InvalidArgumentException if the JSON cannot be decoded.
  * @link http://www.php.net/manual/en/function.json-decode.php
  */
 function json_decode($json, $assoc = false, $depth = 512, $options = 0)
 {
     $data = \json_decode($json, $assoc, $depth, $options);
     if (JSON_ERROR_NONE !== json_last_error()) {
-        throw new \InvalidArgumentException(
+        throw new Exception\InvalidArgumentException(
             'json_decode error: ' . json_last_error_msg()
         );
     }
@@ -317,14 +317,14 @@ function json_decode($json, $assoc = false, $depth = 512, $options = 0)
  * @param int    $depth   Set the maximum depth. Must be greater than zero.
  *
  * @return string
- * @throws \InvalidArgumentException if the JSON cannot be encoded.
+ * @throws Exception\InvalidArgumentException if the JSON cannot be encoded.
  * @link http://www.php.net/manual/en/function.json-encode.php
  */
 function json_encode($value, $options = 0, $depth = 512)
 {
     $json = \json_encode($value, $options, $depth);
     if (JSON_ERROR_NONE !== json_last_error()) {
-        throw new \InvalidArgumentException(
+        throw new Exception\InvalidArgumentException(
             'json_encode error: ' . json_last_error_msg()
         );
     }


### PR DESCRIPTION
Hello there,

Let's say I have the following class:

``` php
class MyClientWrapper {
    private $httpClient;

    public function callSomething(){
          $response = $this->httpClient->get('/');
          return GuzzleHttp\json_decode($response->getBody());
    }
}
```

when I call the function above I have to do something like this:

``` php
try{
   $mywrapper->callSomething();
} catch (\InvalidArgumentException | GuzzleException $e){
    ....
}
```

This has the defect that I if another part of my code throws an `InvalidArgumentException` inside this class I can not separate it from the the GuzzleHttp `InvalidArgumentException`.