### PR TITLE
Remove assertEquals in favor of assertSame

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -114,7 +114,7 @@ class ClientTest extends TestCase
             'handler'  => $mock,
             'base_uri' => 'http://bar.com'
         ]);
-        $this->assertEquals('http://bar.com', (string) $client->getConfig('base_uri'));
+        $this->assertSame('http://bar.com', (string) $client->getConfig('base_uri'));
         $request = new Request('GET', '/baz');
         $client->send($request);
         $this->assertSame(
@@ -596,7 +596,7 @@ class ClientTest extends TestCase
         $mock = new MockHandler([new Response(500)]);
         $client = new Client(['handler' => $mock]);
         $mock2 = new MockHandler([new Response(200)]);
-        $this->assertEquals(
+        $this->assertSame(
             200,
             $client->send(new Request('GET', 'http://foo.com'), [
                 'handler' => $mock2

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
         $client = new Client();
         Server::enqueue([new Response(200, ['Content-Length' => 0])]);
         $response = $client->get(Server::$url);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -40,10 +40,10 @@ class ClientTest extends TestCase
         Server::enqueue([new Response(200, ['Content-Length' => 2], 'hi')]);
         $p = $client->getAsync(Server::$url, ['query' => ['test' => 'foo']]);
         $this->assertInstanceOf(PromiseInterface::class, $p);
-        $this->assertEquals(200, $p->wait()->getStatusCode());
+        $this->assertSame(200, $p->wait()->getStatusCode());
         $received = Server::received(true);
         $this->assertCount(1, $received);
-        $this->assertEquals('test=foo', $received[0]->getUri()->getQuery());
+        $this->assertSame('test=foo', $received[0]->getUri()->getQuery());
     }
 
     public function testCanSendSynchronously()
@@ -52,7 +52,7 @@ class ClientTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $r = $client->send($request);
         $this->assertInstanceOf(ResponseInterface::class, $r);
-        $this->assertEquals(200, $r->getStatusCode());
+        $this->assertSame(200, $r->getStatusCode());
     }
 
     public function testClientHasOptions()
@@ -64,10 +64,10 @@ class ClientTest extends TestCase
             'handler'  => new MockHandler()
         ]);
         $base = $client->getConfig('base_uri');
-        $this->assertEquals('http://foo.com', (string) $base);
+        $this->assertSame('http://foo.com', (string) $base);
         $this->assertInstanceOf(Uri::class, $base);
         $this->assertNotNull($client->getConfig('handler'));
-        $this->assertEquals(2, $client->getConfig('timeout'));
+        $this->assertSame(2, $client->getConfig('timeout'));
         $this->assertArrayHasKey('timeout', $client->getConfig());
         $this->assertArrayHasKey('headers', $client->getConfig());
     }
@@ -80,9 +80,9 @@ class ClientTest extends TestCase
             'handler'  => $mock
         ]);
         $client->get('baz');
-        $this->assertEquals(
+        $this->assertSame(
             'http://foo.com/bar/baz',
-            $mock->getLastRequest()->getUri()
+            (string)$mock->getLastRequest()->getUri()
         );
     }
 
@@ -94,13 +94,13 @@ class ClientTest extends TestCase
             'base_uri' => 'http://foo.com/bar/'
         ]);
         $client->request('GET', new Uri('baz'));
-        $this->assertEquals(
+        $this->assertSame(
             'http://foo.com/bar/baz',
             (string) $mock->getLastRequest()->getUri()
         );
 
         $client->request('GET', new Uri('baz'), ['base_uri' => 'http://example.com/foo/']);
-        $this->assertEquals(
+        $this->assertSame(
             'http://example.com/foo/baz',
             (string) $mock->getLastRequest()->getUri(),
             'Can overwrite the base_uri through the request options'
@@ -117,7 +117,7 @@ class ClientTest extends TestCase
         $this->assertEquals('http://bar.com', (string) $client->getConfig('base_uri'));
         $request = new Request('GET', '/baz');
         $client->send($request);
-        $this->assertEquals(
+        $this->assertSame(
             'http://bar.com/baz',
             (string) $mock->getLastRequest()->getUri()
         );
@@ -126,7 +126,7 @@ class ClientTest extends TestCase
     public function testMergesDefaultOptionsAndDoesNotOverwriteUa()
     {
         $c = new Client(['headers' => ['User-agent' => 'foo']]);
-        $this->assertEquals(['User-agent' => 'foo'], $c->getConfig('headers'));
+        $this->assertSame(['User-agent' => 'foo'], $c->getConfig('headers'));
         $this->assertInternalType('array', $c->getConfig('allow_redirects'));
         $this->assertTrue($c->getConfig('http_errors'));
         $this->assertTrue($c->getConfig('decode_content'));
@@ -141,7 +141,7 @@ class ClientTest extends TestCase
             'handler' => $mock
         ]);
         $c->get('http://example.com', ['headers' => ['User-Agent' => 'bar']]);
-        $this->assertEquals('bar', $mock->getLastRequest()->getHeaderLine('User-Agent'));
+        $this->assertSame('bar', $mock->getLastRequest()->getHeaderLine('User-Agent'));
     }
 
     public function testDoesNotOverwriteHeaderWithDefaultInRequest()
@@ -153,7 +153,7 @@ class ClientTest extends TestCase
         ]);
         $request = new Request('GET', Server::$url, ['User-Agent' => 'bar']);
         $c->send($request);
-        $this->assertEquals('bar', $mock->getLastRequest()->getHeaderLine('User-Agent'));
+        $this->assertSame('bar', $mock->getLastRequest()->getHeaderLine('User-Agent'));
     }
 
     public function testDoesOverwriteHeaderWithSetRequestOption()
@@ -165,7 +165,7 @@ class ClientTest extends TestCase
         ]);
         $request = new Request('GET', Server::$url, ['User-Agent' => 'bar']);
         $c->send($request, ['headers' => ['User-Agent' => 'YO']]);
-        $this->assertEquals('YO', $mock->getLastRequest()->getHeaderLine('User-Agent'));
+        $this->assertSame('YO', $mock->getLastRequest()->getHeaderLine('User-Agent'));
     }
 
     public function testCanUnsetRequestOptionWithNull()
@@ -183,7 +183,7 @@ class ClientTest extends TestCase
     {
         $client = new Client(['handler' => new MockHandler([new Response(404)])]);
         $res = $client->get('http://foo.com', ['exceptions' => false]);
-        $this->assertEquals(404, $res->getStatusCode());
+        $this->assertSame(404, $res->getStatusCode());
     }
 
     public function testRewriteSaveToToSink()
@@ -249,7 +249,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $handler, 'cookies' => true]);
         $client->get('http://foo.com');
         $client->get('http://foo.com');
-        $this->assertEquals('foo=bar', $mock->getLastRequest()->getHeaderLine('Cookie'));
+        $this->assertSame('foo=bar', $mock->getLastRequest()->getHeaderLine('Cookie'));
     }
 
     public function testSetCookieToJar()
@@ -263,7 +263,7 @@ class ClientTest extends TestCase
         $jar = new CookieJar();
         $client->get('http://foo.com', ['cookies' => $jar]);
         $client->get('http://foo.com', ['cookies' => $jar]);
-        $this->assertEquals('foo=bar', $mock->getLastRequest()->getHeaderLine('Cookie'));
+        $this->assertSame('foo=bar', $mock->getLastRequest()->getHeaderLine('Cookie'));
     }
 
     public function testCanDisableContentDecoding()
@@ -282,8 +282,8 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['decode_content' => 'gzip']);
         $last = $mock->getLastRequest();
