### PR TITLE
RequestException should accept throwable as prev

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -24,7 +24,7 @@ class RequestException extends TransferException
         $message,
         RequestInterface $request,
         ResponseInterface $response = null,
-        \Exception $previous = null,
+        \Throwable $previous = null,
         array $handlerContext = []
     ) {
         // Set the code of the exception if the response is set and not future.


### PR DESCRIPTION
Not sure if there should be also a wrapThrowable function or it is an overkill