### PR TITLE
Fix PHPUnit Configuration warning

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
          backupGlobals="true"
          colors="true">
   <testsuites>
-    <testsuite>
+    <testsuite name="Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>


### PR DESCRIPTION
Prevent the following warning being thrown by PHPUnit during testing:

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 6:
  - Element 'testsuite': The attribute 'name' is required but missing.

  Test results may not be as expected.
```