### PR TITLE
[6.5] Fixed deprecation warning in node test server

### DIFF
--- a/tests/server.js
+++ b/tests/server.js
@@ -178,7 +178,7 @@ var GuzzleServer = function(port, log) {
         that.responses = JSON.parse(request.body);
         for (var i = 0; i < that.responses.length; i++) {
           if (that.responses[i].body) {
-            that.responses[i].body = new Buffer(that.responses[i].body, 'base64');
+            that.responses[i].body = new Buffer.from(that.responses[i].body, 'base64');
           }
         }
         if (that.log) {


### PR DESCRIPTION
Will allow us to run on node 12 on the master branch when merged upwards.