### PR TITLE
Fix documented return type for Pool::promise() and Client::__call()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1126,16 +1126,6 @@ parameters:
 			path: src/Pool.php
 
 		-
-			message: "#^Return typehint of method GuzzleHttp\\\\Pool\\:\\:promise\\(\\) has invalid type GuzzleHttp\\\\GuzzleHttp\\\\Promise\\\\Promise\\.$#"
-			count: 1
-			path: src/Pool.php
-
-		-
-			message: "#^Method GuzzleHttp\\\\Pool\\:\\:promise\\(\\) should return GuzzleHttp\\\\GuzzleHttp\\\\Promise\\\\Promise but returns GuzzleHttp\\\\Promise\\\\PromiseInterface\\.$#"
-			count: 1
-			path: src/Pool.php
-
-		-
 			message: "#^Method GuzzleHttp\\\\Pool\\:\\:batch\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Pool.php
@@ -1152,11 +1142,6 @@ parameters:
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Pool.php
-
-		-
-			message: "#^Call to method wait\\(\\) on an unknown class GuzzleHttp\\\\GuzzleHttp\\\\Promise\\\\Promise\\.$#"
 			count: 1
 			path: src/Pool.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,22 +16,12 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: "#^Method GuzzleHttp\\\\Client\\:\\:__call\\(\\) should return GuzzleHttp\\\\Promise\\\\PromiseInterface but returns GuzzleHttp\\\\PromiseInterface\\|Psr\\\\Http\\\\Message\\\\ResponseInterface\\.$#"
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:__call\\(\\) should return GuzzleHttp\\\\Promise\\\\PromiseInterface but returns GuzzleHttp\\\\Promise\\\\PromiseInterface\\|Psr\\\\Http\\\\Message\\\\ResponseInterface\\.$#"
 			count: 1
 			path: src/Client.php
 
 		-
 			message: "#^Method GuzzleHttp\\\\Client\\:\\:sendAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Client.php
-
-		-
-			message: "#^Return typehint of method GuzzleHttp\\\\Client\\:\\:sendAsync\\(\\) has invalid type GuzzleHttp\\\\PromiseInterface\\.$#"
-			count: 1
-			path: src/Client.php
-
-		-
-			message: "#^Method GuzzleHttp\\\\Client\\:\\:sendAsync\\(\\) should return GuzzleHttp\\\\PromiseInterface but returns GuzzleHttp\\\\Promise\\\\PromiseInterface\\.$#"
 			count: 1
 			path: src/Client.php
 
@@ -46,22 +36,7 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: "#^Call to method wait\\(\\) on an unknown class GuzzleHttp\\\\PromiseInterface\\.$#"
-			count: 2
-			path: src/Client.php
-
-		-
 			message: "#^Method GuzzleHttp\\\\Client\\:\\:requestAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Client.php
-
-		-
-			message: "#^Return typehint of method GuzzleHttp\\\\Client\\:\\:requestAsync\\(\\) has invalid type GuzzleHttp\\\\PromiseInterface\\.$#"
-			count: 1
-			path: src/Client.php
-
-		-
-			message: "#^Method GuzzleHttp\\\\Client\\:\\:requestAsync\\(\\) should return GuzzleHttp\\\\PromiseInterface but returns GuzzleHttp\\\\Promise\\\\PromiseInterface\\.$#"
 			count: 1
 			path: src/Client.php
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -102,7 +102,7 @@ class Client implements ClientInterface
      * @param array $options Request options to apply to the given
      *                       request and to the transfer. See \GuzzleHttp\RequestOptions.
      *
-     * @return PromiseInterface
+     * @return Promise\PromiseInterface
      */
     public function sendAsync(RequestInterface $request, array $options = [])
     {
@@ -142,7 +142,7 @@ class Client implements ClientInterface
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply. See \GuzzleHttp\RequestOptions.
      *
-     * @return PromiseInterface
+     * @return Promise\PromiseInterface
      */
     public function requestAsync($method, $uri = '', array $options = [])
     {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp;
 
 use GuzzleHttp\Promise\EachPromise;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
 use Psr\Http\Message\RequestInterface;
 
@@ -72,7 +73,7 @@ class Pool implements PromisorInterface
     /**
      * Get promise
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return PromiseInterface
      */
     public function promise()
     {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -71,7 +71,8 @@ class Pool implements PromisorInterface
 
     /**
      * Get promise
-     * @return GuzzleHttp\Promise\Promise
+     *
+     * @return \GuzzleHttp\Promise\PromiseInterface
      */
     public function promise()
     {


### PR DESCRIPTION
Our static analysis is complaining that the return type of `GuzzleHttp\Pool::promise()` and `GuzzleHttp\Client::__call()` are documented incorrectly.

This replaces #2446 as that targeted the wrong branch.