### PR TITLE
[8.0] Remove the exponentialDelay function from RetryMiddleware

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -821,11 +821,6 @@ parameters:
 			path: src/RetryMiddleware.php
 
 		-
-			message: "#^Method GuzzleHttp\\\\RetryMiddleware\\:\\:doRetry\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/RetryMiddleware.php
-
-		-
 			message: "#^Method GuzzleHttp\\\\RetryMiddleware\\:\\:doRetry\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/RetryMiddleware.php

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\RetryMiddleware;
 use PHPUnit\Framework\TestCase;
 
 class RetryMiddlewareTest extends TestCase


### PR DESCRIPTION
I don't think this is needed to be public.. I guess it is a legacy thing that stayed public because there was no anonymous functions, or we were not so much used to them back then...