### PR TITLE
Add use statement for ClientException code block

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -571,6 +571,7 @@ Guzzle throws exceptions for errors that occur during a transfer.
 
   .. code-block:: php
 
+      use GuzzleHttp\Psr7;
       use GuzzleHttp\Exception\ClientException;
 
       try {


### PR DESCRIPTION
Not sure if it was intentional, but the previous block has it, so I thought this one should too.