### PR TITLE
Added a note to Overview to mention cURL

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -16,6 +16,14 @@ Requirements
     Guzzle no longer requires cURL in order to send HTTP requests. Guzzle will
     use the PHP stream wrapper to send HTTP requests if cURL is not installed.
     Alternatively, you can provide your own HTTP handler used to send requests.
+    
+    
+.. note::
+
+    Although Guzzle does not require cURL in order to work properly, but without
+    cURL, concurrent requests are sent sequentially. In order to get truely 
+    concurrent requests, install cURL extension for you PHP installation.
+
 
 .. _installation:
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -16,13 +16,7 @@ Requirements
     Guzzle no longer requires cURL in order to send HTTP requests. Guzzle will
     use the PHP stream wrapper to send HTTP requests if cURL is not installed.
     Alternatively, you can provide your own HTTP handler used to send requests.
-    
-    
-.. note::
-
-    Although Guzzle does not require cURL in order to work properly, but without
-    cURL, concurrent requests are sent sequentially. In order to get truely 
-    concurrent requests, install cURL extension for you PHP installation.
+    Keep in mind that cURL is still required for sending concurrent requests.
 
 
 .. _installation:


### PR DESCRIPTION
Without cURL, concurrency is not available. See https://bit.ly/33fA7RU and https://bit.ly/2IFVG6o for some SO questions.