### PR TITLE
stringify Content-Length header in PrepareBodyMiddleware

### DIFF
--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -54,7 +54,7 @@ class PrepareBodyMiddleware
         ) {
             $size = $request->getBody()->getSize();
             if ($size !== null) {
-                $modify['set_headers']['Content-Length'] = $size;
+                $modify['set_headers']['Content-Length'] = (string) $size;
             } else {
                 $modify['set_headers']['Transfer-Encoding'] = 'chunked';
             }

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -34,6 +34,7 @@ class PrepareBodyMiddlewareTest extends TestCase
                 $length = strlen($body);
                 if ($length > 0) {
                     $this->assertEquals($length, $request->getHeaderLine('Content-Length'));
+                    $this->assertTrue(is_string($request->getHeaderLine('Content-Length')));
                 } else {
                     $this->assertFalse($request->hasHeader('Content-Length'));
                 }


### PR DESCRIPTION
Please find detailed description of issue here:
https://github.com/guzzle/psr7/issues/273

Bug may be reproduced only on `master` branch of `guzzlehttp/psr7` package.
So update `composer.json` and set with the following line:
`"guzzlehttp/psr7": "dev-master"`