### PR TITLE
Minor perf improvement on PrepareBodyMiddleware

### DIFF
--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -97,9 +97,13 @@ class PrepareBodyMiddleware
         // Always add if the body cannot be rewound, the size cannot be
         // determined, or the size is greater than the cutoff threshold
         $body = $request->getBody();
-        $size = $body->getSize();
+        if (!$body->isSeekable()) {
+            $modify['set_headers']['Expect'] = '100-Continue';
+            return;
+        }
 
-        if ($size === null || $size >= (int) $expect || !$body->isSeekable()) {
+        $size = $body->getSize();
+        if ($size === null || $size >= (int) $expect) {
             $modify['set_headers']['Expect'] = '100-Continue';
         }
     }


### PR DESCRIPTION
Minor perf improvement on PrepareBodyMiddleware by moving a check if the stream is seekable first.

The improvement is that it is better to check first if the stream is readable rather than checking the size of the stream.