### PR TITLE
Use PHPUnit static assertions

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -7,6 +7,7 @@ $config = PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'declare_strict_types' => false,
         'concat_space' => ['spacing'=>'one'],
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
         // 'ordered_imports' => true,
         // 'phpdoc_align' => ['align'=>'vertical'],
         // 'native_function_invocation' => true,
@@ -14,6 +15,7 @@ $config = PhpCsFixer\Config::create()
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__.'/src')
+            ->in(__DIR__.'/tests')
             ->name('*.php')
     )
 ;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php"
-         backupGlobals="true"
-         colors="true">
+  <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+           bootstrap="./tests/bootstrap.php"
+           backupGlobals="true"
+           colors="true"
+           executionOrder="random"
+  >
   <testsuites>
     <testsuite name="Test Suite">
       <directory>tests</directory>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends TestCase
         $client = new Client();
         Server::enqueue([new Response(200, ['Content-Length' => 0])]);
         $response = $client->get(Server::$url);
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -39,11 +39,11 @@ class ClientTest extends TestCase
         Server::flush();
         Server::enqueue([new Response(200, ['Content-Length' => 2], 'hi')]);
         $p = $client->getAsync(Server::$url, ['query' => ['test' => 'foo']]);
-        $this->assertInstanceOf(PromiseInterface::class, $p);
-        $this->assertSame(200, $p->wait()->getStatusCode());
+        self::assertInstanceOf(PromiseInterface::class, $p);
+        self::assertSame(200, $p->wait()->getStatusCode());
         $received = Server::received(true);
-        $this->assertCount(1, $received);
-        $this->assertSame('test=foo', $received[0]->getUri()->getQuery());
+        self::assertCount(1, $received);
+        self::assertSame('test=foo', $received[0]->getUri()->getQuery());
     }
 
     public function testCanSendSynchronously()
@@ -51,8 +51,8 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => new MockHandler([new Response()])]);
         $request = new Request('GET', 'http://example.com');
         $r = $client->send($request);
-        $this->assertInstanceOf(ResponseInterface::class, $r);
-        $this->assertSame(200, $r->getStatusCode());
+        self::assertInstanceOf(ResponseInterface::class, $r);
+        self::assertSame(200, $r->getStatusCode());
     }
 
     public function testClientHasOptions()
@@ -64,12 +64,12 @@ class ClientTest extends TestCase
             'handler'  => new MockHandler()
         ]);
         $base = $client->getConfig('base_uri');
-        $this->assertSame('http://foo.com', (string) $base);
-        $this->assertInstanceOf(Uri::class, $base);
-        $this->assertNotNull($client->getConfig('handler'));
-        $this->assertSame(2, $client->getConfig('timeout'));
-        $this->assertArrayHasKey('timeout', $client->getConfig());
-        $this->assertArrayHasKey('headers', $client->getConfig());
+        self::assertSame('http://foo.com', (string) $base);
+        self::assertInstanceOf(Uri::class, $base);
+        self::assertNotNull($client->getConfig('handler'));
+        self::assertSame(2, $client->getConfig('timeout'));
+        self::assertArrayHasKey('timeout', $client->getConfig());
+        self::assertArrayHasKey('headers', $client->getConfig());
     }
 
     public function testCanMergeOnBaseUri()
@@ -80,7 +80,7 @@ class ClientTest extends TestCase
             'handler'  => $mock
         ]);
         $client->get('baz');
-        $this->assertSame(
+        self::assertSame(
             'http://foo.com/bar/baz',
             (string)$mock->getLastRequest()->getUri()
         );
@@ -94,13 +94,13 @@ class ClientTest extends TestCase
             'base_uri' => 'http://foo.com/bar/'
         ]);
         $client->request('GET', new Uri('baz'));
-        $this->assertSame(
+        self::assertSame(
             'http://foo.com/bar/baz',
             (string) $mock->getLastRequest()->getUri()
         );
 
         $client->request('GET', new Uri('baz'), ['base_uri' => 'http://example.com/foo/']);
-        $this->assertSame(
+        self::assertSame(
             'http://example.com/foo/baz',
             (string) $mock->getLastRequest()->getUri(),
             'Can overwrite the base_uri through the request options'
@@ -114,10 +114,10 @@ class ClientTest extends TestCase
             'handler'  => $mock,
             'base_uri' => 'http://bar.com'
         ]);
-        $this->assertSame('http://bar.com', (string) $client->getConfig('base_uri'));
+        self::assertSame('http://bar.com', (string) $client->getConfig('base_uri'));
         $request = new Request('GET', '/baz');
         $client->send($request);
-        $this->assertSame(
+        self::assertSame(
             'http://bar.com/baz',
             (string) $mock->getLastRequest()->getUri()
         );
@@ -126,11 +126,11 @@ class ClientTest extends TestCase
     public function testMergesDefaultOptionsAndDoesNotOverwriteUa()
     {
         $c = new Client(['headers' => ['User-agent' => 'foo']]);
-        $this->assertSame(['User-agent' => 'foo'], $c->getConfig('headers'));
-        $this->assertInternalType('array', $c->getConfig('allow_redirects'));
-        $this->assertTrue($c->getConfig('http_errors'));
-        $this->assertTrue($c->getConfig('decode_content'));
-        $this->assertTrue($c->getConfig('verify'));
+        self::assertSame(['User-agent' => 'foo'], $c->getConfig('headers'));
+        self::assertInternalType('array', $c->getConfig('allow_redirects'));
+        self::assertTrue($c->getConfig('http_errors'));
+        self::assertTrue($c->getConfig('decode_content'));
+        self::assertTrue($c->getConfig('verify'));
     }
 
     public function testDoesNotOverwriteHeaderWithDefault()
@@ -141,7 +141,7 @@ class ClientTest extends TestCase
             'handler' => $mock
         ]);
         $c->get('http://example.com', ['headers' => ['User-Agent' => 'bar']]);
-        $this->assertSame('bar', $mock->getLastRequest()->getHeaderLine('User-Agent'));
+        self::assertSame('bar', $mock->getLastRequest()->getHeaderLine('User-Agent'));
     }
 
     public function testDoesNotOverwriteHeaderWithDefaultInRequest()
@@ -153,7 +153,7 @@ class ClientTest extends TestCase
         ]);
         $request = new Request('GET', Server::$url, ['User-Agent' => 'bar']);
         $c->send($request);
-        $this->assertSame('bar', $mock->getLastRequest()->getHeaderLine('User-Agent'));
+        self::assertSame('bar', $mock->getLastRequest()->getHeaderLine('User-Agent'));
     }
 
     public function testDoesOverwriteHeaderWithSetRequestOption()
@@ -165,7 +165,7 @@ class ClientTest extends TestCase
         ]);
         $request = new Request('GET', Server::$url, ['User-Agent' => 'bar']);
         $c->send($request, ['headers' => ['User-Agent' => 'YO']]);
-        $this->assertSame('YO', $mock->getLastRequest()->getHeaderLine('User-Agent'));
+        self::assertSame('YO', $mock->getLastRequest()->getHeaderLine('User-Agent'));
     }
 
     public function testCanUnsetRequestOptionWithNull()
@@ -176,14 +176,14 @@ class ClientTest extends TestCase
             'handler' => $mock
         ]);
         $c->get('http://example.com', ['headers' => null]);
-        $this->assertFalse($mock->getLastRequest()->hasHeader('foo'));
+        self::assertFalse($mock->getLastRequest()->hasHeader('foo'));
     }
 
     public function testRewriteExceptionsToHttpErrors()
     {
         $client = new Client(['handler' => new MockHandler([new Response(404)])]);
         $res = $client->get('http://foo.com', ['exceptions' => false]);
-        $this->assertSame(404, $res->getStatusCode());
+        self::assertSame(404, $res->getStatusCode());
     }
 
     public function testRewriteSaveToToSink()
@@ -192,7 +192,7 @@ class ClientTest extends TestCase
         $mock = new MockHandler([new Response(200, [], 'foo')]);
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['save_to' => $r]);
-        $this->assertSame($r, $mock->getLastOptions()['sink']);
+        self::assertSame($r, $mock->getLastOptions()['sink']);
     }
 
     public function testAllowRedirectsCanBeTrue()
@@ -201,7 +201,7 @@ class ClientTest extends TestCase
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
         $client->get('http://foo.com', ['allow_redirects' => true]);
