### PR TITLE
Update Client.php to handle null headers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -225,7 +225,7 @@ class Client implements ClientInterface
         if (array_key_exists('headers', $options)) {
             // Allows default headers to be unset.
             if ($options['headers'] === null) {
-                $defaults['_conditional'] = null;
+                $defaults['_conditional'] = [];
                 unset($options['headers']);
             } elseif (!is_array($options['headers'])) {
                 throw new \InvalidArgumentException('headers must be an array');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -360,6 +360,20 @@ class ClientTest extends TestCase
         $this->assertSame('foo', $last->getHeaderLine('Content-Type'));
     }
 
+    public function testCanAddJsonDataWithNullHeader()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $request = new Request('PUT', 'http://foo.com');
+        $client->send($request, [
+            'headers' => null,
+            'json'    => 'a'
+        ]);
+        $last = $mock->getLastRequest();
+        $this->assertSame('"a"', (string) $mock->getLastRequest()->getBody());
+        $this->assertSame('application/json', $last->getHeaderLine('Content-Type'));
+    }
+
     public function testAuthCanBeTrue()
     {
         $mock = new MockHandler([new Response()]);


### PR DESCRIPTION
Any request with options `['json' => $data, 'headers' => null]` gives an exception on line 326 of Client.php:

```
Undefined index: _conditional in the Psr7\_caseless_remove() call on line 326 
```

This seems like a bug to me, because the code itself says "Allows default headers to be unset", with a specific `if ($options['headers'] === null)` check:

https://github.com/guzzle/guzzle/blob/master/src/Client.php#L226-L229

When that if statement is true, it will currently always throw an exception in one of the `applyOptions` branches, because `$defaults['_conditional']` must be an array.

When the headers key exists but is null, it seems better to set `$defaults['_conditional']` to an empty array instead, this way `headers => null` is handled gracefully.