### PR TITLE
Remove additional backticks in upgrading document

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -34,10 +34,10 @@ Example:
 
 ```php
 // Before:
-`curl_version()`;
+curl_version();
 
 // After:
-`\curl_version()`;
+\curl_version();
 ```
 
 For the full diff you can check [here](https://github.com/guzzle/guzzle/compare/6.5.0..master).


### PR DESCRIPTION
It was already inside of a code block, implying that it would be a shell call 
from php, while it is just a function call.