### PR TITLE
Use composer command instead of php composer.phar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ curl -sS https://getcomposer.org/installer | php
 Next, run the Composer command to install the latest stable version of Guzzle:
 
 ```bash
-php composer.phar require guzzlehttp/guzzle
+composer require guzzlehttp/guzzle
 ```
 
 After installing, you need to require Composer's autoloader:
@@ -68,7 +68,7 @@ require 'vendor/autoload.php';
 You can then later update Guzzle using composer:
 
  ```bash
-php composer.phar update
+composer update
  ```
 
 


### PR DESCRIPTION
The default command for composer is `composer` and maybe `php composer.phar` is outdated