### PR TITLE
Replace microtime() usages with hrtime()

### DIFF
--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -88,7 +88,7 @@ class CurlMultiHandler
     {
         // Add any delayed handles if needed.
         if ($this->delays) {
-            $currentTime = \GuzzleHttp\current_time();
+            $currentTime = \GuzzleHttp\_current_time();
             foreach ($this->delays as $id => $delay) {
                 if ($currentTime >= $delay) {
                     unset($this->delays[$id]);
@@ -140,7 +140,7 @@ class CurlMultiHandler
         if (empty($easy->options['delay'])) {
             curl_multi_add_handle($this->_mh, $easy->handle);
         } else {
-            $this->delays[$id] = \GuzzleHttp\current_time() + ($easy->options['delay'] / 1000);
+            $this->delays[$id] = \GuzzleHttp\_current_time() + ($easy->options['delay'] / 1000);
         }
     }
 
@@ -192,7 +192,7 @@ class CurlMultiHandler
 
     private function timeToNext()
     {
-        $currentTime = \GuzzleHttp\current_time();
+        $currentTime = \GuzzleHttp\_current_time();
         $nextTime = PHP_INT_MAX;
         foreach ($this->delays as $time) {
             if ($time < $nextTime) {

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -88,7 +88,7 @@ class CurlMultiHandler
     {
         // Add any delayed handles if needed.
         if ($this->delays) {
-            $currentTime = function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
+            $currentTime = \GuzzleHttp\current_time();
             foreach ($this->delays as $id => $delay) {
                 if ($currentTime >= $delay) {
                     unset($this->delays[$id]);
@@ -140,7 +140,7 @@ class CurlMultiHandler
         if (empty($easy->options['delay'])) {
             curl_multi_add_handle($this->_mh, $easy->handle);
         } else {
-            $this->delays[$id] = (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) + ($easy->options['delay'] / 1000);
+            $this->delays[$id] = \GuzzleHttp\current_time() + ($easy->options['delay'] / 1000);
         }
     }
 
@@ -192,7 +192,7 @@ class CurlMultiHandler
 
     private function timeToNext()
     {
-        $currentTime = function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
+        $currentTime = \GuzzleHttp\current_time();
         $nextTime = PHP_INT_MAX;
         foreach ($this->delays as $time) {
             if ($time < $nextTime) {

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -88,7 +88,7 @@ class CurlMultiHandler
     {
         // Add any delayed handles if needed.
         if ($this->delays) {
-            $currentTime = microtime(true);
+            $currentTime = function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
             foreach ($this->delays as $id => $delay) {
                 if ($currentTime >= $delay) {
                     unset($this->delays[$id]);
@@ -140,7 +140,7 @@ class CurlMultiHandler
         if (empty($easy->options['delay'])) {
             curl_multi_add_handle($this->_mh, $easy->handle);
         } else {
-            $this->delays[$id] = microtime(true) + ($easy->options['delay'] / 1000);
+            $this->delays[$id] = (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) + ($easy->options['delay'] / 1000);
         }
     }
 
@@ -192,7 +192,7 @@ class CurlMultiHandler
 
     private function timeToNext()
     {
-        $currentTime = microtime(true);
+        $currentTime = function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
         $nextTime = PHP_INT_MAX;
         foreach ($this->delays as $time) {
             if ($time < $nextTime) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -33,7 +33,7 @@ class StreamHandler
             usleep($options['delay'] * 1000);
         }
 
-        $startTime = isset($options['on_stats']) ? (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) : null;
+        $startTime = isset($options['on_stats']) ? \GuzzleHttp\current_time() : null;
 
         try {
             // Does not support the expect header.
@@ -82,7 +82,7 @@ class StreamHandler
             $stats = new TransferStats(
                 $request,
                 $response,
-                (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) - $startTime,
+                \GuzzleHttp\current_time() - $startTime,
                 $error,
                 []
             );

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -33,7 +33,7 @@ class StreamHandler
             usleep($options['delay'] * 1000);
         }
 
-        $startTime = isset($options['on_stats']) ? \GuzzleHttp\current_time() : null;
+        $startTime = isset($options['on_stats']) ? \GuzzleHttp\_current_time() : null;
 
         try {
             // Does not support the expect header.
@@ -82,7 +82,7 @@ class StreamHandler
             $stats = new TransferStats(
                 $request,
                 $response,
-                \GuzzleHttp\current_time() - $startTime,
+                \GuzzleHttp\_current_time() - $startTime,
                 $error,
                 []
             );

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -33,7 +33,7 @@ class StreamHandler
             usleep($options['delay'] * 1000);
         }
 
-        $startTime = isset($options['on_stats']) ? microtime(true) : null;
+        $startTime = isset($options['on_stats']) ? (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) : null;
 
         try {
             // Does not support the expect header.
@@ -82,7 +82,7 @@ class StreamHandler
             $stats = new TransferStats(
                 $request,
                 $response,
-                microtime(true) - $startTime,
+                (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) - $startTime,
                 $error,
                 []
             );

--- a/src/functions.php
+++ b/src/functions.php
@@ -340,5 +340,5 @@ function json_encode($value, $options = 0, $depth = 512)
  */
 function current_time()
 {
-    return function_exists('hrtime') ? hrtime(true) / 1e7 : microtime(true);
+    return function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -337,6 +337,7 @@ function json_encode($value, $options = 0, $depth = 512)
  * (depending on the PHP version, one of the two is used)
  *
  * @return float|mixed UNIX timestamp
+ * @internal
  */
 function current_time()
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -331,3 +331,14 @@ function json_encode($value, $options = 0, $depth = 512)
 
     return $json;
 }
+
+/**
+ * Wrapper for the hrtime() or microtime() functions
+ * (depending on the PHP version, one of the two is used)
+ *
+ * @return float|mixed UNIX timestamp
+ */
+function current_time()
+{
+    return function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -340,5 +340,5 @@ function json_encode($value, $options = 0, $depth = 512)
  */
 function current_time()
 {
-    return function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
+    return function_exists('hrtime') ? hrtime(true) / 1e7 : microtime(true);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -339,7 +339,7 @@ function json_encode($value, $options = 0, $depth = 512)
  * @return float|mixed UNIX timestamp
  * @internal
  */
-function current_time()
+function _current_time()
 {
     return function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
 }

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -47,9 +47,9 @@ class CurlHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new CurlHandler();
         $request = new Request('GET', Server::$url);
-        $s = microtime(true);
+        $s = function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
         $a($request, ['delay' => 0.1])->wait();
-        $this->assertGreaterThan(0.0001, microtime(true) - $s);
+        $this->assertGreaterThan(0.0001, (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) - $s);
     }
 
     public function testCreatesCurlErrorsWithContext()

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -47,9 +47,9 @@ class CurlHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new CurlHandler();
         $request = new Request('GET', Server::$url);
-        $s = function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
+        $s = \GuzzleHttp\current_time();
         $a($request, ['delay' => 0.1])->wait();
-        $this->assertGreaterThan(0.0001, (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) - $s);
+        $this->assertGreaterThan(0.0001, \GuzzleHttp\current_time() - $s);
     }
 
     public function testCreatesCurlErrorsWithContext()

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -47,9 +47,9 @@ class CurlHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new CurlHandler();
         $request = new Request('GET', Server::$url);
-        $s = \GuzzleHttp\current_time();
+        $s = \GuzzleHttp\_current_time();
         $a($request, ['delay' => 0.1])->wait();
-        $this->assertGreaterThan(0.0001, \GuzzleHttp\current_time() - $s);
+        $this->assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
     }
 
     public function testCreatesCurlErrorsWithContext()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -68,10 +68,10 @@ class CurlMultiHandlerTest extends TestCase
         Server::flush();
         Server::enqueue([new Response()]);
         $a = new CurlMultiHandler();
-        $expected = (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) + (100 / 1000);
+        $expected = \GuzzleHttp\current_time() + (100 / 1000);
         $response = $a(new Request('GET', Server::$url), ['delay' => 100]);
         $response->wait();
-        $this->assertGreaterThanOrEqual($expected, function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true));
+        $this->assertGreaterThanOrEqual($expected, \GuzzleHttp\current_time());
     }
 
     public function testUsesTimeoutEnvironmentVariables()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -68,10 +68,10 @@ class CurlMultiHandlerTest extends TestCase
         Server::flush();
         Server::enqueue([new Response()]);
         $a = new CurlMultiHandler();
-        $expected = microtime(true) + (100 / 1000);
+        $expected = (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) + (100 / 1000);
         $response = $a(new Request('GET', Server::$url), ['delay' => 100]);
         $response->wait();
-        $this->assertGreaterThanOrEqual($expected, microtime(true));
+        $this->assertGreaterThanOrEqual($expected, function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true));
     }
 
     public function testUsesTimeoutEnvironmentVariables()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -68,10 +68,10 @@ class CurlMultiHandlerTest extends TestCase
         Server::flush();
         Server::enqueue([new Response()]);
         $a = new CurlMultiHandler();
-        $expected = \GuzzleHttp\current_time() + (100 / 1000);
+        $expected = \GuzzleHttp\_current_time() + (100 / 1000);
         $response = $a(new Request('GET', Server::$url), ['delay' => 100]);
         $response->wait();
-        $this->assertGreaterThanOrEqual($expected, \GuzzleHttp\current_time());
+        $this->assertGreaterThanOrEqual($expected, \GuzzleHttp\_current_time());
     }
 
     public function testUsesTimeoutEnvironmentVariables()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -506,9 +506,9 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new StreamHandler();
         $request = new Request('GET', Server::$url);
-        $s = microtime(true);
+        $s = function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
         $a($request, ['delay' => 0.1])->wait();
-        $this->assertGreaterThan(0.0001, microtime(true) - $s);
+        $this->assertGreaterThan(0.0001, (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) - $s);
     }
 
     /**

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -506,9 +506,9 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new StreamHandler();
         $request = new Request('GET', Server::$url);
-        $s = function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
+        $s = \GuzzleHttp\current_time();
         $a($request, ['delay' => 0.1])->wait();
-        $this->assertGreaterThan(0.0001, (function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true)) - $s);
+        $this->assertGreaterThan(0.0001, \GuzzleHttp\current_time() - $s);
     }
 
     /**

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -506,9 +506,9 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new StreamHandler();
         $request = new Request('GET', Server::$url);
-        $s = \GuzzleHttp\current_time();
+        $s = \GuzzleHttp\_current_time();
         $a($request, ['delay' => 0.1])->wait();
-        $this->assertGreaterThan(0.0001, \GuzzleHttp\current_time() - $s);
+        $this->assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
     }
 
     /**

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -128,6 +128,11 @@ class FunctionsTest extends TestCase
     {
         \GuzzleHttp\json_decode('{{]]');
     }
+
+    public function testCurrentTime()
+    {
+        $this->assertGreaterThan(0, GuzzleHttp\current_time());
+    }
 }
 
 final class StrClass

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -131,7 +131,7 @@ class FunctionsTest extends TestCase
 
     public function testCurrentTime()
     {
-        $this->assertGreaterThan(0, GuzzleHttp\current_time());
+        $this->assertGreaterThan(0, GuzzleHttp\_current_time());
     }
 }
 


### PR DESCRIPTION
Fixes #2214

There are 5 test failures, but they are not caused by this PR. They are failing on master as well.