-        $this->assertEquals('gzip', $last->getHeaderLine('Accept-Encoding'));
-        $this->assertEquals('gzip', $mock->getLastOptions()['decode_content']);
+        $this->assertSame('gzip', $last->getHeaderLine('Accept-Encoding'));
+        $this->assertSame('gzip', $mock->getLastOptions()['decode_content']);
     }
 
     /**
@@ -303,7 +303,7 @@ class ClientTest extends TestCase
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['body' => 'foo']);
         $last = $mock->getLastRequest();
-        $this->assertEquals('foo', (string) $last->getBody());
+        $this->assertSame('foo', (string) $last->getBody());
     }
 
     /**
@@ -323,7 +323,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['query' => 'foo']);
-        $this->assertEquals('foo', $mock->getLastRequest()->getUri()->getQuery());
+        $this->assertSame('foo', $mock->getLastRequest()->getUri()->getQuery());
     }
 
     public function testQueryCanBeArray()
@@ -332,7 +332,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['query' => ['foo' => 'bar baz']]);
-        $this->assertEquals('foo=bar%20baz', $mock->getLastRequest()->getUri()->getQuery());
+        $this->assertSame('foo=bar%20baz', $mock->getLastRequest()->getUri()->getQuery());
     }
 
     public function testCanAddJsonData()
@@ -342,8 +342,8 @@ class ClientTest extends TestCase
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['json' => ['foo' => 'bar']]);
         $last = $mock->getLastRequest();
-        $this->assertEquals('{"foo":"bar"}', (string) $mock->getLastRequest()->getBody());
-        $this->assertEquals('application/json', $last->getHeaderLine('Content-Type'));
+        $this->assertSame('{"foo":"bar"}', (string) $mock->getLastRequest()->getBody());
+        $this->assertSame('application/json', $last->getHeaderLine('Content-Type'));
     }
 
     public function testCanAddJsonDataWithoutOverwritingContentType()
@@ -356,8 +356,8 @@ class ClientTest extends TestCase
             'json'    => 'a'
         ]);
         $last = $mock->getLastRequest();
-        $this->assertEquals('"a"', (string) $mock->getLastRequest()->getBody());
-        $this->assertEquals('foo', $last->getHeaderLine('Content-Type'));
+        $this->assertSame('"a"', (string) $mock->getLastRequest()->getBody());
+        $this->assertSame('foo', $last->getHeaderLine('Content-Type'));
     }
 
     public function testAuthCanBeTrue()
@@ -375,7 +375,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b']]);
         $last = $mock->getLastRequest();
-        $this->assertEquals('Basic YTpi', $last->getHeaderLine('Authorization'));
+        $this->assertSame('Basic YTpi', $last->getHeaderLine('Authorization'));
     }
 
     public function testAuthCanBeArrayForDigestAuth()
@@ -384,7 +384,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b', 'digest']]);
         $last = $mock->getLastOptions();
-        $this->assertEquals([
+        $this->assertSame([
             CURLOPT_HTTPAUTH => 2,
             CURLOPT_USERPWD  => 'a:b'
         ], $last['curl']);
@@ -396,7 +396,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b', 'ntlm']]);
         $last = $mock->getLastOptions();
-        $this->assertEquals([
+        $this->assertSame([
             CURLOPT_HTTPAUTH => 8,
             CURLOPT_USERPWD  => 'a:b'
         ], $last['curl']);
@@ -408,7 +408,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => 'foo']);
         $last = $mock->getLastOptions();
-        $this->assertEquals('foo', $last['auth']);
+        $this->assertSame('foo', $last['auth']);
     }
 
     public function testCanAddFormParams()
@@ -422,11 +422,11 @@ class ClientTest extends TestCase
             ]
         ]);
         $last = $mock->getLastRequest();
-        $this->assertEquals(
+        $this->assertSame(
             'application/x-www-form-urlencoded',
             $last->getHeaderLine('Content-Type')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'foo=bar+bam&baz%5Bboo%5D=qux',
             (string) $last->getBody()
         );
@@ -445,7 +445,7 @@ class ClientTest extends TestCase
             ]
         ]);
         $last = $mock->getLastRequest();
-        $this->assertEquals(
+        $this->assertSame(
             'foo=bar+bam&baz%5Bboo%5D=qux',
             (string) $last->getBody()
         );
@@ -559,14 +559,14 @@ class ClientTest extends TestCase
         $this->assertNull($client->getConfig('proxy'));
         putenv('HTTP_PROXY=127.0.0.1');
         $client = new Client();
-        $this->assertEquals(
+        $this->assertSame(
             ['http' => '127.0.0.1'],
             $client->getConfig('proxy')
         );
         putenv('HTTPS_PROXY=127.0.0.2');
         putenv('NO_PROXY=127.0.0.3, 127.0.0.4');
         $client = new Client();
-        $this->assertEquals(
+        $this->assertSame(
             ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3','127.0.0.4']],
             $client->getConfig('proxy')
         );
@@ -610,7 +610,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['query' => ['foo' => 'bar', 'john' => 'doe']]);
-        $this->assertEquals('foo=bar&john=doe', $mock->getLastRequest()->getUri()->getQuery());
+        $this->assertSame('foo=bar&john=doe', $mock->getLastRequest()->getUri()->getQuery());
     }
 
     public function testSendSendsWithIpAddressAndPortAndHostHeaderInRequestTheHostShouldBePreserved()
@@ -621,7 +621,7 @@ class ClientTest extends TestCase
 
         $client->send($request);
 
-        $this->assertEquals('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
+        $this->assertSame('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
     }
 
     public function testSendSendsWithDomainAndHostHeaderInRequestTheHostShouldBePreserved()
@@ -632,7 +632,7 @@ class ClientTest extends TestCase
 
         $client->send($request);
 
-        $this->assertEquals('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
+        $this->assertSame('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
     }
 
     /**

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -238,7 +238,7 @@ class CookieJarTest extends TestCase
         $this->assertCount(1, $this->jar);
 
         $c = $this->jar->getIterator()->getArrayCopy();
-        $this->assertEquals('zoo', $c[0]->getValue());
+        $this->assertSame('zoo', $c[0]->getValue());
     }
 
     public function testAddsCookiesFromResponseWithRequest()
@@ -313,7 +313,7 @@ class CookieJarTest extends TestCase
 
         $request = new Request('GET', $url);
         $request = $this->jar->withCookieHeader($request);
-        $this->assertEquals($cookies, $request->getHeaderLine('Cookie'));
+        $this->assertSame($cookies, $request->getHeaderLine('Cookie'));
     }
 
     /**
@@ -346,7 +346,7 @@ class CookieJarTest extends TestCase
         $names = array_map(function (SetCookie $c) {
             return $c->getName();
         }, $jar->getIterator()->getArrayCopy());
-        $this->assertEquals(['foo', 'test', 'you'], $names);
+        $this->assertSame(['foo', 'test', 'you'], $names);
     }
 
     public function testCanConvertToAndLoadFromArray()
@@ -406,7 +406,7 @@ class CookieJarTest extends TestCase
         $request = (new Request('GET', $uriPath))->withHeader('Host', 'www.example.com');
         $this->jar->extractCookies($request, $response);
 
-        $this->assertEquals($cookiePath, $this->jar->toArray()[0]['Path']);
-        $this->assertEquals($cookiePath, $this->jar->toArray()[1]['Path']);
+        $this->assertSame($cookiePath, $this->jar->toArray()[0]['Path']);
+        $this->assertSame($cookiePath, $this->jar->toArray()[1]['Path']);
     }
 }

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -29,7 +29,7 @@ class FileCookieJarTest extends TestCase
     public function testLoadsFromFile()
     {
         $jar = new FileCookieJar($this->file);
-        $this->assertEquals([], $jar->getIterator()->getArrayCopy());
+        $this->assertSame([], $jar->getIterator()->getArrayCopy());
         unlink($this->file);
     }
 

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -33,7 +33,7 @@ class SessionCookieJarTest extends TestCase
     public function testLoadsFromSession()
     {
         $jar = new SessionCookieJar($this->sessionVar);
-        $this->assertEquals([], $jar->getIterator()->getArrayCopy());
+        $this->assertSame([], $jar->getIterator()->getArrayCopy());
         unset($_SESSION[$this->sessionVar]);
     }
 

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -196,7 +196,7 @@ class SetCookieTest extends TestCase
             'HttpOnly' => true,
             'Secure' => true
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             'test=123; Domain=foo.com; Path=/abc; Expires=Sun, 27 Oct 2013 23:20:08 GMT; Secure; HttpOnly',
             (string) $cookie
         );
@@ -386,7 +386,7 @@ class SetCookieTest extends TestCase
                     $this->assertEquals($p[$key], $parsed[$key], 'Comparing ' . $key . ' ' . var_export($value, true) . ' : ' . var_export($parsed, true) . ' | ' . var_export($p, true));
                 }
             } else {
-                $this->assertEquals([
+                $this->assertSame([
                     'Name' => null,
                     'Value' => null,
                     'Domain' => null,
@@ -437,7 +437,7 @@ class SetCookieTest extends TestCase
      */
     public function testIsExpired($cookie, $expired)
     {
-        $this->assertEquals(
+        $this->assertSame(
             $expired,
             SetCookie::fromString($cookie)->isExpired()
         );

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -12,7 +12,7 @@ class SetCookieTest extends TestCase
     public function testInitializesDefaultValues()
     {
         $cookie = new SetCookie();
-        $this->assertEquals('/', $cookie->getPath());
+        $this->assertSame('/', $cookie->getPath());
     }
 
     public function testConvertsDateTimeMaxAgeToUnixTimestamp()
@@ -48,17 +48,17 @@ class SetCookieTest extends TestCase
         $cookie = new SetCookie($data);
         $this->assertEquals($data, $cookie->toArray());
 
-        $this->assertEquals('foo', $cookie->getName());
-        $this->assertEquals('baz', $cookie->getValue());
-        $this->assertEquals('baz.com', $cookie->getDomain());
-        $this->assertEquals('/bar', $cookie->getPath());
-        $this->assertEquals($t, $cookie->getExpires());
-        $this->assertEquals(100, $cookie->getMaxAge());
+        $this->assertSame('foo', $cookie->getName());
+        $this->assertSame('baz', $cookie->getValue());
+        $this->assertSame('baz.com', $cookie->getDomain());
+        $this->assertSame('/bar', $cookie->getPath());
+        $this->assertSame($t, $cookie->getExpires());
+        $this->assertSame(100, $cookie->getMaxAge());
         $this->assertTrue($cookie->getSecure());
         $this->assertTrue($cookie->getDiscard());
         $this->assertTrue($cookie->getHttpOnly());
-        $this->assertEquals('baz', $cookie->toArray()['foo']);
-        $this->assertEquals('bam', $cookie->toArray()['bar']);
+        $this->assertSame('baz', $cookie->toArray()['foo']);
+        $this->assertSame('bam', $cookie->toArray()['bar']);
 
         $cookie->setName('a');
         $cookie->setValue('b');
@@ -70,12 +70,12 @@ class SetCookieTest extends TestCase
         $cookie->setHttpOnly(false);
         $cookie->setDiscard(false);
 
-        $this->assertEquals('a', $cookie->getName());
-        $this->assertEquals('b', $cookie->getValue());
-        $this->assertEquals('c', $cookie->getPath());
-        $this->assertEquals('bar.com', $cookie->getDomain());
-        $this->assertEquals(10, $cookie->getExpires());
-        $this->assertEquals(200, $cookie->getMaxAge());
+        $this->assertSame('a', $cookie->getName());
+        $this->assertSame('b', $cookie->getValue());
+        $this->assertSame('c', $cookie->getPath());
+        $this->assertSame('bar.com', $cookie->getDomain());
+        $this->assertSame(10, $cookie->getExpires());
+        $this->assertSame(200, $cookie->getMaxAge());
         $this->assertFalse($cookie->getSecure());
         $this->assertFalse($cookie->getDiscard());
         $this->assertFalse($cookie->getHttpOnly());
@@ -149,7 +149,7 @@ class SetCookieTest extends TestCase
     {
         $cookie = new SetCookie();
         $cookie->setPath($cookiePath);
-        $this->assertEquals($isMatch, $cookie->matchesPath($requestPath));
+        $this->assertSame($isMatch, $cookie->matchesPath($requestPath));
     }
 
     public function cookieValidateProvider()

--- a/tests/Exception/ConnectExceptionTest.php
+++ b/tests/Exception/ConnectExceptionTest.php
@@ -18,8 +18,8 @@ class ConnectExceptionTest extends TestCase
         $this->assertSame($req, $e->getRequest());
         $this->assertNull($e->getResponse());
         $this->assertFalse($e->hasResponse());
-        $this->assertEquals('foo', $e->getMessage());
-        $this->assertEquals('bar', $e->getHandlerContext()['foo']);
+        $this->assertSame('foo', $e->getMessage());
+        $this->assertSame('bar', $e->getHandlerContext()['foo']);
         $this->assertSame($prev, $e->getPrevious());
     }
 }

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -20,13 +20,13 @@ class RequestExceptionTest extends TestCase
         $this->assertSame($req, $e->getRequest());
         $this->assertSame($res, $e->getResponse());
         $this->assertTrue($e->hasResponse());
