### PR TITLE
Fix failing builds (adaptation to PSR7 and Travis updates)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -25,7 +24,9 @@ matrix:
     - php: hhvm
       dist: trusty
     - php: nightly
-  include: 
+  include:
+    - php: 5.5
+      dist: trusty
     - php: hhvm
       dist: trusty
   fast_finish: true

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -186,7 +186,7 @@ class RedirectMiddleware
         if ($options['allow_redirects']['referer']
             && $modify['uri']->getScheme() === $request->getUri()->getScheme()
         ) {
-            $uri = $request->getUri()->withUserInfo('', '');
+            $uri = $request->getUri()->withUserInfo('');
             $modify['set_headers']['Referer'] = (string) $uri;
         } else {
             $modify['remove_headers'][] = 'Referer';

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -60,16 +60,25 @@ class RequestExceptionTest extends TestCase
 
     public function testCreatesGenericErrorResponseException()
     {
-        $e = RequestException::create(new Request('GET', '/'), new Response(600));
+        $e = RequestException::create(new Request('GET', '/'), new Response(300));
         $this->assertContains(
             'GET /',
             $e->getMessage()
         );
         $this->assertContains(
-            '600 ',
+            '300 ',
             $e->getMessage()
         );
         $this->assertInstanceOf('GuzzleHttp\Exception\RequestException', $e);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Status code must be an integer value between 1xx and 5xx.
+     */
+    public function testThrowsInvalidArgumentExceptionOnOutOfBoundsResponseCode()
+    {
+        throw RequestException::create(new Request('GET', '/'), new Response(600));
     }
 
     public function dataPrintableResponses()

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -26,7 +26,7 @@ class MiddlewareTest extends TestCase
             [
                 function (RequestInterface $request) {
                     return new Response(200, [
-                        'Set-Cookie' => new SetCookie([
+                        'Set-Cookie' => (string) new SetCookie([
                             'Name'   => 'name',
                             'Value'  => 'value',
                             'Domain' => 'foo.com'

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -132,6 +132,26 @@ class RedirectMiddlewareTest extends TestCase
         );
     }
 
+    public function testAddsRefererHeaderButClearsUserInfo()
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com']),
+            new Response(200)
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('GET', 'http://foo:bar@example.com?a=b');
+        $promise = $handler($request, [
+            'allow_redirects' => ['max' => 2, 'referer' => true]
+        ]);
+        $promise->wait();
+        $this->assertSame(
+            'http://example.com?a=b',
+            $mock->getLastRequest()->getHeaderLine('Referer')
+        );
+    }
+
     public function testAddsGuzzleRedirectHeader()
     {
         $mock = new MockHandler([


### PR DESCRIPTION
A few fixes which make the builds on Travis CI green again!

-----

# Problem 1

- `testCreatesGenericErrorResponseException()` in `Exception/RequestExceptionTest.php` tries to test the creation of a `GuzzleHttp\Exception\RequestException`:

https://github.com/guzzle/guzzle/blob/de7437d73816cb67ed35d476784d69e010a688b5/tests/Exception/RequestExceptionTest.php#L61-L63

- However, due to recent update https://github.com/guzzle/psr7/commit/c5aea30ff82a3565e6d3decd18d74257c033daf6#diff-f89246dce7e387482b2c6c584a5e7e9dR151 this test now errors:

```
InvalidArgumentException : Status code must be an integer value between 1xx and 5xx.
```

## Research for problem 1

- The `InvalidArgumentException` is correctly thrown, as this range is not valid as defined in PSR7 (https://tools.ietf.org/html/rfc7231#section-6)

- `RequestException` is triggered to be instantiated unextended due to any exception outside of the 4xx and 5xx range: 

https://github.com/guzzle/guzzle/blob/de7437d73816cb67ed35d476784d69e010a688b5/src/Exception/RequestException.php#L81-L91

## Solution for problem 1

1. Test `RequestException` for `300` instead of invalid `600`
2. Add regression test to expect `InvalidArgumentException` when using a `600` code response


# Problem 2

https://github.com/guzzle/guzzle/blob/2297b43ad7c07a6b70a54c19e3fdd27ddd266d0b/tests/MiddlewareTest.php#L22-L34 Throws error:

```
InvalidArgumentException : Header value must be scalar or null but GuzzleHttp\Cookie\SetCookie provided.
```

## Research for problem 2

- Changes in https://github.com/guzzle/psr7/pull/283/commits/91eebe82a902e87fec0742a77d914202e6f66320#diff-5abca4d9d5693da46d10a54795b1192dR189 now require cookies to be scalar.
- All other tests use a string for the set-cookie header
- There's a perfectly fine `__toString()` method for casting usage

## Solution for problem 2

Cast `new setCookie()` as a string, as it would happen in the real world.


# Problem 3

https://github.com/guzzle/guzzle/blob/2297b43ad7c07a6b70a54c19e3fdd27ddd266d0b/src/RedirectMiddleware.php#L186-L190

Failed with error:

```
Failed asserting that two strings are identical.
Expected :'http://example.com?a=b'
Actual   :'http://:@example.com?a=b'
```

## Research for problem 3

- `http://:@example.com?a=b` is a valid URL, but empty UserInfo should not be added during normalizing when it's not in an original URL

- Class `RedirectMiddleWare` attemps to clear the UserInfo when redirecting, but it's trying to do this by providing both an empty user and empty password string: https://github.com/guzzle/guzzle/blob/2297b43ad7c07a6b70a54c19e3fdd27ddd266d0b/src/RedirectMiddleware.php#L186-L189

- `php-fig/http-message` describes that the UserInfo is to be removed when only an empty user has string been supplied: https://github.com/php-fig/http-message/blob/master/src/UriInterface.php#L199-L201

## Solution to problem 3

Clear the UserInfo during a redirect by only supplying an empty string for the username, as per instruction in `php-fig/http-message`.


# Problem 4

Travis CI builds for `php 5.5` were failing ([ref](https://travis-ci.org/baspeeters/guzzle/jobs/571222900)) because it couldn't load the PHP version:

```
0.00s0.02s$ phpenv global 5.5
rbenv: version `5.5' not installed
The command "phpenv global 5.5" failed and exited with 1 during .
```

## Research for problem 4

Travis CI announced in a Apr 15, 2019 blogpost (`https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment#what-does-this-mean-for-your-projects`) that the default build environment changes. It instructs to use the `dist:` config parameter to keep using your current build image:

>Repositories without an explicit dist: YAML key in their .travis.yml file will be routed to Xenial instead of Trusty.

## Solution for problem 4

Configure Travis to use `dist: Trusty` for PHP 5.5, as was used by default prior to CI updates.