### PR TITLE
allow_redirects.referer is false by default

### DIFF
--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -22,7 +22,7 @@ final class RequestOptions
      * - strict: (bool, default=false) Set to true to use strict redirects
      *   meaning redirect POST requests with POST requests vs. doing what most
      *   browsers do which is redirect POST requests with GET requests
-     * - referer: (bool, default=true) Set to false to disable the Referer
+     * - referer: (bool, default=false) Set to true to enable the Referer
      *   header.
      * - protocols: (array, default=['http', 'https']) Allowed redirect
      *   protocols.


### PR DESCRIPTION
According to both the [RedirectMiddleware source code](https://github.com/guzzle/guzzle/blob/6.3.3/src/RedirectMiddleware.php#L28) and the [online docs](http://docs.guzzlephp.org/en/stable/request-options.html), `referer` is `false` by default.

This PR fixes the PHP doc.