### PR TITLE
Require ext-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": ">=5.5",
+        "ext-json": "*",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
     "suggest": {
         "psr/log": "Required for using the Log middleware"
     },
+    "config": {
+        "sort-packages": true
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "6.3-dev"


### PR DESCRIPTION
You have some `json_decode` functions at various places... 

PHPstorm suggests to require `ext-json`

I have also added to composer config to sort packages.