### PR TITLE
[6.5] Don't use internal functions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -217,7 +217,7 @@ class Client implements ClientInterface
 
         if (isset($config['idn_conversion']) && ($config['idn_conversion'] !== false)) {
             $idnOptions = ($config['idn_conversion'] === true) ? IDNA_DEFAULT : $config['idn_conversion'];
-            $uri = _idn_uri_convert($uri, $idnOptions);
+            $uri = Utils::idnUriConvert($uri, $idnOptions);
         }
 
         return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -102,7 +103,7 @@ class CurlMultiHandler
     {
         // Add any delayed handles if needed.
         if ($this->delays) {
-            $currentTime = \GuzzleHttp\_current_time();
+            $currentTime = Utils::currentTime();
             foreach ($this->delays as $id => $delay) {
                 if ($currentTime >= $delay) {
                     unset($this->delays[$id]);
@@ -154,7 +155,7 @@ class CurlMultiHandler
         if (empty($easy->options['delay'])) {
             curl_multi_add_handle($this->_mh, $easy->handle);
         } else {
-            $this->delays[$id] = \GuzzleHttp\_current_time() + ($easy->options['delay'] / 1000);
+            $this->delays[$id] = Utils::currentTime() + ($easy->options['delay'] / 1000);
         }
     }
 
@@ -206,7 +207,7 @@ class CurlMultiHandler
 
     private function timeToNext()
     {
-        $currentTime = \GuzzleHttp\_current_time();
+        $currentTime = Utils::currentTime();
         $nextTime = PHP_INT_MAX;
         foreach ($this->delays as $time) {
             if ($time < $nextTime) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -33,7 +34,7 @@ class StreamHandler
             usleep($options['delay'] * 1000);
         }
 
-        $startTime = isset($options['on_stats']) ? \GuzzleHttp\_current_time() : null;
+        $startTime = isset($options['on_stats']) ? Utils::currentTime() : null;
 
         try {
             // Does not support the expect header.
@@ -82,7 +83,7 @@ class StreamHandler
             $stats = new TransferStats(
                 $request,
                 $response,
-                \GuzzleHttp\_current_time() - $startTime,
+                Utils::currentTime() - $startTime,
                 $error,
                 []
             );

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -193,7 +193,7 @@ class RedirectMiddleware
         $uri = $this->redirectUri($request, $response, $protocols);
         if (isset($options['idn_conversion']) && ($options['idn_conversion'] !== false)) {
             $idnOptions = ($options['idn_conversion'] === true) ? IDNA_DEFAULT : $options['idn_conversion'];
-            $uri = _idn_uri_convert($uri, $idnOptions);
+            $uri = Utils::idnUriConvert($uri, $idnOptions);
         }
 
         $modify['uri'] = $uri;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,67 @@
+<?php
+namespace GuzzleHttp;
+
+use GuzzleHttp\Exception\InvalidArgumentException;
+use Psr\Http\Message\UriInterface;
+
+final class Utils
+{
+    /**
+     * Wrapper for the hrtime() or microtime() functions
+     * (depending on the PHP version, one of the two is used)
+     *
+     * @return float|mixed UNIX timestamp
+     *
+     * @internal
+     */
+    public static function currentTime()
+    {
+        return function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
+    }
+
+    /**
+     * @param int $options
+     *
+     * @return UriInterface
+     * @throws InvalidArgumentException
+     *
+     * @internal
+     */
+    public static function idnUriConvert(UriInterface $uri, $options = 0)
+    {
+        if ($uri->getHost()) {
+            $idnaVariant = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : 0;
+            $asciiHost = $idnaVariant === 0
+                ? idn_to_ascii($uri->getHost(), $options)
+                : idn_to_ascii($uri->getHost(), $options, $idnaVariant, $info);
+            if ($asciiHost === false) {
+                $errorBitSet = isset($info['errors']) ? $info['errors'] : 0;
+
+                $errorConstants = array_filter(array_keys(get_defined_constants()), function ($name) {
+                    return substr($name, 0, 11) === 'IDNA_ERROR_';
+                });
+
+                $errors = [];
+                foreach ($errorConstants as $errorConstant) {
+                    if ($errorBitSet & constant($errorConstant)) {
+                        $errors[] = $errorConstant;
+                    }
+                }
+
+                $errorMessage = 'IDN conversion failed';
+                if ($errors) {
+                    $errorMessage .= ' (errors: ' . implode(', ', $errors) . ')';
+                }
+
+                throw new InvalidArgumentException($errorMessage);
+            } else {
+                if ($uri->getHost() !== $asciiHost) {
+                    // Replace URI only if the ASCII version is different
+                    $uri = $uri->withHost($asciiHost);
+                }
+            }
+        }
+
+        return $uri;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,12 +1,10 @@
 <?php
 namespace GuzzleHttp;
 
-use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Handler\StreamHandler;
-use Psr\Http\Message\UriInterface;
 
 /**
  * Expands a URI template
@@ -99,8 +97,8 @@ function debug_resource($value = null)
  *
  * The returned handler is not wrapped by any default middlewares.
  *
- * @throws \RuntimeException if no viable Handler is available.
  * @return callable Returns the best handler for the given system.
+ * @throws \RuntimeException if no viable Handler is available.
  */
 function choose_handler()
 {
@@ -333,62 +331,4 @@ function json_encode($value, $options = 0, $depth = 512)
     }
 
     return $json;
-}
-
-/**
- * Wrapper for the hrtime() or microtime() functions
- * (depending on the PHP version, one of the two is used)
- *
- * @return float|mixed UNIX timestamp
- * @internal
- */
-function _current_time()
-{
-    return function_exists('hrtime') ? hrtime(true) / 1e9 : microtime(true);
-}
-
-
-/**
- * @param int $options
- *
- * @return UriInterface
- *
- * @internal
- */
-function _idn_uri_convert(UriInterface $uri, $options = 0)
-{
-    if ($uri->getHost()) {
-        $idnaVariant = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : 0;
-        $asciiHost = $idnaVariant === 0
-            ? idn_to_ascii($uri->getHost(), $options)
-            : idn_to_ascii($uri->getHost(), $options, $idnaVariant, $info);
-        if ($asciiHost === false) {
-            $errorBitSet = isset($info['errors']) ? $info['errors'] : 0;
-
-            $errorConstants = array_filter(array_keys(get_defined_constants()), function ($name) {
-                return substr($name, 0, 11) === 'IDNA_ERROR_';
-            });
-
-            $errors = [];
-            foreach ($errorConstants as $errorConstant) {
-                if ($errorBitSet & constant($errorConstant)) {
-                    $errors[] = $errorConstant;
-                }
-            }
-
-            $errorMessage = 'IDN conversion failed';
-            if ($errors) {
-                $errorMessage .= ' (errors: ' . implode(', ', $errors) . ')';
-            }
-
-            throw new InvalidArgumentException($errorMessage);
-        } else {
-            if ($uri->getHost() !== $asciiHost) {
-                // Replace URI only if the ASCII version is different
-                $uri = $uri->withHost($asciiHost);
-            }
-        }
-    }
-
-    return $uri;
 }

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Tests\Server;
+use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -47,9 +48,9 @@ class CurlHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new CurlHandler();
         $request = new Request('GET', Server::$url);
-        $s = \GuzzleHttp\_current_time();
+        $s = Utils::currentTime();
         $a($request, ['delay' => 0.1])->wait();
-        self::assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
+        self::assertGreaterThan(0.0001, Utils::currentTime() - $s);
     }
 
     public function testCreatesCurlErrorsWithContext()

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -5,6 +5,7 @@ use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Tests\Server;
+use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 
 class CurlMultiHandlerTest extends TestCase
@@ -91,10 +92,10 @@ class CurlMultiHandlerTest extends TestCase
         Server::flush();
         Server::enqueue([new Response()]);
         $a = new CurlMultiHandler();
-        $expected = \GuzzleHttp\_current_time() + (100 / 1000);
+        $expected = Utils::currentTime() + (100 / 1000);
         $response = $a(new Request('GET', Server::$url), ['delay' => 100]);
         $response->wait();
-        self::assertGreaterThanOrEqual($expected, \GuzzleHttp\_current_time());
+        self::assertGreaterThanOrEqual($expected, Utils::currentTime());
     }
 
     public function testUsesTimeoutEnvironmentVariables()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
@@ -508,9 +509,9 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([$response]);
         $a = new StreamHandler();
         $request = new Request('GET', Server::$url);
-        $s = \GuzzleHttp\_current_time();
+        $s = Utils::currentTime();
         $a($request, ['delay' => 0.1])->wait();
-        self::assertGreaterThan(0.0001, \GuzzleHttp\_current_time() - $s);
+        self::assertGreaterThan(0.0001, Utils::currentTime() - $s);
     }
 
     /**

--- a/tests/InternalUtilsTest.php
+++ b/tests/InternalUtilsTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace GuzzleHttp\Test;
+
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Utils;
+use PHPUnit\Framework\TestCase;
+
+class InternalUtilsTest extends TestCase
+{
+    public function testCurrentTime()
+    {
+        self::assertGreaterThan(0, Utils::currentTime());
+    }
+
+    public function testIdnConvert()
+    {
+        if (!extension_loaded('intl')) {
+            self::markTestSkipped('intl PHP extension is not loaded');
+        }
+
+        $uri = Psr7\uri_for('https://яндекс.рф/images');
+        $uri = Utils::idnUriConvert($uri);
+        self::assertSame('xn--d1acpjx3f.xn--p1ai', $uri->getHost());
+    }
+}

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -128,22 +128,6 @@ class FunctionsTest extends TestCase
     {
         \GuzzleHttp\json_decode('{{]]');
     }
-
-    public function testCurrentTime()
-    {
-        self::assertGreaterThan(0, GuzzleHttp\_current_time());
-    }
-
-    public function testIdnConvert()
-    {
-        if (!extension_loaded('intl')) {
-            self::markTestSkipped('intl PHP extension is not loaded');
-        }
-
-        $uri = GuzzleHttp\Psr7\uri_for('https://яндекс.рф/images');
-        $uri = GuzzleHttp\_idn_uri_convert($uri);
-        self::assertSame('xn--d1acpjx3f.xn--p1ai', $uri->getHost());
-    }
 }
 
 final class StrClass


### PR DESCRIPTION
Since these functions are internal, this should not be an issue. We maybe could even delete those functions in 7.0.0, outright. A more complete version is available at https://github.com/guzzle/guzzle/pull/2546, targetted at 7.0, since it does the same for the non-internal functions.

---

Fixes #2511.