-        $this->assertInternalType('array', $mock->getLastOptions()['allow_redirects']);
+        self::assertInternalType('array', $mock->getLastOptions()['allow_redirects']);
     }
 
     /**
@@ -249,7 +249,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $handler, 'cookies' => true]);
         $client->get('http://foo.com');
         $client->get('http://foo.com');
-        $this->assertSame('foo=bar', $mock->getLastRequest()->getHeaderLine('Cookie'));
+        self::assertSame('foo=bar', $mock->getLastRequest()->getHeaderLine('Cookie'));
     }
 
     public function testSetCookieToJar()
@@ -263,7 +263,7 @@ class ClientTest extends TestCase
         $jar = new CookieJar();
         $client->get('http://foo.com', ['cookies' => $jar]);
         $client->get('http://foo.com', ['cookies' => $jar]);
-        $this->assertSame('foo=bar', $mock->getLastRequest()->getHeaderLine('Cookie'));
+        self::assertSame('foo=bar', $mock->getLastRequest()->getHeaderLine('Cookie'));
     }
 
     public function testCanDisableContentDecoding()
@@ -272,8 +272,8 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['decode_content' => false]);
         $last = $mock->getLastRequest();
-        $this->assertFalse($last->hasHeader('Accept-Encoding'));
-        $this->assertFalse($mock->getLastOptions()['decode_content']);
+        self::assertFalse($last->hasHeader('Accept-Encoding'));
+        self::assertFalse($mock->getLastOptions()['decode_content']);
     }
 
     public function testCanSetContentDecodingToValue()
@@ -282,8 +282,8 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['decode_content' => 'gzip']);
         $last = $mock->getLastRequest();
-        $this->assertSame('gzip', $last->getHeaderLine('Accept-Encoding'));
-        $this->assertSame('gzip', $mock->getLastOptions()['decode_content']);
+        self::assertSame('gzip', $last->getHeaderLine('Accept-Encoding'));
+        self::assertSame('gzip', $mock->getLastOptions()['decode_content']);
     }
 
     /**
@@ -303,7 +303,7 @@ class ClientTest extends TestCase
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['body' => 'foo']);
         $last = $mock->getLastRequest();
-        $this->assertSame('foo', (string) $last->getBody());
+        self::assertSame('foo', (string) $last->getBody());
     }
 
     /**
@@ -323,7 +323,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['query' => 'foo']);
-        $this->assertSame('foo', $mock->getLastRequest()->getUri()->getQuery());
+        self::assertSame('foo', $mock->getLastRequest()->getUri()->getQuery());
     }
 
     public function testQueryCanBeArray()
@@ -332,7 +332,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['query' => ['foo' => 'bar baz']]);
-        $this->assertSame('foo=bar%20baz', $mock->getLastRequest()->getUri()->getQuery());
+        self::assertSame('foo=bar%20baz', $mock->getLastRequest()->getUri()->getQuery());
     }
 
     public function testCanAddJsonData()
@@ -342,8 +342,8 @@ class ClientTest extends TestCase
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['json' => ['foo' => 'bar']]);
         $last = $mock->getLastRequest();
-        $this->assertSame('{"foo":"bar"}', (string) $mock->getLastRequest()->getBody());
-        $this->assertSame('application/json', $last->getHeaderLine('Content-Type'));
+        self::assertSame('{"foo":"bar"}', (string) $mock->getLastRequest()->getBody());
+        self::assertSame('application/json', $last->getHeaderLine('Content-Type'));
     }
 
     public function testCanAddJsonDataWithoutOverwritingContentType()
@@ -356,8 +356,8 @@ class ClientTest extends TestCase
             'json'    => 'a'
         ]);
         $last = $mock->getLastRequest();
-        $this->assertSame('"a"', (string) $mock->getLastRequest()->getBody());
-        $this->assertSame('foo', $last->getHeaderLine('Content-Type'));
+        self::assertSame('"a"', (string) $mock->getLastRequest()->getBody());
+        self::assertSame('foo', $last->getHeaderLine('Content-Type'));
     }
 
     public function testCanAddJsonDataWithNullHeader()
@@ -370,8 +370,8 @@ class ClientTest extends TestCase
             'json'    => 'a'
         ]);
         $last = $mock->getLastRequest();
-        $this->assertSame('"a"', (string) $mock->getLastRequest()->getBody());
-        $this->assertSame('application/json', $last->getHeaderLine('Content-Type'));
+        self::assertSame('"a"', (string) $mock->getLastRequest()->getBody());
+        self::assertSame('application/json', $last->getHeaderLine('Content-Type'));
     }
 
     public function testAuthCanBeTrue()
@@ -380,7 +380,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => false]);
         $last = $mock->getLastRequest();
-        $this->assertFalse($last->hasHeader('Authorization'));
+        self::assertFalse($last->hasHeader('Authorization'));
     }
 
     public function testAuthCanBeArrayForBasicAuth()
@@ -389,7 +389,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b']]);
         $last = $mock->getLastRequest();
-        $this->assertSame('Basic YTpi', $last->getHeaderLine('Authorization'));
+        self::assertSame('Basic YTpi', $last->getHeaderLine('Authorization'));
     }
 
     public function testAuthCanBeArrayForDigestAuth()
@@ -398,7 +398,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b', 'digest']]);
         $last = $mock->getLastOptions();
-        $this->assertSame([
+        self::assertSame([
             CURLOPT_HTTPAUTH => 2,
             CURLOPT_USERPWD  => 'a:b'
         ], $last['curl']);
@@ -410,7 +410,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b', 'ntlm']]);
         $last = $mock->getLastOptions();
-        $this->assertSame([
+        self::assertSame([
             CURLOPT_HTTPAUTH => 8,
             CURLOPT_USERPWD  => 'a:b'
         ], $last['curl']);
@@ -422,7 +422,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => 'foo']);
         $last = $mock->getLastOptions();
-        $this->assertSame('foo', $last['auth']);
+        self::assertSame('foo', $last['auth']);
     }
 
     public function testCanAddFormParams()
@@ -436,11 +436,11 @@ class ClientTest extends TestCase
             ]
         ]);
         $last = $mock->getLastRequest();
-        $this->assertSame(
+        self::assertSame(
             'application/x-www-form-urlencoded',
             $last->getHeaderLine('Content-Type')
         );
-        $this->assertSame(
+        self::assertSame(
             'foo=bar+bam&baz%5Bboo%5D=qux',
             (string) $last->getBody()
         );
@@ -459,7 +459,7 @@ class ClientTest extends TestCase
             ]
         ]);
         $last = $mock->getLastRequest();
-        $this->assertSame(
+        self::assertSame(
             'foo=bar+bam&baz%5Bboo%5D=qux',
             (string) $last->getBody()
         );
@@ -497,22 +497,22 @@ class ClientTest extends TestCase
         ]);
 
         $last = $mock->getLastRequest();
-        $this->assertContains(
+        self::assertContains(
             'multipart/form-data; boundary=',
             $last->getHeaderLine('Content-Type')
         );
 
-        $this->assertContains(
+        self::assertContains(
             'Content-Disposition: form-data; name="foo"',
             (string) $last->getBody()
         );
 
-        $this->assertContains('bar', (string) $last->getBody());
-        $this->assertContains(
+        self::assertContains('bar', (string) $last->getBody());
+        self::assertContains(
             'Content-Disposition: form-data; name="foo"' . "\r\n",
             (string) $last->getBody()
         );
-        $this->assertContains(
+        self::assertContains(
             'Content-Disposition: form-data; name="test"; filename="ClientTest.php"',
             (string) $last->getBody()
         );
@@ -543,22 +543,22 @@ class ClientTest extends TestCase
         );
 
         $last = $mock->getLastRequest();
-        $this->assertContains(
+        self::assertContains(
             'multipart/form-data; boundary=',
             $last->getHeaderLine('Content-Type')
         );
 
-        $this->assertContains(
+        self::assertContains(
             'Content-Disposition: form-data; name="foo"',
             (string) $last->getBody()
         );
 
-        $this->assertContains('bar', (string) $last->getBody());
-        $this->assertContains(
+        self::assertContains('bar', (string) $last->getBody());
+        self::assertContains(
             'Content-Disposition: form-data; name="foo"' . "\r\n",
             (string) $last->getBody()
         );
-        $this->assertContains(
+        self::assertContains(
             'Content-Disposition: form-data; name="test"; filename="ClientTest.php"',
             (string) $last->getBody()
         );
@@ -570,17 +570,17 @@ class ClientTest extends TestCase
         $https = getenv('HTTPS_PROXY');
         $no = getenv('NO_PROXY');
         $client = new Client();
-        $this->assertNull($client->getConfig('proxy'));
+        self::assertNull($client->getConfig('proxy'));
         putenv('HTTP_PROXY=127.0.0.1');
         $client = new Client();
-        $this->assertSame(
+        self::assertSame(
             ['http' => '127.0.0.1'],
             $client->getConfig('proxy')
         );
         putenv('HTTPS_PROXY=127.0.0.2');
         putenv('NO_PROXY=127.0.0.3, 127.0.0.4');
         $client = new Client();
-        $this->assertSame(
+        self::assertSame(
             ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3','127.0.0.4']],
             $client->getConfig('proxy')
         );
@@ -594,7 +594,7 @@ class ClientTest extends TestCase
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $client->request('GET', 'http://foo.com');
-        $this->assertTrue($mock->getLastOptions()['synchronous']);
+        self::assertTrue($mock->getLastOptions()['synchronous']);
     }
 
     public function testSendSendsWithSync()
@@ -602,7 +602,7 @@ class ClientTest extends TestCase
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $client->send(new Request('GET', 'http://foo.com'));
-        $this->assertTrue($mock->getLastOptions()['synchronous']);
+        self::assertTrue($mock->getLastOptions()['synchronous']);
     }
 
     public function testCanSetCustomHandler()
@@ -610,7 +610,7 @@ class ClientTest extends TestCase
         $mock = new MockHandler([new Response(500)]);
         $client = new Client(['handler' => $mock]);
         $mock2 = new MockHandler([new Response(200)]);
-        $this->assertSame(
+        self::assertSame(
             200,
             $client->send(new Request('GET', 'http://foo.com'), [
                 'handler' => $mock2
@@ -624,7 +624,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $request = new Request('PUT', 'http://foo.com');
         $client->send($request, ['query' => ['foo' => 'bar', 'john' => 'doe']]);
-        $this->assertSame('foo=bar&john=doe', $mock->getLastRequest()->getUri()->getQuery());
+        self::assertSame('foo=bar&john=doe', $mock->getLastRequest()->getUri()->getQuery());
     }
 
     public function testSendSendsWithIpAddressAndPortAndHostHeaderInRequestTheHostShouldBePreserved()
@@ -635,7 +635,7 @@ class ClientTest extends TestCase
 
         $client->send($request);
 
-        $this->assertSame('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
+        self::assertSame('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
     }
 
     public function testSendSendsWithDomainAndHostHeaderInRequestTheHostShouldBePreserved()
@@ -646,7 +646,7 @@ class ClientTest extends TestCase
 
         $client->send($request);
 
-        $this->assertSame('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
+        self::assertSame('foo.com', $mockHandler->getLastRequest()->getHeader('Host')[0]);
     }
 
     /**
@@ -666,7 +666,7 @@ class ClientTest extends TestCase
 
         $client->request('GET', '//example.org/test');
 
-        $this->assertSame('http://example.org/test', (string) $mockHandler->getLastRequest()->getUri());
+        self::assertSame('http://example.org/test', (string) $mockHandler->getLastRequest()->getUri());
     }
 
     public function testOnlyAddSchemeWhenHostIsPresent()
@@ -675,7 +675,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler'  => $mockHandler]);
 
         $client->request('GET', 'baz');
-        $this->assertSame(
+        self::assertSame(
             'baz',
             (string) $mockHandler->getLastRequest()->getUri()
         );
@@ -697,7 +697,7 @@ class ClientTest extends TestCase
         $request = new Request('GET', 'http://foo.com');
         $response = $client->send($request, ['json' => ['a' => 'b']]);
 
-        $this->assertSame($responseBody, (string) $response->getBody());
+        self::assertSame($responseBody, (string) $response->getBody());
     }
 
     public function testResponseContent()
@@ -708,6 +708,6 @@ class ClientTest extends TestCase
         $request = new Request('POST', 'http://foo.com');
         $response = $client->send($request, ['json' => ['a' => 'b']]);
 
-        $this->assertSame($responseBody, $response->getBody()->getContents());
+        self::assertSame($responseBody, $response->getBody()->getContents());
     }
 }

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -38,12 +38,12 @@ class CookieJarTest extends TestCase
             'foo' => 'bar',
             'baz' => 'bam'
         ], 'example.com');
-        $this->assertCount(2, $jar);
+        self::assertCount(2, $jar);
     }
 
     public function testEmptyJarIsCountable()
     {
-        $this->assertCount(0, new CookieJar());
+        self::assertCount(0, new CookieJar());
     }
 
     public function testGetsCookiesByName()
@@ -54,9 +54,9 @@ class CookieJarTest extends TestCase
         }
 
         $testCookie = $cookies[0];
-        $this->assertEquals($testCookie, $this->jar->getCookieByName($testCookie->getName()));
-        $this->assertNull($this->jar->getCookieByName("doesnotexist"));
-        $this->assertNull($this->jar->getCookieByName(""));
+        self::assertEquals($testCookie, $this->jar->getCookieByName($testCookie->getName()));
+        self::assertNull($this->jar->getCookieByName("doesnotexist"));
+        self::assertNull($this->jar->getCookieByName(""));
     }
 
     /**
@@ -82,12 +82,12 @@ class CookieJarTest extends TestCase
     {
         $cookies = $this->getTestCookies();
         foreach ($cookies as $cookie) {
-            $this->assertTrue($this->jar->setCookie($cookie));
+            self::assertTrue($this->jar->setCookie($cookie));
         }
 
-        $this->assertCount(3, $this->jar);
-        $this->assertCount(3, $this->jar->getIterator());
-        $this->assertEquals($cookies, $this->jar->getIterator()->getArrayCopy());
+        self::assertCount(3, $this->jar);
+        self::assertCount(3, $this->jar->getIterator());
+        self::assertEquals($cookies, $this->jar->getIterator()->getArrayCopy());
     }
 
     public function testRemovesTemporaryCookies()
@@ -97,7 +97,7 @@ class CookieJarTest extends TestCase
             $this->jar->setCookie($cookie);
         }
         $this->jar->clearSessionCookies();
-        $this->assertEquals(
+        self::assertEquals(
             [$cookies[1], $cookies[2]],
             $this->jar->getIterator()->getArrayCopy()
         );
@@ -111,33 +111,33 @@ class CookieJarTest extends TestCase
 
         // Remove foo.com cookies
         $this->jar->clear('foo.com');
-        $this->assertCount(2, $this->jar);
+        self::assertCount(2, $this->jar);
         // Try again, removing no further cookies
         $this->jar->clear('foo.com');
-        $this->assertCount(2, $this->jar);
+        self::assertCount(2, $this->jar);
 
         // Remove bar.com cookies with path of /boo
         $this->jar->clear('bar.com', '/boo');
-        $this->assertCount(1, $this->jar);
+        self::assertCount(1, $this->jar);
 
         // Remove cookie by name
         $this->jar->clear(null, null, 'test');
-        $this->assertCount(0, $this->jar);
+        self::assertCount(0, $this->jar);
     }
 
     public function testDoesNotAddIncompleteCookies()
     {
-        $this->assertFalse($this->jar->setCookie(new SetCookie()));
-        $this->assertFalse($this->jar->setCookie(new SetCookie(array(
+        self::assertFalse($this->jar->setCookie(new SetCookie()));
+        self::assertFalse($this->jar->setCookie(new SetCookie(array(
             'Name' => 'foo'
         ))));
-        $this->assertFalse($this->jar->setCookie(new SetCookie(array(
+        self::assertFalse($this->jar->setCookie(new SetCookie(array(
             'Name' => false
         ))));
-        $this->assertFalse($this->jar->setCookie(new SetCookie(array(
+        self::assertFalse($this->jar->setCookie(new SetCookie(array(
             'Name' => true
         ))));
-        $this->assertFalse($this->jar->setCookie(new SetCookie(array(
+        self::assertFalse($this->jar->setCookie(new SetCookie(array(
             'Name'   => 'foo',
             'Domain' => 'foo.com'
         ))));
@@ -145,7 +145,7 @@ class CookieJarTest extends TestCase
 
     public function testDoesNotAddEmptyCookies()
     {
-        $this->assertFalse($this->jar->setCookie(new SetCookie(array(
+        self::assertFalse($this->jar->setCookie(new SetCookie(array(
             'Name'   => '',
             'Domain' => 'foo.com',
             'Value'  => 0
@@ -154,22 +154,22 @@ class CookieJarTest extends TestCase
 
     public function testDoesAddValidCookies()
     {
-        $this->assertTrue($this->jar->setCookie(new SetCookie(array(
+        self::assertTrue($this->jar->setCookie(new SetCookie(array(
             'Name'   => '0',
             'Domain' => 'foo.com',
             'Value'  => 0
         ))));
-        $this->assertTrue($this->jar->setCookie(new SetCookie(array(
+        self::assertTrue($this->jar->setCookie(new SetCookie(array(
             'Name'   => 'foo',
             'Domain' => 'foo.com',
             'Value'  => 0
         ))));
-        $this->assertTrue($this->jar->setCookie(new SetCookie(array(
+        self::assertTrue($this->jar->setCookie(new SetCookie(array(
             'Name'   => 'foo',
             'Domain' => 'foo.com',
             'Value'  => 0.0
         ))));
-        $this->assertTrue($this->jar->setCookie(new SetCookie(array(
+        self::assertTrue($this->jar->setCookie(new SetCookie(array(
             'Name'   => 'foo',
             'Domain' => 'foo.com',
             'Value'  => '0'
@@ -191,26 +191,26 @@ class CookieJarTest extends TestCase
         );
 
         // Make sure that the discard cookie is overridden with the non-discard
-        $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertCount(1, $this->jar);
+        self::assertTrue($this->jar->setCookie(new SetCookie($data)));
+        self::assertCount(1, $this->jar);
 
         $data['Discard'] = false;
-        $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertCount(1, $this->jar);
+        self::assertTrue($this->jar->setCookie(new SetCookie($data)));
+        self::assertCount(1, $this->jar);
 
         $c = $this->jar->getIterator()->getArrayCopy();
-        $this->assertFalse($c[0]->getDiscard());
+        self::assertFalse($c[0]->getDiscard());
 
         // Make sure it doesn't duplicate the cookie
         $this->jar->setCookie(new SetCookie($data));
-        $this->assertCount(1, $this->jar);
+        self::assertCount(1, $this->jar);
 
         // Make sure the more future-ful expiration date supersede the other
         $data['Expires'] = time() + 2000;
-        $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertCount(1, $this->jar);
+        self::assertTrue($this->jar->setCookie(new SetCookie($data)));
+        self::assertCount(1, $this->jar);
         $c = $this->jar->getIterator()->getArrayCopy();
-        $this->assertNotEquals($t, $c[0]->getExpires());
+        self::assertNotEquals($t, $c[0]->getExpires());
     }
 
     public function testOverwritesCookiesThatHaveChanged()
@@ -228,20 +228,20 @@ class CookieJarTest extends TestCase
         );
 
         // Make sure that the discard cookie is overridden with the non-discard
-        $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
+        self::assertTrue($this->jar->setCookie(new SetCookie($data)));
 
         $data['Value'] = 'boo';
-        $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertCount(1, $this->jar);
+        self::assertTrue($this->jar->setCookie(new SetCookie($data)));
+        self::assertCount(1, $this->jar);
 
         // Changing the value plus a parameter also must overwrite the existing one
         $data['Value'] = 'zoo';
         $data['Secure'] = false;
-        $this->assertTrue($this->jar->setCookie(new SetCookie($data)));
-        $this->assertCount(1, $this->jar);
+        self::assertTrue($this->jar->setCookie(new SetCookie($data)));
+        self::assertCount(1, $this->jar);
 
         $c = $this->jar->getIterator()->getArrayCopy();
-        $this->assertSame('zoo', $c[0]->getValue());
+        self::assertSame('zoo', $c[0]->getValue());
     }
 
     public function testAddsCookiesFromResponseWithRequest()
@@ -251,7 +251,7 @@ class CookieJarTest extends TestCase
         ));
         $request = new Request('GET', 'http://www.example.com');
         $this->jar->extractCookies($request, $response);
-        $this->assertCount(1, $this->jar);
+        self::assertCount(1, $this->jar);
     }
 
     public function getMatchingCookiesDataProvider()
@@ -316,7 +316,7 @@ class CookieJarTest extends TestCase
 
         $request = new Request('GET', $url);
         $request = $this->jar->withCookieHeader($request);
-        $this->assertSame($cookies, $request->getHeaderLine('Cookie'));
+        self::assertSame($cookies, $request->getHeaderLine('Cookie'));
     }
 
     /**
@@ -343,13 +343,13 @@ class CookieJarTest extends TestCase
         foreach ($cookies as $cookie) {
             $jar->setCookie($cookie);
         }
-        $this->assertCount(4, $jar);
+        self::assertCount(4, $jar);
         $jar->clear('bar.com', '/boo', 'other');
-        $this->assertCount(3, $jar);
+        self::assertCount(3, $jar);
         $names = array_map(function (SetCookie $c) {
             return $c->getName();
         }, $jar->getIterator()->getArrayCopy());
-        $this->assertSame(['foo', 'test', 'you'], $names);
+        self::assertSame(['foo', 'test', 'you'], $names);
     }
 
     public function testCanConvertToAndLoadFromArray()
@@ -358,12 +358,12 @@ class CookieJarTest extends TestCase
         foreach ($this->getTestCookies() as $cookie) {
             $jar->setCookie($cookie);
         }
-        $this->assertCount(3, $jar);
+        self::assertCount(3, $jar);
         $arr = $jar->toArray();
-        $this->assertCount(3, $arr);
+        self::assertCount(3, $arr);
         $newCookieJar = new CookieJar(false, $arr);
-        $this->assertCount(3, $newCookieJar);
-        $this->assertSame($jar->toArray(), $newCookieJar->toArray());
+        self::assertCount(3, $newCookieJar);
+        self::assertSame($jar->toArray(), $newCookieJar->toArray());
     }
 
     public function testAddsCookiesWithEmptyPathFromResponse()
@@ -374,7 +374,7 @@ class CookieJarTest extends TestCase
         $request = new Request('GET', 'http://www.example.com');
         $this->jar->extractCookies($request, $response);
         $newRequest = $this->jar->withCookieHeader(new Request('GET', 'http://www.example.com/foo'));
-        $this->assertTrue($newRequest->hasHeader('Cookie'));
+        self::assertTrue($newRequest->hasHeader('Cookie'));
     }
 
     public function getCookiePathsDataProvider()
@@ -409,8 +409,8 @@ class CookieJarTest extends TestCase
         $request = (new Request('GET', $uriPath))->withHeader('Host', 'www.example.com');
         $this->jar->extractCookies($request, $response);
 
-        $this->assertSame($cookiePath, $this->jar->toArray()[0]['Path']);
-        $this->assertSame($cookiePath, $this->jar->toArray()[1]['Path']);
+        self::assertSame($cookiePath, $this->jar->toArray()[0]['Path']);
+        self::assertSame($cookiePath, $this->jar->toArray()[1]['Path']);
     }
 
     private function futureExpirationDate()

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -29,7 +29,7 @@ class FileCookieJarTest extends TestCase
     public function testLoadsFromFile()
     {
         $jar = new FileCookieJar($this->file);
-        $this->assertSame([], $jar->getIterator()->getArrayCopy());
+        self::assertSame([], $jar->getIterator()->getArrayCopy());
         unlink($this->file);
     }
 
@@ -57,21 +57,21 @@ class FileCookieJarTest extends TestCase
             'Domain'  => 'foo.com',
         ]));
 
-        $this->assertCount(3, $jar);
+        self::assertCount(3, $jar);
         unset($jar);
 
         // Make sure it wrote to the file
         $contents = file_get_contents($this->file);
-        $this->assertNotEmpty($contents);
+        self::assertNotEmpty($contents);
 
         // Load the cookieJar from the file
         $jar = new FileCookieJar($this->file);
 
         if ($testSaveSessionCookie) {
-            $this->assertCount(3, $jar);
+            self::assertCount(3, $jar);
         } else {
             // Weeds out temporary and session cookies
-            $this->assertCount(2, $jar);
+            self::assertCount(2, $jar);
         }
 
         unset($jar);

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -33,7 +33,7 @@ class SessionCookieJarTest extends TestCase
     public function testLoadsFromSession()
     {
         $jar = new SessionCookieJar($this->sessionVar);
-        $this->assertSame([], $jar->getIterator()->getArrayCopy());
+        self::assertSame([], $jar->getIterator()->getArrayCopy());
         unset($_SESSION[$this->sessionVar]);
     }
 
@@ -61,21 +61,21 @@ class SessionCookieJarTest extends TestCase
             'Domain'  => 'foo.com',
         ]));
 
-        $this->assertCount(3, $jar);
+        self::assertCount(3, $jar);
         unset($jar);
 
         // Make sure it wrote to the sessionVar in $_SESSION
         $contents = $_SESSION[$this->sessionVar];
-        $this->assertNotEmpty($contents);
+        self::assertNotEmpty($contents);
 
         // Load the cookieJar from the file
         $jar = new SessionCookieJar($this->sessionVar);
 
         if ($testSaveSessionCookie) {
-            $this->assertCount(3, $jar);
+            self::assertCount(3, $jar);
         } else {
             // Weeds out temporary and session cookies
-            $this->assertCount(2, $jar);
+            self::assertCount(2, $jar);
         }
 
         unset($jar);

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -12,20 +12,20 @@ class SetCookieTest extends TestCase
     public function testInitializesDefaultValues()
     {
         $cookie = new SetCookie();
-        $this->assertSame('/', $cookie->getPath());
+        self::assertSame('/', $cookie->getPath());
     }
 
     public function testConvertsDateTimeMaxAgeToUnixTimestamp()
     {
         $cookie = new SetCookie(['Expires' => 'November 20, 1984']);
-        $this->assertInternalType('integer', $cookie->getExpires());
+        self::assertInternalType('integer', $cookie->getExpires());
     }
 
     public function testAddsExpiresBasedOnMaxAge()
     {
         $t = time();
         $cookie = new SetCookie(['Max-Age' => 100]);
-        $this->assertEquals($t + 100, $cookie->getExpires());
+        self::assertEquals($t + 100, $cookie->getExpires());
     }
 
     public function testHoldsValues()
@@ -46,19 +46,19 @@ class SetCookieTest extends TestCase
         );
 
         $cookie = new SetCookie($data);
-        $this->assertEquals($data, $cookie->toArray());
+        self::assertEquals($data, $cookie->toArray());
 
-        $this->assertSame('foo', $cookie->getName());
-        $this->assertSame('baz', $cookie->getValue());
-        $this->assertSame('baz.com', $cookie->getDomain());
-        $this->assertSame('/bar', $cookie->getPath());
-        $this->assertSame($t, $cookie->getExpires());
-        $this->assertSame(100, $cookie->getMaxAge());
-        $this->assertTrue($cookie->getSecure());
-        $this->assertTrue($cookie->getDiscard());
-        $this->assertTrue($cookie->getHttpOnly());
-        $this->assertSame('baz', $cookie->toArray()['foo']);
-        $this->assertSame('bam', $cookie->toArray()['bar']);
+        self::assertSame('foo', $cookie->getName());
+        self::assertSame('baz', $cookie->getValue());
+        self::assertSame('baz.com', $cookie->getDomain());
+        self::assertSame('/bar', $cookie->getPath());
+        self::assertSame($t, $cookie->getExpires());
+        self::assertSame(100, $cookie->getMaxAge());
+        self::assertTrue($cookie->getSecure());
+        self::assertTrue($cookie->getDiscard());
+        self::assertTrue($cookie->getHttpOnly());
+        self::assertSame('baz', $cookie->toArray()['foo']);
+        self::assertSame('bam', $cookie->toArray()['bar']);
 
         $cookie->setName('a');
         $cookie->setValue('b');
@@ -70,55 +70,55 @@ class SetCookieTest extends TestCase
         $cookie->setHttpOnly(false);
         $cookie->setDiscard(false);
 
-        $this->assertSame('a', $cookie->getName());
-        $this->assertSame('b', $cookie->getValue());
-        $this->assertSame('c', $cookie->getPath());
-        $this->assertSame('bar.com', $cookie->getDomain());
-        $this->assertSame(10, $cookie->getExpires());
-        $this->assertSame(200, $cookie->getMaxAge());
-        $this->assertFalse($cookie->getSecure());
-        $this->assertFalse($cookie->getDiscard());
-        $this->assertFalse($cookie->getHttpOnly());
+        self::assertSame('a', $cookie->getName());
+        self::assertSame('b', $cookie->getValue());
+        self::assertSame('c', $cookie->getPath());
+        self::assertSame('bar.com', $cookie->getDomain());
+        self::assertSame(10, $cookie->getExpires());
+        self::assertSame(200, $cookie->getMaxAge());
+        self::assertFalse($cookie->getSecure());
+        self::assertFalse($cookie->getDiscard());
+        self::assertFalse($cookie->getHttpOnly());
     }
 
     public function testDeterminesIfExpired()
     {
         $c = new SetCookie();
         $c->setExpires(10);
-        $this->assertTrue($c->isExpired());
+        self::assertTrue($c->isExpired());
         $c->setExpires(time() + 10000);
-        $this->assertFalse($c->isExpired());
+        self::assertFalse($c->isExpired());
     }
 
     public function testMatchesDomain()
     {
         $cookie = new SetCookie();
-        $this->assertTrue($cookie->matchesDomain('baz.com'));
+        self::assertTrue($cookie->matchesDomain('baz.com'));
 
         $cookie->setDomain('baz.com');
-        $this->assertTrue($cookie->matchesDomain('baz.com'));
-        $this->assertFalse($cookie->matchesDomain('bar.com'));
+        self::assertTrue($cookie->matchesDomain('baz.com'));
+        self::assertFalse($cookie->matchesDomain('bar.com'));
 
         $cookie->setDomain('.baz.com');
-        $this->assertTrue($cookie->matchesDomain('.baz.com'));
-        $this->assertTrue($cookie->matchesDomain('foo.baz.com'));
-        $this->assertFalse($cookie->matchesDomain('baz.bar.com'));
-        $this->assertTrue($cookie->matchesDomain('baz.com'));
+        self::assertTrue($cookie->matchesDomain('.baz.com'));
+        self::assertTrue($cookie->matchesDomain('foo.baz.com'));
+        self::assertFalse($cookie->matchesDomain('baz.bar.com'));
+        self::assertTrue($cookie->matchesDomain('baz.com'));
 
         $cookie->setDomain('.127.0.0.1');
-        $this->assertTrue($cookie->matchesDomain('127.0.0.1'));
+        self::assertTrue($cookie->matchesDomain('127.0.0.1'));
 
         $cookie->setDomain('127.0.0.1');
-        $this->assertTrue($cookie->matchesDomain('127.0.0.1'));
+        self::assertTrue($cookie->matchesDomain('127.0.0.1'));
 
         $cookie->setDomain('.com.');
-        $this->assertFalse($cookie->matchesDomain('baz.com'));
+        self::assertFalse($cookie->matchesDomain('baz.com'));
 
         $cookie->setDomain('.local');
-        $this->assertTrue($cookie->matchesDomain('example.local'));
+        self::assertTrue($cookie->matchesDomain('example.local'));
 
         $cookie->setDomain('example.com/'); // malformed domain
-        $this->assertFalse($cookie->matchesDomain('example.com'));
+        self::assertFalse($cookie->matchesDomain('example.com'));
     }
 
     public function pathMatchProvider()
@@ -149,7 +149,7 @@ class SetCookieTest extends TestCase
     {
         $cookie = new SetCookie();
         $cookie->setPath($cookiePath);
-        $this->assertSame($isMatch, $cookie->matchesPath($requestPath));
+        self::assertSame($isMatch, $cookie->matchesPath($requestPath));
     }
 
     public function cookieValidateProvider()
@@ -175,13 +175,13 @@ class SetCookieTest extends TestCase
             'Value'  => $value,
             'Domain' => $domain
         ));
-        $this->assertSame($result, $cookie->validate());
+        self::assertSame($result, $cookie->validate());
     }
 
     public function testDoesNotMatchIp()
     {
         $cookie = new SetCookie(['Domain' => '192.168.16.']);
-        $this->assertFalse($cookie->matchesDomain('192.168.16.121'));
+        self::assertFalse($cookie->matchesDomain('192.168.16.121'));
     }
 
     public function testConvertsToString()
@@ -196,7 +196,7 @@ class SetCookieTest extends TestCase
             'HttpOnly' => true,
             'Secure' => true
         ]);
-        $this->assertSame(
+        self::assertSame(
             'test=123; Domain=foo.com; Path=/abc; Expires=Sun, 27 Oct 2013 23:20:08 GMT; Secure; HttpOnly',
             (string) $cookie
         );
@@ -380,13 +380,13 @@ class SetCookieTest extends TestCase
 
             if (!empty($parsed)) {
                 foreach ($parsed as $key => $value) {
-                    $this->assertEquals($parsed[$key], $p[$key], 'Comparing ' . $key . ' ' . var_export($value, true) . ' : ' . var_export($parsed, true) . ' | ' . var_export($p, true));
+                    self::assertEquals($parsed[$key], $p[$key], 'Comparing ' . $key . ' ' . var_export($value, true) . ' : ' . var_export($parsed, true) . ' | ' . var_export($p, true));
                 }
                 foreach ($p as $key => $value) {
-                    $this->assertEquals($p[$key], $parsed[$key], 'Comparing ' . $key . ' ' . var_export($value, true) . ' : ' . var_export($parsed, true) . ' | ' . var_export($p, true));
+                    self::assertEquals($p[$key], $parsed[$key], 'Comparing ' . $key . ' ' . var_export($value, true) . ' : ' . var_export($parsed, true) . ' | ' . var_export($p, true));
                 }
             } else {
-                $this->assertSame([
+                self::assertSame([
                     'Name' => null,
                     'Value' => null,
                     'Domain' => null,
@@ -437,7 +437,7 @@ class SetCookieTest extends TestCase
      */
     public function testIsExpired($cookie, $expired)
     {
-        $this->assertSame(
+        self::assertSame(
             $expired,
             SetCookie::fromString($cookie)->isExpired()
         );

--- a/tests/Exception/ConnectExceptionTest.php
+++ b/tests/Exception/ConnectExceptionTest.php
@@ -15,11 +15,11 @@ class ConnectExceptionTest extends TestCase
         $req = new Request('GET', '/');
         $prev = new \Exception();
         $e = new ConnectException('foo', $req, $prev, ['foo' => 'bar']);
-        $this->assertSame($req, $e->getRequest());
-        $this->assertNull($e->getResponse());
-        $this->assertFalse($e->hasResponse());
-        $this->assertSame('foo', $e->getMessage());
-        $this->assertSame('bar', $e->getHandlerContext()['foo']);
-        $this->assertSame($prev, $e->getPrevious());
+        self::assertSame($req, $e->getRequest());
+        self::assertNull($e->getResponse());
+        self::assertFalse($e->hasResponse());
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
+        self::assertSame($prev, $e->getPrevious());
     }
 }

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -17,59 +17,59 @@ class RequestExceptionTest extends TestCase
         $req = new Request('GET', '/');
         $res = new Response(200);
         $e = new RequestException('foo', $req, $res);
