### PR TITLE
Adds typehint in method equals phpDocs

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -210,7 +210,7 @@ class Client implements ClientInterface
      *
      * @return array
      */
-    private function prepareDefaults($options)
+    private function prepareDefaults(array $options)
     {
         $defaults = $this->config;
 


### PR DESCRIPTION
Looking in the classes, I found one class that have a typehint in phpDocs but doesn't have in the method, so, this PR adds the typehint in method.