### PR TITLE
Fix: Add test case for Url::combine()

### DIFF
--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -175,6 +175,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             ['http://api.flickr.com/services/',   'http://www.flickr.com/services/oauth/access_token', 'http://www.flickr.com/services/oauth/access_token'],
             ['https://www.example.com/path',      '//foo.com/abc', 'https://foo.com/abc'],
             ['https://www.example.com/0/',        'relative/foo', 'https://www.example.com/0/relative/foo'],
+            ['https://www.example.com/0',         'relative/foo', 'https://www.example.com/relative/foo'],
             ['',                                  '0', '0'],
             // RFC 3986 test cases
             [self::RFC3986_BASE, 'g:h',           'g:h'],


### PR DESCRIPTION
This PR

* [x] adds a test case for `Url::combine()` to document the current behaviour

💁‍♂️ Might be interesting for people who have run into issues when configuring a client with a `base_url` that has a path component, but does not end with a trailing `/`, and then issuing requests using a relative path.