-        $this->assertEquals('foo', $e->getMessage());
+        $this->assertSame('foo', $e->getMessage());
     }
 
     public function testCreatesGenerateException()
     {
         $e = RequestException::create(new Request('GET', '/'));
-        $this->assertEquals('Error completing request', $e->getMessage());
+        $this->assertSame('Error completing request', $e->getMessage());
         $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
     }
 
@@ -135,7 +135,7 @@ class RequestExceptionTest extends TestCase
     public function testHasStatusCodeAsExceptionCode()
     {
         $e = RequestException::create(new Request('GET', '/'), new Response(442));
-        $this->assertEquals(442, $e->getCode());
+        $this->assertSame(442, $e->getCode());
     }
 
     public function testWrapsRequestExceptions()
@@ -159,7 +159,7 @@ class RequestExceptionTest extends TestCase
     {
         $r = new Request('GET', 'http://www.oo.com');
         $e = new RequestException('foo', $r, null, null, ['bar' => 'baz']);
-        $this->assertEquals(['bar' => 'baz'], $e->getHandlerContext());
+        $this->assertSame(['bar' => 'baz'], $e->getHandlerContext());
     }
 
     public function testObfuscateUrlWithUsername()

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -48,19 +48,19 @@ class CurlFactoryTest extends TestCase
         $this->assertInternalType('array', $result->headers);
         $this->assertSame($stream, $result->sink);
         curl_close($result->handle);
