### PR TITLE
Collect appconnect_time in CurlFactory TransferStats

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -120,6 +120,7 @@ class CurlFactory implements CurlFactoryInterface
     private static function invokeStats(EasyHandle $easy)
     {
         $curlStats = curl_getinfo($easy->handle);
+        $curlStats['appconnect_time'] = curl_getinfo($easy->handle, CURLINFO_APPCONNECT_TIME);
         $stats = new TransferStats(
             $easy->request,
             $easy->response,
@@ -139,6 +140,7 @@ class CurlFactory implements CurlFactoryInterface
         $ctx = [
             'errno' => $easy->errno,
             'error' => curl_error($easy->handle),
+            'appconnect_time' => curl_getinfo($easy->handle, CURLINFO_APPCONNECT_TIME),
         ] + curl_getinfo($easy->handle);
         $ctx[self::CURL_VERSION_STR] = curl_version()['version'];
         $factory->release($easy);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -685,6 +685,7 @@ class CurlFactoryTest extends TestCase
             (string) $gotStats->getRequest()->getUri()
         );
         $this->assertGreaterThan(0, $gotStats->getTransferTime());
+        $this->assertArrayHasKey('appconnect_time', $gotStats->getHandlerStats());
     }
 
     public function testInvokesOnStatsOnError()
@@ -711,6 +712,7 @@ class CurlFactoryTest extends TestCase
         );
         $this->assertInternalType('float', $gotStats->getTransferTime());
         $this->assertInternalType('int', $gotStats->getHandlerErrorData());
+        $this->assertArrayHasKey('appconnect_time', $gotStats->getHandlerStats());
     }
 
     public function testRewindsBodyIfPossible()


### PR DESCRIPTION
### Context

For some historical reason the original implementation of `curl_getinfo($ch)` did not include the `appconect_time` metric and wasn't available until PHP 5.5.0, where it can be retrieved separatedly by passing the `CURLINFO_APPCONNECT_TIME` constant as the second parameter of `curl_getinfo($ch, $opt)`. `appconnect_time` is the time it takes cURL to negotiate the TLS handshake with the server after it establishes a TCP connection.

This PR records `appconnect_time` into the TransferStats::$handlerStats array, so it can be read and used in `on_stats` callables.

### References

https://www.php.net/manual/en/function.curl-getinfo.php#refsect1-function.curl-getinfo-changelog
https://curl.haxx.se/libcurl/c/CURLINFO_APPCONNECT_TIME.html
http://docs.guzzlephp.org/en/stable/request-options.html#on-stats