### PR TITLE
Deprecate Client::__call()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -84,6 +84,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * @param array  $args
      *
      * @return PromiseInterface|ResponseInterface
+     *
+     * @deprecated Client::__call() will be removed in guzzlehttp/guzzle:8.0. Use the actual function instead of calling a magic one.
      */
     public function __call($method, $args)
     {


### PR DESCRIPTION
I propose to merge this after 7.0.0 release. 