### PR TITLE
[7.1] Deprecate the getConfig method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -189,6 +189,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * @param string|null $option The config option to retrieve.
      *
      * @return mixed
+     *
+     * @deprecated Client::getConfig will be removed in guzzlehttp/guzzle:8.0.
      */
     public function getConfig(?string $option = null)
     {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -71,6 +71,8 @@ interface ClientInterface
      * @param string|null $option The config option to retrieve.
      *
      * @return mixed
+     *
+     * @deprecated ClientInterface::getConfig will be removed in guzzlehttp/guzzle:8.0.
      */
     public function getConfig(?string $option = null);
 }


### PR DESCRIPTION
This depends on https://github.com/guzzle/guzzle/pull/2515 being merged first.

---

Closes #2514.