### PR TITLE
Make GuzzleException extend Throwable whereever it's available

### DIFF
--- a/src/Exception/GuzzleException.php
+++ b/src/Exception/GuzzleException.php
@@ -1,13 +1,20 @@
 <?php
 namespace GuzzleHttp\Exception;
 
-/**
- * @method string getMessage()
- * @method \Throwable|null getPrevious()
- * @method mixed getCode()
- * @method string getFile()
- * @method int getLine()
- * @method array getTrace()
- * @method string getTraceAsString()
- */
-interface GuzzleException {}
+use Throwable;
+
+if (interface_exists(Throwable::class)) {
+    interface GuzzleException extends Throwable {}
+} else {
+    /**
+     * @method string getMessage()
+     * @method \Throwable|null getPrevious()
+     * @method mixed getCode()
+     * @method string getFile()
+     * @method int getLine()
+     * @method array getTrace()
+     * @method string getTraceAsString()
+     */
+    interface GuzzleException {}
+}
+


### PR DESCRIPTION
Our static analyzer is giving us some issues when catching Guzzles exceptions, because they don't extend throwable and thus aren't technically catchable.

I get that we don't want to extend it by default because it would break BC with PHP5.x, but I think the proposed solution would give us the best of both worlds.