### PR TITLE
Update our extension requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "ext-json": "*",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.6.1",
         "psr/http-client": "^1.0"
     },
     "require-dev": {
+        "ext-curl": "*",
         "phpunit/phpunit": "^8.5",
         "psr/log": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": "^7.2.5",
+        "ext-json": "*",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.6.1",
         "psr/http-client": "^1.0"


### PR DESCRIPTION
From https://www.php.net/manual/en/json.installation.php

> As of PHP 5.2.0, the JSON extension is bundled and compiled into PHP by default.

