### PR TITLE
Require latest version of guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=5.5",
         "ext-json": "*",
         "guzzlehttp/promises": "^1.0",
-        "guzzlehttp/psr7": "^1.4"
+        "guzzlehttp/psr7": "^1.6.1"
     },
     "require-dev": {
         "ext-curl": "*",


### PR DESCRIPTION
To avoid any issues with older versions. 