### PR TITLE
[CurlFactory] Prevent undefined offset when using array for ssl_key options

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -454,11 +454,12 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (isset($options['ssl_key'])) {
-            $sslKey = $options['ssl_key'];
-            if (is_array($sslKey)) {
-                $conf[CURLOPT_SSLKEYPASSWD] = $sslKey[1];
-                $sslKey = $sslKey[0];
+            if (is_array($options['ssl_key']) && count($options['ssl_key']) === 2) {
+                list($sslKey, $conf[CURLOPT_SSLKEYPASSWD]) = $options['ssl_key'];
             }
+
+            $sslKey = isset($sslKey) ? $sslKey: $options['ssl_key'];
+
             if (!file_exists($sslKey)) {
                 throw new \InvalidArgumentException(
                     "SSL private key not found: {$sslKey}"

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1,13 +1,13 @@
 <?php
 namespace GuzzleHttp\Handler;
 
-use GuzzleHttp\Psr7;
-use GuzzleHttp\TransferStats;
-use GuzzleHttp\Psr7\LazyOpenStream;
-use Psr\Http\Message\RequestInterface;
-use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\TransferStats;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Creates curl resources from a request

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -454,8 +454,12 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (isset($options['ssl_key'])) {
-            if (is_array($options['ssl_key']) && count($options['ssl_key']) === 2) {
-                list($sslKey, $conf[CURLOPT_SSLKEYPASSWD]) = $options['ssl_key'];
+            if (is_array($options['ssl_key'])) {
+                if (count($options['ssl_key']) === 2) {
+                    list($sslKey, $conf[CURLOPT_SSLKEYPASSWD]) = $options['ssl_key'];
+                } else {
+                    list($sslKey) = $options['ssl_key'];
+                }
             }
 
             $sslKey = isset($sslKey) ? $sslKey: $options['ssl_key'];

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1,13 +1,13 @@
 <?php
 namespace GuzzleHttp\Handler;
 
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\Psr7\LazyOpenStream;
 use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 
 /**
  * Creates curl resources from a request

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Tests\Server;
 use GuzzleHttp\Handler;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\TransferStats;
+use PHPUnit\Framework\Error\Notice;
 use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -214,6 +215,14 @@ class CurlFactoryTest extends TestCase
         $f->create(new Psr7\Request('GET', Server::$url), ['ssl_key' => [__FILE__, 'test']]);
         $this->assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLKEY]);
         $this->assertEquals('test', $_SERVER['_curl'][CURLOPT_SSLKEYPASSWD]);
+    }
+
+    public function testAddsSslKeyWhenUsingArraySyntaxButNoPassword()
+    {
+        $f = new Handler\CurlFactory(3);
+        $f->create(new Psr7\Request('GET', Server::$url), ['ssl_key' => [__FILE__]]);
+
+        $this->assertEquals(__FILE__, $_SERVER['_curl'][CURLOPT_SSLKEY]);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1,15 +1,14 @@
 <?php
 namespace GuzzleHttp\Test\Handler;
 
-use GuzzleHttp\Handler\CurlFactory;
-use GuzzleHttp\Handler\EasyHandle;
-use GuzzleHttp\Tests\Server;
-use GuzzleHttp\Handler;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Handler;
+use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
-use PHPUnit\Framework\Error\Notice;
-use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Handler\EasyHandle;
+use GuzzleHttp\Handler\CurlFactory;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @covers \GuzzleHttp\Handler\CurlFactory

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace GuzzleHttp\Test\Handler;
 
-use GuzzleHttp\Psr7;
-use GuzzleHttp\Handler;
-use GuzzleHttp\Tests\Server;
-use GuzzleHttp\TransferStats;
-use PHPUnit\Framework\TestCase;
-use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Handler\CurlFactory;
+use GuzzleHttp\Handler\EasyHandle;
+use GuzzleHttp\Tests\Server;
+use GuzzleHttp\Handler;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\TransferStats;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \GuzzleHttp\Handler\CurlFactory


### PR DESCRIPTION
Hopefully resolves #2339 where the `ssl_key` options are provided using the array format, but without a password as the second item in the array.

Still waiting conformation that this was the cause of the warnings, but this will avoid them going forward.

As always, feedback is appreciated.