### PR TITLE
[7.0] Avoid functions due to global install conflicts

### DIFF
--- a/docs/handlers-and-middleware.rst
+++ b/docs/handlers-and-middleware.rst
@@ -214,13 +214,14 @@ stack.
 
 .. code-block:: php
 
-    use Psr\Http\Message\RequestInterface;
+    use GuzzleHttp\Client;
     use GuzzleHttp\HandlerStack;
     use GuzzleHttp\Middleware;
-    use GuzzleHttp\Client;
+    use GuzzleHttp\Utils;
+    use Psr\Http\Message\RequestInterface;
 
     $stack = new HandlerStack();
-    $stack->setHandler(\GuzzleHttp\choose_handler());
+    $stack->setHandler(Utils::chooseHandler());
 
     $stack->push(Middleware::mapRequest(function (RequestInterface $r) {
         echo 'A';

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -206,6 +206,11 @@ parameters:
 			path: src/Cookie/CookieJarInterface.php
 
 		-
+			message: "#^Argument of an invalid type array\\|bool\\|float\\|int\\|object\\|string\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Cookie/FileCookieJar.php
+
+		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, bool\\|float\\|int\\|object\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Cookie/FileCookieJar.php
@@ -896,12 +901,57 @@ parameters:
 			path: src/TransferStats.php
 
 		-
-			message: "#^Function GuzzleHttp\\\\describe_type\\(\\) has parameter \\$input with no typehint specified\\.$#"
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:describeType\\(\\) has parameter \\$input with no typehint specified\\.$#"
 			count: 1
-			path: src/functions.php
+			path: src/Utils.php
 
 		-
 			message: "#^Parameter \\#1 \\$str of function rtrim expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:headersFromLines\\(\\) has parameter \\$lines with no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:headersFromLines\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:debugResource\\(\\) should return resource but returns resource\\|false\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:normalizeHeaderKeys\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:normalizeHeaderKeys\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Cannot access offset 0 on array\\<int, string\\>\\|false\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:jsonDecode\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:jsonEncode\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Function GuzzleHttp\\\\describe_type\\(\\) has parameter \\$input with no typehint specified\\.$#"
 			count: 1
 			path: src/functions.php
 
@@ -916,11 +966,6 @@ parameters:
 			path: src/functions.php
 
 		-
-			message: "#^Function GuzzleHttp\\\\debug_resource\\(\\) should return resource but returns resource\\|false\\.$#"
-			count: 1
-			path: src/functions.php
-
-		-
 			message: "#^Function GuzzleHttp\\\\normalize_header_keys\\(\\) has parameter \\$headers with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/functions.php
@@ -931,17 +976,7 @@ parameters:
 			path: src/functions.php
 
 		-
-			message: "#^Cannot access offset 0 on array\\<int, string\\>\\|false\\.$#"
-			count: 1
-			path: src/functions.php
-
-		-
 			message: "#^Function GuzzleHttp\\\\json_decode\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/functions.php
-
-		-
-			message: "#^Function GuzzleHttp\\\\json_encode\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: src/functions.php
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -205,7 +205,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
         if (isset($config['idn_conversion']) && ($config['idn_conversion'] !== false)) {
             $idnOptions = ($config['idn_conversion'] === true) ? IDNA_DEFAULT : $config['idn_conversion'];
-            $uri = _idn_uri_convert($uri, $idnOptions);
+            $uri = Utils::idnUriConvert($uri, $idnOptions);
         }
 
         return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;
@@ -234,15 +234,15 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         // We can only trust the HTTP_PROXY environment variable in a CLI
         // process due to the fact that PHP has no reliable mechanism to
         // get environment variables that start with "HTTP_".
-        if (PHP_SAPI === 'cli' && ($proxy = \GuzzleHttp\_getenv('HTTP_PROXY'))) {
+        if (PHP_SAPI === 'cli' && ($proxy = Utils::getenv('HTTP_PROXY'))) {
             $defaults['proxy']['http'] = $proxy;
         }
 
-        if ($proxy = \GuzzleHttp\_getenv('HTTPS_PROXY')) {
+        if ($proxy = Utils::getenv('HTTPS_PROXY')) {
             $defaults['proxy']['https'] = $proxy;
         }
 
-        if ($noProxy = \GuzzleHttp\_getenv('NO_PROXY')) {
+        if ($noProxy = Utils::getenv('NO_PROXY')) {
             $cleanedNoProxy = \str_replace(' ', '', $noProxy);
             $defaults['proxy']['no'] = \explode(',', $cleanedNoProxy);
         }
@@ -255,7 +255,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
         // Add the default user-agent header.
         if (!isset($this->config['headers'])) {
-            $this->config['headers'] = ['User-Agent' => default_user_agent()];
+            $this->config['headers'] = ['User-Agent' => Utils::defaultUserAgent()];
         } else {
             // Add the User-Agent header if one was not already set.
             foreach (\array_keys($this->config['headers']) as $name) {
@@ -263,7 +263,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     return;
                 }
             }
-            $this->config['headers']['User-Agent'] = default_user_agent();
+            $this->config['headers']['User-Agent'] = Utils::defaultUserAgent();
         }
     }
 
@@ -363,7 +363,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         if (isset($options['json'])) {
-            $options['body'] = \GuzzleHttp\json_encode($options['json']);
+            $options['body'] = Utils::jsonEncode($options['json']);
             unset($options['json']);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\_caseless_remove(['Content-Type'], $options['_conditional']);

--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -1,6 +1,8 @@
 <?php
 namespace GuzzleHttp\Cookie;
 
+use GuzzleHttp\Utils;
+
 /**
  * Persists non-session cookies using a JSON formatted file
  */
@@ -57,7 +59,7 @@ class FileCookieJar extends CookieJar
             }
         }
 
-        $jsonStr = \GuzzleHttp\json_encode($json);
+        $jsonStr = Utils::jsonEncode($json);
         if (false === \file_put_contents($filename, $jsonStr, LOCK_EX)) {
             throw new \RuntimeException("Unable to save file {$filename}");
         }
@@ -81,9 +83,9 @@ class FileCookieJar extends CookieJar
             return;
         }
 
-        $data = \GuzzleHttp\json_decode($json, true);
+        $data = Utils::jsonDecode($json, true);
         if (\is_array($data)) {
-            foreach (\json_decode($json, true) as $cookie) {
+            foreach (Utils::jsonDecode($json, true) as $cookie) {
                 $this->setCookie(new SetCookie($cookie));
             }
         } elseif (\strlen($data)) {

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -434,7 +435,7 @@ class CurlFactory implements CurlFactoryInterface
                 if (isset($options['proxy'][$scheme])) {
                     $host = $easy->request->getUri()->getHost();
                     if (!isset($options['proxy']['no']) ||
-                        !\GuzzleHttp\is_host_in_noproxy($host, $options['proxy']['no'])
+                        !Utils::isHostInNoProxy($host, $options['proxy']['no'])
                     ) {
                         $conf[CURLOPT_PROXY] = $options['proxy'][$scheme];
                     }
@@ -494,7 +495,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (!empty($options['debug'])) {
-            $conf[CURLOPT_STDERR] = \GuzzleHttp\debug_resource($options['debug']);
+            $conf[CURLOPT_STDERR] = Utils::debugResource($options['debug']);
             $conf[CURLOPT_VERBOSE] = true;
         }
     }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -42,7 +43,7 @@ class CurlMultiHandler
 
         if (isset($options['select_timeout'])) {
             $this->selectTimeout = $options['select_timeout'];
-        } elseif ($selectTimeout = \GuzzleHttp\_getenv('GUZZLE_CURL_SELECT_TIMEOUT')) {
+        } elseif ($selectTimeout = Utils::getenv('GUZZLE_CURL_SELECT_TIMEOUT')) {
             $this->selectTimeout = (int) $selectTimeout;
         } else {
             $this->selectTimeout = 1;
@@ -101,7 +102,7 @@ class CurlMultiHandler
     {
         // Add any delayed handles if needed.
         if ($this->delays) {
-            $currentTime = \GuzzleHttp\_current_time();
+            $currentTime = Utils::currentTime();
             foreach ($this->delays as $id => $delay) {
                 if ($currentTime >= $delay) {
                     unset($this->delays[$id]);
@@ -153,7 +154,7 @@ class CurlMultiHandler
         if (empty($easy->options['delay'])) {
             \curl_multi_add_handle($this->_mh, $easy->handle);
         } else {
-            $this->delays[$id] = \GuzzleHttp\_current_time() + ($easy->options['delay'] / 1000);
+            $this->delays[$id] = Utils::currentTime() + ($easy->options['delay'] / 1000);
         }
     }
 
@@ -205,7 +206,7 @@ class CurlMultiHandler
 
     private function timeToNext(): int
     {
-        $currentTime = \GuzzleHttp\_current_time();
+        $currentTime = Utils::currentTime();
         $nextTime = PHP_INT_MAX;
         foreach ($this->delays as $time) {
             if ($time < $nextTime) {

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -50,8 +51,8 @@ final class EasyHandle
 
         // HTTP-version SP status-code SP reason-phrase
         $startLine = \explode(' ', \array_shift($this->headers), 3);
-        $headers = \GuzzleHttp\headers_from_lines($this->headers);
-        $normalizedKeys = \GuzzleHttp\normalize_header_keys($headers);
+        $headers = Utils::headersFromLines($this->headers);
+        $normalizedKeys = Utils::normalizeHeaderKeys($headers);
 
         if (!empty($this->options['decode_content'])
             && isset($normalizedKeys['content-encoding'])

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -5,6 +5,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -158,7 +159,7 @@ class MockHandler implements \Countable
             ) {
                 $this->queue[] = $value;
             } else {
-                throw new \TypeError('Expected a Response, Promise, Throwable or callable. Found ' . \GuzzleHttp\describe_type($value));
+                throw new \TypeError('Expected a Response, Promise, Throwable or callable. Found ' . Utils::describeType($value));
             }
         }
     }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -32,7 +33,7 @@ class StreamHandler
             \usleep($options['delay'] * 1000);
         }
 
-        $startTime = isset($options['on_stats']) ? \GuzzleHttp\_current_time() : null;
+        $startTime = isset($options['on_stats']) ? Utils::currentTime() : null;
 
         try {
             // Does not support the expect header.
@@ -81,7 +82,7 @@ class StreamHandler
             $stats = new TransferStats(
                 $request,
                 $response,
-                \GuzzleHttp\_current_time() - $startTime,
+                Utils::currentTime() - $startTime,
                 $error,
                 []
             );
@@ -101,7 +102,7 @@ class StreamHandler
         $ver = \explode('/', $parts[0])[1];
         $status = $parts[1];
         $reason = isset($parts[2]) ? $parts[2] : null;
-        $headers = \GuzzleHttp\headers_from_lines($hdrs);
+        $headers = Utils::headersFromLines($hdrs);
         list($stream, $headers) = $this->checkDecode($options, $headers, $stream);
         $stream = Psr7\stream_for($stream);
         $sink = $stream;
@@ -156,7 +157,7 @@ class StreamHandler
     {
         // Automatically decode responses when instructed.
         if (!empty($options['decode_content'])) {
-            $normalizedKeys = \GuzzleHttp\normalize_header_keys($headers);
+            $normalizedKeys = Utils::normalizeHeaderKeys($headers);
             if (isset($normalizedKeys['content-encoding'])) {
                 $encoding = $headers[$normalizedKeys['content-encoding']];
                 if ($encoding[0] === 'gzip' || $encoding[0] === 'deflate') {
@@ -412,7 +413,7 @@ class StreamHandler
             $scheme = $request->getUri()->getScheme();
             if (isset($value[$scheme])) {
                 if (!isset($value['no'])
-                    || !\GuzzleHttp\is_host_in_noproxy(
+                    || !Utils::isHostInNoProxy(
                         $request->getUri()->getHost(),
                         $value['no']
                     )
@@ -436,7 +437,7 @@ class StreamHandler
             // PHP 5.6 or greater will find the system cert by default. When
             // < 5.6, use the Guzzle bundled cacert.
             if (PHP_VERSION_ID < 50600) {
-                $options['ssl']['cafile'] = \GuzzleHttp\default_ca_bundle();
+                $options['ssl']['cafile'] = Utils::defaultCaBundle();
             }
         } elseif (\is_string($value)) {
             $options['ssl']['cafile'] = $value;
@@ -503,7 +504,7 @@ class StreamHandler
         static $args = ['severity', 'message', 'message_code',
             'bytes_transferred', 'bytes_max'];
 
-        $value = \GuzzleHttp\debug_resource($value);
+        $value = Utils::debugResource($value);
         $ident = $request->getMethod() . ' ' . $request->getUri()->withFragment('');
         $this->addNotification(
             $params,

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -37,7 +37,7 @@ class HandlerStack
      */
     public static function create(?callable $handler = null): self
     {
-        $stack = new self($handler ?: choose_handler());
+        $stack = new self($handler ?: Utils::chooseHandler());
         $stack->push(Middleware::httpErrors(), 'http_errors');
         $stack->push(Middleware::redirect(), 'allow_redirects');
         $stack->push(Middleware::cookies(), 'cookies');

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -171,7 +171,7 @@ class RedirectMiddleware
         $uri = $this->redirectUri($request, $response, $protocols);
         if (isset($options['idn_conversion']) && ($options['idn_conversion'] !== false)) {
             $idnOptions = ($options['idn_conversion'] === true) ? IDNA_DEFAULT : $options['idn_conversion'];
-            $uri = _idn_uri_convert($uri, $idnOptions);
+            $uri = Utils::idnUriConvert($uri, $idnOptions);
         }
 
         $modify['uri'] = $uri;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,380 @@
+<?php
+namespace GuzzleHttp;
+
+use GuzzleHttp\Exception\InvalidArgumentException;
+use GuzzleHttp\Handler\CurlHandler;
+use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\Handler\Proxy;
+use GuzzleHttp\Handler\StreamHandler;
+use Psr\Http\Message\UriInterface;
+
+final class Utils
+{
+    /**
+     * Debug function used to describe the provided value type and class.
+     *
+     * @return string Returns a string containing the type of the variable and
+     *                if a class is provided, the class name.
+     */
+    public static function describeType($input): string
+    {
+        switch (\gettype($input)) {
+            case 'object':
+                return 'object(' . \get_class($input) . ')';
+            case 'array':
+                return 'array(' . \count($input) . ')';
+            default:
+                \ob_start();
+                \var_dump($input);
+                // normalize float vs double
+                return \str_replace('double(', 'float(', \rtrim(\ob_get_clean()));
+        }
+    }
+
+    /**
+     * Parses an array of header lines into an associative array of headers.
+     *
+     * @param iterable $lines Header lines array of strings in the following
+     *                        format: "Name: Value"
+     */
+    public static function headersFromLines($lines): array
+    {
+        $headers = [];
+
+        foreach ($lines as $line) {
+            $parts = \explode(':', $line, 2);
+            $headers[\trim($parts[0])][] = isset($parts[1])
+                ? \trim($parts[1])
+                : null;
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Returns a debug stream based on the provided variable.
+     *
+     * @param mixed $value Optional value
+     *
+     * @return resource
+     */
+    public static function debugResource($value = null)
+    {
+        if (\is_resource($value)) {
+            return $value;
+        } elseif (\defined('STDOUT')) {
+            return STDOUT;
+        }
+
+        return \fopen('php://output', 'w');
+    }
+
+    /**
+     * Chooses and creates a default handler to use based on the environment.
+     *
+     * The returned handler is not wrapped by any default middlewares.
+     *
+     * @throws \RuntimeException if no viable Handler is available.
+     *
+     * @return callable Returns the best handler for the given system.
+     */
+    public static function chooseHandler(): callable
+    {
+        $handler = null;
+        if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
+            $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
+        } elseif (\function_exists('curl_exec')) {
+            $handler = new CurlHandler();
+        } elseif (\function_exists('curl_multi_exec')) {
+            $handler = new CurlMultiHandler();
+        }
+
+        if (\ini_get('allow_url_fopen')) {
+            $handler = $handler
+                ? Proxy::wrapStreaming($handler, new StreamHandler())
+                : new StreamHandler();
+        } elseif (!$handler) {
+            throw new \RuntimeException('GuzzleHttp requires cURL, the '
+                . 'allow_url_fopen ini setting, or a custom HTTP handler.');
+        }
+
+        return $handler;
+    }
+
+    /**
+     * Get the default User-Agent string to use with Guzzle.
+     */
+    public static function defaultUserAgent(): string
+    {
+        static $defaultAgent = '';
+
+        if (!$defaultAgent) {
+            $defaultAgent = 'GuzzleHttp/Guzzle';
+            if (\extension_loaded('curl') && \function_exists('curl_version')) {
+                $defaultAgent .= ' curl/' . \curl_version()['version'];
+            }
+            $defaultAgent .= ' PHP/' . PHP_VERSION;
+        }
+
+        return $defaultAgent;
+    }
+
+    /**
+     * Returns the default cacert bundle for the current system.
+     *
+     * First, the openssl.cafile and curl.cainfo php.ini settings are checked.
+     * If those settings are not configured, then the common locations for
+     * bundles found on Red Hat, CentOS, Fedora, Ubuntu, Debian, FreeBSD, OS X
+     * and Windows are checked. If any of these file locations are found on
+     * disk, they will be utilized.
+     *
+     * Note: the result of this function is cached for subsequent calls.
+     *
+     * @throws \RuntimeException if no bundle can be found.
+     */
+    public static function defaultCaBundle(): string
+    {
+        static $cached = null;
+        static $cafiles = [
+            // Red Hat, CentOS, Fedora (provided by the ca-certificates package)
+            '/etc/pki/tls/certs/ca-bundle.crt',
+            // Ubuntu, Debian (provided by the ca-certificates package)
+            '/etc/ssl/certs/ca-certificates.crt',
+            // FreeBSD (provided by the ca_root_nss package)
+            '/usr/local/share/certs/ca-root-nss.crt',
+            // SLES 12 (provided by the ca-certificates package)
+            '/var/lib/ca-certificates/ca-bundle.pem',
+            // OS X provided by homebrew (using the default path)
+            '/usr/local/etc/openssl/cert.pem',
+            // Google app engine
+            '/etc/ca-certificates.crt',
+            // Windows?
+            'C:\\windows\\system32\\curl-ca-bundle.crt',
+            'C:\\windows\\curl-ca-bundle.crt',
+        ];
+
+        if ($cached) {
+            return $cached;
+        }
+
+        if ($ca = \ini_get('openssl.cafile')) {
+            return $cached = $ca;
+        }
+
+        if ($ca = \ini_get('curl.cainfo')) {
+            return $cached = $ca;
+        }
+
+        foreach ($cafiles as $filename) {
+            if (\file_exists($filename)) {
+                return $cached = $filename;
+            }
+        }
+
+        throw new \RuntimeException(
+            <<< EOT
+No system CA bundle could be found in any of the the common system locations.
+PHP versions earlier than 5.6 are not properly configured to use the system's
+CA bundle by default. In order to verify peer certificates, you will need to
+supply the path on disk to a certificate bundle to the 'verify' request
+option: http://docs.guzzlephp.org/en/latest/clients.html#verify. If you do not
+need a specific certificate bundle, then Mozilla provides a commonly used CA
+bundle which can be downloaded here (provided by the maintainer of cURL):
+https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt. Once
+you have a CA bundle available on disk, you can set the 'openssl.cafile' PHP
+ini setting to point to the path to the file, allowing you to omit the 'verify'
+request option. See http://curl.haxx.se/docs/sslcerts.html for more
+information.
+EOT
+        );
+    }
+
+    /**
+     * Creates an associative array of lowercase header names to the actual
+     * header casing.
+     */
+    public static function normalizeHeaderKeys(array $headers): array
+    {
+        $result = [];
+        foreach (\array_keys($headers) as $key) {
+            $result[\strtolower($key)] = $key;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns true if the provided host matches any of the no proxy areas.
+     *
+     * This method will strip a port from the host if it is present. Each pattern
+     * can be matched with an exact match (e.g., "foo.com" == "foo.com") or a
+     * partial match: (e.g., "foo.com" == "baz.foo.com" and ".foo.com" ==
+     * "baz.foo.com", but ".foo.com" != "foo.com").
+     *
+     * Areas are matched in the following cases:
+     * 1. "*" (without quotes) always matches any hosts.
+     * 2. An exact match.
+     * 3. The area starts with "." and the area is the last part of the host. e.g.
+     *    '.mit.edu' will match any host that ends with '.mit.edu'.
+     *
+     * @param string   $host         Host to check against the patterns.
+     * @param string[] $noProxyArray An array of host patterns.
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function isHostInNoProxy(string $host, array $noProxyArray): bool
+    {
+        if (\strlen($host) === 0) {
+            throw new InvalidArgumentException('Empty host provided');
+        }
+
+        // Strip port if present.
+        if (\strpos($host, ':')) {
+            $host = \explode($host, ':', 2)[0];
+        }
+
+        foreach ($noProxyArray as $area) {
+            // Always match on wildcards.
+            if ($area === '*') {
+                return true;
+            } elseif (empty($area)) {
+                // Don't match on empty values.
+                continue;
+            } elseif ($area === $host) {
+                // Exact matches.
+                return true;
+            } else {
+                // Special match if the area when prefixed with ".". Remove any
+                // existing leading "." and add a new leading ".".
+                $area = '.' . \ltrim($area, '.');
+                if (\substr($host, -(\strlen($area))) === $area) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Wrapper for json_decode that throws when an error occurs.
+     *
+     * @param string $json    JSON data to parse
+     * @param bool   $assoc   When true, returned objects will be converted
+     *                        into associative arrays.
+     * @param int    $depth   User specified recursion depth.
+     * @param int    $options Bitmask of JSON decode options.
+     *
+     * @return object|array|string|int|float|bool|null
+     *
+     * @throws InvalidArgumentException if the JSON cannot be decoded.
+     *
+     * @link http://www.php.net/manual/en/function.json-decode.php
+     */
+    public static function jsonDecode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
+    {
+        $data = \json_decode($json, $assoc, $depth, $options);
+        if (JSON_ERROR_NONE !== \json_last_error()) {
+            throw new InvalidArgumentException(
+                'json_decode error: ' . \json_last_error_msg()
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Wrapper for JSON encoding that throws when an error occurs.
+     *
+     * @param mixed $value   The value being encoded
+     * @param int   $options JSON encode option bitmask
+     * @param int   $depth   Set the maximum depth. Must be greater than zero.
+     *
+     * @throws InvalidArgumentException if the JSON cannot be encoded.
+     *
+     * @link http://www.php.net/manual/en/function.json-encode.php
+     */
+    public static function jsonEncode($value, int $options = 0, int $depth = 512): string
+    {
+        $json = \json_encode($value, $options, $depth);
+        if (JSON_ERROR_NONE !== \json_last_error()) {
+            throw new InvalidArgumentException(
+                'json_encode error: ' . \json_last_error_msg()
+            );
+        }
+
+        return $json;
+    }
+
+    /**
+     * Wrapper for the hrtime() or microtime() functions
+     * (depending on the PHP version, one of the two is used)
+     *
+     * @return float|mixed UNIX timestamp
+     *
+     * @internal
+     */
+    public static function currentTime()
+    {
+        return \function_exists('hrtime') ? \hrtime(true) / 1e9 : \microtime(true);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     *
+     * @internal
+     */
+    public static function idnUriConvert(UriInterface $uri, int $options = 0): UriInterface
+    {
+        if ($uri->getHost()) {
+            $idnaVariant = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : 0;
+            $asciiHost = $idnaVariant === 0
+                ? idn_to_ascii($uri->getHost(), $options)
+                : idn_to_ascii($uri->getHost(), $options, $idnaVariant, $info);
+            if ($asciiHost === false) {
+                $errorBitSet = isset($info['errors']) ? $info['errors'] : 0;
+
+                $errorConstants = array_filter(array_keys(get_defined_constants()), function ($name) {
+                    return substr($name, 0, 11) === 'IDNA_ERROR_';
+                });
+
+                $errors = [];
+                foreach ($errorConstants as $errorConstant) {
+                    if ($errorBitSet & constant($errorConstant)) {
+                        $errors[] = $errorConstant;
+                    }
+                }
+
+                $errorMessage = 'IDN conversion failed';
+                if ($errors) {
+                    $errorMessage .= ' (errors: ' . implode(', ', $errors) . ')';
+                }
+
+                throw new InvalidArgumentException($errorMessage);
+            } else {
+                if ($uri->getHost() !== $asciiHost) {
+                    // Replace URI only if the ASCII version is different
+                    $uri = $uri->withHost($asciiHost);
+                }
+            }
+        }
+
+        return $uri;
+    }
+
+    /**
+     * @internal
+     */
+    public static function getenv(string $name): ?string
+    {
+        if (isset($_SERVER[$name])) {
+            return (string) $_SERVER[$name];
+        }
+
+        if (PHP_SAPI === 'cli' && ($value = \getenv($name)) !== false && $value !== null) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+}

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Tests\Server;
+use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -46,9 +47,9 @@ class CurlHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new CurlHandler();
         $request = new Request('GET', Server::$url);
-        $s = \GuzzleHttp\_current_time();
+        $s = Utils::currentTime();
         $a($request, ['delay' => 0.1])->wait();
-        self::assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
+        self::assertGreaterThan(0.0001, Utils::currentTime() - $s);
     }
 
     public function testCreatesCurlErrorsWithContext()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Tests\Helpers;
 use GuzzleHttp\Tests\Server;
+use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 
 class CurlMultiHandlerTest extends TestCase
@@ -91,10 +92,10 @@ class CurlMultiHandlerTest extends TestCase
         Server::flush();
         Server::enqueue([new Response()]);
         $a = new CurlMultiHandler();
-        $expected = \GuzzleHttp\_current_time() + (100 / 1000);
+        $expected = Utils::currentTime() + (100 / 1000);
         $response = $a(new Request('GET', Server::$url), ['delay' => 100]);
         $response->wait();
-        self::assertGreaterThanOrEqual($expected, \GuzzleHttp\_current_time());
+        self::assertGreaterThanOrEqual($expected, Utils::currentTime());
     }
 
     public function testUsesTimeoutEnvironmentVariables()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -318,7 +319,7 @@ class StreamHandlerTest extends TestCase
 
     public function testVerifyCanBeSetToPath()
     {
-        $path = $path = \GuzzleHttp\default_ca_bundle();
+        $path = $path = Utils::defaultCaBundle();
         $res = $this->getSendResult(['verify' => $path]);
         $opts = \stream_context_get_options($res->getBody()->detach());
         self::assertTrue($opts['ssl']['verify_peer']);
@@ -329,7 +330,7 @@ class StreamHandlerTest extends TestCase
 
     public function testUsesSystemDefaultBundle()
     {
-        $path = $path = \GuzzleHttp\default_ca_bundle();
+        $path = $path = Utils::defaultCaBundle();
         $res = $this->getSendResult(['verify' => true]);
         $opts = \stream_context_get_options($res->getBody()->detach());
         if (PHP_VERSION_ID < 50600) {
@@ -502,9 +503,9 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new StreamHandler();
         $request = new Request('GET', Server::$url);
-        $s = \GuzzleHttp\_current_time();
+        $s = Utils::currentTime();
         $a($request, ['delay' => 0.1])->wait();
-        self::assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
+        self::assertGreaterThan(0.0001, Utils::currentTime() - $s);
     }
 
     public function testEnsuresOnHeadersIsCallable()

--- a/tests/InternalUtilsTest.php
+++ b/tests/InternalUtilsTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace GuzzleHttp\Test;
+
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Utils;
+use PHPUnit\Framework\TestCase;
+
+class InternalUtilsTest extends TestCase
+{
+    public function testCurrentTime()
+    {
+        self::assertGreaterThan(0, Utils::currentTime());
+    }
+
+    public function testIdnConvert()
+    {
+        if (!extension_loaded('intl')) {
+            self::markTestSkipped('intl PHP extension is not loaded');
+        }
+
+        $uri = Psr7\uri_for('https://яндекс.рф/images');
+        $uri = Utils::idnUriConvert($uri);
+        self::assertSame('xn--d1acpjx3f.xn--p1ai', $uri->getHost());
+    }
+}

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -134,22 +134,6 @@ class FunctionsTest extends TestCase
 
         \GuzzleHttp\json_decode('{{]]');
     }
-
-    public function testCurrentTime()
-    {
-        self::assertGreaterThan(0, GuzzleHttp\_current_time());
-    }
-
-    public function testIdnConvert()
-    {
-        if (!extension_loaded('intl')) {
-            self::markTestSkipped('intl PHP extension is not loaded');
-        }
-
-        $uri = GuzzleHttp\Psr7\uri_for('https://яндекс.рф/images');
-        $uri = GuzzleHttp\_idn_uri_convert($uri);
-        self::assertSame('xn--d1acpjx3f.xn--p1ai', $uri->getHost());
-    }
 }
 
 final class StrClass


### PR DESCRIPTION
Don't call the GuzzleHttp "functions"; instead use class static methods. The functions themselves could be marked as deprecated in 7.1.0.

---

This is the full version of https://github.com/guzzle/guzzle/pull/2548, which was only applied to the new internal functions added on or after 6.4.0, which are directly causing problems for people.