### PR TITLE
Deprecate ClientInterface::VERSION

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -12,6 +12,9 @@ use Psr\Http\Message\UriInterface;
  */
 interface ClientInterface
 {
+    /**
+     * @deprecated Will be removed in Guzzle 7.0.0
+     */
     const VERSION = '6.4.1';
 
     /**


### PR DESCRIPTION
This variable is not helpful and is technically a BC break every time we make a release. 