### PR TITLE
[7.x] Avoid the getenv function when unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please see [the upgrade document](UPGRADING.md) that describes all BC breaking c
 * Added visibility to all constants [#2462](https://github.com/guzzle/guzzle/pull/2462)
 * Dont allow passing `null` as URI to `Client::request()` and `Client::requestAsync()` [#2461](https://github.com/guzzle/guzzle/pull/2461)
 * Widen the exception argument to throwable [#2495](https://github.com/guzzle/guzzle/pull/2495)
+* Avoid the getenv function when unsafe [#2531](https://github.com/guzzle/guzzle/pull/2531)
 
 ### Fixed 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## UNRELEASHED
+
+### Changed
+
+* Avoid the getenv function when unsafe [#2531](https://github.com/guzzle/guzzle/pull/2531)
+
 ## 7.0.0-beta1 - 2019-12-30
 
 The diff might look very big but 95% of Guzzle users will be able to upgrade without modification. 
@@ -20,7 +26,6 @@ Please see [the upgrade document](UPGRADING.md) that describes all BC breaking c
 * Added visibility to all constants [#2462](https://github.com/guzzle/guzzle/pull/2462)
 * Dont allow passing `null` as URI to `Client::request()` and `Client::requestAsync()` [#2461](https://github.com/guzzle/guzzle/pull/2461)
 * Widen the exception argument to throwable [#2495](https://github.com/guzzle/guzzle/pull/2495)
-* Avoid the getenv function when unsafe [#2531](https://github.com/guzzle/guzzle/pull/2531)
 
 ### Fixed 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,6 +25,7 @@ Please make sure:
 - Function `GuzzleHttp\Cookie\CookieJar::getCookieValue` is removed.
 - Request option `exception` is removed. Please use `http_errors`.
 - Request option `save_to` is removed. Please use `sink`. 
+- We now look for environment variables in the `$_SERVER` super global, due to thread safety issues with `getenv`. We continue to fallback to `getenv` in CLI environments, for maximum compatibility.
 
 #### Native functions calls
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -316,11 +316,6 @@ parameters:
 			path: src/Handler/CurlHandler.php
 
 		-
-			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:\\$selectTimeout has no typehint specified\\.$#"
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
 			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:\\$active has no typehint specified\\.$#"
 			count: 1
 			path: src/Handler/CurlMultiHandler.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -246,15 +246,15 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         // We can only trust the HTTP_PROXY environment variable in a CLI
         // process due to the fact that PHP has no reliable mechanism to
         // get environment variables that start with "HTTP_".
-        if (PHP_SAPI === 'cli' && \getenv('HTTP_PROXY')) {
-            $defaults['proxy']['http'] = \getenv('HTTP_PROXY');
+        if (PHP_SAPI === 'cli' && ($proxy = \GuzzleHttp\_getenv('HTTP_PROXY'))) {
+            $defaults['proxy']['http'] = $proxy;
         }
 
-        if ($proxy = \getenv('HTTPS_PROXY')) {
+        if ($proxy = \GuzzleHttp\_getenv('HTTPS_PROXY')) {
             $defaults['proxy']['https'] = $proxy;
         }
 
-        if ($noProxy = \getenv('NO_PROXY')) {
+        if ($noProxy = \GuzzleHttp\_getenv('NO_PROXY')) {
             $cleanedNoProxy = \str_replace(' ', '', $noProxy);
             $defaults['proxy']['no'] = \explode(',', $cleanedNoProxy);
         }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -19,6 +19,7 @@ class CurlMultiHandler
 {
     /** @var CurlFactoryInterface */
     private $factory;
+    /** @var int */
     private $selectTimeout;
     private $active;
     private $handles = [];
@@ -41,8 +42,8 @@ class CurlMultiHandler
 
         if (isset($options['select_timeout'])) {
             $this->selectTimeout = $options['select_timeout'];
-        } elseif ($selectTimeout = \getenv('GUZZLE_CURL_SELECT_TIMEOUT')) {
-            $this->selectTimeout = $selectTimeout;
+        } elseif ($selectTimeout = \GuzzleHttp\_getenv('GUZZLE_CURL_SELECT_TIMEOUT')) {
+            $this->selectTimeout = (int) $selectTimeout;
         } else {
             $this->selectTimeout = 1;
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -357,10 +357,6 @@ function _idn_uri_convert(UriInterface $uri, int $options = 0): UriInterface
 }
 
 /**
- * @param string $name
- *
- * @return string|null
- *
  * @internal
  */
 function _getenv(string $name): ?string

--- a/src/functions.php
+++ b/src/functions.php
@@ -369,7 +369,7 @@ function _getenv(string $name): ?string
         return (string) $_SERVER[$name];
     }
 
-    if (PHP_SAPI === 'cli' && ($value = \getenv($name) !== false)) {
+    if (PHP_SAPI === 'cli' && ($value = \getenv($name)) !== false) {
         return (string) $value;
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -365,7 +365,7 @@ function _getenv(string $name): ?string
         return (string) $_SERVER[$name];
     }
 
-    if (PHP_SAPI === 'cli' && ($value = \getenv($name)) !== false) {
+    if (PHP_SAPI === 'cli' && ($value = \getenv($name)) !== false && $value !== null) {
         return (string) $value;
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -355,3 +355,23 @@ function _idn_uri_convert(UriInterface $uri, int $options = 0): UriInterface
 
     return $uri;
 }
+
+/**
+ * @param string $name
+ *
+ * @return string|null
+ *
+ * @internal
+ */
+function _getenv(string $name): ?string
+{
+    if (isset($_SERVER[$name])) {
+        return (string) $_SERVER[$name];
+    }
+
+    if (PHP_SAPI === 'cli' && ($value = \getenv($name) !== false)) {
+        return (string) $value;
+    }
+
+    return null;
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -546,27 +546,34 @@ class ClientTest extends TestCase
 
     public function testUsesProxyEnvironmentVariables()
     {
-        $http = \getenv('HTTP_PROXY');
-        $https = \getenv('HTTPS_PROXY');
-        $no = \getenv('NO_PROXY');
-        $client = new Client();
-        self::assertNull($client->getConfig('proxy'));
-        \putenv('HTTP_PROXY=127.0.0.1');
-        $client = new Client();
-        self::assertSame(
-            ['http' => '127.0.0.1'],
-            $client->getConfig('proxy')
-        );
-        \putenv('HTTPS_PROXY=127.0.0.2');
-        \putenv('NO_PROXY=127.0.0.3, 127.0.0.4');
-        $client = new Client();
-        self::assertSame(
-            ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3','127.0.0.4']],
-            $client->getConfig('proxy')
-        );
-        \putenv("HTTP_PROXY=$http");
-        \putenv("HTTPS_PROXY=$https");
-        \putenv("NO_PROXY=$no");
+        unset($_SERVER['HTTP_PROXY'], $_SERVER['HTTPS_PROXY'], $_SERVER['NO_PROXY']);
+        \putenv('HTTP_PROXY=');
+        \putenv('HTTPS_PROXY=');
+        \putenv('NO_PROXY=');
+
+        try {
+            $client = new Client();
+            self::assertNull($client->getConfig('proxy'));
+
+            \putenv('HTTP_PROXY=127.0.0.1');
+            $client = new Client();
+            self::assertSame(
+                ['http' => '127.0.0.1'],
+                $client->getConfig('proxy')
+            );
+
+            \putenv('HTTPS_PROXY=127.0.0.2');
+            \putenv('NO_PROXY=127.0.0.3, 127.0.0.4');
+            $client = new Client();
+            self::assertSame(
+                ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3','127.0.0.4']],
+                $client->getConfig('proxy')
+            );
+        } finally {
+            \putenv('HTTP_PROXY=');
+            \putenv('HTTPS_PROXY=');
+            \putenv('NO_PROXY=');
+        }
     }
 
     public function testRequestSendsWithSync()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -99,15 +99,21 @@ class CurlMultiHandlerTest extends TestCase
 
     public function testUsesTimeoutEnvironmentVariables()
     {
-        $a = new CurlMultiHandler();
+        unset($_SERVER['GUZZLE_CURL_SELECT_TIMEOUT']);
+        \putenv('GUZZLE_CURL_SELECT_TIMEOUT=');
 
-        // Default if no options are given and no environment variable is set
-        self::assertEquals(1, Helpers::readObjectAttribute($a, 'selectTimeout'));
+        try {
+            $a = new CurlMultiHandler();
+            // Default if no options are given and no environment variable is set
+            self::assertEquals(1, Helpers::readObjectAttribute($a, 'selectTimeout'));
 
-        \putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
-        $a = new CurlMultiHandler();
-        // Handler reads from the environment if no options are given
-        self::assertEquals(3, Helpers::readObjectAttribute($a, 'selectTimeout'));
+            \putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
+            $a = new CurlMultiHandler();
+            // Handler reads from the environment if no options are given
+            self::assertEquals(3, Helpers::readObjectAttribute($a, 'selectTimeout'));
+        } finally {
+            \putenv('GUZZLE_CURL_SELECT_TIMEOUT=');
+        }
     }
 
     public function throwsWhenAccessingInvalidProperty()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -101,14 +101,13 @@ class CurlMultiHandlerTest extends TestCase
     {
         $a = new CurlMultiHandler();
 
-        //default if no options are given and no environment variable is set
+        // Default if no options are given and no environment variable is set
         self::assertEquals(1, Helpers::readObjectAttribute($a, 'selectTimeout'));
 
         \putenv("GUZZLE_CURL_SELECT_TIMEOUT=3");
         $a = new CurlMultiHandler();
-        $selectTimeout = \getenv('GUZZLE_CURL_SELECT_TIMEOUT');
-        //Handler reads from the environment if no options are given
-        self::assertEquals($selectTimeout, Helpers::readObjectAttribute($a, 'selectTimeout'));
+        // Handler reads from the environment if no options are given
+        self::assertEquals(3, Helpers::readObjectAttribute($a, 'selectTimeout'));
     }
 
     public function throwsWhenAccessingInvalidProperty()


### PR DESCRIPTION
This is the 7.x version of https://github.com/guzzle/guzzle/pull/2530.