-        $this->assertEquals('PUT', $_SERVER['_curl'][CURLOPT_CUSTOMREQUEST]);
-        $this->assertEquals(
+        $this->assertSame('PUT', $_SERVER['_curl'][CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame(
             'http://127.0.0.1:8126/',
             $_SERVER['_curl'][CURLOPT_URL]
         );
         // Sends via post fields when the request is small enough
-        $this->assertEquals('testing', $_SERVER['_curl'][CURLOPT_POSTFIELDS]);
-        $this->assertEquals(0, $_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
-        $this->assertEquals(0, $_SERVER['_curl'][CURLOPT_HEADER]);
-        $this->assertEquals(150, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT]);
+        $this->assertSame('testing', $_SERVER['_curl'][CURLOPT_POSTFIELDS]);
+        $this->assertSame(0, $_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
+        $this->assertSame(0, $_SERVER['_curl'][CURLOPT_HEADER]);
+        $this->assertSame(150, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT]);
         $this->assertInstanceOf('Closure', $_SERVER['_curl'][CURLOPT_HEADERFUNCTION]);
         if (defined('CURLOPT_PROTOCOLS')) {
-            $this->assertEquals(
+            $this->assertSame(
                 CURLPROTO_HTTP | CURLPROTO_HTTPS,
                 $_SERVER['_curl'][CURLOPT_PROTOCOLS]
             );

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -512,11 +512,11 @@ class CurlFactoryTest extends TestCase
         ], 'test');
         $handler = new Handler\CurlMultiHandler();
         $response = $handler($request, [])->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals('Hello', $response->getHeaderLine('Test'));
-        $this->assertEquals('4', $response->getHeaderLine('Content-Length'));
-        $this->assertEquals('test', (string) $response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('OK', $response->getReasonPhrase());
+        $this->assertSame('Hello', $response->getHeaderLine('Test'));
+        $this->assertSame('4', $response->getHeaderLine('Content-Length'));
+        $this->assertSame('test', (string) $response->getBody());
     }
 
     /**
@@ -545,8 +545,8 @@ class CurlFactoryTest extends TestCase
             'timeout'         => 0.1,
             'connect_timeout' => 0.2
         ]);
-        $this->assertEquals(100, $_SERVER['_curl'][CURLOPT_TIMEOUT_MS]);
-        $this->assertEquals(200, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT_MS]);
+        $this->assertSame(100, $_SERVER['_curl'][CURLOPT_TIMEOUT_MS]);
+        $this->assertSame(200, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT_MS]);
     }
 
     public function testAddsStreamingBody()
@@ -656,9 +656,9 @@ class CurlFactoryTest extends TestCase
         ]);
 
         $response = $promise->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('bar', $response->getHeaderLine('X-Foo'));
-        $this->assertEquals('abc 123', (string) $response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getHeaderLine('X-Foo'));
+        $this->assertSame('abc 123', (string) $response->getBody());
     }
 
     public function testInvokesOnStatsOnSuccess()
@@ -674,13 +674,13 @@ class CurlFactoryTest extends TestCase
             }
         ]);
         $response = $promise->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(200, $gotStats->getResponse()->getStatusCode());
-        $this->assertEquals(
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(200, $gotStats->getResponse()->getStatusCode());
+        $this->assertSame(
             Server::$url,
             (string) $gotStats->getEffectiveUri()
         );
-        $this->assertEquals(
+        $this->assertSame(
             Server::$url,
             (string) $gotStats->getRequest()->getUri()
         );
@@ -701,11 +701,11 @@ class CurlFactoryTest extends TestCase
         ]);
         $promise->wait(false);
         $this->assertFalse($gotStats->hasResponse());
-        $this->assertEquals(
+        $this->assertSame(
             'http://127.0.0.1:123',
             $gotStats->getEffectiveUri()
         );
-        $this->assertEquals(
+        $this->assertSame(
             'http://127.0.0.1:123',
             $gotStats->getRequest()->getUri()
         );

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -56,7 +56,7 @@ class CurlFactoryTest extends TestCase
         // Sends via post fields when the request is small enough
         $this->assertSame('testing', $_SERVER['_curl'][CURLOPT_POSTFIELDS]);
         $this->assertFalse($_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
-        $this->assertSame(0, $_SERVER['_curl'][CURLOPT_HEADER]);
+        $this->assertFalse($_SERVER['_curl'][CURLOPT_HEADER]);
         $this->assertSame(150, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT]);
         $this->assertInstanceOf('Closure', $_SERVER['_curl'][CURLOPT_HEADERFUNCTION]);
         if (defined('CURLOPT_PROTOCOLS')) {
@@ -545,8 +545,8 @@ class CurlFactoryTest extends TestCase
             'timeout'         => 0.1,
             'connect_timeout' => 0.2
         ]);
-        $this->assertSame(100, $_SERVER['_curl'][CURLOPT_TIMEOUT_MS]);
-        $this->assertSame(200, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT_MS]);
+        $this->assertEquals(100, $_SERVER['_curl'][CURLOPT_TIMEOUT_MS]);
+        $this->assertEquals(200, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT_MS]);
     }
 
     public function testAddsStreamingBody()
@@ -703,7 +703,7 @@ class CurlFactoryTest extends TestCase
         $this->assertFalse($gotStats->hasResponse());
         $this->assertSame(
             'http://127.0.0.1:123',
-            $gotStats->getEffectiveUri()
+            (string) $gotStats->getEffectiveUri()
         );
         $this->assertSame(
             'http://127.0.0.1:123',

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -55,7 +55,7 @@ class CurlFactoryTest extends TestCase
         );
         // Sends via post fields when the request is small enough
         $this->assertSame('testing', $_SERVER['_curl'][CURLOPT_POSTFIELDS]);
-        $this->assertSame(0, $_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
+        $this->assertFalse($_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
         $this->assertSame(0, $_SERVER['_curl'][CURLOPT_HEADER]);
         $this->assertSame(150, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT]);
         $this->assertInstanceOf('Closure', $_SERVER['_curl'][CURLOPT_HEADERFUNCTION]);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -55,8 +55,8 @@ class CurlFactoryTest extends TestCase
         );
         // Sends via post fields when the request is small enough
         $this->assertSame('testing', $_SERVER['_curl'][CURLOPT_POSTFIELDS]);
-        $this->assertFalse($_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
-        $this->assertFalse($_SERVER['_curl'][CURLOPT_HEADER]);
+        $this->assertEquals(0, $_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
+        $this->assertEquals(0, $_SERVER['_curl'][CURLOPT_HEADER]);
         $this->assertSame(150, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT]);
         $this->assertInstanceOf('Closure', $_SERVER['_curl'][CURLOPT_HEADERFUNCTION]);
         if (defined('CURLOPT_PROTOCOLS')) {

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -707,7 +707,7 @@ class CurlFactoryTest extends TestCase
         );
         $this->assertSame(
             'http://127.0.0.1:123',
-            $gotStats->getRequest()->getUri()
+            (string) $gotStats->getRequest()->getUri()
         );
         $this->assertInternalType('float', $gotStats->getTransferTime());
         $this->assertInternalType('int', $gotStats->getHandlerErrorData());

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -15,7 +15,7 @@ class CurlMultiHandlerTest extends TestCase
         $a = new CurlMultiHandler();
         $request = new Request('GET', Server::$url);
         $response = $a($request, [])->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -48,7 +48,7 @@ class CurlMultiHandlerTest extends TestCase
         }
 
         foreach($responses as $r) {
-            $this->assertEquals('rejected', $response->getState());
+            $this->assertSame('rejected', $response->getState());
         }
     }
 
@@ -60,7 +60,7 @@ class CurlMultiHandlerTest extends TestCase
         $response = $a(new Request('GET', Server::$url), []);
         $response->wait();
         $response->cancel();
-        $this->assertEquals('fulfilled', $response->getState());
+        $this->assertSame('fulfilled', $response->getState());
     }
 
     public function testDelaysConcurrently()

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -65,7 +65,7 @@ class MockHandlerTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $mock($request, ['foo' => 'bar']);
         $this->assertSame($request, $mock->getLastRequest());
-        $this->assertEquals(['foo' => 'bar'], $mock->getLastOptions());
+        $this->assertSame(['foo' => 'bar'], $mock->getLastOptions());
     }
 
     public function testSinkFilename()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -194,7 +194,7 @@ class StreamHandlerTest extends TestCase
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => true])->wait();
-        $this->assertEquals('test', (string) $response->getBody());
+        $this->assertSame('test', (string) $response->getBody());
         $this->assertFalse($response->hasHeader('content-encoding'));
         $this->assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == $response->getBody()->getSize());
     }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -37,16 +37,16 @@ class StreamHandlerTest extends TestCase
             new Request('GET', Server::$url, ['Foo' => 'Bar']),
             []
         )->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals('Bar', $response->getHeaderLine('Foo'));
-        $this->assertEquals('8', $response->getHeaderLine('Content-Length'));
-        $this->assertEquals('hi there', (string) $response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('OK', $response->getReasonPhrase());
+        $this->assertSame('Bar', $response->getHeaderLine('Foo'));
+        $this->assertSame('8', $response->getHeaderLine('Content-Length'));
+        $this->assertSame('hi there', (string) $response->getBody());
         $sent = Server::received()[0];
-        $this->assertEquals('GET', $sent->getMethod());
-        $this->assertEquals('/', $sent->getUri()->getPath());
-        $this->assertEquals('127.0.0.1:8126', $sent->getHeaderLine('Host'));
-        $this->assertEquals('Bar', $sent->getHeaderLine('foo'));
+        $this->assertSame('GET', $sent->getMethod());
+        $this->assertSame('/', $sent->getUri()->getPath());
+        $this->assertSame('127.0.0.1:8126', $sent->getHeaderLine('Host'));
+        $this->assertSame('Bar', $sent->getHeaderLine('foo'));
     }
 
     /**
@@ -72,20 +72,20 @@ class StreamHandlerTest extends TestCase
             'test'
         );
         $response = $handler($request, ['stream' => true])->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('OK', $response->getReasonPhrase());
-        $this->assertEquals('8', $response->getHeaderLine('Content-Length'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('OK', $response->getReasonPhrase());
+        $this->assertSame('8', $response->getHeaderLine('Content-Length'));
         $body = $response->getBody();
         $stream = $body->detach();
         $this->assertInternalType('resource', $stream);
-        $this->assertEquals('http', stream_get_meta_data($stream)['wrapper_type']);
-        $this->assertEquals('hi there', stream_get_contents($stream));
+        $this->assertSame('http', stream_get_meta_data($stream)['wrapper_type']);
+        $this->assertSame('hi there', stream_get_contents($stream));
         fclose($stream);
         $sent = Server::received()[0];
-        $this->assertEquals('PUT', $sent->getMethod());
-        $this->assertEquals('http://127.0.0.1:8126/foo?baz=bar', (string) $sent->getUri());
-        $this->assertEquals('Bar', $sent->getHeaderLine('Foo'));
-        $this->assertEquals('test', (string) $sent->getBody());
+        $this->assertSame('PUT', $sent->getMethod());
+        $this->assertSame('http://127.0.0.1:8126/foo?baz=bar', (string) $sent->getUri());
+        $this->assertSame('Bar', $sent->getHeaderLine('Foo'));
+        $this->assertSame('test', (string) $sent->getBody());
     }
 
     public function testDrainsResponseIntoTempStream()
@@ -96,8 +96,8 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, [])->wait();
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertEquals('php://temp', stream_get_meta_data($stream)['uri']);
-        $this->assertEquals('hi', fread($stream, 2));
+        $this->assertSame('php://temp', stream_get_meta_data($stream)['uri']);
+        $this->assertSame('hi', fread($stream, 2));
         fclose($stream);
     }
 
@@ -109,9 +109,9 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['sink' => $r])->wait();
         $body = $response->getBody()->detach();
-        $this->assertEquals('php://temp', stream_get_meta_data($body)['uri']);
-        $this->assertEquals('hi', fread($body, 2));
-        $this->assertEquals(' there', stream_get_contents($r));
+        $this->assertSame('php://temp', stream_get_meta_data($body)['uri']);
+        $this->assertSame('hi', fread($body, 2));
+        $this->assertSame(' there', stream_get_contents($r));
         fclose($r);
     }
 
@@ -123,8 +123,8 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['sink' => $tmpfname])->wait();
         $body = $response->getBody();
-        $this->assertEquals($tmpfname, $body->getMetadata('uri'));
-        $this->assertEquals('hi', $body->read(2));
+        $this->assertSame($tmpfname, $body->getMetadata('uri'));
+        $this->assertSame('hi', $body->read(2));
         $body->close();
         unlink($tmpfname);
     }
@@ -138,8 +138,8 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['sink' => $tmpfname])->wait();
         $body = $response->getBody();
-        $this->assertEquals($tmpfname, $body->getMetadata('uri'));
-        $this->assertEquals('hi', $body->read(2));
+        $this->assertSame($tmpfname, $body->getMetadata('uri'));
+        $this->assertSame('hi', $body->read(2));
         $body->close();
         unlink($tmpfname);
     }
@@ -158,7 +158,7 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, [])->wait();
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertEquals('hi there', stream_get_contents($stream));
+        $this->assertSame('hi there', stream_get_contents($stream));
         fclose($stream);
     }
 
@@ -177,7 +177,7 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, [])->wait();
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertEquals('', stream_get_contents($stream));
+        $this->assertSame('', stream_get_contents($stream));
         fclose($stream);
     }
 
@@ -237,8 +237,8 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => false])->wait();
         $this->assertSame($content, (string) $response->getBody());
-        $this->assertEquals('gzip', $response->getHeaderLine('content-encoding'));
-        $this->assertEquals(strlen($content), $response->getHeaderLine('content-length'));
+        $this->assertSame('gzip', $response->getHeaderLine('content-encoding'));
+        $this->assertSame(strlen($content), $response->getHeaderLine('content-length'));
     }
 
     public function testProtocolVersion()
@@ -247,7 +247,7 @@ class StreamHandlerTest extends TestCase
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url, [], null, '1.0');
         $handler($request, []);
-        $this->assertEquals('1.0', Server::received()[0]->getProtocolVersion());
+        $this->assertSame('1.0', Server::received()[0]->getProtocolVersion());
     }
 
     protected function getSendResult(array $opts)
@@ -275,7 +275,7 @@ class StreamHandlerTest extends TestCase
         $url = rtrim($url, '/');
         $res = $this->getSendResult(['proxy' => ['http' => $url]]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertEquals($url, $opts['http']['proxy']);
+        $this->assertSame($url, $opts['http']['proxy']);
     }
 
     public function testAddsProxyButHonorsNoProxy()
@@ -293,7 +293,7 @@ class StreamHandlerTest extends TestCase
     {
         $res = $this->getSendResult(['stream' => true, 'timeout' => 200]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertEquals(200, $opts['http']['timeout']);
+        $this->assertSame(200, $opts['http']['timeout']);
     }
 
     /**
@@ -327,7 +327,7 @@ class StreamHandlerTest extends TestCase
         $opts = stream_context_get_options($res->getBody()->detach());
         $this->assertTrue($opts['ssl']['verify_peer']);
         $this->assertTrue($opts['ssl']['verify_peer_name']);
-        $this->assertEquals($path, $opts['ssl']['cafile']);
+        $this->assertSame($path, $opts['ssl']['cafile']);
         $this->assertFileExists($opts['ssl']['cafile']);
     }
 
@@ -337,7 +337,7 @@ class StreamHandlerTest extends TestCase
         $res = $this->getSendResult(['verify' => true]);
         $opts = stream_context_get_options($res->getBody()->detach());
         if (PHP_VERSION_ID < 50600) {
-            $this->assertEquals($path, $opts['ssl']['cafile']);
+            $this->assertSame($path, $opts['ssl']['cafile']);
         } else {
             $this->assertArrayNotHasKey('cafile', $opts['ssl']);
         }
@@ -357,8 +357,8 @@ class StreamHandlerTest extends TestCase
         $path = __FILE__;
         $res = $this->getSendResult(['cert' => [$path, 'foo']]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertEquals($path, $opts['ssl']['local_cert']);
-        $this->assertEquals('foo', $opts['ssl']['passphrase']);
+        $this->assertSame($path, $opts['ssl']['local_cert']);
+        $this->assertSame('foo', $opts['ssl']['passphrase']);
     }
 
     public function testDebugAttributeWritesToStream()
@@ -440,9 +440,9 @@ class StreamHandlerTest extends TestCase
             ],
         ]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertEquals('HEAD', $opts['http']['method']);
+        $this->assertSame('HEAD', $opts['http']['method']);
         $this->assertTrue($opts['http']['request_fulluri']);
-        $this->assertEquals('127.0.0.1:0', $opts['socket']['bindto']);
+        $this->assertSame('127.0.0.1:0', $opts['socket']['bindto']);
         $this->assertFalse($opts['ssl']['verify_peer']);
     }
 
@@ -494,10 +494,10 @@ class StreamHandlerTest extends TestCase
         $request = new Request('PUT', Server::$url, ['Expect' => '100-Continue'], 'test');
         $handler = new StreamHandler();
         $response = $handler($request, [])->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('Hello', $response->getHeaderLine('Test'));
-        $this->assertEquals('4', $response->getHeaderLine('Content-Length'));
-        $this->assertEquals('test', (string) $response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Hello', $response->getHeaderLine('Test'));
+        $this->assertSame('4', $response->getHeaderLine('Content-Length'));
+        $this->assertSame('test', (string) $response->getBody());
     }
 
     public function testDoesSleep()
@@ -564,14 +564,14 @@ class StreamHandlerTest extends TestCase
             'sink'       => $stream,
             'on_headers' => function (ResponseInterface $res) use (&$got) {
                 $got = $res;
-                $this->assertEquals('bar', $res->getHeaderLine('X-Foo'));
+                $this->assertSame('bar', $res->getHeaderLine('X-Foo'));
             }
         ]);
 
         $response = $promise->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('bar', $response->getHeaderLine('X-Foo'));
-        $this->assertEquals('abc 123', (string) $response->getBody());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('bar', $response->getHeaderLine('X-Foo'));
+        $this->assertSame('abc 123', (string) $response->getBody());
     }
 
     public function testInvokesOnStatsOnSuccess()
@@ -587,13 +587,13 @@ class StreamHandlerTest extends TestCase
             }
         ]);
         $response = $promise->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(200, $gotStats->getResponse()->getStatusCode());
-        $this->assertEquals(
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(200, $gotStats->getResponse()->getStatusCode());
+        $this->assertSame(
             Server::$url,
             (string) $gotStats->getEffectiveUri()
         );
-        $this->assertEquals(
+        $this->assertSame(
             Server::$url,
             (string) $gotStats->getRequest()->getUri()
         );
@@ -614,11 +614,11 @@ class StreamHandlerTest extends TestCase
         ]);
         $promise->wait(false);
         $this->assertFalse($gotStats->hasResponse());
-        $this->assertEquals(
+        $this->assertSame(
             'http://127.0.0.1:123',
             (string) $gotStats->getEffectiveUri()
         );
-        $this->assertEquals(
+        $this->assertSame(
             'http://127.0.0.1:123',
             (string) $gotStats->getRequest()->getUri()
         );
@@ -641,7 +641,7 @@ class StreamHandlerTest extends TestCase
             'timeout' => 0
         ]);
         $response = $promise->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testDrainsResponseAndReadsAllContentWhenContentLengthIsZero()
@@ -658,7 +658,7 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, [])->wait();
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertEquals('hi there... This has a lot of data!', stream_get_contents($stream));
+        $this->assertSame('hi there... This has a lot of data!', stream_get_contents($stream));
         fclose($stream);
     }
 
@@ -673,11 +673,11 @@ class StreamHandlerTest extends TestCase
                 RequestOptions::STREAM => true,
             ]
         )->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('OK', $response->getReasonPhrase());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('OK', $response->getReasonPhrase());
         $body = $response->getBody()->detach();
         $line = fgets($body);
-        $this->assertEquals("sleeping 60 seconds ...\n", $line);
+        $this->assertSame("sleeping 60 seconds ...\n", $line);
         $line = fgets($body);
         $this->assertFalse($line);
         $this->assertTrue(stream_get_meta_data($body)['timed_out']);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -293,7 +293,7 @@ class StreamHandlerTest extends TestCase
     {
         $res = $this->getSendResult(['stream' => true, 'timeout' => 200]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertSame(200, $opts['http']['timeout']);
+        $this->assertEquals(200, $opts['http']['timeout']);
     }
 
     /**

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -238,7 +238,7 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, ['decode_content' => false])->wait();
         $this->assertSame($content, (string) $response->getBody());
         $this->assertSame('gzip', $response->getHeaderLine('content-encoding'));
-        $this->assertSame(strlen($content), $response->getHeaderLine('content-length'));
+        $this->assertEquals(strlen($content), $response->getHeaderLine('content-length'));
     }
 
     public function testProtocolVersion()

--- a/tests/HandlerStackTest.php
+++ b/tests/HandlerStackTest.php
@@ -47,8 +47,8 @@ class HandlerStackTest extends TestCase
         $builder->push($meths[3]);
         $builder->push($meths[4]);
         $composed = $builder->resolve();
-        $this->assertEquals('Hello - test123', $composed('test'));
-        $this->assertEquals(
+        $this->assertSame('Hello - test123', $composed('test'));
+        $this->assertSame(
             [['a', 'test'], ['b', 'test1'], ['c', 'test12']],
             $meths[0]
         );
@@ -63,8 +63,8 @@ class HandlerStackTest extends TestCase
         $builder->unshift($meths[3]);
         $builder->unshift($meths[4]);
         $composed = $builder->resolve();
-        $this->assertEquals('Hello - test321', $composed('test'));
-        $this->assertEquals(
+        $this->assertSame('Hello - test321', $composed('test'));
+        $this->assertSame(
             [['c', 'test'], ['b', 'test3'], ['a', 'test32']],
             $meths[0]
         );
@@ -82,7 +82,7 @@ class HandlerStackTest extends TestCase
         $builder->push($meths[2]);
         $builder->remove($meths[3]);
         $composed = $builder->resolve();
-        $this->assertEquals('Hello - test1131', $composed('test'));
+        $this->assertSame('Hello - test1131', $composed('test'));
     }
 
     public function testCanPrintMiddleware()
@@ -163,10 +163,10 @@ class HandlerStackTest extends TestCase
             'allow_redirects' => true,
             'cookies' => $jar
         ])->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
         $lastRequest = $mock->getLastRequest();
-        $this->assertEquals('http://foo.com/baz', (string) $lastRequest->getUri());
-        $this->assertEquals('foo=bar', $lastRequest->getHeaderLine('Cookie'));
+        $this->assertSame('http://foo.com/baz', (string) $lastRequest->getUri());
+        $this->assertSame('foo=bar', $lastRequest->getHeaderLine('Cookie'));
     }
 
     private function getFunctions()

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -88,6 +88,6 @@ class MessageFormatterTest extends TestCase
     public function testFormatsMessages($template, $args, $result)
     {
         $f = new MessageFormatter($template);
-        $this->assertEquals((string) $result, call_user_func_array(array($f, 'format'), $args));
+        $this->assertSame((string) $result, call_user_func_array(array($f, 'format'), $args));
     }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -51,9 +51,9 @@ class MiddlewareTest extends TestCase
         $h = new MockHandler([new Response(404)]);
         $f = $m($h);
         $p = $f(new Request('GET', 'http://foo.com'), ['http_errors' => true]);
-        $this->assertEquals('pending', $p->getState());
+        $this->assertSame('pending', $p->getState());
         $p->wait();
-        $this->assertEquals('rejected', $p->getState());
+        $this->assertSame('rejected', $p->getState());
     }
 
     /**
@@ -65,9 +65,9 @@ class MiddlewareTest extends TestCase
         $h = new MockHandler([new Response(500)]);
         $f = $m($h);
         $p = $f(new Request('GET', 'http://foo.com'), ['http_errors' => true]);
-        $this->assertEquals('pending', $p->getState());
+        $this->assertSame('pending', $p->getState());
         $p->wait();
-        $this->assertEquals('rejected', $p->getState());
+        $this->assertSame('rejected', $p->getState());
     }
 
     /**
@@ -83,12 +83,12 @@ class MiddlewareTest extends TestCase
         $p1->wait();
         $p2->wait();
         $this->assertCount(2, $container);
-        $this->assertEquals(200, $container[0]['response']->getStatusCode());
-        $this->assertEquals(201, $container[1]['response']->getStatusCode());
-        $this->assertEquals('GET', $container[0]['request']->getMethod());
-        $this->assertEquals('HEAD', $container[1]['request']->getMethod());
-        $this->assertEquals('bar', $container[0]['options']['headers']['foo']);
-        $this->assertEquals('baz', $container[1]['options']['headers']['foo']);
+        $this->assertSame(200, $container[0]['response']->getStatusCode());
+        $this->assertSame(201, $container[1]['response']->getStatusCode());
+        $this->assertSame('GET', $container[0]['request']->getMethod());
+        $this->assertSame('HEAD', $container[1]['request']->getMethod());
+        $this->assertSame('bar', $container[0]['options']['headers']['foo']);
+        $this->assertSame('baz', $container[1]['options']['headers']['foo']);
     }
 
     public function getHistoryUseCases()
@@ -108,7 +108,7 @@ class MiddlewareTest extends TestCase
         $f = $m($h);
         $f($request, [])->wait(false);
         $this->assertCount(1, $container);
-        $this->assertEquals('GET', $container[0]['request']->getMethod());
+        $this->assertSame('GET', $container[0]['request']->getMethod());
         $this->assertInstanceOf(RequestException::class, $container[0]['error']);
     }
 
@@ -137,16 +137,16 @@ class MiddlewareTest extends TestCase
         $b->push($m);
         $comp = $b->resolve();
         $p = $comp(new Request('GET', 'http://foo.com'), []);
-        $this->assertEquals('123', implode('', $calls));
+        $this->assertSame('123', implode('', $calls));
         $this->assertInstanceOf(PromiseInterface::class, $p);
-        $this->assertEquals(200, $p->wait()->getStatusCode());
+        $this->assertSame(200, $p->wait()->getStatusCode());
     }
 
     public function testMapsRequest()
     {
         $h = new MockHandler([
             function (RequestInterface $request, array $options) {
-                $this->assertEquals('foo', $request->getHeaderLine('Bar'));
+                $this->assertSame('foo', $request->getHeaderLine('Bar'));
                 return new Response(200);
             }
         ]);
@@ -169,7 +169,7 @@ class MiddlewareTest extends TestCase
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);
         $p->wait();
-        $this->assertEquals('foo', $p->wait()->getHeaderLine('Bar'));
+        $this->assertSame('foo', $p->wait()->getHeaderLine('Bar'));
     }
 
     public function testLogsRequestsAndResponses()

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -117,10 +117,10 @@ class PoolTest extends TestCase
         $client = new Client(['handler' => $handler]);
         $results = Pool::batch($client, $requests);
         $this->assertCount(4, $results);
-        $this->assertEquals([0, 1, 2, 3], array_keys($results));
-        $this->assertEquals(200, $results[0]->getStatusCode());
-        $this->assertEquals(201, $results[1]->getStatusCode());
-        $this->assertEquals(202, $results[2]->getStatusCode());
+        $this->assertSame([0, 1, 2, 3], array_keys($results));
+        $this->assertSame(200, $results[0]->getStatusCode());
+        $this->assertSame(201, $results[1]->getStatusCode());
+        $this->assertSame(202, $results[2]->getStatusCode());
         $this->assertInstanceOf(ClientException::class, $results[3]);
     }
 

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -47,7 +47,7 @@ class PrepareBodyMiddlewareTest extends TestCase
         $p = $comp(new Request($method, 'http://www.google.com', [], $body), []);
         $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testAddsTransferEncodingWhenNoContentLength()
@@ -58,7 +58,7 @@ class PrepareBodyMiddlewareTest extends TestCase
         $h = new MockHandler([
             function (RequestInterface $request) {
                 $this->assertFalse($request->hasHeader('Content-Length'));
-                $this->assertEquals('chunked', $request->getHeaderLine('Transfer-Encoding'));
+                $this->assertSame('chunked', $request->getHeaderLine('Transfer-Encoding'));
                 return new Response(200);
             }
         ]);
@@ -69,7 +69,7 @@ class PrepareBodyMiddlewareTest extends TestCase
         $p = $comp(new Request('PUT', 'http://www.google.com', [], $body), []);
         $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testAddsContentTypeWhenMissingAndPossible()
@@ -77,7 +77,7 @@ class PrepareBodyMiddlewareTest extends TestCase
         $bd = Psr7\stream_for(fopen(__DIR__ . '/../composer.json', 'r'));
         $h = new MockHandler([
             function (RequestInterface $request) {
-                $this->assertEquals('application/json', $request->getHeaderLine('Content-Type'));
+                $this->assertSame('application/json', $request->getHeaderLine('Content-Type'));
                 $this->assertTrue($request->hasHeader('Content-Length'));
                 return new Response(200);
             }
@@ -89,7 +89,7 @@ class PrepareBodyMiddlewareTest extends TestCase
         $p = $comp(new Request('PUT', 'http://www.google.com', [], $bd), []);
         $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function expectProvider()
@@ -111,7 +111,7 @@ class PrepareBodyMiddlewareTest extends TestCase
 
         $h = new MockHandler([
             function (RequestInterface $request) use ($result) {
-                $this->assertEquals($result, $request->getHeader('Expect'));
+                $this->assertSame($result, $request->getHeader('Expect'));
                 return new Response(200);
             }
         ]);
@@ -125,7 +125,7 @@ class PrepareBodyMiddlewareTest extends TestCase
         ]);
         $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testIgnoresIfExpectIsPresent()
@@ -133,7 +133,7 @@ class PrepareBodyMiddlewareTest extends TestCase
         $bd = Psr7\stream_for(fopen(__DIR__ . '/../composer.json', 'r'));
         $h = new MockHandler([
             function (RequestInterface $request) {
-                $this->assertEquals(['Foo'], $request->getHeader('Expect'));
+                $this->assertSame(['Foo'], $request->getHeader('Expect'));
                 return new Response(200);
             }
         ]);
@@ -148,6 +148,6 @@ class PrepareBodyMiddlewareTest extends TestCase
         );
         $this->assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 }

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -33,7 +33,7 @@ class PrepareBodyMiddlewareTest extends TestCase
             function (RequestInterface $request) use ($body) {
                 $length = strlen($body);
                 if ($length > 0) {
-                    $this->assertEquals($length, $request->getHeaderLine('Content-Length'));
+                    $this->assertSame($length, $request->getHeaderLine('Content-Length'));
                 } else {
                     $this->assertFalse($request->hasHeader('Content-Length'));
                 }

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -33,7 +33,7 @@ class PrepareBodyMiddlewareTest extends TestCase
             function (RequestInterface $request) use ($body) {
                 $length = strlen($body);
                 if ($length > 0) {
-                    $this->assertSame($length, $request->getHeaderLine('Content-Length'));
+                    $this->assertEquals($length, $request->getHeaderLine('Content-Length'));
                 } else {
                     $this->assertFalse($request->hasHeader('Content-Length'));
                 }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -25,7 +25,7 @@ class RedirectMiddlewareTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $promise = $handler($request, []);
         $response = $promise->wait();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testIgnoresWhenNoLocation()
@@ -37,7 +37,7 @@ class RedirectMiddlewareTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $promise = $handler($request, []);
         $response = $promise->wait();
-        $this->assertEquals(304, $response->getStatusCode());
+        $this->assertSame(304, $response->getStatusCode());
     }
 
     public function testRedirectsWithAbsoluteUri()
@@ -54,8 +54,8 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['max' => 2]
         ]);
         $response = $promise->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('http://test.com', $mock->getLastRequest()->getUri());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('http://test.com', (string)$mock->getLastRequest()->getUri());
     }
 
     public function testRedirectsWithRelativeUri()
@@ -72,8 +72,8 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['max' => 2]
         ]);
         $response = $promise->wait();
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('http://example.com/foo', $mock->getLastRequest()->getUri());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('http://example.com/foo', (string)$mock->getLastRequest()->getUri());
     }
 
     /**
@@ -126,7 +126,7 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['max' => 2, 'referer' => true]
         ]);
         $promise->wait();
-        $this->assertEquals(
+        $this->assertSame(
             'http://example.com?a=b',
             $mock->getLastRequest()->getHeaderLine('Referer')
         );
@@ -149,7 +149,7 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['track_redirects' => true]
         ]);
         $response = $promise->wait(true);
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'http://example.com',
                 'http://example.com/foo',
@@ -177,12 +177,12 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['track_redirects' => true]
         ]);
         $response = $promise->wait(true);
-        $this->assertEquals(
+        $this->assertSame(
             [
-                301,
-                302,
-                301,
-                302,
+                '301',
+                '302',
+                '301',
+                '302',
             ],
             $response->getHeader(RedirectMiddleware::STATUS_HISTORY_HEADER)
         );
@@ -220,9 +220,9 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => [
                 'max' => 2,
                 'on_redirect' => function ($request, $response, $uri) use (&$call) {
-                    $this->assertEquals(302, $response->getStatusCode());
-                    $this->assertEquals('GET', $request->getMethod());
-                    $this->assertEquals('http://test.com', (string) $uri);
+                    $this->assertSame(302, $response->getStatusCode());
+                    $this->assertSame('GET', $request->getMethod());
+                    $this->assertSame('http://test.com', (string) $uri);
                     $call = true;
                 }
             ]

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -33,8 +33,8 @@ class RetryMiddlewareTest extends TestCase
         $p = $c->sendAsync(new Request('GET', 'http://test.com'), []);
         $p->wait();
         $this->assertCount(3, $calls);
-        $this->assertEquals(2, $delayCalls);
-        $this->assertEquals(202, $p->wait()->getStatusCode());
+        $this->assertSame(2, $delayCalls);
+        $this->assertSame(202, $p->wait()->getStatusCode());
     }
 
     public function testDoesNotRetryWhenDeciderReturnsFalse()
@@ -58,22 +58,22 @@ class RetryMiddlewareTest extends TestCase
         $h = new MockHandler([new \Exception(), new Response(201)]);
         $c = new Client(['handler' => $m($h)]);
         $p = $c->sendAsync(new Request('GET', 'http://test.com'), []);
-        $this->assertEquals(201, $p->wait()->getStatusCode());
+        $this->assertSame(201, $p->wait()->getStatusCode());
         $this->assertCount(2, $calls);
-        $this->assertEquals(0, $calls[0][0]);
+        $this->assertSame(0, $calls[0][0]);
         $this->assertNull($calls[0][2]);
         $this->assertInstanceOf('Exception', $calls[0][3]);
-        $this->assertEquals(1, $calls[1][0]);
+        $this->assertSame(1, $calls[1][0]);
         $this->assertInstanceOf(Response::class, $calls[1][2]);
         $this->assertNull($calls[1][3]);
     }
 
     public function testBackoffCalculateDelay()
     {
-        $this->assertEquals(0, RetryMiddleware::exponentialDelay(0));
-        $this->assertEquals(1, RetryMiddleware::exponentialDelay(1));
-        $this->assertEquals(2, RetryMiddleware::exponentialDelay(2));
-        $this->assertEquals(4, RetryMiddleware::exponentialDelay(3));
-        $this->assertEquals(8, RetryMiddleware::exponentialDelay(4));
+        $this->assertSame(0, RetryMiddleware::exponentialDelay(0));
+        $this->assertSame(1, RetryMiddleware::exponentialDelay(1));
+        $this->assertSame(2, RetryMiddleware::exponentialDelay(2));
+        $this->assertSame(4, RetryMiddleware::exponentialDelay(3));
+        $this->assertSame(8, RetryMiddleware::exponentialDelay(4));
     }
 }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -22,7 +22,7 @@ class RetryMiddlewareTest extends TestCase
         };
         $delay = function ($retries, $response) use (&$delayCalls) {
             $delayCalls++;
-            $this->assertEquals($retries, $delayCalls);
+            $this->assertSame($retries, $delayCalls);
             $this->assertInstanceOf(Response::class, $response);
             return 1;
         };
@@ -44,7 +44,7 @@ class RetryMiddlewareTest extends TestCase
         $h = new MockHandler([new Response(200)]);
         $c = new Client(['handler' => $m($h)]);
         $p = $c->sendAsync(new Request('GET', 'http://test.com'), []);
-        $this->assertEquals(200, $p->wait()->getStatusCode());
+        $this->assertSame(200, $p->wait()->getStatusCode());
     }
 
     public function testCanRetryExceptions()

--- a/tests/TransferStatsTest.php
+++ b/tests/TransferStatsTest.php
@@ -21,8 +21,8 @@ class TransferStatsTest extends TestCase
         $this->assertSame($request, $stats->getRequest());
         $this->assertSame($response, $stats->getResponse());
         $this->assertTrue($stats->hasResponse());
-        $this->assertEquals(['foo' => 'bar'], $stats->getHandlerStats());
-        $this->assertEquals('bar', $stats->getHandlerStat('foo'));
+        $this->assertSame(['foo' => 'bar'], $stats->getHandlerStats());
+        $this->assertSame('bar', $stats->getHandlerStat('foo'));
         $this->assertSame($request->getUri(), $stats->getEffectiveUri());
         $this->assertEquals(10.5, $stats->getTransferTime());
         $this->assertNull($stats->getHandlerErrorData());

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -121,7 +121,7 @@ class UriTemplateTest extends TestCase
     public function testExpandsUriTemplates($template, $expansion, $params)
     {
         $uri = new UriTemplate();
-        $this->assertEquals($expansion, $uri->expand($template, $params));
+        $this->assertSame($expansion, $uri->expand($template, $params));
     }
 
     public function expressionProvider()
@@ -131,7 +131,7 @@ class UriTemplateTest extends TestCase
                 '{+var*}', array(
                 'operator' => '+',
                 'values'   => array(
-                    array('value' => 'var', 'modifier' => '*')
+                    array('modifier' => '*', 'value' => 'var')
                 )
             ),
             ),
@@ -171,7 +171,7 @@ class UriTemplateTest extends TestCase
         $method->setAccessible(true);
 
         $exp = substr($exp, 1, -1);
-        $this->assertEquals($data, $method->invokeArgs($template, array($exp)));
+        $this->assertSame($data, $method->invokeArgs($template, array($exp)));
     }
 
     /**

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -197,6 +197,6 @@ class UriTemplateTest extends TestCase
             )
         ));
 
-        $this->assertEquals('http://example.com/foo/bar/one,two?query=test&more%5B0%5D=fun&more%5B1%5D=ice%20cream&baz%5Bbar%5D=fizz&baz%5Btest%5D=buzz&bam=boo', $result);
+        $this->assertSame('http://example.com/foo/bar/one,two?query=test&more%5B0%5D=fun&more%5B1%5D=ice%20cream&baz%5Bbar%5D=fizz&baz%5Btest%5D=buzz&bam=boo', $result);
     }
 }

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -8,7 +8,7 @@ class FunctionsTest extends TestCase
 {
     public function testExpandsTemplate()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'foo/123',
             GuzzleHttp\uri_template('foo/{bar}', ['bar' => '123'])
         );
@@ -41,13 +41,13 @@ class FunctionsTest extends TestCase
      */
     public function testDescribesType($input, $output)
     {
-        $this->assertEquals($output, GuzzleHttp\describe_type($input));
+        $this->assertSame($output, GuzzleHttp\describe_type($input));
     }
 
     public function testParsesHeadersFromLines()
     {
         $lines = ['Foo: bar', 'Foo: baz', 'Abc: 123', 'Def: a, b'];
-        $this->assertEquals([
+        $this->assertSame([
             'Foo' => ['bar', 'baz'],
             'Abc' => ['123'],
             'Def' => ['a, b'],
@@ -57,7 +57,7 @@ class FunctionsTest extends TestCase
     public function testParsesHeadersFromLinesWithMultipleLines()
     {
         $lines = ['Foo: bar', 'Foo: baz', 'Foo: 123'];
-        $this->assertEquals([
+        $this->assertSame([
             'Foo' => ['bar', 'baz', '123'],
         ], GuzzleHttp\headers_from_lines($lines));
     }
@@ -105,7 +105,7 @@ class FunctionsTest extends TestCase
 
     public function testEncodesJson()
     {
-        $this->assertEquals('true', \GuzzleHttp\json_encode(true));
+        $this->assertSame('true', \GuzzleHttp\json_encode(true));
     }
 
     /**


### PR DESCRIPTION
Although in most of these changes using `assertSame` instead of `assertEquals` does not make much of a difference I believe that well known libraries like guzzle should promote using `assertSame`.  It feels like I am walking through a code that has `==` vs `===`.