### PR TITLE
[6.5] Avoid the unsafe getenv function

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -536,11 +536,6 @@ parameters:
 			path: src/Handler/CurlHandler.php
 
 		-
-			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:\\$selectTimeout has no typehint specified\\.$#"
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
 			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:\\$active has no typehint specified\\.$#"
 			count: 1
 			path: src/Handler/CurlMultiHandler.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -254,15 +254,15 @@ class Client implements ClientInterface
         // We can only trust the HTTP_PROXY environment variable in a CLI
         // process due to the fact that PHP has no reliable mechanism to
         // get environment variables that start with "HTTP_".
-        if (php_sapi_name() === 'cli' && getenv('HTTP_PROXY')) {
-            $defaults['proxy']['http'] = getenv('HTTP_PROXY');
+        if (php_sapi_name() === 'cli' && ($proxy = \GuzzleHttp\_getenv('HTTP_PROXY'))) {
+            $defaults['proxy']['http'] = $proxy;
         }
 
-        if ($proxy = getenv('HTTPS_PROXY')) {
+        if ($proxy = \GuzzleHttp\_getenv('HTTPS_PROXY')) {
             $defaults['proxy']['https'] = $proxy;
         }
 
-        if ($noProxy = getenv('NO_PROXY')) {
+        if ($noProxy = \GuzzleHttp\_getenv('NO_PROXY')) {
             $cleanedNoProxy = str_replace(' ', '', $noProxy);
             $defaults['proxy']['no'] = explode(',', $cleanedNoProxy);
         }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -19,6 +19,7 @@ class CurlMultiHandler
 {
     /** @var CurlFactoryInterface */
     private $factory;
+    /** @var int */
     private $selectTimeout;
     private $active;
     private $handles = [];
@@ -43,8 +44,8 @@ class CurlMultiHandler
 
         if (isset($options['select_timeout'])) {
             $this->selectTimeout = $options['select_timeout'];
-        } elseif ($selectTimeout = getenv('GUZZLE_CURL_SELECT_TIMEOUT')) {
-            $this->selectTimeout = $selectTimeout;
+        } elseif ($selectTimeout = \GuzzleHttp\_getenv('GUZZLE_CURL_SELECT_TIMEOUT')) {
+            $this->selectTimeout = (int) $selectTimeout;
         } else {
             $this->selectTimeout = 1;
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -406,7 +406,7 @@ function _getenv($name)
         return (string) $_SERVER[$name];
     }
 
-    if (PHP_SAPI === 'cli' && ($value = getenv($name) !== false)) {
+    if (PHP_SAPI === 'cli' && ($value = getenv($name)) !== false) {
         return (string) $value;
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -392,3 +392,23 @@ function _idn_uri_convert(UriInterface $uri, $options = 0)
 
     return $uri;
 }
+
+/**
+ * @param string $name
+ *
+ * @return string|null
+ *
+ * @internal
+ */
+function _getenv($name)
+{
+    if (isset($_SERVER[$name])) {
+        return (string) $_SERVER[$name];
+    }
+
+    if (PHP_SAPI === 'cli' && ($value = getenv($name) !== false)) {
+        return (string) $value;
+    }
+
+    return null;
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -406,7 +406,7 @@ function _getenv($name)
         return (string) $_SERVER[$name];
     }
 
-    if (PHP_SAPI === 'cli' && ($value = getenv($name)) !== false) {
+    if (PHP_SAPI === 'cli' && ($value = getenv($name)) !== false && $value !== null) {
         return (string) $value;
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -569,27 +569,34 @@ class ClientTest extends TestCase
 
     public function testUsesProxyEnvironmentVariables()
     {
-        $http = getenv('HTTP_PROXY');
-        $https = getenv('HTTPS_PROXY');
-        $no = getenv('NO_PROXY');
-        $client = new Client();
-        self::assertNull($client->getConfig('proxy'));
-        putenv('HTTP_PROXY=127.0.0.1');
-        $client = new Client();
-        self::assertSame(
-            ['http' => '127.0.0.1'],
-            $client->getConfig('proxy')
-        );
-        putenv('HTTPS_PROXY=127.0.0.2');
-        putenv('NO_PROXY=127.0.0.3, 127.0.0.4');
-        $client = new Client();
-        self::assertSame(
-            ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3','127.0.0.4']],
-            $client->getConfig('proxy')
-        );
-        putenv("HTTP_PROXY=$http");
-        putenv("HTTPS_PROXY=$https");
-        putenv("NO_PROXY=$no");
+        unset($_SERVER['HTTP_PROXY'], $_SERVER['HTTPS_PROXY'], $_SERVER['NO_PROXY']);
+        putenv('HTTP_PROXY=');
+        putenv('HTTPS_PROXY=');
+        putenv('NO_PROXY=');
+
+        try {
+            $client = new Client();
+            self::assertNull($client->getConfig('proxy'));
+
+            putenv('HTTP_PROXY=127.0.0.1');
+            $client = new Client();
+            self::assertSame(
+                ['http' => '127.0.0.1'],
+                $client->getConfig('proxy')
+            );
+
+            putenv('HTTPS_PROXY=127.0.0.2');
+            putenv('NO_PROXY=127.0.0.3, 127.0.0.4');
+            $client = new Client();
+            self::assertSame(
+                ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3','127.0.0.4']],
+                $client->getConfig('proxy')
+            );
+        } finally {
+            putenv('HTTP_PROXY=');
+            putenv('HTTPS_PROXY=');
+            putenv('NO_PROXY=');
+        }
     }
 
     public function testRequestSendsWithSync()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -99,15 +99,22 @@ class CurlMultiHandlerTest extends TestCase
 
     public function testUsesTimeoutEnvironmentVariables()
     {
-        $a = new CurlMultiHandler();
+        unset($_SERVER['GUZZLE_CURL_SELECT_TIMEOUT']);
+        putenv('GUZZLE_CURL_SELECT_TIMEOUT=');
 
-        // Default if no options are given and no environment variable is set
-        self::assertEquals(1, self::readAttribute($a, 'selectTimeout'));
+        try {
+            $a = new CurlMultiHandler();
 
-        putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
-        $a = new CurlMultiHandler();
-        // Handler reads from the environment if no options are given
-        self::assertEquals(3, self::readAttribute($a, 'selectTimeout'));
+            // Default if no options are given and no environment variable is set
+            self::assertEquals(1, self::readAttribute($a, 'selectTimeout'));
+
+            putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
+            $a = new CurlMultiHandler();
+            // Handler reads from the environment if no options are given
+            self::assertEquals(3, self::readAttribute($a, 'selectTimeout'));
+        } finally {
+            putenv('GUZZLE_CURL_SELECT_TIMEOUT=');
+        }
     }
 
     /**

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -101,14 +101,13 @@ class CurlMultiHandlerTest extends TestCase
     {
         $a = new CurlMultiHandler();
 
-        //default if no options are given and no environment variable is set
+        // Default if no options are given and no environment variable is set
         self::assertEquals(1, self::readAttribute($a, 'selectTimeout'));
 
         putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
         $a = new CurlMultiHandler();
-        $selectTimeout = getenv('GUZZLE_CURL_SELECT_TIMEOUT');
-        //Handler reads from the environment if no options are given
-        self::assertEquals($selectTimeout, self::readAttribute($a, 'selectTimeout'));
+        // Handler reads from the environment if no options are given
+        self::assertEquals(3, self::readAttribute($a, 'selectTimeout'));
     }
 
     /**


### PR DESCRIPTION
#### TLDR: `getenv` is not thread safe!

The `genv` and `putenv` functions are not threadsafe, so environment variables set in one thread using `putenv` may leak into another via `getenv`. This not just a "theoretical" bug. It actually happens in real apps and servers, and was the result of hundreds of bug reports on the Laravel framework over the years, where people were confused by variables not being what they expected!

---

EDIT: In order to minimize breakage, for CLI apps, I've allowed to still read from `getenv` for that.