### PR TITLE
Prevent concurrent writes

### DIFF
--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -56,7 +56,7 @@ class FileCookieJar extends CookieJar
         }
 
         $jsonStr = \GuzzleHttp\json_encode($json);
-        if (false === file_put_contents($filename, $jsonStr)) {
+        if (false === file_put_contents($filename, $jsonStr, LOCK_EX)) {
             throw new \RuntimeException("Unable to save file {$filename}");
         }
     }


### PR DESCRIPTION
Concurrent writes might lead to invalid JSON being saved in the cookie jar.

Backport changes from https://github.com/guzzle/guzzle/pull/1884 to the master (so they will be available for the 6.x release).
Related https://github.com/guzzle/guzzle/issues/1883