### PR TITLE
Internationalized domain name (IDN) support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,13 @@
     },
     "require-dev": {
         "ext-curl": "*",
+        "ext-intl": "*",
         "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
         "psr/log": "^1.1"
     },
     "suggest": {
-        "psr/log": "Required for using the Log middleware"
+        "psr/log": "Required for using the Log middleware",
+        "ext-intl": "Required for Internationalized Domain Name (IDN) support"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "ext-intl": "*",
         "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
         "psr/log": "^1.1"
     },

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -556,8 +556,8 @@ http_errors
 idn_conversion
 ---
 
-:Summary: Set to ``false`` to disable Internationalized Domain Name (IDN) to
-    ASCII conversion.
+:Summary: Internationalized Domain Name (IDN) support (enabled by default if
+    ``intl`` extension is available).
 :Types:
     - bool
     - int
@@ -567,15 +567,15 @@ idn_conversion
 .. code-block:: php
 
     $client->request('GET', 'https://яндекс.рф');
-    // яндекс.рф is translated to  internally
+    // яндекс.рф is translated to xn--d1acpjx3f.xn--p1ai before passing it to the handler
 
     $res = $client->request('GET', 'https://яндекс.рф', ['idn_conversion' => false]);
     // The domain part (яндекс.рф) stays unmodified
 
-Also a combination of IDNA_* constants (except IDNA_ERROR_*) also can be used
-for precise control of the IDN support (see ``$options`` parameter in
+Enables/disables IDN support, can also be used for precise control by combining
+IDNA_* constants (except IDNA_ERROR_*), see ``$options`` parameter in
 `idn_to_ascii() <https://www.php.net/manual/en/function.idn-to-ascii.php>`_
-documentation for more details).
+documentation for more details.
 
 
 json

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -553,6 +553,31 @@ http_errors
     default when creating a handler with ``GuzzleHttp\default_handler``.
 
 
+idn_conversion
+---
+
+:Summary: Set to ``false`` to disable Internationalized Domain Name (IDN) to
+    ASCII conversion.
+:Types:
+    - bool
+    - int
+:Default: ``true`` if ``intl`` extension is available, ``false`` otherwise
+:Constant: ``GuzzleHttp\RequestOptions::IDN_CONVERSION``
+
+.. code-block:: php
+
+    $client->request('GET', 'https://яндекс.рф');
+    // яндекс.рф is translated to  internally
+
+    $res = $client->request('GET', 'https://яндекс.рф', ['idn_conversion' => false]);
+    // The domain part (яндекс.рф) stays unmodified
+
+Also a combination of IDNA_* constants (except IDNA_ERROR_*) also can be used
+for precise control of the IDN support (see ``$options`` parameter in
+`idn_to_ascii() <https://www.php.net/manual/en/function.idn-to-ascii.php>`_
+documentation for more details).
+
+
 json
 ----
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -111,11 +111,6 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: "#^PHPDoc tag @throws with type GuzzleHttp\\\\InvalidArgumentException is not subtype of Throwable$#"
-			count: 1
-			path: src/Client.php
-
-		-
 			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:send\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/ClientInterface.php
@@ -612,11 +607,6 @@ parameters:
 
 		-
 			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:\\$_mh \\(resource\\) does not accept resource\\|false\\.$#"
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_setopt expects resource, resource\\|false given\\.$#"
 			count: 1
 			path: src/Handler/CurlMultiHandler.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -611,6 +611,11 @@ parameters:
 			path: src/Handler/CurlMultiHandler.php
 
 		-
+			message: "#^Parameter \\#1 \\$mh of function curl_multi_setopt expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
 			message: "#^Method GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:__invoke\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Handler/CurlMultiHandler.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,4 @@ parameters:
     level: max
     paths:
       - src
+    bootstrap: tests/bootstrap-phpstan.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
@@ -214,6 +215,38 @@ class Client implements ClientInterface
             $uri = Psr7\UriResolver::resolve(Psr7\uri_for($config['base_uri']), $uri);
         }
 
