### PR TITLE
Prevent trying to autoload Throwable

### DIFF
--- a/src/Exception/GuzzleException.php
+++ b/src/Exception/GuzzleException.php
@@ -3,7 +3,7 @@ namespace GuzzleHttp\Exception;
 
 use Throwable;
 
-if (interface_exists(Throwable::class)) {
+if (interface_exists(Throwable::class, false)) {
     interface GuzzleException extends Throwable
     {
     }


### PR DESCRIPTION
PR for comment in https://github.com/guzzle/guzzle/pull/2273#discussion_r346277358 .

It will prevent `interface_exists` from attempting to autoload the SPL interface, which is bound to fail.

With an autoloader implementation that doesn't properly handle not finding a class it *can* cause warnings (had this issue with the Magento1 autoloader).

The only risk I can think of is very abstract, as I don't think it's common that PHP5 environments would provide a polyfill for `\Throwable` in autoloaded code.

I didn't figure out how to write a relevant test for this change.