### PR TITLE
idn_to_ascii() fix for old PHP versions

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -359,7 +359,9 @@ function _idn_uri_convert(UriInterface $uri, $options = 0)
 {
     if ($uri->getHost()) {
         $idnaVariant = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : 0;
-        $asciiHost = idn_to_ascii($uri->getHost(), $options, $idnaVariant, $info);
+        $asciiHost = $idnaVariant === 0
+            ? idn_to_ascii($uri->getHost(), $options)
+            : idn_to_ascii($uri->getHost(), $options, $idnaVariant, $info);
         if ($asciiHost === false) {
             $errorBitSet = isset($info['errors']) ? $info['errors'] : 0;
 


### PR DESCRIPTION
Fixes #2488

https://3v4l.org/NgNZa is an example of the issue. This feature is hard to test on different PHP version with different extensions/libs...