### PR TITLE
Allow developer to configure size of response body on exception

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -179,16 +179,6 @@ class RequestException extends TransferException
     }
 
     /**
-     * Restore the amount of bytes to use when summarizing the response exception to it's default value.
-     *
-     * @return void
-     */
-    public static function restoreDefaultResponseSize()
-    {
-        self::$responseSize = 120;
-    }
-
-    /**
      * Obfuscates URI if there is an username and a password present
      *
      * @param UriInterface $uri

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -118,7 +118,7 @@ class RequestExceptionTest extends TestCase
         $response = new Response(500, [], $content);
         $e = RequestException::create(new Request('GET', '/'), $response);
         $this->assertContains($content, $e->getMessage());
-        RequestException::restoreDefaultResponseSize();
+        RequestException::setResponseSize(120);
     }
 
     public function testExceptionMessageIgnoresEmptyBody()

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -111,6 +111,16 @@ class RequestExceptionTest extends TestCase
         $this->assertContains($expected, $e->getMessage());
     }
 
+    public function testCreatesExceptionWithoutTruncatingResponseBody()
+    {
+        RequestException::setResponseSize(null);
+        $content = '{"message":"The given data was invalid.","errors":{"email":["The email field is required."],"password":["The password field is required."],"first_name":["The first name field is required."],"last_name":["The last name field is required."],"address":["The address field is required."],"zipcode":["The zipcode field is required."]}}';
+        $response = new Response(500, [], $content);
+        $e = RequestException::create(new Request('GET', '/'), $response);
+        $this->assertContains($content, $e->getMessage());
+        RequestException::restoreDefaultResponseSize();
+    }
+
     public function testExceptionMessageIgnoresEmptyBody()
     {
         $e = RequestException::create(new Request('GET', '/'), new Response(500));


### PR DESCRIPTION
Following up on https://twitter.com/mtdowling/status/1102266416005144577 I'm proposing a solution to https://github.com/guzzle/guzzle/issues/2185. 
Currently, Guzzle will truncate the response body in case of exception to protect the developer from spamming their own logging system. However, 120 characters is incredibly small and doesn't cover enough characters to assess what caused the operation to fail.
Furthermore, it is a pretty valid use-case where the developer is in control of both the client and the server. Knowing the full extend of the server application gives the developer privileged knowledge on what is the best amount of characters to log. For my use-case, personally, I don't need a limit as I know all my endpoints will return a valid JSON response that can easily fit in my logging system.

This pull request allows Guzzle to provide an opt-in alternative that complies with the Exception `getMessage()` method. A logging system usually have a code that resembles the following snippet:

```
public function report(Throwable | Exception $e): void {
    $this->logger->error($e->getMessage());
}
```

With the current state of Guzzle, that code has to cater for a special case just for Guzzle:

```
public function report(Throwable | Exception $e): void {
    if ($e instanceof GuzzleHttp\Exception\RequestException) {
        $this->logger->error(json_encode($e->getResponse->getBody()->getContents()));
    }

    $this->logger->error($e->getMessage());
}
```

If this proposal gets merged, we can go back to relying on polymorphism on the Exception Handler if we're willing to configure Guzzle with `RequestException::$responseSize = null` and the 1st snippet would be enough.