### PR TITLE
Cleanup upgrade docs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,36 +3,44 @@ Guzzle Upgrade Guide
 
 6.0 to 7.0
 ----------
-In order Guzzle to take advantage of the new features of PHP, we dropped the support of PHP 5.
-The minimum supported PHP version is now PHP 7.2.
 
-Wherever it was possible type hints and return types for functions and methods are applied. 
+In order to take advantage of the new features of PHP, Guzzle dropped the support
+of PHP 5. The minimum supported PHP version is now PHP 7.2. Type hints and return
+types for functions and methods have been added wherever possible. 
 
 Please make sure:
-- If you have enabled strict types that you are calling a function or a method with the correct type.
-- If you extend a class of Guzzle and you are overriding a method make sure you add the return type and type hints of the overriden method.
+- You are calling a function or a method with the correct type.
+- If you extend a class of Guzzle; update all signatures on methods you override.
 
-Moreover:
-- All internal native functions calls of Guzzle are now prefixed with a slash. 
-This change makes it impossible for the users of the library to change the behavior of any of these functions
+#### Other backwards compatibility breaking changes
 
-Before:
-`curl_version()`
-
-After:
-`\curl_version()`
- 
 - Class `GuzzleHttp\UriTemplate` is removed.
 - Class `GuzzleHttp\Exception\SeekException` is removed.
-- Classes `GuzzleHttp\Exception\BadResponseException`, `GuzzleHttp\Exception\ClientException`, `GuzzleHttp\Exception\ServerException` can no longer be initialized with an empty Response as argument.
+- Classes `GuzzleHttp\Exception\BadResponseException`, `GuzzleHttp\Exception\ClientException`, 
+  `GuzzleHttp\Exception\ServerException` can no longer be initialized with an empty
+  Response as argument.
 - Constant `GuzzleHttp\ClientInterface::VERSION` is removed.
-- Function `GuzzleHttp\Exception\RequestException::getResponseBodySummary` is removed. Use `\GuzzleHttp\Psr7\get_message_body_summary`
-as an alternative
+- Function `GuzzleHttp\Exception\RequestException::getResponseBodySummary` is removed.
+  Use `\GuzzleHttp\Psr7\get_message_body_summary` as an alternative.
 - Function `GuzzleHttp\Cookie\CookieJar::getCookieValue` is removed.
-- Request option `exception` which was an alias of `http_errors` is removed.
-- Request option `save_to` which was an alias of `sink` is removed.
+- Request option `exception` is removed. Please use `http_errors`.
+- Request option `save_to` is removed. Please use `sink`. 
 
-For the full diff you can check [here](https://github.com/guzzle/guzzle/compare/6.5.0..7.0.0)
+#### Native functions calls
+
+All internal native functions calls of Guzzle are now prefixed with a slash. This
+change makes it impossible for method overloading by other libraries or applications.
+Example:
+
+```php
+// Before:
+`curl_version()`;
+
+// After:
+`\curl_version()`;
+```
+
+For the full diff you can check [here](https://github.com/guzzle/guzzle/compare/6.5.0..master).
 
 5.0 to 6.0
 ----------


### PR DESCRIPTION
I've looked at the [diff](https://github.com/guzzle/guzzle/compare/6.5.0..master) and I found this document to be up to date. 

The only thing we can argue that is missing is the changes introduced in https://github.com/guzzle/guzzle/pull/2495. But I am happy not including them. 