### PR TITLE
Update `CurlFactory::finishError()` in order to use `curl_strerror()` if `curl_error()` returns 0 on failure

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -139,7 +139,8 @@ class CurlFactory implements CurlFactoryInterface
         // Get error information and release the handle to the factory.
         $ctx = [
             'errno' => $easy->errno,
-            'error' => curl_error($easy->handle),
+            // @see https://bugs.php.net/bug.php?id=77946
+            'error' => curl_error($easy->handle) ?: curl_strerror($easy->errno),
             'appconnect_time' => curl_getinfo($easy->handle, CURLINFO_APPCONNECT_TIME),
         ] + curl_getinfo($easy->handle);
         $ctx[self::CURL_VERSION_STR] = curl_version()['version'];

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -96,4 +96,14 @@ class CurlMultiHandlerTest extends TestCase
         $h = new CurlMultiHandler();
         $h->foo;
     }
+
+    /**
+     * @expectedException \GuzzleHttp\Exception\ConnectException
+     * @expectedExceptionMessage Could not resolve host:
+     */
+    public function testCurlErrorMessage()
+    {
+        $a = new CurlMultiHandler();
+        $a(new Request('GET', 'http://'.uniqid().uniqid()), [])->wait();
+    }
 }


### PR DESCRIPTION
Under certain conditions that I'm trying to debug, I get incomplete error messages.
The missing part is which `curl_error()` should return, by instance "Could not resolve host: nonexistent-host".

**Expected**:
>cURL error 6: Could not resolve host: nonexistent-host (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)

**Actual**:
>cURL error 6:  (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)

`CurlFactory::finishError()` is where I've narrowed the issue, but I'm still not able to tell how this scenario occurs:
https://github.com/guzzle/guzzle/blob/bf595424e4d442a190582e088985dc835a789071/src/Handler/CurlFactory.php#L142

I have noticed this issue after upgrading from PHP `7.2.0` to `7.3.4`, with the exact same library version:
<details><summary>composer show guzzlehttp/guzzle</summary>

```
name     : guzzlehttp/guzzle
descrip. : Guzzle is a PHP HTTP client library
keywords : client, curl, framework, http, http client, rest, web service
versions : * 6.3.3
type     : library
license  : MIT License (MIT) (OSI approved) https://spdx.org/licenses/MIT.html#licenseText
source   : [git] https://github.com/guzzle/guzzle.git 407b0cb880ace85c9b63c5f9551db498cb2d50ba
dist     : [zip] https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba 407b0cb880ace85c9b63c5f9551db498cb2d50ba
path     : /var/www/html/mynubity/vendor/guzzlehttp/guzzle
names    : guzzlehttp/guzzle

autoload
files
psr-4
GuzzleHttp\ => src/

requires
guzzlehttp/promises ^1.0
guzzlehttp/psr7 ^1.4
php >=5.5

requires (dev)
ext-curl *
phpunit/phpunit ^4.8.35 || ^5.7 || ^6.4 || ^7.0
psr/log ^1.0

suggests
psr/log Required for using the Log middleware
```
</details>

I suspect that the problem is originated by `CurlMultiHandler` under certain condition, so I must keep testing.