### PR TITLE
Fix documented return type in GuzzleHttp\Pool::promise()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1076,16 +1076,6 @@ parameters:
 			path: src/Pool.php
 
 		-
-			message: "#^Return typehint of method GuzzleHttp\\\\Pool\\:\\:promise\\(\\) has invalid type GuzzleHttp\\\\GuzzleHttp\\\\Promise\\\\Promise\\.$#"
-			count: 1
-			path: src/Pool.php
-
-		-
-			message: "#^Method GuzzleHttp\\\\Pool\\:\\:promise\\(\\) should return GuzzleHttp\\\\GuzzleHttp\\\\Promise\\\\Promise but returns GuzzleHttp\\\\Promise\\\\PromiseInterface\\.$#"
-			count: 1
-			path: src/Pool.php
-
-		-
 			message: "#^Method GuzzleHttp\\\\Pool\\:\\:batch\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Pool.php
@@ -1102,11 +1092,6 @@ parameters:
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Pool.php
-
-		-
-			message: "#^Call to method wait\\(\\) on an unknown class GuzzleHttp\\\\GuzzleHttp\\\\Promise\\\\Promise\\.$#"
 			count: 1
 			path: src/Pool.php
 

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -72,7 +72,7 @@ class Pool implements PromisorInterface
     /**
      * Get promise
      *
-     * @return \GuzzleHttp\Promise\Promise
+     * @return PromiseInterface
      */
     public function promise()
     {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -72,7 +72,7 @@ class Pool implements PromisorInterface
     /**
      * Get promise
      *
-     * @return GuzzleHttp\Promise\Promise
+     * @return \GuzzleHttp\Promise\Promise
      */
     public function promise()
     {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -72,7 +72,7 @@ class Pool implements PromisorInterface
     /**
      * Get promise
      *
-     * @return PromiseInterface
+     * @return \GuzzleHttp\Promise\PromiseInterface
      */
     public function promise()
     {


### PR DESCRIPTION
Our static analysis is complaining that the return type of `GuzzleHttp\Pool::promise()` is documented incorrectly as `GuzzleHttp\GuzzleHttp\Promise\Promise`. It looks like there was a missing backslash to move to the root namespace.