### PR TITLE
Allow json encode options

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -27,6 +27,7 @@ class Client implements ClientInterface
     /** @var array Default request options */
     private $config;
 
+
     /**
      * Clients accept an array of constructor parameters.
      *
@@ -321,10 +322,10 @@ class Client implements ClientInterface
 
         if (isset($options['json'])) {
 
-            if (! isset($options['json']['options'])) {
+            if (! isset($options['json']['_options'])) {
                 $options['body'] = \GuzzleHttp\json_encode(isset($options['json']['body']) ? $options['json']['body'] : $options['json']);
             } else {
-                $options['body'] = \GuzzleHttp\json_encode($options['json']['body'], $options['json']['options']);
+                $options['body'] = \GuzzleHttp\json_encode($options['json']['body'], $options['json']['_options']);
             }
 
             unset($options['json']);

--- a/src/Client.php
+++ b/src/Client.php
@@ -320,7 +320,13 @@ class Client implements ClientInterface
         }
 
         if (isset($options['json'])) {
-            $options['body'] = \GuzzleHttp\json_encode($options['json']);
+
+            if (! isset($options['json']['options'])) {
+                $options['body'] = \GuzzleHttp\json_encode(isset($options['json']['body']) ? $options['json']['body'] : $options['json']);
+            } else {
+                $options['body'] = \GuzzleHttp\json_encode($options['json']['body'], $options['json']['options']);
+            }
+
             unset($options['json']);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);

--- a/src/Client.php
+++ b/src/Client.php
@@ -320,13 +320,11 @@ class Client implements ClientInterface
         }
 
         if (isset($options['json'])) {
-
-            if (! isset($options['json']['_options'])) {
-                $options['body'] = \GuzzleHttp\json_encode(isset($options['json']['body']) ? $options['json']['body'] : $options['json']);
-            } else {
-                $options['body'] = \GuzzleHttp\json_encode($options['json']['body'], $options['json']['_options']);
+            if (! $options['json'] instanceof JsonPayload && is_array($options['json'])) {
+                $options['json'] = new JsonPayload($options['json']);
             }
 
+            $options['body'] = $options['json']->serialize();
             unset($options['json']);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,9 +1,9 @@
 <?php
 namespace GuzzleHttp;
 
-use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Cookie\CookieJar;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -26,7 +26,6 @@ class Client implements ClientInterface
 {
     /** @var array Default request options */
     private $config;
-
 
     /**
      * Clients accept an array of constructor parameters.

--- a/src/JsonPayload.php
+++ b/src/JsonPayload.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GuzzleHttp;
+
+class JsonPayload
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * @var int
+     */
+    private $options;
+
+    public function __construct(array $data, $options = 0)
+    {
+        $this->data = $data;
+        $this->options = $options;
+    }
+
+    public function serialize()
+    {
+        return  \GuzzleHttp\json_encode($this->data, $this->options);
+    }
+}


### PR DESCRIPTION
As requested in #2342 this PR will allow for JSON encoding options to used if they are provided. Otherwise, all previous behavior is retained.

Wasn't sure if this was of interest outside the initial issue but decided to throw a quick something together. 

The JSON option block will now accept the following:

```php
'json' => [
    '_options' => JSON_UNESCAPED_UNICODE,
    'body' => ['foo' => 'bar']
]
```

As well as the original array:
```php
'json' => ['foo' => 'bar']
```

I'll update the documentation accordingly if everyone is happy. Feedback is appreciated.