### PR TITLE
Add get, post, ... to the client interface, removing the need for dynamic dispatch

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: "#^Method GuzzleHttp\\\\Client\\:\\:__call\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Client.php
-
-		-
 			message: "#^Method GuzzleHttp\\\\Client\\:\\:sendAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Client.php
@@ -27,12 +22,12 @@ parameters:
 
 		-
 			message: "#^Method GuzzleHttp\\\\Client\\:\\:requestAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
+			count: 2
 			path: src/Client.php
 
 		-
 			message: "#^Method GuzzleHttp\\\\Client\\:\\:request\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
+			count: 2
 			path: src/Client.php
 
 		-
@@ -76,6 +71,66 @@ parameters:
 			path: src/Client.php
 
 		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:get\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:head\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:put\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:post\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:patch\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:delete\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:getAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:headAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:putAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:postAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:patchAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Client\\:\\:deleteAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
 			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:send\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/ClientInterface.php
@@ -91,7 +146,67 @@ parameters:
 			path: src/ClientInterface.php
 
 		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:head\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:put\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:post\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:patch\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:delete\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
 			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:requestAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:getAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:headAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:putAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:postAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:patchAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ClientInterface.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:deleteAsync\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/ClientInterface.php
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,22 +9,10 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
-/**
- * @method ResponseInterface get(string|UriInterface $uri, array $options = [])
- * @method ResponseInterface head(string|UriInterface $uri, array $options = [])
- * @method ResponseInterface put(string|UriInterface $uri, array $options = [])
- * @method ResponseInterface post(string|UriInterface $uri, array $options = [])
- * @method ResponseInterface patch(string|UriInterface $uri, array $options = [])
- * @method ResponseInterface delete(string|UriInterface $uri, array $options = [])
- * @method Promise\PromiseInterface getAsync(string|UriInterface $uri, array $options = [])
- * @method Promise\PromiseInterface headAsync(string|UriInterface $uri, array $options = [])
- * @method Promise\PromiseInterface putAsync(string|UriInterface $uri, array $options = [])
- * @method Promise\PromiseInterface postAsync(string|UriInterface $uri, array $options = [])
- * @method Promise\PromiseInterface patchAsync(string|UriInterface $uri, array $options = [])
- * @method Promise\PromiseInterface deleteAsync(string|UriInterface $uri, array $options = [])
- */
 class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 {
+    use ClientTrait;
+
     /** @var array Default request options */
     private $config;
 
@@ -74,26 +62,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         $this->configureDefaults($config);
-    }
-
-    /**
-     * @param string $method
-     * @param array  $args
-     *
-     * @return PromiseInterface|ResponseInterface
-     */
-    public function __call($method, $args)
-    {
-        if (\count($args) < 1) {
-            throw new InvalidArgumentException('Magic request methods require a URI and optional options array');
-        }
-
-        $uri = $args[0];
-        $opts = isset($args[1]) ? $args[1] : [];
-
-        return \substr($method, -5) === 'Async'
-            ? $this->requestAsync(\substr($method, 0, -5), $uri, $opts)
-            : $this->request($method, $uri, $opts);
     }
 
     /**

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -3,35 +3,14 @@ namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Promise\PromiseInterface;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
  * Client interface for sending HTTP requests.
  */