+        if ($uri->getHost() && isset($config['idn_conversion']) && ($config['idn_conversion'] !== false)) {
+            $idnOptions = ($config['idn_conversion'] === true) ? IDNA_DEFAULT : $config['idn_conversion'];
+
+            $asciiHost = idn_to_ascii($uri->getHost(), $idnOptions, INTL_IDNA_VARIANT_UTS46, $info);
+            if ($asciiHost === false) {
+                $errorBitSet = isset($info['errors']) ? $info['errors'] : 0;
+
+                $errorConstants = array_filter(array_keys(get_defined_constants()), function ($name) {
+                    return substr($name, 0, 11) === 'IDNA_ERROR_';
+                });
+
+                $errors = [];
+                foreach ($errorConstants as $errorConstant) {
+                    if ($errorBitSet & constant($errorConstant)) {
+                        $errors[] = $errorConstant;
+                    }
+                }
+
+                $errorMessage = 'IDN conversion failed';
+                if ($errors) {
+                    $errorMessage .= ' (errors: ' . implode(', ', $errors) . ')';
+                }
+
+                throw new InvalidArgumentException($errorMessage);
+            } else {
+                if ($uri->getHost() !== $asciiHost) {
+                    // Replace URI only if the ASCII version is different
+                    $uri = $uri->withHost($asciiHost);
+                }
+            }
+        }
+
         return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;
     }
 
@@ -232,6 +265,9 @@ class Client implements ClientInterface
             'verify'          => true,
             'cookies'         => false
         ];
+
+        // idn_to_ascii() is a part of ext-intl and might be not available
+        $defaults['idn_conversion'] = function_exists('idn_to_ascii');
 
         // Use the standard Linux HTTP_PROXY and HTTPS_PROXY if set.
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -274,7 +274,7 @@ class Client implements ClientInterface
         // We can only trust the HTTP_PROXY environment variable in a CLI
         // process due to the fact that PHP has no reliable mechanism to
         // get environment variables that start with "HTTP_".