-        $this->assertSame($req, $e->getRequest());
-        $this->assertSame($res, $e->getResponse());
-        $this->assertTrue($e->hasResponse());
-        $this->assertSame('foo', $e->getMessage());
+        self::assertSame($req, $e->getRequest());
+        self::assertSame($res, $e->getResponse());
+        self::assertTrue($e->hasResponse());
+        self::assertSame('foo', $e->getMessage());
     }
 
     public function testCreatesGenerateException()
     {
         $e = RequestException::create(new Request('GET', '/'));
-        $this->assertSame('Error completing request', $e->getMessage());
-        $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
+        self::assertSame('Error completing request', $e->getMessage());
+        self::assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
     }
 
     public function testCreatesClientErrorResponseException()
     {
         $e = RequestException::create(new Request('GET', '/'), new Response(400));
-        $this->assertContains(
+        self::assertContains(
             'GET /',
             $e->getMessage()
         );
-        $this->assertContains(
+        self::assertContains(
             '400 Bad Request',
             $e->getMessage()
         );
-        $this->assertInstanceOf('GuzzleHttp\Exception\ClientException', $e);
+        self::assertInstanceOf('GuzzleHttp\Exception\ClientException', $e);
     }
 
     public function testCreatesServerErrorResponseException()
     {
         $e = RequestException::create(new Request('GET', '/'), new Response(500));
-        $this->assertContains(
+        self::assertContains(
             'GET /',
             $e->getMessage()
         );
-        $this->assertContains(
+        self::assertContains(
             '500 Internal Server Error',
             $e->getMessage()
         );
-        $this->assertInstanceOf('GuzzleHttp\Exception\ServerException', $e);
+        self::assertInstanceOf('GuzzleHttp\Exception\ServerException', $e);
     }
 
     public function testCreatesGenericErrorResponseException()
     {
         $e = RequestException::create(new Request('GET', '/'), new Response(300));
-        $this->assertContains(
+        self::assertContains(
             'GET /',
             $e->getMessage()
         );
-        $this->assertContains(
+        self::assertContains(
             '300 ',
             $e->getMessage()
         );
-        $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
+        self::assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
     }
 
     /**
@@ -104,11 +104,11 @@ class RequestExceptionTest extends TestCase
             $content
         );
         $e = RequestException::create(new Request('GET', '/'), $response);
-        $this->assertContains(
+        self::assertContains(
             $content,
             $e->getMessage()
         );
-        $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
+        self::assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
     }
 
     public function testCreatesExceptionWithTruncatedSummary()
@@ -117,13 +117,13 @@ class RequestExceptionTest extends TestCase
         $response = new Response(500, [], $content);
         $e = RequestException::create(new Request('GET', '/'), $response);
         $expected = str_repeat('+', 120) . ' (truncated...)';
-        $this->assertContains($expected, $e->getMessage());
+        self::assertContains($expected, $e->getMessage());
     }
 
     public function testExceptionMessageIgnoresEmptyBody()
     {
         $e = RequestException::create(new Request('GET', '/'), new Response(500));
-        $this->assertStringEndsWith('response', $e->getMessage());
+        self::assertStringEndsWith('response', $e->getMessage());
     }
 
     public function testCreatesExceptionWithoutPrintableBody()
@@ -134,17 +134,17 @@ class RequestExceptionTest extends TestCase
             $content = base64_decode('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7') // 1x1 gif
         );
         $e = RequestException::create(new Request('GET', '/'), $response);
-        $this->assertNotContains(
+        self::assertNotContains(
             $content,
             $e->getMessage()
         );
-        $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
+        self::assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
     }
 
     public function testHasStatusCodeAsExceptionCode()
     {
         $e = RequestException::create(new Request('GET', '/'), new Response(442));
-        $this->assertSame(442, $e->getCode());
+        self::assertSame(442, $e->getCode());
     }
 
     public function testWrapsRequestExceptions()
@@ -152,8 +152,8 @@ class RequestExceptionTest extends TestCase
         $e = new \Exception('foo');
         $r = new Request('GET', 'http://www.oo.com');
         $ex = RequestException::wrapException($r, $e);
-        $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $ex);
-        $this->assertSame($e, $ex->getPrevious());
+        self::assertInstanceOf('GuzzleHttp\Exception\RequestException', $ex);
+        self::assertSame($e, $ex->getPrevious());
     }
 
     public function testDoesNotWrapExistingRequestExceptions()
@@ -161,33 +161,33 @@ class RequestExceptionTest extends TestCase
         $r = new Request('GET', 'http://www.oo.com');
         $e = new RequestException('foo', $r);
         $e2 = RequestException::wrapException($r, $e);
-        $this->assertSame($e, $e2);
+        self::assertSame($e, $e2);
     }
 
     public function testCanProvideHandlerContext()
     {
         $r = new Request('GET', 'http://www.oo.com');
         $e = new RequestException('foo', $r, null, null, ['bar' => 'baz']);
-        $this->assertSame(['bar' => 'baz'], $e->getHandlerContext());
+        self::assertSame(['bar' => 'baz'], $e->getHandlerContext());
     }
 
     public function testObfuscateUrlWithUsername()
     {
         $r = new Request('GET', 'http://username@www.oo.com');
         $e = RequestException::create($r, new Response(500));
-        $this->assertContains('http://username@www.oo.com', $e->getMessage());
+        self::assertContains('http://username@www.oo.com', $e->getMessage());
     }
 
     public function testObfuscateUrlWithUsernameAndPassword()
     {
         $r = new Request('GET', 'http://user:password@www.oo.com');
         $e = RequestException::create($r, new Response(500));
-        $this->assertContains('http://user:***@www.oo.com', $e->getMessage());
+        self::assertContains('http://user:***@www.oo.com', $e->getMessage());
     }
 
     public function testGetResponseBodySummaryOfNonReadableStream()
     {
-        $this->assertNull(RequestException::getResponseBodySummary(new Response(500, [], new ReadSeekOnlyStream())));
+        self::assertNull(RequestException::getResponseBodySummary(new Response(500, [], new ReadSeekOnlyStream())));
     }
 }
 

--- a/tests/Exception/SeekExceptionTest.php
+++ b/tests/Exception/SeekExceptionTest.php
@@ -11,7 +11,7 @@ class SeekExceptionTest extends TestCase
     {
         $s = Psr7\stream_for('foo');
         $e = new SeekException($s, 10);
-        $this->assertSame($s, $e->getStream());
-        $this->assertContains('10', $e->getMessage());
+        self::assertSame($s, $e->getStream());
+        self::assertContains('10', $e->getMessage());
     }
 }

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -221,7 +221,7 @@ class CurlFactoryTest extends TestCase
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['ssl_key' => [__FILE__]]);
 
-        $this->assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLKEY]);
+        self::assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLKEY]);
     }
 
     /**
@@ -595,20 +595,20 @@ class CurlFactoryTest extends TestCase
         $easy = $f->create($req, []);
         $h1 = $easy->handle;
         $f->release($easy);
-        self::assertCount(1, $this->readAttribute($f, 'handles'));
+        self::assertCount(1, self::readAttribute($f, 'handles'));
         $easy = $f->create($req, []);
         self::assertSame($easy->handle, $h1);
         $easy2 = $f->create($req, []);
         $easy3 = $f->create($req, []);
         $easy4 = $f->create($req, []);
         $f->release($easy);
-        self::assertCount(1, $this->readAttribute($f, 'handles'));
+        self::assertCount(1, self::readAttribute($f, 'handles'));
         $f->release($easy2);
-        self::assertCount(2, $this->readAttribute($f, 'handles'));
+        self::assertCount(2, self::readAttribute($f, 'handles'));
         $f->release($easy3);
-        self::assertCount(3, $this->readAttribute($f, 'handles'));
+        self::assertCount(3, self::readAttribute($f, 'handles'));
         $f->release($easy4);
-        self::assertCount(3, $this->readAttribute($f, 'handles'));
+        self::assertCount(3, self::readAttribute($f, 'handles'));
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -43,33 +43,33 @@ class CurlFactoryTest extends TestCase
         ], 'testing');
         $f = new Handler\CurlFactory(3);
         $result = $f->create($request, ['sink' => $stream]);
-        $this->assertInstanceOf(EasyHandle::class, $result);
-        $this->assertInternalType('resource', $result->handle);
-        $this->assertInternalType('array', $result->headers);
-        $this->assertSame($stream, $result->sink);
+        self::assertInstanceOf(EasyHandle::class, $result);
+        self::assertInternalType('resource', $result->handle);
+        self::assertInternalType('array', $result->headers);
+        self::assertSame($stream, $result->sink);
         curl_close($result->handle);
-        $this->assertSame('PUT', $_SERVER['_curl'][CURLOPT_CUSTOMREQUEST]);
-        $this->assertSame(
+        self::assertSame('PUT', $_SERVER['_curl'][CURLOPT_CUSTOMREQUEST]);
+        self::assertSame(
             'http://127.0.0.1:8126/',
             $_SERVER['_curl'][CURLOPT_URL]
         );
         // Sends via post fields when the request is small enough
-        $this->assertSame('testing', $_SERVER['_curl'][CURLOPT_POSTFIELDS]);
-        $this->assertEquals(0, $_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
-        $this->assertEquals(0, $_SERVER['_curl'][CURLOPT_HEADER]);
-        $this->assertSame(150, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT]);
-        $this->assertInstanceOf('Closure', $_SERVER['_curl'][CURLOPT_HEADERFUNCTION]);
+        self::assertSame('testing', $_SERVER['_curl'][CURLOPT_POSTFIELDS]);
+        self::assertEquals(0, $_SERVER['_curl'][CURLOPT_RETURNTRANSFER]);
+        self::assertEquals(0, $_SERVER['_curl'][CURLOPT_HEADER]);
+        self::assertSame(150, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT]);
+        self::assertInstanceOf('Closure', $_SERVER['_curl'][CURLOPT_HEADERFUNCTION]);
         if (defined('CURLOPT_PROTOCOLS')) {
-            $this->assertSame(
+            self::assertSame(
                 CURLPROTO_HTTP | CURLPROTO_HTTPS,
                 $_SERVER['_curl'][CURLOPT_PROTOCOLS]
             );
         }
-        $this->assertContains('Expect:', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
-        $this->assertContains('Accept:', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
-        $this->assertContains('Content-Type:', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
-        $this->assertContains('Hi: 123', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
-        $this->assertContains('Host: 127.0.0.1:8126', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
+        self::assertContains('Expect:', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
+        self::assertContains('Accept:', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
+        self::assertContains('Content-Type:', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
+        self::assertContains('Hi: 123', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
+        self::assertContains('Host: 127.0.0.1:8126', $_SERVER['_curl'][CURLOPT_HTTPHEADER]);
     }
 
     public function testSendsHeadRequests()
@@ -79,12 +79,12 @@ class CurlFactoryTest extends TestCase
         $a = new Handler\CurlMultiHandler();
         $response = $a(new Psr7\Request('HEAD', Server::$url), []);
         $response->wait();
-        $this->assertEquals(true, $_SERVER['_curl'][CURLOPT_NOBODY]);
+        self::assertEquals(true, $_SERVER['_curl'][CURLOPT_NOBODY]);
         $checks = [CURLOPT_WRITEFUNCTION, CURLOPT_READFUNCTION, CURLOPT_INFILE];
         foreach ($checks as $check) {
-            $this->assertArrayNotHasKey($check, $_SERVER['_curl']);
+            self::assertArrayNotHasKey($check, $_SERVER['_curl']);
         }
-        $this->assertEquals('HEAD', Server::received()[0]->getMethod());
+        self::assertEquals('HEAD', Server::received()[0]->getMethod());
     }
 
     public function testCanAddCustomCurlOptions()
@@ -94,7 +94,7 @@ class CurlFactoryTest extends TestCase
         $a = new Handler\CurlMultiHandler();
         $req = new Psr7\Request('GET', Server::$url);
         $a($req, ['curl' => [CURLOPT_LOW_SPEED_LIMIT => 10]]);
-        $this->assertEquals(10, $_SERVER['_curl'][CURLOPT_LOW_SPEED_LIMIT]);
+        self::assertEquals(10, $_SERVER['_curl'][CURLOPT_LOW_SPEED_LIMIT]);
     }
 
     public function testCanChangeCurlOptions()
@@ -104,7 +104,7 @@ class CurlFactoryTest extends TestCase
         $a = new Handler\CurlMultiHandler();
         $req = new Psr7\Request('GET', Server::$url);
         $a($req, ['curl' => [CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_0]]);
-        $this->assertEquals(CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][CURLOPT_HTTP_VERSION]);
+        self::assertEquals(CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][CURLOPT_HTTP_VERSION]);
     }
 
     /**
@@ -121,42 +121,42 @@ class CurlFactoryTest extends TestCase
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', 'http://foo.com'), ['verify' => __FILE__]);
-        $this->assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_CAINFO]);
-        $this->assertEquals(2, $_SERVER['_curl'][CURLOPT_SSL_VERIFYHOST]);
-        $this->assertEquals(true, $_SERVER['_curl'][CURLOPT_SSL_VERIFYPEER]);
+        self::assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_CAINFO]);
+        self::assertEquals(2, $_SERVER['_curl'][CURLOPT_SSL_VERIFYHOST]);
+        self::assertEquals(true, $_SERVER['_curl'][CURLOPT_SSL_VERIFYPEER]);
     }
 
     public function testCanSetVerifyToDir()
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', 'http://foo.com'), ['verify' => __DIR__]);
-        $this->assertEquals(__DIR__, $_SERVER['_curl'][CURLOPT_CAPATH]);
-        $this->assertEquals(2, $_SERVER['_curl'][CURLOPT_SSL_VERIFYHOST]);
-        $this->assertEquals(true, $_SERVER['_curl'][CURLOPT_SSL_VERIFYPEER]);
+        self::assertEquals(__DIR__, $_SERVER['_curl'][CURLOPT_CAPATH]);
+        self::assertEquals(2, $_SERVER['_curl'][CURLOPT_SSL_VERIFYHOST]);
+        self::assertEquals(true, $_SERVER['_curl'][CURLOPT_SSL_VERIFYPEER]);
     }
 
     public function testAddsVerifyAsTrue()
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['verify' => true]);
-        $this->assertEquals(2, $_SERVER['_curl'][CURLOPT_SSL_VERIFYHOST]);
-        $this->assertEquals(true, $_SERVER['_curl'][CURLOPT_SSL_VERIFYPEER]);
-        $this->assertArrayNotHasKey(CURLOPT_CAINFO, $_SERVER['_curl']);
+        self::assertEquals(2, $_SERVER['_curl'][CURLOPT_SSL_VERIFYHOST]);
+        self::assertEquals(true, $_SERVER['_curl'][CURLOPT_SSL_VERIFYPEER]);
+        self::assertArrayNotHasKey(CURLOPT_CAINFO, $_SERVER['_curl']);
     }
 
     public function testCanDisableVerify()
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['verify' => false]);
-        $this->assertEquals(0, $_SERVER['_curl'][CURLOPT_SSL_VERIFYHOST]);
-        $this->assertEquals(false, $_SERVER['_curl'][CURLOPT_SSL_VERIFYPEER]);
+        self::assertEquals(0, $_SERVER['_curl'][CURLOPT_SSL_VERIFYHOST]);
+        self::assertEquals(false, $_SERVER['_curl'][CURLOPT_SSL_VERIFYPEER]);
     }
 
     public function testAddsProxy()
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['proxy' => 'http://bar.com']);
-        $this->assertEquals('http://bar.com', $_SERVER['_curl'][CURLOPT_PROXY]);
+        self::assertEquals('http://bar.com', $_SERVER['_curl'][CURLOPT_PROXY]);
     }
 
     public function testAddsViaScheme()
@@ -165,7 +165,7 @@ class CurlFactoryTest extends TestCase
         $f->create(new Psr7\Request('GET', Server::$url), [
             'proxy' => ['http' => 'http://bar.com', 'https' => 'https://t'],
         ]);
-        $this->assertEquals('http://bar.com', $_SERVER['_curl'][CURLOPT_PROXY]);
+        self::assertEquals('http://bar.com', $_SERVER['_curl'][CURLOPT_PROXY]);
         $this->checkNoProxyForHost('http://test.test.com', ['test.test.com'], false);
         $this->checkNoProxyForHost('http://test.test.com', ['.test.com'], false);
         $this->checkNoProxyForHost('http://test.test.com', ['*.test.com'], true);
@@ -184,9 +184,9 @@ class CurlFactoryTest extends TestCase
             ],
         ]);
         if ($assertUseProxy) {
-            $this->assertArrayHasKey(CURLOPT_PROXY, $_SERVER['_curl']);
+            self::assertArrayHasKey(CURLOPT_PROXY, $_SERVER['_curl']);
         } else {
-            $this->assertArrayNotHasKey(CURLOPT_PROXY, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(CURLOPT_PROXY, $_SERVER['_curl']);
         }
     }
 
@@ -205,15 +205,15 @@ class CurlFactoryTest extends TestCase
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['ssl_key' => __FILE__]);
-        $this->assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLKEY]);
+        self::assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLKEY]);
     }
 
     public function testAddsSslKeyWithPassword()
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['ssl_key' => [__FILE__, 'test']]);
-        $this->assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLKEY]);
-        $this->assertEquals('test', $_SERVER['_curl'][CURLOPT_SSLKEYPASSWD]);
+        self::assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLKEY]);
+        self::assertEquals('test', $_SERVER['_curl'][CURLOPT_SSLKEYPASSWD]);
     }
 
     /**
@@ -230,15 +230,15 @@ class CurlFactoryTest extends TestCase
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['cert' => __FILE__]);
-        $this->assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLCERT]);
+        self::assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLCERT]);
     }
 
     public function testAddsCertWithPassword()
     {
         $f = new Handler\CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['cert' => [__FILE__, 'test']]);
-        $this->assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLCERT]);
-        $this->assertEquals('test', $_SERVER['_curl'][CURLOPT_SSLCERTPASSWD]);
+        self::assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLCERT]);
+        self::assertEquals('test', $_SERVER['_curl'][CURLOPT_SSLCERTPASSWD]);
     }
 
     /**
@@ -261,8 +261,8 @@ class CurlFactoryTest extends TestCase
         $response->wait();
         rewind($res);
         $output = str_replace("\r", '', stream_get_contents($res));
-        $this->assertContains("> HEAD / HTTP/1.1", $output);
-        $this->assertContains("< HTTP/1.1 200", $output);
+        self::assertContains("> HEAD / HTTP/1.1", $output);
+        self::assertContains("< HTTP/1.1 200", $output);
         fclose($res);
     }
 
@@ -279,9 +279,9 @@ class CurlFactoryTest extends TestCase
             },
         ]);
         $response->wait();
-        $this->assertNotEmpty($called);
+        self::assertNotEmpty($called);
         foreach ($called as $call) {
-            $this->assertCount(4, $call);
+            self::assertCount(4, $call);
         }
     }
 
@@ -305,10 +305,10 @@ class CurlFactoryTest extends TestCase
         $request = new Psr7\Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => true]);
         $response = $response->wait();
-        $this->assertEquals('test', (string) $response->getBody());
-        $this->assertEquals('', $_SERVER['_curl'][CURLOPT_ENCODING]);
+        self::assertEquals('test', (string) $response->getBody());
+        self::assertEquals('', $_SERVER['_curl'][CURLOPT_ENCODING]);
         $sent = Server::received()[0];
-        $this->assertFalse($sent->hasHeader('Accept-Encoding'));
+        self::assertFalse($sent->hasHeader('Accept-Encoding'));
     }
 
     public function testReportsOriginalSizeAndContentEncodingAfterDecoding()
@@ -318,11 +318,11 @@ class CurlFactoryTest extends TestCase
         $request = new Psr7\Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => true]);
         $response = $response->wait();
-        $this->assertSame(
+        self::assertSame(
             'gzip',
             $response->getHeaderLine('x-encoded-content-encoding')
         );
-        $this->assertSame(
+        self::assertSame(
             strlen(gzencode('test')),
             (int) $response->getHeaderLine('x-encoded-content-length')
         );
@@ -335,12 +335,12 @@ class CurlFactoryTest extends TestCase
         $request = new Psr7\Request('GET', Server::$url, ['Accept-Encoding' => 'gzip']);
         $response = $handler($request, ['decode_content' => true]);
         $response = $response->wait();
-        $this->assertEquals('gzip', $_SERVER['_curl'][CURLOPT_ENCODING]);
+        self::assertEquals('gzip', $_SERVER['_curl'][CURLOPT_ENCODING]);
         $sent = Server::received()[0];
-        $this->assertEquals('gzip', $sent->getHeaderLine('Accept-Encoding'));
-        $this->assertEquals('test', (string) $response->getBody());
-        $this->assertFalse($response->hasHeader('content-encoding'));
-        $this->assertTrue(
+        self::assertEquals('gzip', $sent->getHeaderLine('Accept-Encoding'));
+        self::assertEquals('test', (string) $response->getBody());
+        self::assertFalse($response->hasHeader('content-encoding'));
+        self::assertTrue(
             !$response->hasHeader('content-length') ||
             $response->getHeaderLine('content-length') == $response->getBody()->getSize()
         );
@@ -354,8 +354,8 @@ class CurlFactoryTest extends TestCase
         $response = $handler($request, ['decode_content' => false]);
         $response = $response->wait();
         $sent = Server::received()[0];
-        $this->assertFalse($sent->hasHeader('Accept-Encoding'));
-        $this->assertEquals($content, (string) $response->getBody());
+        self::assertFalse($sent->hasHeader('Accept-Encoding'));
+        self::assertEquals($content, (string) $response->getBody());
     }
 
     public function testProtocolVersion()
@@ -365,7 +365,7 @@ class CurlFactoryTest extends TestCase
         $a = new Handler\CurlMultiHandler();
         $request = new Psr7\Request('GET', Server::$url, [], null, '1.0');
         $a($request, []);
-        $this->assertEquals(CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][CURLOPT_HTTP_VERSION]);
+        self::assertEquals(CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][CURLOPT_HTTP_VERSION]);
     }
 
     public function testSavesToStream()
@@ -380,7 +380,7 @@ class CurlFactoryTest extends TestCase
         ]);
         $response->wait();
         rewind($stream);
-        $this->assertEquals('test', stream_get_contents($stream));
+        self::assertEquals('test', stream_get_contents($stream));
     }
 
     public function testSavesToGuzzleStream()
@@ -394,7 +394,7 @@ class CurlFactoryTest extends TestCase
             'sink'           => $stream,
         ]);
         $response->wait();
-        $this->assertEquals('test', (string) $stream);
+        self::assertEquals('test', (string) $stream);
     }
 
     public function testSavesToFileOnDisk()
@@ -408,7 +408,7 @@ class CurlFactoryTest extends TestCase
             'sink'           => $tmpfile,
         ]);
         $response->wait();
-        $this->assertStringEqualsFile($tmpfile, 'test');
+        self::assertStringEqualsFile($tmpfile, 'test');
         unlink($tmpfile);
     }
 
@@ -420,9 +420,9 @@ class CurlFactoryTest extends TestCase
         $response = $handler($request, []);
         $response->wait();
         $sent = Server::received()[0];
-        $this->assertEquals(3, $sent->getHeaderLine('Content-Length'));
-        $this->assertFalse($sent->hasHeader('Transfer-Encoding'));
-        $this->assertEquals('foo', (string) $sent->getBody());
+        self::assertEquals(3, $sent->getHeaderLine('Content-Length'));
+        self::assertFalse($sent->hasHeader('Transfer-Encoding'));
+        self::assertEquals('foo', (string) $sent->getBody());
     }
 
     public function testSendsPostWithNoBodyOrDefaultContentType()
@@ -434,9 +434,9 @@ class CurlFactoryTest extends TestCase
         $response = $handler($request, []);
         $response->wait();
         $received = Server::received()[0];
-        $this->assertEquals('POST', $received->getMethod());
-        $this->assertFalse($received->hasHeader('content-type'));
-        $this->assertSame('0', $received->getHeaderLine('content-length'));
+        self::assertEquals('POST', $received->getMethod());
+        self::assertFalse($received->hasHeader('content-type'));
+        self::assertSame('0', $received->getHeaderLine('content-length'));
     }
 
     /**
@@ -476,9 +476,9 @@ class CurlFactoryTest extends TestCase
         $easy = $factory->create($req, []);
         $res = Handler\CurlFactory::finish($fn, $easy, $factory);
         $res = $res->wait();
-        $this->assertTrue($callHandler);
-        $this->assertTrue($called);
-        $this->assertEquals('200', $res->getStatusCode());
+        self::assertTrue($callHandler);
+        self::assertTrue($called);
+        self::assertEquals('200', $res->getStatusCode());
     }
 
     /**
@@ -497,7 +497,7 @@ class CurlFactoryTest extends TestCase
         $mock = new Handler\MockHandler([$fn, $fn, $fn]);
         $p = $mock(new Psr7\Request('PUT', Server::$url, [], 'test'), []);
         $p->wait(false);
-        $this->assertEquals(3, $call);
+        self::assertEquals(3, $call);
         $p->wait(true);
     }
 
@@ -512,11 +512,11 @@ class CurlFactoryTest extends TestCase
         ], 'test');
         $handler = new Handler\CurlMultiHandler();
         $response = $handler($request, [])->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('OK', $response->getReasonPhrase());
-        $this->assertSame('Hello', $response->getHeaderLine('Test'));
-        $this->assertSame('4', $response->getHeaderLine('Content-Length'));
-        $this->assertSame('test', (string) $response->getBody());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('OK', $response->getReasonPhrase());
+        self::assertSame('Hello', $response->getHeaderLine('Test'));
+        self::assertSame('4', $response->getHeaderLine('Content-Length'));
+        self::assertSame('test', (string) $response->getBody());
     }
 
     /**
@@ -545,8 +545,8 @@ class CurlFactoryTest extends TestCase
             'timeout'         => 0.1,
             'connect_timeout' => 0.2
         ]);
-        $this->assertEquals(100, $_SERVER['_curl'][CURLOPT_TIMEOUT_MS]);
-        $this->assertEquals(200, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT_MS]);
+        self::assertEquals(100, $_SERVER['_curl'][CURLOPT_TIMEOUT_MS]);
+        self::assertEquals(200, $_SERVER['_curl'][CURLOPT_CONNECTTIMEOUT_MS]);
     }
 
     public function testAddsStreamingBody()
@@ -559,8 +559,8 @@ class CurlFactoryTest extends TestCase
         ]);
         $request = new Psr7\Request('PUT', Server::$url, [], $bd);
         $f->create($request, []);
-        $this->assertEquals(1, $_SERVER['_curl'][CURLOPT_UPLOAD]);
-        $this->assertInternalType('callable', $_SERVER['_curl'][CURLOPT_READFUNCTION]);
+        self::assertEquals(1, $_SERVER['_curl'][CURLOPT_UPLOAD]);
+        self::assertInternalType('callable', $_SERVER['_curl'][CURLOPT_READFUNCTION]);
     }
 
     /**
@@ -582,20 +582,20 @@ class CurlFactoryTest extends TestCase
         $easy = $f->create($req, []);
         $h1 = $easy->handle;
         $f->release($easy);
-        $this->assertCount(1, $this->readAttribute($f, 'handles'));
+        self::assertCount(1, $this->readAttribute($f, 'handles'));
         $easy = $f->create($req, []);
-        $this->assertSame($easy->handle, $h1);
+        self::assertSame($easy->handle, $h1);
         $easy2 = $f->create($req, []);
         $easy3 = $f->create($req, []);
         $easy4 = $f->create($req, []);
         $f->release($easy);
-        $this->assertCount(1, $this->readAttribute($f, 'handles'));
+        self::assertCount(1, $this->readAttribute($f, 'handles'));
         $f->release($easy2);
-        $this->assertCount(2, $this->readAttribute($f, 'handles'));
+        self::assertCount(2, $this->readAttribute($f, 'handles'));
         $f->release($easy3);
-        $this->assertCount(3, $this->readAttribute($f, 'handles'));
+        self::assertCount(3, $this->readAttribute($f, 'handles'));
         $f->release($easy4);
-        $this->assertCount(3, $this->readAttribute($f, 'handles'));
+        self::assertCount(3, $this->readAttribute($f, 'handles'));
     }
 
     /**
@@ -641,7 +641,7 @@ class CurlFactoryTest extends TestCase
         $stream = Psr7\stream_for();
         $stream = Psr7\FnStream::decorate($stream, [
             'write' => function ($data) use ($stream, &$got) {
-                $this->assertNotNull($got);
+                self::assertNotNull($got);
                 return $stream->write($data);
             }
         ]);
@@ -651,14 +651,14 @@ class CurlFactoryTest extends TestCase
             'sink'       => $stream,
             'on_headers' => function (ResponseInterface $res) use (&$got) {
                 $got = $res;
-                $this->assertEquals('bar', $res->getHeaderLine('X-Foo'));
+                self::assertEquals('bar', $res->getHeaderLine('X-Foo'));
             }
         ]);
 
         $response = $promise->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('bar', $response->getHeaderLine('X-Foo'));
-        $this->assertSame('abc 123', (string) $response->getBody());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getHeaderLine('X-Foo'));
+        self::assertSame('abc 123', (string) $response->getBody());
     }
 
     public function testInvokesOnStatsOnSuccess()
@@ -674,18 +674,18 @@ class CurlFactoryTest extends TestCase
             }
         ]);
         $response = $promise->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame(200, $gotStats->getResponse()->getStatusCode());
-        $this->assertSame(
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $gotStats->getResponse()->getStatusCode());
+        self::assertSame(
             Server::$url,
             (string) $gotStats->getEffectiveUri()
         );
-        $this->assertSame(
+        self::assertSame(
             Server::$url,
             (string) $gotStats->getRequest()->getUri()
         );
-        $this->assertGreaterThan(0, $gotStats->getTransferTime());
-        $this->assertArrayHasKey('appconnect_time', $gotStats->getHandlerStats());
+        self::assertGreaterThan(0, $gotStats->getTransferTime());
+        self::assertArrayHasKey('appconnect_time', $gotStats->getHandlerStats());
     }
 
     public function testInvokesOnStatsOnError()
@@ -701,25 +701,25 @@ class CurlFactoryTest extends TestCase
             }
         ]);
         $promise->wait(false);
-        $this->assertFalse($gotStats->hasResponse());
-        $this->assertSame(
+        self::assertFalse($gotStats->hasResponse());
+        self::assertSame(
             'http://127.0.0.1:123',
             (string) $gotStats->getEffectiveUri()
         );
-        $this->assertSame(
+        self::assertSame(
             'http://127.0.0.1:123',
             (string) $gotStats->getRequest()->getUri()
         );
-        $this->assertInternalType('float', $gotStats->getTransferTime());
-        $this->assertInternalType('int', $gotStats->getHandlerErrorData());
-        $this->assertArrayHasKey('appconnect_time', $gotStats->getHandlerStats());
+        self::assertInternalType('float', $gotStats->getTransferTime());
+        self::assertInternalType('int', $gotStats->getHandlerErrorData());
+        self::assertArrayHasKey('appconnect_time', $gotStats->getHandlerStats());
     }
 
     public function testRewindsBodyIfPossible()
     {
         $body = Psr7\stream_for(str_repeat('x', 1024 * 1024 * 2));
         $body->seek(1024 * 1024);
-        $this->assertSame(1024 * 1024, $body->tell());
+        self::assertSame(1024 * 1024, $body->tell());
 
         $req = new Psr7\Request('POST', 'https://www.example.com', [
             'Content-Length' => 1024 * 1024 * 2,
@@ -727,7 +727,7 @@ class CurlFactoryTest extends TestCase
         $factory = new CurlFactory(1);
         $factory->create($req, []);
 
-        $this->assertSame(0, $body->tell());
+        self::assertSame(0, $body->tell());
     }
 
     public function testDoesNotRewindUnseekableBody()
@@ -735,7 +735,7 @@ class CurlFactoryTest extends TestCase
         $body = Psr7\stream_for(str_repeat('x', 1024 * 1024 * 2));
         $body->seek(1024 * 1024);
         $body = new Psr7\NoSeekStream($body);
-        $this->assertSame(1024 * 1024, $body->tell());
+        self::assertSame(1024 * 1024, $body->tell());
 
         $req = new Psr7\Request('POST', 'https://www.example.com', [
             'Content-Length' => 1024 * 1024,
@@ -743,7 +743,7 @@ class CurlFactoryTest extends TestCase
         $factory = new CurlFactory(1);
         $factory->create($req, []);
 
-        $this->assertSame(1024 * 1024, $body->tell());
+        self::assertSame(1024 * 1024, $body->tell());
     }
 
     public function testRelease()
@@ -752,6 +752,6 @@ class CurlFactoryTest extends TestCase
         $easyHandle = new EasyHandle();
         $easyHandle->handle = curl_init();
 
-        $this->assertEmpty($factory->release($easyHandle));
+        self::assertEmpty($factory->release($easyHandle));
     }
 }

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -37,8 +37,8 @@ class CurlHandlerTest extends TestCase
         Server::enqueue([$response, $response]);
         $a = new CurlHandler();
         $request = new Request('GET', Server::$url);
-        $this->assertInstanceOf('GuzzleHttp\Promise\FulfilledPromise', $a($request, []));
-        $this->assertInstanceOf('GuzzleHttp\Promise\FulfilledPromise', $a($request, []));
+        self::assertInstanceOf('GuzzleHttp\Promise\FulfilledPromise', $a($request, []));
+        self::assertInstanceOf('GuzzleHttp\Promise\FulfilledPromise', $a($request, []));
     }
 
     public function testDoesSleep()
@@ -49,7 +49,7 @@ class CurlHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $s = \GuzzleHttp\_current_time();
         $a($request, ['delay' => 0.1])->wait();
-        $this->assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
+        self::assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
     }
 
     public function testCreatesCurlErrorsWithContext()
@@ -60,10 +60,10 @@ class CurlHandlerTest extends TestCase
         $p = $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])
             ->otherwise(function (ConnectException $e) use (&$called) {
                 $called = true;
-                $this->assertArrayHasKey('errno', $e->getHandlerContext());
+                self::assertArrayHasKey('errno', $e->getHandlerContext());
             });
         $p->wait();
-        $this->assertTrue($called);
+        self::assertTrue($called);
     }
 
     public function testUsesContentLengthWhenOverInMemorySize()
@@ -80,7 +80,7 @@ class CurlHandlerTest extends TestCase
         );
         $handler($request, [])->wait();
         $received = Server::received()[0];
-        $this->assertEquals(1000000, $received->getHeaderLine('Content-Length'));
-        $this->assertFalse($received->hasHeader('Transfer-Encoding'));
+        self::assertEquals(1000000, $received->getHeaderLine('Content-Length'));
+        self::assertFalse($received->hasHeader('Transfer-Encoding'));
     }
 }

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -54,7 +54,7 @@ class CurlMultiHandlerTest extends TestCase
     public function testCanSetSelectTimeout()
     {
         $a = new CurlMultiHandler(['select_timeout' => 2]);
-        self::assertEquals(2, $this->readAttribute($a, 'selectTimeout'));
+        self::assertEquals(2, self::readAttribute($a, 'selectTimeout'));
     }
 
     public function testCanCancel()
@@ -102,13 +102,13 @@ class CurlMultiHandlerTest extends TestCase
         $a = new CurlMultiHandler();
 
         //default if no options are given and no environment variable is set
-        self::assertEquals(1, $this->readAttribute($a, 'selectTimeout'));
+        self::assertEquals(1, self::readAttribute($a, 'selectTimeout'));
 
         putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
         $a = new CurlMultiHandler();
         $selectTimeout = getenv('GUZZLE_CURL_SELECT_TIMEOUT');
         //Handler reads from the environment if no options are given
-        self::assertEquals($selectTimeout, $this->readAttribute($a, 'selectTimeout'));
+        self::assertEquals($selectTimeout, self::readAttribute($a, 'selectTimeout'));
     }
 
     /**

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -29,7 +29,7 @@ class CurlMultiHandlerTest extends TestCase
         ]]);
         $request = new Request('GET', Server::$url);
         $a($request, []);
-        $this->assertEquals(5, $_SERVER['_curl_multi'][CURLMOPT_MAXCONNECTS]);
+        self::assertEquals(5, $_SERVER['_curl_multi'][CURLMOPT_MAXCONNECTS]);
     }
 
     public function testSendsRequest()
@@ -38,7 +38,7 @@ class CurlMultiHandlerTest extends TestCase
         $a = new CurlMultiHandler();
         $request = new Request('GET', Server::$url);
         $response = $a($request, [])->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -54,7 +54,7 @@ class CurlMultiHandlerTest extends TestCase
     public function testCanSetSelectTimeout()
     {
         $a = new CurlMultiHandler(['select_timeout' => 2]);
-        $this->assertEquals(2, $this->readAttribute($a, 'selectTimeout'));
+        self::assertEquals(2, $this->readAttribute($a, 'selectTimeout'));
     }
 
     public function testCanCancel()
@@ -71,7 +71,7 @@ class CurlMultiHandlerTest extends TestCase
         }
 
         foreach($responses as $r) {
-            $this->assertSame('rejected', $response->getState());
+            self::assertSame('rejected', $response->getState());
         }
     }
 
@@ -83,7 +83,7 @@ class CurlMultiHandlerTest extends TestCase
         $response = $a(new Request('GET', Server::$url), []);
         $response->wait();
         $response->cancel();
-        $this->assertSame('fulfilled', $response->getState());
+        self::assertSame('fulfilled', $response->getState());
     }
 
     public function testDelaysConcurrently()
@@ -94,7 +94,7 @@ class CurlMultiHandlerTest extends TestCase
         $expected = \GuzzleHttp\_current_time() + (100 / 1000);
         $response = $a(new Request('GET', Server::$url), ['delay' => 100]);
         $response->wait();
-        $this->assertGreaterThanOrEqual($expected, \GuzzleHttp\_current_time());
+        self::assertGreaterThanOrEqual($expected, \GuzzleHttp\_current_time());
     }
 
     public function testUsesTimeoutEnvironmentVariables()
@@ -102,13 +102,13 @@ class CurlMultiHandlerTest extends TestCase
         $a = new CurlMultiHandler();
 
         //default if no options are given and no environment variable is set
-        $this->assertEquals(1, $this->readAttribute($a, 'selectTimeout'));
+        self::assertEquals(1, $this->readAttribute($a, 'selectTimeout'));
 
         putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
         $a = new CurlMultiHandler();
         $selectTimeout = getenv('GUZZLE_CURL_SELECT_TIMEOUT');
         //Handler reads from the environment if no options are given
-        $this->assertEquals($selectTimeout, $this->readAttribute($a, 'selectTimeout'));
+        self::assertEquals($selectTimeout, $this->readAttribute($a, 'selectTimeout'));
     }
 
     /**

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -52,7 +52,7 @@ class MockHandlerTest extends TestCase
         $p = $mock($request, []);
         try {
             $p->wait();
-            $this->fail();
+            self::fail();
         } catch (\Exception $e2) {
             self::assertSame($e, $e2);
         }

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -19,19 +19,19 @@ class MockHandlerTest extends TestCase
         $mock = new MockHandler([$res]);
         $request = new Request('GET', 'http://example.com');
         $p = $mock($request, []);
-        $this->assertSame($res, $p->wait());
+        self::assertSame($res, $p->wait());
     }
 
     public function testIsCountable()
     {
         $res = new Response();
         $mock = new MockHandler([$res, $res]);
-        $this->assertCount(2, $mock);
+        self::assertCount(2, $mock);
     }
 
     public function testEmptyHandlerIsCountable()
     {
-        $this->assertCount(0, new MockHandler());
+        self::assertCount(0, new MockHandler());
     }
 
     /**
@@ -54,7 +54,7 @@ class MockHandlerTest extends TestCase
             $p->wait();
             $this->fail();
         } catch (\Exception $e2) {
-            $this->assertSame($e, $e2);
+            self::assertSame($e, $e2);
         }
     }
 
@@ -64,8 +64,8 @@ class MockHandlerTest extends TestCase
         $mock = new MockHandler([$res]);
         $request = new Request('GET', 'http://example.com');
         $mock($request, ['foo' => 'bar']);
-        $this->assertSame($request, $mock->getLastRequest());
-        $this->assertSame(['foo' => 'bar'], $mock->getLastOptions());
+        self::assertSame($request, $mock->getLastRequest());
+        self::assertSame(['foo' => 'bar'], $mock->getLastOptions());
     }
 
     public function testSinkFilename()
@@ -77,8 +77,8 @@ class MockHandlerTest extends TestCase
         $p = $mock($request, ['sink' => $filename]);
         $p->wait();
 
-        $this->assertFileExists($filename);
-        $this->assertStringEqualsFile($filename, 'TEST CONTENT');
+        self::assertFileExists($filename);
+        self::assertStringEqualsFile($filename, 'TEST CONTENT');
 
         unlink($filename);
     }
@@ -93,8 +93,8 @@ class MockHandlerTest extends TestCase
         $p = $mock($request, ['sink' => $file]);
         $p->wait();
 
-        $this->assertFileExists($meta['uri']);
-        $this->assertStringEqualsFile($meta['uri'], 'TEST CONTENT');
+        self::assertFileExists($meta['uri']);
+        self::assertStringEqualsFile($meta['uri'], 'TEST CONTENT');
     }
 
     public function testSinkStream()
@@ -106,8 +106,8 @@ class MockHandlerTest extends TestCase
         $p = $mock($request, ['sink' => $stream]);
         $p->wait();
 
-        $this->assertFileExists($stream->getMetadata('uri'));
-        $this->assertStringEqualsFile($stream->getMetadata('uri'), 'TEST CONTENT');
+        self::assertFileExists($stream->getMetadata('uri'));
+        self::assertStringEqualsFile($stream->getMetadata('uri'), 'TEST CONTENT');
     }
 
     public function testCanEnqueueCallables()
@@ -117,7 +117,7 @@ class MockHandlerTest extends TestCase
         $mock = new MockHandler([$fn]);
         $request = new Request('GET', 'http://example.com');
         $p = $mock($request, ['foo' => 'bar']);
-        $this->assertSame($r, $p->wait());
+        self::assertSame($r, $p->wait());
     }
 
     /**
@@ -157,7 +157,7 @@ class MockHandlerTest extends TestCase
         });
         $request = new Request('GET', 'http://example.com');
         $mock($request, [])->wait();
-        $this->assertSame($res, $c);
+        self::assertSame($res, $c);
     }
 
     public function testInvokesOnRejected()
@@ -167,7 +167,7 @@ class MockHandlerTest extends TestCase
         $mock = new MockHandler([$e], null, function ($v) use (&$c) { $c = $v; });
         $request = new Request('GET', 'http://example.com');
         $mock($request, [])->wait(false);
-        $this->assertSame($e, $c);
+        self::assertSame($e, $c);
     }
 
     /**
@@ -203,8 +203,8 @@ class MockHandlerTest extends TestCase
         };
         $p = $mock($request, ['on_stats' => $onStats]);
         $p->wait();
-        $this->assertSame($res, $stats->getResponse());
-        $this->assertSame($request, $stats->getRequest());
+        self::assertSame($res, $stats->getResponse());
+        self::assertSame($request, $stats->getRequest());
     }
 
     public function testInvokesOnStatsFunctionForError()
@@ -220,9 +220,9 @@ class MockHandlerTest extends TestCase
             $stats = $s;
         };
         $mock($request, ['on_stats' => $onStats])->wait(false);
-        $this->assertSame($e, $stats->getHandlerErrorData());
-        $this->assertNull($stats->getResponse());
-        $this->assertSame($request, $stats->getRequest());
+        self::assertSame($e, $stats->getHandlerErrorData());
+        self::assertNull($stats->getResponse());
+        self::assertSame($request, $stats->getRequest());
     }
 
     public function testTransferTime()
@@ -236,18 +236,18 @@ class MockHandlerTest extends TestCase
             $stats = $s;
         };
         $mock($request, [ 'on_stats' => $onStats, 'transfer_time' => 0.4 ])->wait(false);
-        $this->assertEquals(0.4, $stats->getTransferTime());
+        self::assertEquals(0.4, $stats->getTransferTime());
     }
 
     public function testResetQueue()
     {
         $mock = new MockHandler([new Response(200), new Response(204)]);
-        $this->assertCount(2, $mock);
+        self::assertCount(2, $mock);
 
         $mock->reset();
-        $this->assertEmpty($mock);
+        self::assertEmpty($mock);
 
         $mock->append(new Response(500));
-        $this->assertCount(1, $mock);
+        self::assertCount(1, $mock);
     }
 }

--- a/tests/Handler/ProxyTest.php
+++ b/tests/Handler/ProxyTest.php
@@ -19,8 +19,8 @@ class ProxyTest extends TestCase
         $m2 = new MockHandler([function ($v) use (&$b) { $b = $v; }]);
         $h = Proxy::wrapSync($m1, $m2);
         $h(new Request('GET', 'http://foo.com'), []);
-        $this->assertNotNull($a);
-        $this->assertNull($b);
+        self::assertNotNull($a);
+        self::assertNull($b);
     }
 
     public function testSendsToSync()
@@ -30,8 +30,8 @@ class ProxyTest extends TestCase
         $m2 = new MockHandler([function ($v) use (&$b) { $b = $v; }]);
         $h = Proxy::wrapSync($m1, $m2);
         $h(new Request('GET', 'http://foo.com'), [RequestOptions::SYNCHRONOUS => true]);
-        $this->assertNull($a);
-        $this->assertNotNull($b);
+        self::assertNull($a);
+        self::assertNotNull($b);
     }
 
     public function testSendsToStreaming()
@@ -41,8 +41,8 @@ class ProxyTest extends TestCase
         $m2 = new MockHandler([function ($v) use (&$b) { $b = $v; }]);
         $h = Proxy::wrapStreaming($m1, $m2);
         $h(new Request('GET', 'http://foo.com'), []);
-        $this->assertNotNull($a);
-        $this->assertNull($b);
+        self::assertNotNull($a);
+        self::assertNull($b);
     }
 
     public function testSendsToNonStreaming()
@@ -52,7 +52,7 @@ class ProxyTest extends TestCase
         $m2 = new MockHandler([function ($v) use (&$b) { $b = $v; }]);
         $h = Proxy::wrapStreaming($m1, $m2);
         $h(new Request('GET', 'http://foo.com'), ['stream' => true]);
-        $this->assertNull($a);
-        $this->assertNotNull($b);
+        self::assertNull($a);
+        self::assertNotNull($b);
     }
 }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -37,16 +37,16 @@ class StreamHandlerTest extends TestCase
             new Request('GET', Server::$url, ['Foo' => 'Bar']),
             []
         )->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('OK', $response->getReasonPhrase());
-        $this->assertSame('Bar', $response->getHeaderLine('Foo'));
-        $this->assertSame('8', $response->getHeaderLine('Content-Length'));
-        $this->assertSame('hi there', (string) $response->getBody());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('OK', $response->getReasonPhrase());
+        self::assertSame('Bar', $response->getHeaderLine('Foo'));
+        self::assertSame('8', $response->getHeaderLine('Content-Length'));
+        self::assertSame('hi there', (string) $response->getBody());
         $sent = Server::received()[0];
-        $this->assertSame('GET', $sent->getMethod());
-        $this->assertSame('/', $sent->getUri()->getPath());
-        $this->assertSame('127.0.0.1:8126', $sent->getHeaderLine('Host'));
-        $this->assertSame('Bar', $sent->getHeaderLine('foo'));
+        self::assertSame('GET', $sent->getMethod());
+        self::assertSame('/', $sent->getUri()->getPath());
+        self::assertSame('127.0.0.1:8126', $sent->getHeaderLine('Host'));
+        self::assertSame('Bar', $sent->getHeaderLine('foo'));
     }
 
     /**
@@ -72,20 +72,20 @@ class StreamHandlerTest extends TestCase
             'test'
         );
         $response = $handler($request, ['stream' => true])->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('OK', $response->getReasonPhrase());
-        $this->assertSame('8', $response->getHeaderLine('Content-Length'));
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('OK', $response->getReasonPhrase());
+        self::assertSame('8', $response->getHeaderLine('Content-Length'));
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertInternalType('resource', $stream);
-        $this->assertSame('http', stream_get_meta_data($stream)['wrapper_type']);
-        $this->assertSame('hi there', stream_get_contents($stream));
+        self::assertInternalType('resource', $stream);
+        self::assertSame('http', stream_get_meta_data($stream)['wrapper_type']);
+        self::assertSame('hi there', stream_get_contents($stream));
         fclose($stream);
         $sent = Server::received()[0];
-        $this->assertSame('PUT', $sent->getMethod());
-        $this->assertSame('http://127.0.0.1:8126/foo?baz=bar', (string) $sent->getUri());
-        $this->assertSame('Bar', $sent->getHeaderLine('Foo'));
-        $this->assertSame('test', (string) $sent->getBody());
+        self::assertSame('PUT', $sent->getMethod());
+        self::assertSame('http://127.0.0.1:8126/foo?baz=bar', (string) $sent->getUri());
+        self::assertSame('Bar', $sent->getHeaderLine('Foo'));
+        self::assertSame('test', (string) $sent->getBody());
     }
 
     public function testDrainsResponseIntoTempStream()
@@ -96,8 +96,8 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, [])->wait();
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertSame('php://temp', stream_get_meta_data($stream)['uri']);
-        $this->assertSame('hi', fread($stream, 2));
+        self::assertSame('php://temp', stream_get_meta_data($stream)['uri']);
+        self::assertSame('hi', fread($stream, 2));
         fclose($stream);
     }
 
@@ -109,9 +109,9 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['sink' => $r])->wait();
         $body = $response->getBody()->detach();
-        $this->assertSame('php://temp', stream_get_meta_data($body)['uri']);
-        $this->assertSame('hi', fread($body, 2));
-        $this->assertSame(' there', stream_get_contents($r));
+        self::assertSame('php://temp', stream_get_meta_data($body)['uri']);
+        self::assertSame('hi', fread($body, 2));
+        self::assertSame(' there', stream_get_contents($r));
         fclose($r);
     }
 
@@ -123,8 +123,8 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['sink' => $tmpfname])->wait();
         $body = $response->getBody();
-        $this->assertSame($tmpfname, $body->getMetadata('uri'));
-        $this->assertSame('hi', $body->read(2));
+        self::assertSame($tmpfname, $body->getMetadata('uri'));
+        self::assertSame('hi', $body->read(2));
         $body->close();
         unlink($tmpfname);
     }
@@ -138,8 +138,8 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['sink' => $tmpfname])->wait();
         $body = $response->getBody();
-        $this->assertSame($tmpfname, $body->getMetadata('uri'));
-        $this->assertSame('hi', $body->read(2));
+        self::assertSame($tmpfname, $body->getMetadata('uri'));
+        self::assertSame('hi', $body->read(2));
         $body->close();
         unlink($tmpfname);
     }
@@ -158,7 +158,7 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, [])->wait();
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertSame('hi there', stream_get_contents($stream));
+        self::assertSame('hi there', stream_get_contents($stream));
         fclose($stream);
     }
 
@@ -177,7 +177,7 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, [])->wait();
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertSame('', stream_get_contents($stream));
+        self::assertSame('', stream_get_contents($stream));
         fclose($stream);
     }
 
@@ -194,9 +194,9 @@ class StreamHandlerTest extends TestCase
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => true])->wait();
-        $this->assertSame('test', (string) $response->getBody());
-        $this->assertFalse($response->hasHeader('content-encoding'));
-        $this->assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == $response->getBody()->getSize());
+        self::assertSame('test', (string) $response->getBody());
+        self::assertFalse($response->hasHeader('content-encoding'));
+        self::assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == $response->getBody()->getSize());
     }
 
     public function testReportsOriginalSizeAndContentEncodingAfterDecoding()
@@ -213,11 +213,11 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => true])->wait();
 
-        $this->assertSame(
+        self::assertSame(
             'gzip',
             $response->getHeaderLine('x-encoded-content-encoding')
         );
-        $this->assertSame(
+        self::assertSame(
             strlen($content),
             (int) $response->getHeaderLine('x-encoded-content-length')
         );
@@ -236,9 +236,9 @@ class StreamHandlerTest extends TestCase
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => false])->wait();
-        $this->assertSame($content, (string) $response->getBody());
-        $this->assertSame('gzip', $response->getHeaderLine('content-encoding'));
-        $this->assertEquals(strlen($content), $response->getHeaderLine('content-length'));
+        self::assertSame($content, (string) $response->getBody());
+        self::assertSame('gzip', $response->getHeaderLine('content-encoding'));
+        self::assertEquals(strlen($content), $response->getHeaderLine('content-length'));
     }
 
     public function testProtocolVersion()
@@ -247,7 +247,7 @@ class StreamHandlerTest extends TestCase
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url, [], null, '1.0');
         $handler($request, []);
-        $this->assertSame('1.0', Server::received()[0]->getProtocolVersion());
+        self::assertSame('1.0', Server::received()[0]->getProtocolVersion());
     }
 
     protected function getSendResult(array $opts)
@@ -275,7 +275,7 @@ class StreamHandlerTest extends TestCase
         $url = rtrim($url, '/');
         $res = $this->getSendResult(['proxy' => ['http' => $url]]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertSame($url, $opts['http']['proxy']);
+        self::assertSame($url, $opts['http']['proxy']);
     }
 
     public function testAddsProxyButHonorsNoProxy()
@@ -286,14 +286,14 @@ class StreamHandlerTest extends TestCase
             'no'   => ['*']
         ]]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertArrayNotHasKey('proxy', $opts['http']);
+        self::assertArrayNotHasKey('proxy', $opts['http']);
     }
 
     public function testAddsTimeout()
     {
         $res = $this->getSendResult(['stream' => true, 'timeout' => 200]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertEquals(200, $opts['http']['timeout']);
+        self::assertEquals(200, $opts['http']['timeout']);
     }
 
     /**
@@ -308,7 +308,7 @@ class StreamHandlerTest extends TestCase
     public function testVerifyCanBeDisabled()
     {
         $handler = $this->getSendResult(['verify' => false]);
-        $this->assertInstanceOf('GuzzleHttp\Psr7\Response', $handler);
+        self::assertInstanceOf('GuzzleHttp\Psr7\Response', $handler);
     }
 
     /**
@@ -325,10 +325,10 @@ class StreamHandlerTest extends TestCase
         $path = $path = \GuzzleHttp\default_ca_bundle();
         $res = $this->getSendResult(['verify' => $path]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertTrue($opts['ssl']['verify_peer']);
-        $this->assertTrue($opts['ssl']['verify_peer_name']);
-        $this->assertSame($path, $opts['ssl']['cafile']);
-        $this->assertFileExists($opts['ssl']['cafile']);
+        self::assertTrue($opts['ssl']['verify_peer']);
+        self::assertTrue($opts['ssl']['verify_peer_name']);
+        self::assertSame($path, $opts['ssl']['cafile']);
+        self::assertFileExists($opts['ssl']['cafile']);
     }
 
     public function testUsesSystemDefaultBundle()
@@ -337,9 +337,9 @@ class StreamHandlerTest extends TestCase
         $res = $this->getSendResult(['verify' => true]);
         $opts = stream_context_get_options($res->getBody()->detach());
         if (PHP_VERSION_ID < 50600) {
-            $this->assertSame($path, $opts['ssl']['cafile']);
+            self::assertSame($path, $opts['ssl']['cafile']);
         } else {
-            $this->assertArrayNotHasKey('cafile', $opts['ssl']);
+            self::assertArrayNotHasKey('cafile', $opts['ssl']);
         }
     }
 
@@ -357,8 +357,8 @@ class StreamHandlerTest extends TestCase
         $path = __FILE__;
         $res = $this->getSendResult(['cert' => [$path, 'foo']]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertSame($path, $opts['ssl']['local_cert']);
-        $this->assertSame('foo', $opts['ssl']['passphrase']);
+        self::assertSame($path, $opts['ssl']['local_cert']);
+        self::assertSame('foo', $opts['ssl']['passphrase']);
     }
 
     public function testDebugAttributeWritesToStream()
@@ -368,9 +368,9 @@ class StreamHandlerTest extends TestCase
         $this->getSendResult(['debug' => $f]);
         fseek($f, 0);
         $contents = stream_get_contents($f);
-        $this->assertContains('<GET http://127.0.0.1:8126/> [CONNECT]', $contents);
-        $this->assertContains('<GET http://127.0.0.1:8126/> [FILE_SIZE_IS]', $contents);
-        $this->assertContains('<GET http://127.0.0.1:8126/> [PROGRESS]', $contents);
+        self::assertContains('<GET http://127.0.0.1:8126/> [CONNECT]', $contents);
+        self::assertContains('<GET http://127.0.0.1:8126/> [FILE_SIZE_IS]', $contents);
+        self::assertContains('<GET http://127.0.0.1:8126/> [PROGRESS]', $contents);
     }
 
     public function testDebugAttributeWritesStreamInfoToBuffer()
@@ -384,10 +384,10 @@ class StreamHandlerTest extends TestCase
         ]);
         fseek($buffer, 0);
         $contents = stream_get_contents($buffer);
-        $this->assertContains('<GET http://127.0.0.1:8126/> [CONNECT]', $contents);
-        $this->assertContains('<GET http://127.0.0.1:8126/> [FILE_SIZE_IS] message: "Content-Length: 8"', $contents);
-        $this->assertContains('<GET http://127.0.0.1:8126/> [PROGRESS] bytes_max: "8"', $contents);
-        $this->assertTrue($called);
+        self::assertContains('<GET http://127.0.0.1:8126/> [CONNECT]', $contents);
+        self::assertContains('<GET http://127.0.0.1:8126/> [FILE_SIZE_IS] message: "Content-Length: 8"', $contents);
+        self::assertContains('<GET http://127.0.0.1:8126/> [PROGRESS] bytes_max: "8"', $contents);
+        self::assertTrue($called);
     }
 
     public function testEmitsProgressInformation()
@@ -399,9 +399,9 @@ class StreamHandlerTest extends TestCase
                 $called[] = func_get_args();
             },
         ]);
-        $this->assertNotEmpty($called);
-        $this->assertEquals(8, $called[0][0]);
-        $this->assertEquals(0, $called[0][1]);
+        self::assertNotEmpty($called);
+        self::assertEquals(8, $called[0][0]);
+        self::assertEquals(0, $called[0][1]);
     }
 
     public function testEmitsProgressInformationAndDebugInformation()
@@ -415,11 +415,11 @@ class StreamHandlerTest extends TestCase
                 $called[] = func_get_args();
             },
         ]);
-        $this->assertNotEmpty($called);
-        $this->assertEquals(8, $called[0][0]);
-        $this->assertEquals(0, $called[0][1]);
+        self::assertNotEmpty($called);
+        self::assertEquals(8, $called[0][0]);
+        self::assertEquals(0, $called[0][1]);
         rewind($buffer);
-        $this->assertNotEmpty(stream_get_contents($buffer));
+        self::assertNotEmpty(stream_get_contents($buffer));
         fclose($buffer);
     }
 
@@ -440,10 +440,10 @@ class StreamHandlerTest extends TestCase
             ],
         ]);
         $opts = stream_context_get_options($res->getBody()->detach());
-        $this->assertSame('HEAD', $opts['http']['method']);
-        $this->assertTrue($opts['http']['request_fulluri']);
-        $this->assertSame('127.0.0.1:0', $opts['socket']['bindto']);
-        $this->assertFalse($opts['ssl']['verify_peer']);
+        self::assertSame('HEAD', $opts['http']['method']);
+        self::assertTrue($opts['http']['request_fulluri']);
+        self::assertSame('127.0.0.1:0', $opts['socket']['bindto']);
+        self::assertFalse($opts['ssl']['verify_peer']);
     }
 
     /**
@@ -462,8 +462,8 @@ class StreamHandlerTest extends TestCase
         $request = new Request('PUT', Server::$url, ['Content-Length' => 3], 'foo');
         $handler($request, []);
         $req = Server::received()[0];
-        $this->assertEquals('', $req->getHeaderLine('Content-Type'));
-        $this->assertEquals(3, $req->getHeaderLine('Content-Length'));
+        self::assertEquals('', $req->getHeaderLine('Content-Type'));
+        self::assertEquals(3, $req->getHeaderLine('Content-Length'));
     }
 
     public function testAddsContentLengthByDefault()
@@ -473,7 +473,7 @@ class StreamHandlerTest extends TestCase
         $request = new Request('PUT', Server::$url, [], 'foo');
         $handler($request, []);
         $req = Server::received()[0];
-        $this->assertEquals(3, $req->getHeaderLine('Content-Length'));
+        self::assertEquals(3, $req->getHeaderLine('Content-Length'));
     }
 
     public function testAddsContentLengthEvenWhenEmpty()
@@ -483,7 +483,7 @@ class StreamHandlerTest extends TestCase
         $request = new Request('PUT', Server::$url, [], '');
         $handler($request, []);
         $req = Server::received()[0];
-        $this->assertEquals(0, $req->getHeaderLine('Content-Length'));
+        self::assertEquals(0, $req->getHeaderLine('Content-Length'));
     }
 
     public function testSupports100Continue()
@@ -494,10 +494,10 @@ class StreamHandlerTest extends TestCase
         $request = new Request('PUT', Server::$url, ['Expect' => '100-Continue'], 'test');
         $handler = new StreamHandler();
         $response = $handler($request, [])->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('Hello', $response->getHeaderLine('Test'));
-        $this->assertSame('4', $response->getHeaderLine('Content-Length'));
-        $this->assertSame('test', (string) $response->getBody());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('Hello', $response->getHeaderLine('Test'));
+        self::assertSame('4', $response->getHeaderLine('Content-Length'));
+        self::assertSame('test', (string) $response->getBody());
     }
 
     public function testDoesSleep()
@@ -508,7 +508,7 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $s = \GuzzleHttp\_current_time();
         $a($request, ['delay' => 0.1])->wait();
-        $this->assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
+        self::assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
     }
 
     /**
@@ -554,7 +554,7 @@ class StreamHandlerTest extends TestCase
         $stream = Psr7\stream_for();
         $stream = FnStream::decorate($stream, [
             'write' => function ($data) use ($stream, &$got) {
-                $this->assertNotNull($got);
+                self::assertNotNull($got);
                 return $stream->write($data);
             }
         ]);
@@ -564,14 +564,14 @@ class StreamHandlerTest extends TestCase
             'sink'       => $stream,
             'on_headers' => function (ResponseInterface $res) use (&$got) {
                 $got = $res;
-                $this->assertSame('bar', $res->getHeaderLine('X-Foo'));
+                self::assertSame('bar', $res->getHeaderLine('X-Foo'));
             }
         ]);
 
         $response = $promise->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('bar', $response->getHeaderLine('X-Foo'));
-        $this->assertSame('abc 123', (string) $response->getBody());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getHeaderLine('X-Foo'));
+        self::assertSame('abc 123', (string) $response->getBody());
     }
 
     public function testInvokesOnStatsOnSuccess()
@@ -587,17 +587,17 @@ class StreamHandlerTest extends TestCase
             }
         ]);
         $response = $promise->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame(200, $gotStats->getResponse()->getStatusCode());
-        $this->assertSame(
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $gotStats->getResponse()->getStatusCode());
+        self::assertSame(
             Server::$url,
             (string) $gotStats->getEffectiveUri()
         );
-        $this->assertSame(
+        self::assertSame(
             Server::$url,
             (string) $gotStats->getRequest()->getUri()
         );
-        $this->assertGreaterThan(0, $gotStats->getTransferTime());
+        self::assertGreaterThan(0, $gotStats->getTransferTime());
     }
 
     public function testInvokesOnStatsOnError()
@@ -613,17 +613,17 @@ class StreamHandlerTest extends TestCase
             }
         ]);
         $promise->wait(false);
-        $this->assertFalse($gotStats->hasResponse());
-        $this->assertSame(
+        self::assertFalse($gotStats->hasResponse());
+        self::assertSame(
             'http://127.0.0.1:123',
             (string) $gotStats->getEffectiveUri()
         );
-        $this->assertSame(
+        self::assertSame(
             'http://127.0.0.1:123',
             (string) $gotStats->getRequest()->getUri()
         );
-        $this->assertInternalType('float', $gotStats->getTransferTime());
-        $this->assertInstanceOf(
+        self::assertInternalType('float', $gotStats->getTransferTime());
+        self::assertInstanceOf(
             ConnectException::class,
             $gotStats->getHandlerErrorData()
         );
@@ -641,7 +641,7 @@ class StreamHandlerTest extends TestCase
             'timeout' => 0
         ]);
         $response = $promise->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     public function testDrainsResponseAndReadsAllContentWhenContentLengthIsZero()
@@ -658,7 +658,7 @@ class StreamHandlerTest extends TestCase
         $response = $handler($request, [])->wait();
         $body = $response->getBody();
         $stream = $body->detach();
-        $this->assertSame('hi there... This has a lot of data!', stream_get_contents($stream));
+        self::assertSame('hi there... This has a lot of data!', stream_get_contents($stream));
         fclose($stream);
     }
 
@@ -673,14 +673,14 @@ class StreamHandlerTest extends TestCase
                 RequestOptions::STREAM => true,
             ]
         )->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('OK', $response->getReasonPhrase());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('OK', $response->getReasonPhrase());
         $body = $response->getBody()->detach();
         $line = fgets($body);
-        $this->assertSame("sleeping 60 seconds ...\n", $line);
+        self::assertSame("sleeping 60 seconds ...\n", $line);
         $line = fgets($body);
-        $this->assertFalse($line);
-        $this->assertTrue(stream_get_meta_data($body)['timed_out']);
-        $this->assertFalse(feof($body));
+        self::assertFalse($line);
+        self::assertTrue(stream_get_meta_data($body)['timed_out']);
+        self::assertFalse(feof($body));
     }
 }

--- a/tests/HandlerStackTest.php
+++ b/tests/HandlerStackTest.php
@@ -15,7 +15,7 @@ class HandlerStackTest extends TestCase
         $f = function () {};
         $m1 = function () {};
         $h = new HandlerStack($f, [$m1]);
-        $this->assertTrue($h->hasHandler());
+        self::assertTrue($h->hasHandler());
     }
 
     /**
@@ -47,8 +47,8 @@ class HandlerStackTest extends TestCase
         $builder->push($meths[3]);
         $builder->push($meths[4]);
         $composed = $builder->resolve();
-        $this->assertSame('Hello - test123', $composed('test'));
-        $this->assertSame(
+        self::assertSame('Hello - test123', $composed('test'));
+        self::assertSame(
             [['a', 'test'], ['b', 'test1'], ['c', 'test12']],
             $meths[0]
         );
@@ -63,8 +63,8 @@ class HandlerStackTest extends TestCase
         $builder->unshift($meths[3]);
         $builder->unshift($meths[4]);
         $composed = $builder->resolve();
-        $this->assertSame('Hello - test321', $composed('test'));
-        $this->assertSame(
+        self::assertSame('Hello - test321', $composed('test'));
+        self::assertSame(
             [['c', 'test'], ['b', 'test3'], ['a', 'test32']],
             $meths[0]
         );
@@ -82,7 +82,7 @@ class HandlerStackTest extends TestCase
         $builder->push($meths[2]);
         $builder->remove($meths[3]);
         $composed = $builder->resolve();
-        $this->assertSame('Hello - test1131', $composed('test'));
+        self::assertSame('Hello - test1131', $composed('test'));
     }
 
     public function testCanPrintMiddleware()
@@ -95,15 +95,15 @@ class HandlerStackTest extends TestCase
         $builder->push([$this, 'bar']);
         $builder->push(__CLASS__ . '::' . 'foo');
         $lines = explode("\n", (string) $builder);
-        $this->assertContains("> 4) Name: 'a', Function: callable(", $lines[0]);
-        $this->assertContains("> 3) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[1]);
-        $this->assertContains("> 2) Name: '', Function: callable(['GuzzleHttp\\Tests\\HandlerStackTest', 'bar'])", $lines[2]);
-        $this->assertContains("> 1) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[3]);
-        $this->assertContains("< 0) Handler: callable(", $lines[4]);
-        $this->assertContains("< 1) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[5]);
-        $this->assertContains("< 2) Name: '', Function: callable(['GuzzleHttp\\Tests\\HandlerStackTest', 'bar'])", $lines[6]);
-        $this->assertContains("< 3) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[7]);
-        $this->assertContains("< 4) Name: 'a', Function: callable(", $lines[8]);
+        self::assertContains("> 4) Name: 'a', Function: callable(", $lines[0]);
+        self::assertContains("> 3) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[1]);
+        self::assertContains("> 2) Name: '', Function: callable(['GuzzleHttp\\Tests\\HandlerStackTest', 'bar'])", $lines[2]);
+        self::assertContains("> 1) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[3]);
+        self::assertContains("< 0) Handler: callable(", $lines[4]);
+        self::assertContains("< 1) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[5]);
+        self::assertContains("< 2) Name: '', Function: callable(['GuzzleHttp\\Tests\\HandlerStackTest', 'bar'])", $lines[6]);
+        self::assertContains("< 3) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[7]);
+        self::assertContains("< 4) Name: 'a', Function: callable(", $lines[8]);
     }
 
     public function testCanAddBeforeByName()
@@ -116,10 +116,10 @@ class HandlerStackTest extends TestCase
         $builder->before('baz', $meths[4], 'bar');
         $builder->before('baz', $meths[4], 'qux');
         $lines = explode("\n", (string) $builder);
-        $this->assertContains('> 4) Name: \'bar\'', $lines[0]);
-        $this->assertContains('> 3) Name: \'qux\'', $lines[1]);
-        $this->assertContains('> 2) Name: \'baz\'', $lines[2]);
-        $this->assertContains('> 1) Name: \'foo\'', $lines[3]);
+        self::assertContains('> 4) Name: \'bar\'', $lines[0]);
+        self::assertContains('> 3) Name: \'qux\'', $lines[1]);
+        self::assertContains('> 2) Name: \'baz\'', $lines[2]);
+        self::assertContains('> 1) Name: \'foo\'', $lines[3]);
     }
 
     /**
@@ -141,10 +141,10 @@ class HandlerStackTest extends TestCase
         $builder->after('a', $meths[4], 'c');
         $builder->after('b', $meths[4], 'd');
         $lines = explode("\n", (string) $builder);
-        $this->assertContains('4) Name: \'a\'', $lines[0]);
-        $this->assertContains('3) Name: \'c\'', $lines[1]);
-        $this->assertContains('2) Name: \'b\'', $lines[2]);
-        $this->assertContains('1) Name: \'d\'', $lines[3]);
+        self::assertContains('4) Name: \'a\'', $lines[0]);
+        self::assertContains('3) Name: \'c\'', $lines[1]);
+        self::assertContains('2) Name: \'b\'', $lines[2]);
+        self::assertContains('1) Name: \'d\'', $lines[3]);
     }
 
     public function testPicksUpCookiesFromRedirects()
@@ -163,10 +163,10 @@ class HandlerStackTest extends TestCase
             'allow_redirects' => true,
             'cookies' => $jar
         ])->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
         $lastRequest = $mock->getLastRequest();
-        $this->assertSame('http://foo.com/baz', (string) $lastRequest->getUri());
-        $this->assertSame('foo=bar', $lastRequest->getHeaderLine('Cookie'));
+        self::assertSame('http://foo.com/baz', (string) $lastRequest->getUri());
+        self::assertSame('foo=bar', $lastRequest->getHeaderLine('Cookie'));
     }
 
     private function getFunctions()

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -16,9 +16,9 @@ class MessageFormatterTest extends TestCase
     public function testCreatesWithClfByDefault()
     {
         $f = new MessageFormatter();
-        $this->assertEquals(MessageFormatter::CLF, $this->readAttribute($f, 'template'));
+        self::assertEquals(MessageFormatter::CLF, $this->readAttribute($f, 'template'));
         $f = new MessageFormatter(null);
-        $this->assertEquals(MessageFormatter::CLF, $this->readAttribute($f, 'template'));
+        self::assertEquals(MessageFormatter::CLF, $this->readAttribute($f, 'template'));
     }
 
     public function dateProvider()
@@ -38,7 +38,7 @@ class MessageFormatterTest extends TestCase
         $f = new MessageFormatter($format);
         $request = new Request('GET', '/');
         $result = $f->format($request);
-        $this->assertRegExp($pattern, $result);
+        self::assertRegExp($pattern, $result);
     }
 
     public function formatProvider()
@@ -88,6 +88,6 @@ class MessageFormatterTest extends TestCase
     public function testFormatsMessages($template, $args, $result)
     {
         $f = new MessageFormatter($template);
-        $this->assertSame((string) $result, call_user_func_array(array($f, 'format'), $args));
+        self::assertSame((string) $result, call_user_func_array(array($f, 'format'), $args));
     }
 }

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -16,9 +16,9 @@ class MessageFormatterTest extends TestCase
     public function testCreatesWithClfByDefault()
     {
         $f = new MessageFormatter();
-        self::assertEquals(MessageFormatter::CLF, $this->readAttribute($f, 'template'));
+        self::assertEquals(MessageFormatter::CLF, self::readAttribute($f, 'template'));
         $f = new MessageFormatter(null);
-        self::assertEquals(MessageFormatter::CLF, $this->readAttribute($f, 'template'));
+        self::assertEquals(MessageFormatter::CLF, self::readAttribute($f, 'template'));
     }
 
     public function dateProvider()

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -37,7 +37,7 @@ class MiddlewareTest extends TestCase
         );
         $f = $m($h);
         $f(new Request('GET', 'http://foo.com'), ['cookies' => $jar])->wait();
-        $this->assertCount(1, $jar);
+        self::assertCount(1, $jar);
     }
 
     /**
@@ -49,9 +49,9 @@ class MiddlewareTest extends TestCase
         $h = new MockHandler([new Response(404)]);
         $f = $m($h);
         $p = $f(new Request('GET', 'http://foo.com'), ['http_errors' => true]);
-        $this->assertSame('pending', $p->getState());
+        self::assertSame('pending', $p->getState());
         $p->wait();
-        $this->assertSame('rejected', $p->getState());
+        self::assertSame('rejected', $p->getState());
     }
 
     /**
@@ -63,9 +63,9 @@ class MiddlewareTest extends TestCase
         $h = new MockHandler([new Response(500)]);
         $f = $m($h);
         $p = $f(new Request('GET', 'http://foo.com'), ['http_errors' => true]);
-        $this->assertSame('pending', $p->getState());
+        self::assertSame('pending', $p->getState());
         $p->wait();
-        $this->assertSame('rejected', $p->getState());
+        self::assertSame('rejected', $p->getState());
     }
 
     /**
@@ -80,13 +80,13 @@ class MiddlewareTest extends TestCase
         $p2 = $f(new Request('HEAD', 'http://foo.com'), ['headers' => ['foo' => 'baz']]);
         $p1->wait();
         $p2->wait();
-        $this->assertCount(2, $container);
-        $this->assertSame(200, $container[0]['response']->getStatusCode());
-        $this->assertSame(201, $container[1]['response']->getStatusCode());
-        $this->assertSame('GET', $container[0]['request']->getMethod());
-        $this->assertSame('HEAD', $container[1]['request']->getMethod());
-        $this->assertSame('bar', $container[0]['options']['headers']['foo']);
-        $this->assertSame('baz', $container[1]['options']['headers']['foo']);
+        self::assertCount(2, $container);
+        self::assertSame(200, $container[0]['response']->getStatusCode());
+        self::assertSame(201, $container[1]['response']->getStatusCode());
+        self::assertSame('GET', $container[0]['request']->getMethod());
+        self::assertSame('HEAD', $container[1]['request']->getMethod());
+        self::assertSame('bar', $container[0]['options']['headers']['foo']);
+        self::assertSame('baz', $container[1]['options']['headers']['foo']);
     }
 
     public function getHistoryUseCases()
@@ -105,9 +105,9 @@ class MiddlewareTest extends TestCase
         $h = new MockHandler([new RequestException('error', $request)]);
         $f = $m($h);
         $f($request, [])->wait(false);
-        $this->assertCount(1, $container);
-        $this->assertSame('GET', $container[0]['request']->getMethod());
-        $this->assertInstanceOf(RequestException::class, $container[0]['error']);
+        self::assertCount(1, $container);
+        self::assertSame('GET', $container[0]['request']->getMethod());
+        self::assertInstanceOf(RequestException::class, $container[0]['error']);
     }
 
     public function testTapsBeforeAndAfter()
@@ -135,16 +135,16 @@ class MiddlewareTest extends TestCase
         $b->push($m);
         $comp = $b->resolve();
         $p = $comp(new Request('GET', 'http://foo.com'), []);
-        $this->assertSame('123', implode('', $calls));
-        $this->assertInstanceOf(PromiseInterface::class, $p);
-        $this->assertSame(200, $p->wait()->getStatusCode());
+        self::assertSame('123', implode('', $calls));
+        self::assertInstanceOf(PromiseInterface::class, $p);
+        self::assertSame(200, $p->wait()->getStatusCode());
     }
 
     public function testMapsRequest()
     {
         $h = new MockHandler([
             function (RequestInterface $request, array $options) {
-                $this->assertSame('foo', $request->getHeaderLine('Bar'));
+                self::assertSame('foo', $request->getHeaderLine('Bar'));
                 return new Response(200);
             }
         ]);
@@ -154,7 +154,7 @@ class MiddlewareTest extends TestCase
         }));
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);
-        $this->assertInstanceOf(PromiseInterface::class, $p);
+        self::assertInstanceOf(PromiseInterface::class, $p);
     }
 
     public function testMapsResponse()
@@ -167,7 +167,7 @@ class MiddlewareTest extends TestCase
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);
         $p->wait();
-        $this->assertSame('foo', $p->wait()->getHeaderLine('Bar'));
+        self::assertSame('foo', $p->wait()->getHeaderLine('Bar'));
     }
 
     public function testLogsRequestsAndResponses()
@@ -180,8 +180,8 @@ class MiddlewareTest extends TestCase
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);
         $p->wait();
-        $this->assertCount(1, $logger->records);
-        $this->assertContains('"PUT / HTTP/1.1" 200', $logger->records[0]['message']);
+        self::assertCount(1, $logger->records);
+        self::assertContains('"PUT / HTTP/1.1" 200', $logger->records[0]['message']);
     }
 
     public function testLogsRequestsAndResponsesCustomLevel()
@@ -194,9 +194,9 @@ class MiddlewareTest extends TestCase
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);
         $p->wait();
-        $this->assertCount(1, $logger->records);
-        $this->assertContains('"PUT / HTTP/1.1" 200', $logger->records[0]['message']);
-        $this->assertSame('debug', $logger->records[0]['level']);
+        self::assertCount(1, $logger->records);
+        self::assertContains('"PUT / HTTP/1.1" 200', $logger->records[0]['message']);
+        self::assertSame('debug', $logger->records[0]['level']);
     }
 
     public function testLogsRequestsAndErrors()
@@ -210,8 +210,8 @@ class MiddlewareTest extends TestCase
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), ['http_errors' => true]);
         $p->wait(false);
-        $this->assertCount(1, $logger->records);
-        $this->assertContains('PUT http://www.google.com', $logger->records[0]['message']);
-        $this->assertContains('404 Not Found', $logger->records[0]['message']);
+        self::assertCount(1, $logger->records);
+        self::assertContains('PUT http://www.google.com', $logger->records[0]['message']);
+        self::assertContains('404 Not Found', $logger->records[0]['message']);
     }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -75,8 +75,8 @@ class PoolTest extends TestCase
         $opts = ['options' => ['headers' => ['x-foo' => 'bar']]];
         $p = new Pool($c, [new Request('GET', 'http://example.com')], $opts);
         $p->promise()->wait();
-        $this->assertCount(1, $h);
-        $this->assertTrue($h[0]->hasHeader('x-foo'));
+        self::assertCount(1, $h);
+        self::assertTrue($h[0]->hasHeader('x-foo'));
     }
 
     public function testCanProvideCallablesThatReturnResponses()
@@ -97,8 +97,8 @@ class PoolTest extends TestCase
         $opts = ['options' => ['headers' => ['x-foo' => 'bar']]];
         $p = new Pool($c, [$fn], $opts);
         $p->promise()->wait();
-        $this->assertCount(1, $h);
-        $this->assertTrue($h[0]->hasHeader('x-foo'));
+        self::assertCount(1, $h);
+        self::assertTrue($h[0]->hasHeader('x-foo'));
     }
 
     public function testBatchesResults()
@@ -116,12 +116,12 @@ class PoolTest extends TestCase
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
         $results = Pool::batch($client, $requests);
-        $this->assertCount(4, $results);
-        $this->assertSame([0, 1, 2, 3], array_keys($results));
-        $this->assertSame(200, $results[0]->getStatusCode());
-        $this->assertSame(201, $results[1]->getStatusCode());
-        $this->assertSame(202, $results[2]->getStatusCode());
-        $this->assertInstanceOf(ClientException::class, $results[3]);
+        self::assertCount(4, $results);
+        self::assertSame([0, 1, 2, 3], array_keys($results));
+        self::assertSame(200, $results[0]->getStatusCode());
+        self::assertSame(201, $results[1]->getStatusCode());
+        self::assertSame(202, $results[2]->getStatusCode());
+        self::assertInstanceOf(ClientException::class, $results[3]);
     }
 
     public function testBatchesResultsWithCallbacks()
@@ -139,8 +139,8 @@ class PoolTest extends TestCase
         $results = Pool::batch($client, $requests, [
             'fulfilled' => function ($value) use (&$called) { $called = true; }
         ]);
-        $this->assertCount(2, $results);
-        $this->assertTrue($called);
+        self::assertCount(2, $results);
+        self::assertTrue($called);
     }
 
     public function testUsesYieldedKeyInFulfilledCallback()
@@ -161,8 +161,8 @@ class PoolTest extends TestCase
             'fulfilled' => function($res, $index) use (&$keys) { $keys[] = $index; }
         ]);
         $p->promise()->wait();
-        $this->assertCount(3, $keys);
-        $this->assertSame($keys, array_keys($requests));
+        self::assertCount(3, $keys);
+        self::assertSame($keys, array_keys($requests));
     }
 
     private function getClient($total = 1)

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -33,9 +33,9 @@ class PrepareBodyMiddlewareTest extends TestCase
             function (RequestInterface $request) use ($body) {
                 $length = strlen($body);
                 if ($length > 0) {
-                    $this->assertEquals($length, $request->getHeaderLine('Content-Length'));
+                    self::assertEquals($length, $request->getHeaderLine('Content-Length'));
                 } else {
-                    $this->assertFalse($request->hasHeader('Content-Length'));
+                    self::assertFalse($request->hasHeader('Content-Length'));
                 }
                 return new Response(200);
             }
@@ -45,9 +45,9 @@ class PrepareBodyMiddlewareTest extends TestCase
         $stack->push($m);
         $comp = $stack->resolve();
         $p = $comp(new Request($method, 'http://www.google.com', [], $body), []);
-        $this->assertInstanceOf(PromiseInterface::class, $p);
+        self::assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     public function testAddsTransferEncodingWhenNoContentLength()
@@ -57,8 +57,8 @@ class PrepareBodyMiddlewareTest extends TestCase
         ]);
         $h = new MockHandler([
             function (RequestInterface $request) {
-                $this->assertFalse($request->hasHeader('Content-Length'));
-                $this->assertSame('chunked', $request->getHeaderLine('Transfer-Encoding'));
+                self::assertFalse($request->hasHeader('Content-Length'));
+                self::assertSame('chunked', $request->getHeaderLine('Transfer-Encoding'));
                 return new Response(200);
             }
         ]);
@@ -67,9 +67,9 @@ class PrepareBodyMiddlewareTest extends TestCase
         $stack->push($m);
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com', [], $body), []);
-        $this->assertInstanceOf(PromiseInterface::class, $p);
+        self::assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     public function testAddsContentTypeWhenMissingAndPossible()
@@ -77,8 +77,8 @@ class PrepareBodyMiddlewareTest extends TestCase
         $bd = Psr7\stream_for(fopen(__DIR__ . '/../composer.json', 'r'));
         $h = new MockHandler([
             function (RequestInterface $request) {
-                $this->assertSame('application/json', $request->getHeaderLine('Content-Type'));
-                $this->assertTrue($request->hasHeader('Content-Length'));
+                self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+                self::assertTrue($request->hasHeader('Content-Length'));
                 return new Response(200);
             }
         ]);
@@ -87,9 +87,9 @@ class PrepareBodyMiddlewareTest extends TestCase
         $stack->push($m);
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com', [], $bd), []);
-        $this->assertInstanceOf(PromiseInterface::class, $p);
+        self::assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     public function expectProvider()
@@ -111,7 +111,7 @@ class PrepareBodyMiddlewareTest extends TestCase
 
         $h = new MockHandler([
             function (RequestInterface $request) use ($result) {
-                $this->assertSame($result, $request->getHeader('Expect'));
+                self::assertSame($result, $request->getHeader('Expect'));
                 return new Response(200);
             }
         ]);
@@ -123,9 +123,9 @@ class PrepareBodyMiddlewareTest extends TestCase
         $p = $comp(new Request('PUT', 'http://www.google.com', [], $bd), [
             'expect' => $value
         ]);
-        $this->assertInstanceOf(PromiseInterface::class, $p);
+        self::assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     public function testIgnoresIfExpectIsPresent()
@@ -133,7 +133,7 @@ class PrepareBodyMiddlewareTest extends TestCase
         $bd = Psr7\stream_for(fopen(__DIR__ . '/../composer.json', 'r'));
         $h = new MockHandler([
             function (RequestInterface $request) {
-                $this->assertSame(['Foo'], $request->getHeader('Expect'));
+                self::assertSame(['Foo'], $request->getHeader('Expect'));
                 return new Response(200);
             }
         ]);
@@ -146,8 +146,8 @@ class PrepareBodyMiddlewareTest extends TestCase
             new Request('PUT', 'http://www.google.com', ['Expect' => 'Foo'], $bd),
             ['expect' => true]
         );
-        $this->assertInstanceOf(PromiseInterface::class, $p);
+        self::assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -25,7 +25,7 @@ class RedirectMiddlewareTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $promise = $handler($request, []);
         $response = $promise->wait();
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     public function testIgnoresWhenNoLocation()
@@ -37,7 +37,7 @@ class RedirectMiddlewareTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $promise = $handler($request, []);
         $response = $promise->wait();
-        $this->assertSame(304, $response->getStatusCode());
+        self::assertSame(304, $response->getStatusCode());
     }
 
     public function testRedirectsWithAbsoluteUri()
@@ -54,8 +54,8 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['max' => 2]
         ]);
         $response = $promise->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('http://test.com', (string)$mock->getLastRequest()->getUri());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('http://test.com', (string)$mock->getLastRequest()->getUri());
     }
 
     public function testRedirectsWithRelativeUri()
@@ -72,8 +72,8 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['max' => 2]
         ]);
         $response = $promise->wait();
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('http://example.com/foo', (string)$mock->getLastRequest()->getUri());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('http://example.com/foo', (string)$mock->getLastRequest()->getUri());
     }
 
     /**
@@ -126,7 +126,7 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['max' => 2, 'referer' => true]
         ]);
         $promise->wait();
-        $this->assertSame(
+        self::assertSame(
             'http://example.com?a=b',
             $mock->getLastRequest()->getHeaderLine('Referer')
         );
@@ -146,7 +146,7 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['max' => 2, 'referer' => true]
         ]);
         $promise->wait();
-        $this->assertSame(
+        self::assertSame(
             'http://example.com?a=b',
             $mock->getLastRequest()->getHeaderLine('Referer')
         );
@@ -169,7 +169,7 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['track_redirects' => true]
         ]);
         $response = $promise->wait(true);
-        $this->assertSame(
+        self::assertSame(
             [
                 'http://example.com',
                 'http://example.com/foo',
@@ -197,7 +197,7 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['track_redirects' => true]
         ]);
         $response = $promise->wait(true);
-        $this->assertSame(
+        self::assertSame(
             [
                 '301',
                 '302',
@@ -222,7 +222,7 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => ['max' => 2, 'referer' => true]
         ]);
         $promise->wait();
-        $this->assertFalse($mock->getLastRequest()->hasHeader('Referer'));
+        self::assertFalse($mock->getLastRequest()->hasHeader('Referer'));
     }
 
     public function testInvokesOnRedirectForRedirects()
@@ -240,15 +240,15 @@ class RedirectMiddlewareTest extends TestCase
             'allow_redirects' => [
                 'max' => 2,
                 'on_redirect' => function ($request, $response, $uri) use (&$call) {
-                    $this->assertSame(302, $response->getStatusCode());
-                    $this->assertSame('GET', $request->getMethod());
-                    $this->assertSame('http://test.com', (string) $uri);
+                    self::assertSame(302, $response->getStatusCode());
+                    self::assertSame('GET', $request->getMethod());
+                    self::assertSame('http://test.com', (string) $uri);
                     $call = true;
                 }
             ]
         ]);
         $promise->wait();
-        $this->assertTrue($call);
+        self::assertTrue($call);
     }
 
     public function testRemoveAuthorizationHeaderOnRedirect()
@@ -256,7 +256,7 @@ class RedirectMiddlewareTest extends TestCase
         $mock = new MockHandler([
             new Response(302, ['Location' => 'http://test.com']),
             function (RequestInterface $request) {
-                $this->assertFalse($request->hasHeader('Authorization'));
+                self::assertFalse($request->hasHeader('Authorization'));
                 return new Response(200);
             }
         ]);
@@ -270,7 +270,7 @@ class RedirectMiddlewareTest extends TestCase
         $mock = new MockHandler([
             new Response(302, ['Location' => 'http://example.com/2']),
             function (RequestInterface $request) {
-                $this->assertTrue($request->hasHeader('Authorization'));
+                self::assertTrue($request->hasHeader('Authorization'));
                 return new Response(200);
             }
         ]);

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -22,8 +22,8 @@ class RetryMiddlewareTest extends TestCase
         };
         $delay = function ($retries, $response) use (&$delayCalls) {
             $delayCalls++;
-            $this->assertSame($retries, $delayCalls);
-            $this->assertInstanceOf(Response::class, $response);
+            self::assertSame($retries, $delayCalls);
+            self::assertInstanceOf(Response::class, $response);
             return 1;
         };
         $m = Middleware::retry($decider, $delay);
@@ -32,9 +32,9 @@ class RetryMiddlewareTest extends TestCase
         $c = new Client(['handler' => $f]);
         $p = $c->sendAsync(new Request('GET', 'http://test.com'), []);
         $p->wait();
-        $this->assertCount(3, $calls);
-        $this->assertSame(2, $delayCalls);
-        $this->assertSame(202, $p->wait()->getStatusCode());
+        self::assertCount(3, $calls);
+        self::assertSame(2, $delayCalls);
+        self::assertSame(202, $p->wait()->getStatusCode());
     }
 
     public function testDoesNotRetryWhenDeciderReturnsFalse()
@@ -44,7 +44,7 @@ class RetryMiddlewareTest extends TestCase
         $h = new MockHandler([new Response(200)]);
         $c = new Client(['handler' => $m($h)]);
         $p = $c->sendAsync(new Request('GET', 'http://test.com'), []);
-        $this->assertSame(200, $p->wait()->getStatusCode());
+        self::assertSame(200, $p->wait()->getStatusCode());
     }
 
     public function testCanRetryExceptions()
@@ -58,22 +58,22 @@ class RetryMiddlewareTest extends TestCase
         $h = new MockHandler([new \Exception(), new Response(201)]);
         $c = new Client(['handler' => $m($h)]);
         $p = $c->sendAsync(new Request('GET', 'http://test.com'), []);
-        $this->assertSame(201, $p->wait()->getStatusCode());
-        $this->assertCount(2, $calls);
-        $this->assertSame(0, $calls[0][0]);
-        $this->assertNull($calls[0][2]);
-        $this->assertInstanceOf('Exception', $calls[0][3]);
-        $this->assertSame(1, $calls[1][0]);
-        $this->assertInstanceOf(Response::class, $calls[1][2]);
-        $this->assertNull($calls[1][3]);
+        self::assertSame(201, $p->wait()->getStatusCode());
+        self::assertCount(2, $calls);
+        self::assertSame(0, $calls[0][0]);
+        self::assertNull($calls[0][2]);
+        self::assertInstanceOf('Exception', $calls[0][3]);
+        self::assertSame(1, $calls[1][0]);
+        self::assertInstanceOf(Response::class, $calls[1][2]);
+        self::assertNull($calls[1][3]);
     }
 
     public function testBackoffCalculateDelay()
     {
-        $this->assertSame(0, RetryMiddleware::exponentialDelay(0));
-        $this->assertSame(1, RetryMiddleware::exponentialDelay(1));
-        $this->assertSame(2, RetryMiddleware::exponentialDelay(2));
-        $this->assertSame(4, RetryMiddleware::exponentialDelay(3));
-        $this->assertSame(8, RetryMiddleware::exponentialDelay(4));
+        self::assertSame(0, RetryMiddleware::exponentialDelay(0));
+        self::assertSame(1, RetryMiddleware::exponentialDelay(1));
+        self::assertSame(2, RetryMiddleware::exponentialDelay(2));
+        self::assertSame(4, RetryMiddleware::exponentialDelay(3));
+        self::assertSame(8, RetryMiddleware::exponentialDelay(4));
     }
 }

--- a/tests/TransferStatsTest.php
+++ b/tests/TransferStatsTest.php
@@ -18,13 +18,13 @@ class TransferStatsTest extends TestCase
             null,
             ['foo' => 'bar']
         );
-        $this->assertSame($request, $stats->getRequest());
-        $this->assertSame($response, $stats->getResponse());
-        $this->assertTrue($stats->hasResponse());
-        $this->assertSame(['foo' => 'bar'], $stats->getHandlerStats());
-        $this->assertSame('bar', $stats->getHandlerStat('foo'));
-        $this->assertSame($request->getUri(), $stats->getEffectiveUri());
-        $this->assertEquals(10.5, $stats->getTransferTime());
-        $this->assertNull($stats->getHandlerErrorData());
+        self::assertSame($request, $stats->getRequest());
+        self::assertSame($response, $stats->getResponse());
+        self::assertTrue($stats->hasResponse());
+        self::assertSame(['foo' => 'bar'], $stats->getHandlerStats());
+        self::assertSame('bar', $stats->getHandlerStat('foo'));
+        self::assertSame($request->getUri(), $stats->getEffectiveUri());
+        self::assertEquals(10.5, $stats->getTransferTime());
+        self::assertNull($stats->getHandlerErrorData());
     }
 }

--- a/tests/UriTemplateTest.php
+++ b/tests/UriTemplateTest.php
@@ -121,7 +121,7 @@ class UriTemplateTest extends TestCase
     public function testExpandsUriTemplates($template, $expansion, $params)
     {
         $uri = new UriTemplate();
-        $this->assertSame($expansion, $uri->expand($template, $params));
+        self::assertSame($expansion, $uri->expand($template, $params));
     }
 
     public function expressionProvider()
@@ -171,7 +171,7 @@ class UriTemplateTest extends TestCase
         $method->setAccessible(true);
 
         $exp = substr($exp, 1, -1);
-        $this->assertSame($data, $method->invokeArgs($template, array($exp)));
+        self::assertSame($data, $method->invokeArgs($template, array($exp)));
     }
 
     /**
@@ -197,6 +197,6 @@ class UriTemplateTest extends TestCase
             )
         ));
 
-        $this->assertSame('http://example.com/foo/bar/one,two?query=test&more%5B0%5D=fun&more%5B1%5D=ice%20cream&baz%5Bbar%5D=fizz&baz%5Btest%5D=buzz&bam=boo', $result);
+        self::assertSame('http://example.com/foo/bar/one,two?query=test&more%5B0%5D=fun&more%5B1%5D=ice%20cream&baz%5Bbar%5D=fizz&baz%5Btest%5D=buzz&bam=boo', $result);
     }
 }

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -8,7 +8,7 @@ class FunctionsTest extends TestCase
 {
     public function testExpandsTemplate()
     {
-        $this->assertSame(
+        self::assertSame(
             'foo/123',
             GuzzleHttp\uri_template('foo/{bar}', ['bar' => '123'])
         );
@@ -21,7 +21,7 @@ class FunctionsTest extends TestCase
     public function testProvidesDefaultUserAgent()
     {
         $ua = GuzzleHttp\default_user_agent();
-        $this->assertRegExp('#^GuzzleHttp/.+ curl/.+ PHP/.+$#', $ua);
+        self::assertRegExp('#^GuzzleHttp/.+ curl/.+ PHP/.+$#', $ua);
     }
 
     public function typeProvider()
@@ -41,13 +41,13 @@ class FunctionsTest extends TestCase
      */
     public function testDescribesType($input, $output)
     {
-        $this->assertSame($output, GuzzleHttp\describe_type($input));
+        self::assertSame($output, GuzzleHttp\describe_type($input));
     }
 
     public function testParsesHeadersFromLines()
     {
         $lines = ['Foo: bar', 'Foo: baz', 'Abc: 123', 'Def: a, b'];
-        $this->assertSame([
+        self::assertSame([
             'Foo' => ['bar', 'baz'],
             'Abc' => ['123'],
             'Def' => ['a, b'],
@@ -57,19 +57,19 @@ class FunctionsTest extends TestCase
     public function testParsesHeadersFromLinesWithMultipleLines()
     {
         $lines = ['Foo: bar', 'Foo: baz', 'Foo: 123'];
-        $this->assertSame([
+        self::assertSame([
             'Foo' => ['bar', 'baz', '123'],
         ], GuzzleHttp\headers_from_lines($lines));
     }
 
     public function testReturnsDebugResource()
     {
-        $this->assertInternalType('resource', GuzzleHttp\debug_resource());
+        self::assertInternalType('resource', GuzzleHttp\debug_resource());
     }
 
     public function testProvidesDefaultCaBundler()
     {
-        $this->assertFileExists(GuzzleHttp\default_ca_bundle());
+        self::assertFileExists(GuzzleHttp\default_ca_bundle());
     }
 
     public function noProxyProvider()
@@ -89,7 +89,7 @@ class FunctionsTest extends TestCase
      */
     public function testChecksNoProxyList($host, $list, $result)
     {
-        $this->assertSame(
+        self::assertSame(
             $result,
             \GuzzleHttp\is_host_in_noproxy($host, $list)
         );
@@ -105,7 +105,7 @@ class FunctionsTest extends TestCase
 
     public function testEncodesJson()
     {
-        $this->assertSame('true', \GuzzleHttp\json_encode(true));
+        self::assertSame('true', \GuzzleHttp\json_encode(true));
     }
 
     /**
@@ -118,7 +118,7 @@ class FunctionsTest extends TestCase
 
     public function testDecodesJson()
     {
-        $this->assertTrue(\GuzzleHttp\json_decode('true'));
+        self::assertTrue(\GuzzleHttp\json_decode('true'));
     }
 
     /**
@@ -131,7 +131,7 @@ class FunctionsTest extends TestCase
 
     public function testCurrentTime()
     {
-        $this->assertGreaterThan(0, GuzzleHttp\_current_time());
+        self::assertGreaterThan(0, GuzzleHttp\_current_time());
     }
 }
 


### PR DESCRIPTION
There are static (eg. `self::assertEquals()`) and dynamic (eg. `$this->assertEquals()`  methods in PHPUnit. There's no reason not to call them properly. Also it speeds up a tests a bit.