### PR TITLE
Remove an impossible condition

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -111,13 +111,8 @@ parameters:
 			path: src/Cookie/CookieJar.php
 
 		-
-			message: "#^Result of \\|\\| is always false\\.$#"
-			count: 1
-			path: src/Cookie/CookieJar.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
-			count: 2
+			count: 1
 			path: src/Cookie/CookieJar.php
 
 		-

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -82,10 +82,6 @@ class CookieJar implements CookieJarInterface
      */
     public function getCookieByName(string $name): ?SetCookie
     {
-        // don't allow a non string name
-        if ($name === null || !\is_scalar($name)) {
-            return null;
-        }
         foreach ($this->cookies as $cookie) {
             if ($cookie->getName() !== null && \strcasecmp($cookie->getName(), $name) === 0) {
                 return $cookie;


### PR DESCRIPTION
The param type hint ensures the value is always a string inside the
method.

(Detected by phan and the phpstan baseline)