-        if (php_sapi_name() == 'cli' && getenv('HTTP_PROXY')) {
+        if (php_sapi_name() === 'cli' && getenv('HTTP_PROXY')) {
             $defaults['proxy']['http'] = getenv('HTTP_PROXY');
         }
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -133,10 +133,10 @@ final class RequestOptions
     const HTTP_ERRORS = 'http_errors';
 
     /**
-     * idn: (bool|int, default=true) Set to false to disable exceptions
-     * when a non- successful HTTP response is received. By default,
-     * exceptions will be thrown for 4xx and 5xx responses. This option only
-     * works if your handler has the `httpErrors` middleware.
+     * idn: (bool|int, default=true) A combination of IDNA_* constants for
+     * idn_to_ascii() PHP's function (see "options" parameter). Set to false to
+     * disable IDN support completely, or to true to use the default
+     * configuration (IDNA_DEFAULT constant).
      */
     const IDN_CONVERSION = 'idn_conversion';
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -133,6 +133,14 @@ final class RequestOptions
     const HTTP_ERRORS = 'http_errors';
 
     /**
+     * idn: (bool|int, default=true) Set to false to disable exceptions
+     * when a non- successful HTTP response is received. By default,
+     * exceptions will be thrown for 4xx and 5xx responses. This option only
+     * works if your handler has the `httpErrors` middleware.
+     */
+    const IDN_CONVERSION = 'idn_conversion';
+
+    /**
      * json: (mixed) Adds JSON data to a request. The provided value is JSON
      * encoded and a Content-Type header of application/json will be added to
      * the request if no Content-Type header is already present.

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -720,14 +720,17 @@ class ClientTest extends TestCase
         $config = $client->getConfig();
 
         if (extension_loaded('intl')) {
-            $this->assertTrue($config['idn_conversion']);
+            self::assertTrue($config['idn_conversion']);
         } else {
-            $this->assertFalse($config['idn_conversion']);
+            self::assertFalse($config['idn_conversion']);
         }
     }
 
     public function testIdnIsTranslatedToAsciiWhenConversionIsEnabled()
     {
+        if (!extension_loaded('intl')) {
+            self::markTestSkipped('intl PHP extension is not loaded');
+        }
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
@@ -735,8 +738,8 @@ class ClientTest extends TestCase
 
         $request = $mockHandler->getLastRequest();
 
-        $this->assertSame('https://xn--d1acpjx3f.xn--p1ai/images', (string) $request->getUri());
-        $this->assertSame('xn--d1acpjx3f.xn--p1ai', (string) $request->getHeaderLine('Host'));
+        self::assertSame('https://xn--d1acpjx3f.xn--p1ai/images', (string) $request->getUri());
+        self::assertSame('xn--d1acpjx3f.xn--p1ai', (string) $request->getHeaderLine('Host'));
     }
 
     public function testIdnStaysTheSameWhenConversionIsDisabled()
@@ -748,8 +751,8 @@ class ClientTest extends TestCase
 
         $request = $mockHandler->getLastRequest();
 
-        $this->assertSame('https://яндекс.рф/images', (string) $request->getUri());
-        $this->assertSame('яндекс.рф', (string) $request->getHeaderLine('Host'));
+        self::assertSame('https://яндекс.рф/images', (string) $request->getUri());
+        self::assertSame('яндекс.рф', (string) $request->getHeaderLine('Host'));
     }
 
     /**
@@ -758,6 +761,9 @@ class ClientTest extends TestCase
      */
     public function testExceptionOnInvalidIdn()
     {
+        if (!extension_loaded('intl')) {
+            self::markTestSkipped('intl PHP extension is not loaded');
+        }
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
@@ -771,7 +777,7 @@ class ClientTest extends TestCase
     public function testIdnBaseUri()
     {
         if (!extension_loaded('intl')) {
-            $this->markTestSkipped('intl PHP extension is not loaded');
+            self::markTestSkipped('intl PHP extension is not loaded');
         }
 
         $mock = new MockHandler([new Response()]);
@@ -779,10 +785,10 @@ class ClientTest extends TestCase
             'handler'  => $mock,
             'base_uri' => 'http://яндекс.рф',
         ]);
-        $this->assertSame('http://яндекс.рф', (string) $client->getConfig('base_uri'));
+        self::assertSame('http://яндекс.рф', (string) $client->getConfig('base_uri'));
         $request = new Request('GET', '/baz');
         $client->send($request);
-        $this->assertSame('http://xn--d1acpjx3f.xn--p1ai/baz', (string) $mock->getLastRequest()->getUri());
-        $this->assertSame('xn--d1acpjx3f.xn--p1ai', (string) $mock->getLastRequest()->getHeaderLine('Host'));
+        self::assertSame('http://xn--d1acpjx3f.xn--p1ai/baz', (string) $mock->getLastRequest()->getUri());
+        self::assertSame('xn--d1acpjx3f.xn--p1ai', (string) $mock->getLastRequest()->getHeaderLine('Host'));
     }
 }

--- a/tests/bootstrap-phpstan.php
+++ b/tests/bootstrap-phpstan.php
@@ -1,0 +1,10 @@
+<?php
+
+if (!defined('IDNA_DEFAULT')) {
+    define('IDNA_DEFAULT', 0);
+}
+
+if (!defined('INTL_IDNA_VARIANT_UTS46')) {
+    define('INTL_IDNA_VARIANT_UTS46', 1);
+}
+

--- a/tests/bootstrap-phpstan.php
+++ b/tests/bootstrap-phpstan.php
@@ -7,4 +7,3 @@ if (!defined('IDNA_DEFAULT')) {
 if (!defined('INTL_IDNA_VARIANT_UTS46')) {
     define('INTL_IDNA_VARIANT_UTS46', 1);
 }
-

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace {
+    setlocale(LC_ALL, 'C');
+}
+
 namespace GuzzleHttp\Test {
     require __DIR__ . '/../vendor/autoload.php';
     require __DIR__ . '/Server.php';


### PR DESCRIPTION
This PR introduces IDN support on client's level, so all the handlers will work with the ASCII version of the IDN with no need for additional conversion.

Also fixes #2285.