### PR TITLE
Avoid PHP bug #77946

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "~7.2.22 || ^7.3.9",
         "ext-json": "*",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.6.1",

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Tests\Handler;
 
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -122,5 +123,15 @@ class CurlMultiHandlerTest extends TestCase
 
         $this->expectException(\BadMethodCallException::class);
         $h->foo;
+    }
+
+    public function testCurlErrorMessage(): void
+    {
+        $a = new CurlMultiHandler();
+
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('Could not resolve host: ');
+
+        $a(new Request('GET', 'http://' . uniqid() . uniqid()), [])->wait();
     }
 }


### PR DESCRIPTION
PHP bug [#77946](https://bugs.php.net/bug.php?id=77946) is fixed since [PHP 7.2.22](https://github.com/php/php-src/commit/c8c183eb62b666b5e9c92ca2cbf13f5464ae3aa9).

Related to #2292.