### PR TITLE
[7.x] Enforce the json_decode string first param type

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -267,7 +267,7 @@ function is_host_in_noproxy(string $host, array $noProxyArray): bool
  *
  * @link http://www.php.net/manual/en/function.json-decode.php
  */
-function json_decode($json, bool $assoc = false, int $depth = 512, int $options = 0)
+function json_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
 {
     $data = \json_decode($json, $assoc, $depth, $options);
     if (JSON_ERROR_NONE !== \json_last_error()) {


### PR DESCRIPTION
Do we want this, or are we happy with it being coerced to a string when the internal PHP function is called? If so, we should probably make the param doc type wider.