### PR TITLE
Fix Http Error status code doc for when exception is thrown

### DIFF
--- a/docs/handlers-and-middleware.rst
+++ b/docs/handlers-and-middleware.rst
@@ -50,7 +50,7 @@ The ``create`` method adds default handlers to the ``HandlerStack``. When the
   2. ``cookies`` - extracts response cookies into the cookie jar.
   3. ``allow_redirects`` - Follows redirects.
   4. ``http_errors`` - throws exceptions when the response status code ``>=``
-     300.
+     400.
 
 When provided no ``$handler`` argument, ``GuzzleHttp\HandlerStack::create()``
 will choose the most appropriate handler based on the extensions available on


### PR DESCRIPTION
While reading the docs, I noticed that it didn't match the code at https://github.com/guzzle/guzzle/blob/master/src/Middleware.php#L62