### PR TITLE
 Fix invalid `on_headers` option handling in MockHandler

### DIFF
--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -97,7 +97,7 @@ class MockHandler implements \Countable
         $this->lastOptions = $options;
         $response = \array_shift($this->queue);
 
-        if (isset($options['on_headers'])) {
+        if (isset($options['on_headers']) && $response instanceof ResponseInterface) {
             if (!\is_callable($options['on_headers'])) {
                 throw new \InvalidArgumentException('on_headers must be callable');
             }


### PR DESCRIPTION
Before this fix when use `on_headers` (as in [example](http://docs.guzzlephp.org/en/stable/request-options.html#on-headers)) with any exception in mock queue you will receive TypeError.

Test case without fix:
```bash
There was 1 error:

1) GuzzleHttp\Test\Handler\MockHandlerTest::testEnsuresResponseTypeBeforeOnHeaders
TypeError: Argument 3 passed to GuzzleHttp\Exception\RequestException::__construct() must implement interface Psr\Http\Message\ResponseInterface or be null, instance of Exception given, called in /Projects/guzzle/src/Handler/MockHandler.php on line 85

/Projects/guzzle/src/Exception/RequestException.php:23
/Projects/guzzle/src/Handler/MockHandler.php:85
/Projects/guzzle/tests/Handler/MockHandlerTest.php:164
```