### PR TITLE
Add a new option if the form params has a nested array

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -376,6 +376,21 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $options['_conditional']['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
+        if (isset($options['form_nested_params'])) {
+            if (isset($options['multipart'])) {
+                throw new \InvalidArgumentException('You cannot use '
+                    . 'form_params and multipart at the same time. Use the '
+                    . 'form_params option if you want to send application/'
+                    . 'x-www-form-urlencoded requests, and the multipart '
+                    . 'option to send multipart/form-data requests.');
+            }
+            $options['body'] = Psr7\build_query($options['form_nested_params'], PHP_QUERY_RFC1738);
+            unset($options['form_nested_params']);
+            // Ensure that we don't have the header in different case and set the new value.
+            $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);
+            $options['_conditional']['Content-Type'] = 'application/x-www-form-urlencoded';
+        }
+
         if (isset($options['multipart'])) {
             $options['body'] = new Psr7\MultipartStream($options['multipart']);
             unset($options['multipart']);


### PR DESCRIPTION
### The problem:
A couple of days ago I was working on a project in my job which consumes [`Graphite/render` API](https://graphite.readthedocs.io/en/latest/render_api.html), it is a call to the API that returns to us some data-points for specific [`target`](https://graphite.readthedocs.io/en/latest/render_api.html#target) we specify to the API. We know the API can take many targets as much as the length of the URL can take as it is `GET` request.
### Solution:
1. So, we decided to use `POST` instead of `GET` and `graphite` takes data in the post as `application/x-www-form-urlencoded` but when I implemented the call for `form_params` as an option it didn't work properly as it was building the body like that:
`target[0]=target1&target[1]=target2&&from=1575158400&until=1577196130&tz=UTC&format=json&cacheTimeout=60&maxDataPoints=-1`
and graphite doesn't know what this means `[index]`.
2. As you might be suggested how about just build a string from this `$params` array and call guzzle with `body` option and `'Content-Type' => 'application/x-www-form-urlencoded'` in the headers, yes this works as expected:
```PHP
$targets = ['target1', 'target2', 'target3'];
$q = implode('&', $targets)."&from=1575158400&to=1577196130&tz=UTC&format=json&cacheTimeout=60&maxDataPoints=-1";
$response = $client->request('POST', '{graphite_api}/render', [
        'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
        'body' => $q,
    ]);
```
3. The 3rd way is to use the `\GuzzleHttp\Psr7\build_query` function so it can build the query from the array in the correct way that I need it:
`target=target1&target=target2&&from=1575158400&until=1577196130&tz=UTC&format=json&cacheTimeout=60&maxDataPoints=-1`
then call graphite like that: *I had to specify the content-type otherwise it won't work*
```php
$params = [
    'target' => $targets,
    'from' => 1575158400,
    'until' => 1577196130,
    'tz' => 'UTC',
    'format' => 'json',
    'cacheTimeout' => '60',
    'maxDataPoints' => '-1',
];
$query = \GuzzleHttp\Psr7\build_query($params, PHP_QUERY_RFC1738);
$client->request('POST', '{graphite_api}/render', [
        'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
        'body' => $query,
    ]);
```
And it works perfectly.
4. I wanted to use Guzzle as it is (keep everything hidden there away from me) without without making workarounds or even uses functions from `Psr7` like in the 3rd way above. So, I wanted to introduce this new option if possible which is `form_nested_params` that you do normally as you do with form_params except for this one you are telling guzzle it has an item as array & you don't want to build it as `data[0]=x& data[1]=y` no you need it to be as it is `data=x&data=y`, I can't think about very popular example that you might face this case but I faced it with graphite API.
```PHP
$params = [
    'target' => $targets,
    'from' => 1575158400,
    'until' => 1577196130,
    'tz' => 'UTC',
    'format' => 'json',
    'cacheTimeout' => '60',
    'maxDataPoints' => '-1',
];
$response = $client->request('POST', 'http://cloud-metrics.leaseweb.net/render', [
        'form_nested_params' => $params,
    ]);
```
Just simple like that :).

I saw on StackOverflow and other websites when I was looking into the problem some people faced the same issue so I thought why not introduce a new option that solves this issue and in the same time I like to keep `Guzzle` do everything for me I just call it with what I want to do and it does it for me, I guess everyone wants that :).

I hope this new option `form_nested_params` will be helpful for other developers.