### PR TITLE
Deprecate functions and create internal ones

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -274,7 +274,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
         // Add the default user-agent header.
         if (!isset($this->config['headers'])) {
-            $this->config['headers'] = ['User-Agent' => default_user_agent()];
+            $this->config['headers'] = ['User-Agent' => _default_user_agent()];
         } else {
             // Add the User-Agent header if one was not already set.
             foreach (\array_keys($this->config['headers']) as $name) {
@@ -282,7 +282,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     return;
                 }
             }
-            $this->config['headers']['User-Agent'] = default_user_agent();
+            $this->config['headers']['User-Agent'] = _default_user_agent();
         }
     }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -494,7 +494,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (!empty($options['debug'])) {
-            $conf[CURLOPT_STDERR] = \GuzzleHttp\debug_resource($options['debug']);
+            $conf[CURLOPT_STDERR] = \GuzzleHttp\_debug_resource($options['debug']);
             $conf[CURLOPT_VERBOSE] = true;
         }
     }

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -139,7 +139,7 @@ class MockHandler implements \Countable
                 $this->queue[] = $value;
             } else {
                 throw new \InvalidArgumentException('Expected a response or '
-                    . 'exception. Found ' . \GuzzleHttp\describe_type($value));
+                    . 'exception. Found ' . \GuzzleHttp\_describe_type($value));
             }
         }
     }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -503,7 +503,7 @@ class StreamHandler
         static $args = ['severity', 'message', 'message_code',
             'bytes_transferred', 'bytes_max'];
 
-        $value = \GuzzleHttp\debug_resource($value);
+        $value = \GuzzleHttp\_debug_resource($value);
         $ident = $request->getMethod() . ' ' . $request->getUri()->withFragment('');
         $this->addNotification(
             $params,

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -37,7 +37,7 @@ class HandlerStack
      */
     public static function create(?callable $handler = null): self
     {
-        $stack = new self($handler ?: choose_handler());
+        $stack = new self($handler ?: _choose_handler());
         $stack->push(Middleware::httpErrors(), 'http_errors');
         $stack->push(Middleware::redirect(), 'allow_redirects');
         $stack->push(Middleware::cookies(), 'cookies');

--- a/src/functions.php
+++ b/src/functions.php
@@ -13,8 +13,24 @@ use Psr\Http\Message\UriInterface;
  *
  * @return string Returns a string containing the type of the variable and
  *                if a class is provided, the class name.
+ *
+ * @deprecated
  */
 function describe_type($input): string
+{
+    @trigger_error(sprintf('Function %s is deprecated and will be removed on guzzle 8.0', __FUNCTION__), E_USER_DEPRECATED);
+    return _describe_type($input);
+}
+
+/**
+ * Debug function used to describe the provided value type and class.
+ *
+ * @return string Returns a string containing the type of the variable and
+ *                if a class is provided, the class name.
+ *
+ * @internal
+ */
+function _describe_type($input): string
 {
     switch (\gettype($input)) {
         case 'object':
@@ -55,8 +71,25 @@ function headers_from_lines($lines): array
  * @param mixed $value Optional value
  *
  * @return resource
+ *
+ * @deprecated
  */
 function debug_resource($value = null)
+{
+    @trigger_error(sprintf('Function %s is deprecated and will be removed on guzzle 8.0', __FUNCTION__), E_USER_DEPRECATED);
+    return _debug_resource($value);
+}
+
+/**
+ * Returns a debug stream based on the provided variable.
+ *
+ * @param mixed $value Optional value
+ *
+ * @return resource
+ *
+ * @internal
+ */
+function _debug_resource($value = null)
 {
     if (\is_resource($value)) {
         return $value;
@@ -75,8 +108,27 @@ function debug_resource($value = null)
  * @throws \RuntimeException if no viable Handler is available.
  *
  * @return callable Returns the best handler for the given system.
+ *
+ * @deprecated
  */
 function choose_handler(): callable
+{
+    @trigger_error(sprintf('Function %s is deprecated and will be removed on guzzle 8.0', __FUNCTION__), E_USER_DEPRECATED);
+    return _choose_handler();
+}
+
+/**
+ * Chooses and creates a default handler to use based on the environment.
+ *
+ * The returned handler is not wrapped by any default middlewares.
+ *
+ * @throws \RuntimeException if no viable Handler is available.
+ *
+ * @return callable Returns the best handler for the given system.
+ *
+ * @internal
+ */
+function _choose_handler(): callable
 {
     $handler = null;
     if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
@@ -101,8 +153,21 @@ function choose_handler(): callable
 
 /**
  * Get the default User-Agent string to use with Guzzle
+ *
+ * @deprecated
  */
 function default_user_agent(): string
+{
+    @trigger_error(sprintf('Function %s is deprecated and will be removed on guzzle 8.0', __FUNCTION__), E_USER_DEPRECATED);
+    return _default_user_agent();
+}
+
+/**
+ * Get the default User-Agent string to use with Guzzle
+ *
+ * @internal
+ */
+function _default_user_agent(): string
 {
     static $defaultAgent = '';
 

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -45,7 +45,7 @@ class FunctionsTest extends TestCase
         }
 
         try {
-            self::assertSame($output, GuzzleHttp\describe_type($input));
+            self::assertSame($output, GuzzleHttp\_describe_type($input));
         } finally {
             if (extension_loaded('xdebug')) {
                 ini_set('xdebug.overload_var_dump', $originalOverload);
@@ -73,7 +73,7 @@ class FunctionsTest extends TestCase
 
     public function testReturnsDebugResource()
     {
-        self::assertIsResource(GuzzleHttp\debug_resource());
+        self::assertIsResource(GuzzleHttp\_debug_resource());
     }
 
     public function testProvidesDefaultCaBundler()


### PR DESCRIPTION
Some of these functions seem to be for internal use. This is a replacement in sort of a way of https://github.com/guzzle/guzzle/pull/2439