### PR TITLE
Fix logger error when mock file is not found

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -197,7 +197,8 @@ final class Middleware
                         $response = $reason instanceof RequestException
                             ? $reason->getResponse()
                             : null;
-                        $message = $formatter->format($request, $response, $reason);
+                        $exception = $reason instanceof RequestException ? $reason : null;
+                        $message = $formatter->format($request, $response, $exception);
                         $logger->notice($message);
                         return \GuzzleHttp\Promise\rejection_for($reason);
                     }


### PR DESCRIPTION
Fix error:
```
Argument 3 passed to GuzzleHttp
MessageFormatter::format() must be an instance of Exception or null, string given, called in /var/www/vendor/guzzlehttp/guzzle/src/Middleware.php on line 199
```