### PR TITLE
Fix logging with a string rejection

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -197,7 +197,7 @@ final class Middleware
                         $response = $reason instanceof RequestException
                             ? $reason->getResponse()
                             : null;
-                        $message = $formatter->format($request, $response, $reason);
+                        $message = $formatter->format($request, $response, \GuzzleHttp\Promise\exception_for($reason));
                         $logger->notice($message);
                         return \GuzzleHttp\Promise\rejection_for($reason);
                     }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -186,7 +186,7 @@ final class Middleware
     public static function log(LoggerInterface $logger, MessageFormatter $formatter, string $logLevel = 'info' /* \Psr\Log\LogLevel::INFO */): callable
     {
         return function (callable $handler) use ($logger, $formatter, $logLevel): callable {
-            return function (RequestInterface $request, array $options) use ($handler, $logger, $formatter, $logLevel) {
+            return function (RequestInterface $request, array $options = []) use ($handler, $logger, $formatter, $logLevel) {
                 return $handler($request, $options)->then(
                     function ($response) use ($logger, $request, $formatter, $logLevel): ResponseInterface {
                         $message = $formatter->format($request, $response);

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -221,7 +221,7 @@ class MiddlewareTest extends TestCase
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);
         $p->wait(false);
-        $this->assertCount(1, $logger->records);
-        $this->assertContains('some problem', $logger->records[0]['message']);
+        self::assertCount(1, $logger->records);
+        self::assertContains('some problem', $logger->records[0]['message']);
     }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -210,4 +210,18 @@ class MiddlewareTest extends TestCase
         self::assertStringContainsString('PUT http://www.google.com', $logger->records[0]['message']);
         self::assertStringContainsString('404 Not Found', $logger->records[0]['message']);
     }
+
+    public function testLogsWithStringError()
+    {
+        $h = new MockHandler([\GuzzleHttp\Promise\rejection_for('some problem')]);
+        $stack = new HandlerStack($h);
+        $logger = new TestLogger();
+        $formatter = new MessageFormatter('{error}');
+        $stack->push(Middleware::log($logger, $formatter));
+        $comp = $stack->resolve();
+        $p = $comp(new Request('PUT', 'http://www.google.com'), []);
+        $p->wait(false);
+        $this->assertCount(1, $logger->records);
+        $this->assertContains('some problem', $logger->records[0]['message']);
+    }
 }


### PR DESCRIPTION
Promises aren't always rejected with an exception. I haven't changed `MessageFormatter` as that'd be a BC break.