### PR TITLE
Remove deprecated request options

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -363,18 +363,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      */
     private function transfer(RequestInterface $request, array $options): PromiseInterface
     {
-        // save_to -> sink
-        if (isset($options['save_to'])) {
-            $options['sink'] = $options['save_to'];
-            unset($options['save_to']);
-        }
-
-        // exceptions -> http_errors
-        if (isset($options['exceptions'])) {
-            $options['http_errors'] = $options['exceptions'];
-            unset($options['exceptions']);
-        }
-
         $request = $this->applyOptions($request, $options);
         /** @var HandlerStack $handler */
         $handler = $options['handler'];

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -191,7 +191,7 @@ class ClientTest extends TestCase
         $mock = new MockHandler([new Response(200, [], 'foo')]);
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['save_to' => $r]);
-        self::assertSame($r, $mock->getLastOptions()['sink']);
+        self::assertSame($r, $mock->getLastOptions()['save_to']);
     }
 
     public function testAllowRedirectsCanBeTrue()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -178,22 +178,6 @@ class ClientTest extends TestCase
         self::assertFalse($mock->getLastRequest()->hasHeader('foo'));
     }
 
-    public function testRewriteExceptionsToHttpErrors()
-    {
-        $client = new Client(['handler' => new MockHandler([new Response(404)])]);
-        $res = $client->get('http://foo.com', ['exceptions' => false]);
-        self::assertSame(404, $res->getStatusCode());
-    }
-
-    public function testRewriteSaveToToSink()
-    {
-        $r = Psr7\stream_for(\fopen('php://temp', 'r+'));
-        $mock = new MockHandler([new Response(200, [], 'foo')]);
-        $client = new Client(['handler' => $mock]);
-        $client->get('http://foo.com', ['save_to' => $r]);
-        self::assertSame($r, $mock->getLastOptions()['save_to']);
-    }
-
     public function testAllowRedirectsCanBeTrue()
     {
         $mock = new MockHandler([new Response(200, [], 'foo')]);


### PR DESCRIPTION
Are these considered deprecated that should be removed for v7?