-interface ClientInterface
+trait ClientTrait
 {
-    /**
-     * Send an HTTP request.
-     *
-     * @param RequestInterface $request Request to send
-     * @param array            $options Request options to apply to the given
-     *                                  request and to the transfer.
-     *
-     * @throws GuzzleException
-     */
-    public function send(RequestInterface $request, array $options = []): ResponseInterface;
-
-    /**
-     * Asynchronously send an HTTP request.
-     *
-     * @param RequestInterface $request Request to send
-     * @param array            $options Request options to apply to the given
-     *                                  request and to the transfer.
-     */
-    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface;
-
     /**
      * Create and send an HTTP request.
      *
@@ -45,7 +24,7 @@ interface ClientInterface
      *
      * @throws GuzzleException
      */
-    public function request(string $method, $uri, array $options = []): ResponseInterface;
+    abstract public function request(string $method, $uri, array $options = []): ResponseInterface;
 
     /**
      * Create and send an HTTP GET request.
@@ -59,7 +38,10 @@ interface ClientInterface
      *
      * @throws GuzzleException
      */
-    public function get($uri, array $options = []): ResponseInterface;
+    public function get($uri, array $options = []): ResponseInterface
+    {
+        return $this->request('GET', $uri, $options);
+    }
 
     /**
      * Create and send an HTTP HEAD request.
@@ -73,7 +55,10 @@ interface ClientInterface
      *
      * @throws GuzzleException
      */
-    public function head($uri, array $options = []): ResponseInterface;
+    public function head($uri, array $options = []): ResponseInterface
+    {
+        return $this->request('HEAD', $uri, $options);
+    }
 
     /**
      * Create and send an HTTP PUT request.
@@ -87,7 +72,10 @@ interface ClientInterface
      *
      * @throws GuzzleException
      */
-    public function put($uri, array $options = []): ResponseInterface;
+    public function put($uri, array $options = []): ResponseInterface
+    {
+        return $this->request('PUT', $uri, $options);
+    }
 
     /**
      * Create and send an HTTP POST request.
@@ -101,7 +89,10 @@ interface ClientInterface
      *
      * @throws GuzzleException
      */
-    public function post($uri, array $options = []): ResponseInterface;
+    public function post($uri, array $options = []): ResponseInterface
+    {
+        return $this->request('POST', $uri, $options);
+    }
 
     /**
      * Create and send an HTTP PATCH request.
@@ -115,7 +106,10 @@ interface ClientInterface
      *
      * @throws GuzzleException
      */
-    public function patch($uri, array $options = []): ResponseInterface;
+    public function patch($uri, array $options = []): ResponseInterface
+    {
+        return $this->request('PATCH', $uri, $options);
+    }
 
     /**
      * Create and send an HTTP DELETE request.
@@ -129,7 +123,10 @@ interface ClientInterface
      *
      * @throws GuzzleException
      */
-    public function delete($uri, array $options = []): ResponseInterface;
+    public function delete($uri, array $options = []): ResponseInterface
+    {
+        return $this->request('DELETE', $uri, $options);
+    }
 
     /**
      * Create and send an asynchronous HTTP request.
@@ -143,7 +140,7 @@ interface ClientInterface
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply.
      */
-    public function requestAsync(string $method, $uri, array $options = []): PromiseInterface;
+    abstract public function requestAsync(string $method, $uri, array $options = []): PromiseInterface;
 
     /**
      * Create and send an asynchronous HTTP GET request.
@@ -156,7 +153,10 @@ interface ClientInterface
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply.
      */
-    public function getAsync($uri, array $options = []): PromiseInterface;
+    public function getAsync($uri, array $options = []): PromiseInterface
+    {
+        return $this->requestAsync('GET', $uri, $options);
+    }
 
     /**
      * Create and send an asynchronous HTTP HEAD request.
@@ -169,7 +169,10 @@ interface ClientInterface
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply.
      */
-    public function headAsync($uri, array $options = []): PromiseInterface;
+    public function headAsync($uri, array $options = []): PromiseInterface
+    {
+        return $this->requestAsync('HEAD', $uri, $options);
+    }
 
     /**
      * Create and send an asynchronous HTTP PUT request.
@@ -182,7 +185,10 @@ interface ClientInterface
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply.
      */
-    public function putAsync($uri, array $options = []): PromiseInterface;
+    public function putAsync($uri, array $options = []): PromiseInterface
+    {
+        return $this->requestAsync('PUT', $uri, $options);
+    }
 
     /**
      * Create and send an asynchronous HTTP POST request.
@@ -195,7 +201,10 @@ interface ClientInterface
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply.
      */
-    public function postAsync($uri, array $options = []): PromiseInterface;
+    public function postAsync($uri, array $options = []): PromiseInterface
+    {
+        return $this->requestAsync('POST', $uri, $options);
+    }
 
     /**
      * Create and send an asynchronous HTTP PATCH request.
@@ -208,7 +217,10 @@ interface ClientInterface
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply.
      */
-    public function patchAsync($uri, array $options = []): PromiseInterface;
+    public function patchAsync($uri, array $options = []): PromiseInterface
+    {
+        return $this->requestAsync('PATCH', $uri, $options);
+    }
 
     /**
      * Create and send an asynchronous HTTP DELETE request.
@@ -221,18 +233,8 @@ interface ClientInterface
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply.
      */
-    public function deleteAsync($uri, array $options = []): PromiseInterface;
-
-    /**
-     * Get a client configuration option.
-     *
-     * These options include default request options of the client, a "handler"
-     * (if utilized by the concrete client), and a "base_uri" if utilized by
-     * the concrete client.
-     *
-     * @param string|null $option The config option to retrieve.
-     *
-     * @return mixed
-     */
-    public function getConfig(?string $option = null);
+    public function deleteAsync($uri, array $options = []): PromiseInterface
+    {
+        return $this->requestAsync('DELETE', $uri, $options);
+    }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -25,16 +25,7 @@ class ClientTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testValidatesArgsForMagicMethods()
-    {
-        $client = new Client();
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Magic request methods require a URI and optional options array');
-        $client->get();
-    }
-
-    public function testCanSendMagicAsyncRequests()
+    public function testCanSendAsyncGetRequests()
     {
         $client = new Client();
         Server::flush();


### PR DESCRIPTION
I think this is pragmatic solution (replacing #2482) to allow people to still call the short hand methods they want to, but also make the interface easy to implement, by providing a trait that implements these extra methods by calling `request` and `requestAsync`.

---

Closes #2482.