### PR TITLE
Decouple from the UriInterface implementation

### DIFF
--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -216,7 +216,7 @@ class RedirectMiddleware
     ) {
         $location = Psr7\UriResolver::resolve(
             $request->getUri(),
-            new Psr7\Uri($response->getHeaderLine('Location'))
+            Psr7\uri_for($response->getHeaderLine('Location'))
         );
 
         // Ensure that the redirect URI is allowed based on the protocols.

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -93,13 +93,13 @@ class ClientTest extends TestCase
             'handler'  => $mock,
             'base_uri' => 'http://foo.com/bar/'
         ]);
-        $client->request('GET', new Uri('baz'));
+        $client->request('GET', Psr7\uri_for('baz'));
         $this->assertSame(
             'http://foo.com/bar/baz',
             (string) $mock->getLastRequest()->getUri()
         );
 
-        $client->request('GET', new Uri('baz'), ['base_uri' => 'http://example.com/foo/']);
+        $client->request('GET', Psr7\uri_for('baz'), ['base_uri' => 'http://example.com/foo/']);
         $this->assertSame(
             'http://example.com/foo/baz',
             (string) $mock->getLastRequest()->getUri(),


### PR DESCRIPTION
A small change to make Guzzle and the current `UriInterface` implementation from `psr7` package decoupled. The main goal currently is to be able to change the implementation (see guzzle/psr7#296) without any changes in `guzzle` main package itself.