### PR TITLE
Pass handle to 'progress' callable

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -750,6 +750,7 @@ The function accepts the following positional arguments:
         '/',
         [
             'progress' => function(
+                $handle,
                 $downloadTotal,
                 $downloadedBytes,
                 $uploadTotal,

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -460,14 +460,7 @@ class CurlFactory implements CurlFactoryInterface
                 );
             }
             $conf[CURLOPT_NOPROGRESS] = false;
-            $conf[CURLOPT_PROGRESSFUNCTION] = function () use ($progress) {
-                $args = func_get_args();
-                // PHP 5.5 pushed the handle onto the start of the args
-                if (is_resource($args[0])) {
-                    array_shift($args);
-                }
-                call_user_func_array($progress, $args);
-            };
+            $conf[CURLOPT_PROGRESSFUNCTION] = $progress;
         }
 
         if (!empty($options['debug'])) {

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -171,9 +171,10 @@ final class RequestOptions
     /**
      * progress: (callable) Defines a function to invoke when transfer
      * progress is made. The function accepts the following positional
-     * arguments: the total number of bytes expected to be downloaded, the
-     * number of bytes downloaded so far, the number of bytes expected to be
-     * uploaded, the number of bytes uploaded so far.
+     * arguments: the cURL resource, the total number of bytes expected
+     * to be downloaded, the number of bytes downloaded so far, the
+     * number of bytes expected to be uploaded, the number of bytes
+     * uploaded so far.
      */
     const PROGRESS = 'progress';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -281,7 +281,7 @@ class CurlFactoryTest extends TestCase
         $response->wait();
         $this->assertNotEmpty($called);
         foreach ($called as $call) {
-            $this->assertCount(4, $call);
+            $this->assertCount(5, $call);
         }
     }
 


### PR DESCRIPTION
The progress callable accepts 5 parameters where first is the handle as mentioned here http://php.net/manual/en/function.curl-setopt.php

![image](https://user-images.githubusercontent.com/327717/47269396-4fa9c100-d55d-11e8-8a41-de01a96f9cda.png)

Current state of the library passes only 4 arguments and removes the first argument containing the handle because it was not available in php versions <5.5. However this library requires [5.5+](https://github.com/guzzle/guzzle/blob/master/composer.json#L16) so it can be added https://github.com/guzzle/guzzle/blob/master/composer.json#L16

I guess it's BC break.