### PR TITLE
Prevent Exception

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -63,7 +63,7 @@ class CurlFactory implements CurlFactoryInterface
         $resource = $easy->handle;
         unset($easy->handle);
 
-        if (@count($this->handles) >= $this->maxHandles) {
+        if (count($this->handles) >= $this->maxHandles) {
             curl_close($resource);
         } else {
             // Remove all callback functions as they can hold onto references

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -63,7 +63,7 @@ class CurlFactory implements CurlFactoryInterface
         $resource = $easy->handle;
         unset($easy->handle);
 
-        if (count($this->handles) >= $this->maxHandles) {
+        if (@count($this->handles) >= $this->maxHandles) {
             curl_close($resource);
         } else {
             // Remove all callback functions as they can hold onto references

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -743,4 +743,13 @@ class CurlFactoryTest extends TestCase
 
         $this->assertSame(1024 * 1024, $body->tell());
     }
+
+    public function testRelease()
+    {
+        $factory = new CurlFactory(1);
+        $easyHandle = new EasyHandle();
+        $easyHandle->handle = curl_init();
+
+        $this->assertEmpty($factory->release($easyHandle));
+    }
 }


### PR DESCRIPTION
For PHP 7.x this may cause a "count(): Parameter must be an array or an object that implements Countable" Exception. See https://www.drupal.org/project/drupal/issues/2885610