### PR TITLE
The $downloadTotal parameter can be zero in progress callback

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -737,7 +737,7 @@ progress
 
 The function accepts the following positional arguments:
 
-- the total number of bytes expected to be downloaded
+- the total number of bytes expected to be downloaded, zero if unknown
 - the number of bytes downloaded so far
 - the total number of bytes expected to be uploaded
 - the number of bytes uploaded so far


### PR DESCRIPTION
It would be worth mentioning that this may be zero when the `Content-Length` header is not available.