### PR TITLE
fix problem double backslash

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -376,6 +376,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
         if (isset($options['json'])) {
             $options['body'] = \GuzzleHttp\json_encode($options['json']);
+            //we need to keep forward slash
+            if(strpos($options['body'], '/') !== false)
+                $options['body'] = str_replace("\\", "", $options['body']);
             unset($options['json']);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);


### PR DESCRIPTION
fix double backslash `\\` that automatically added when we use forward slash `/`. in my case it cause error in data processing.
i have a data that must be stay same when it sended to a third party API, it's contains a special character like forward slash.