### PR TITLE
Fixed deprecation warnings in tests

### DIFF
--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -5,6 +5,7 @@ use GuzzleHttp\Handler;
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Tests\Helpers;
 use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
 use PHPUnit\Framework\TestCase;
@@ -586,20 +587,20 @@ class CurlFactoryTest extends TestCase
         $easy = $f->create($req, []);
         $h1 = $easy->handle;
         $f->release($easy);
-        self::assertCount(1, self::readAttribute($f, 'handles'));
+        self::assertCount(1, Helpers::readObjectAttribute($f, 'handles'));
         $easy = $f->create($req, []);
         self::assertSame($easy->handle, $h1);
         $easy2 = $f->create($req, []);
         $easy3 = $f->create($req, []);
         $easy4 = $f->create($req, []);
         $f->release($easy);
-        self::assertCount(1, self::readAttribute($f, 'handles'));
+        self::assertCount(1, Helpers::readObjectAttribute($f, 'handles'));
         $f->release($easy2);
-        self::assertCount(2, self::readAttribute($f, 'handles'));
+        self::assertCount(2, Helpers::readObjectAttribute($f, 'handles'));
         $f->release($easy3);
-        self::assertCount(3, self::readAttribute($f, 'handles'));
+        self::assertCount(3, Helpers::readObjectAttribute($f, 'handles'));
         $f->release($easy4);
-        self::assertCount(3, self::readAttribute($f, 'handles'));
+        self::assertCount(3, Helpers::readObjectAttribute($f, 'handles'));
     }
 
     public function testEnsuresOnHeadersIsCallable()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests\Handler;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Tests\Helpers;
 use GuzzleHttp\Tests\Server;
 use PHPUnit\Framework\TestCase;
 
@@ -53,7 +54,7 @@ class CurlMultiHandlerTest extends TestCase
     public function testCanSetSelectTimeout()
     {
         $a = new CurlMultiHandler(['select_timeout' => 2]);
-        self::assertEquals(2, self::readAttribute($a, 'selectTimeout'));
+        self::assertEquals(2, Helpers::readObjectAttribute($a, 'selectTimeout'));
     }
 
     public function testCanCancel()
@@ -101,13 +102,13 @@ class CurlMultiHandlerTest extends TestCase
         $a = new CurlMultiHandler();
 
         //default if no options are given and no environment variable is set
-        self::assertEquals(1, self::readAttribute($a, 'selectTimeout'));
+        self::assertEquals(1, Helpers::readObjectAttribute($a, 'selectTimeout'));
 
         \putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
         $a = new CurlMultiHandler();
         $selectTimeout = \getenv('GUZZLE_CURL_SELECT_TIMEOUT');
         //Handler reads from the environment if no options are given
-        self::assertEquals($selectTimeout, self::readAttribute($a, 'selectTimeout'));
+        self::assertEquals($selectTimeout, Helpers::readObjectAttribute($a, 'selectTimeout'));
     }
 
     public function throwsWhenAccessingInvalidProperty()

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -1,0 +1,34 @@
+<?php
+namespace GuzzleHttp\Tests;
+
+class Helpers
+{
+    public static function readObjectAttribute(object $object, string $attributeName)
+    {
+        $reflector = new \ReflectionObject($object);
+
+        do {
+            try {
+                $attribute = $reflector->getProperty($attributeName);
+
+                if (!$attribute || $attribute->isPublic()) {
+                    return $object->$attributeName;
+                }
+
+                $attribute->setAccessible(true);
+
+                try {
+                    return $attribute->getValue($object);
+                } finally {
+                    $attribute->setAccessible(false);
+                }
+            } catch (\ReflectionException $e) {
+                // do nothing
+            }
+        } while ($reflector = $reflector->getParentClass());
+
+        throw new \Exception(
+            sprintf('Attribute "%s" not found in object.', $attributeName)
+        );
+    }
+}

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -16,9 +16,9 @@ class MessageFormatterTest extends TestCase
     public function testCreatesWithClfByDefault()
     {
         $f = new MessageFormatter();
-        self::assertEquals(MessageFormatter::CLF, self::readAttribute($f, 'template'));
+        self::assertEquals(MessageFormatter::CLF, Helpers::readObjectAttribute($f, 'template'));
         $f = new MessageFormatter(null);
-        self::assertEquals(MessageFormatter::CLF, self::readAttribute($f, 'template'));
+        self::assertEquals(MessageFormatter::CLF, Helpers::readObjectAttribute($f, 'template'));
     }
 
     public function dateProvider()

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -222,6 +222,6 @@ class MiddlewareTest extends TestCase
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);
         $p->wait(false);
         self::assertCount(1, $logger->records);
-        self::assertContains('some problem', $logger->records[0]['message']);
+        self::assertStringContainsString('some problem', $logger->records[0]['message']);
     }
 }


### PR DESCRIPTION
This will be necessary when we later update phpunit to "^8|^9", which will be necessary to test on PHP 8+.