### PR TITLE
[7.1] Avoid global functions in dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
-        "guzzlehttp/promises": "^1.0",
-        "guzzlehttp/psr7": "^1.6.1",
+        "guzzlehttp/promises": "^2.0",
+        "guzzlehttp/psr7": "^2.0",
         "psr/http-client": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
-        "guzzlehttp/promises": "^2.0",
-        "guzzlehttp/psr7": "^2.0",
+        "guzzlehttp/promises": "^1.4",
+        "guzzlehttp/psr7": "^1.7",
         "psr/http-client": "^1.0"
     },
     "require-dev": {

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp\Exception;
 
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -95,7 +96,7 @@ class RequestException extends TransferException implements RequestExceptionInte
             $response->getReasonPhrase()
         );
 
-        $summary = \GuzzleHttp\Psr7\get_message_body_summary($response);
+        $summary = Psr7Utils::getMessageBodySummary($response);
 
         if ($summary !== null) {
             $message .= ":\n{$summary}\n";

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -5,8 +5,9 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\RequestInterface;
 
@@ -168,7 +169,7 @@ class CurlFactory implements CurlFactoryInterface
         // If an exception was encountered during the onHeaders event, then
         // return a rejected promise that wraps that exception.
         if ($easy->onHeadersException) {
-            return \GuzzleHttp\Promise\rejection_for(
+            return PromiseUtils::rejectionFor(
                 new RequestException(
                     'An error was encountered during the on_headers event',
                     $easy->request,
@@ -200,7 +201,7 @@ class CurlFactory implements CurlFactoryInterface
             ? new ConnectException($message, $easy->request, null, $ctx)
             : new RequestException($message, $easy->request, $easy->response, null, $ctx);
 
-        return \GuzzleHttp\Promise\rejection_for($error);
+        return PromiseUtils::rejectionFor($error);
     }
 
     /**
@@ -382,7 +383,7 @@ class CurlFactory implements CurlFactoryInterface
         if (isset($options['sink'])) {
             $sink = $options['sink'];
             if (!\is_string($sink)) {
-                $sink = \GuzzleHttp\Psr7\stream_for($sink);
+                $sink = Psr7Utils::streamFor($sink);
             } elseif (!\is_dir(\dirname($sink))) {
                 // Ensure that the directory exists before failing in curl.
                 throw new \RuntimeException(\sprintf(
@@ -400,7 +401,7 @@ class CurlFactory implements CurlFactoryInterface
         } else {
             // Use a default temp stream if no sink was set.
             $conf[CURLOPT_FILE] = \fopen('php://temp', 'w+');
-            $easy->sink = Psr7\stream_for($conf[CURLOPT_FILE]);
+            $easy->sink = Psr7Utils::streamFor($conf[CURLOPT_FILE]);
         }
         $timeoutRequiresNoSignal = false;
         if (isset($options['timeout'])) {

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -1,9 +1,9 @@
 <?php
 namespace GuzzleHttp\Handler;
 
-use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -114,7 +114,7 @@ class CurlMultiHandler
         }
 
         // Step through the task queue which may add additional requests.
-        P\queue()->run();
+        PromiseUtils::queue()->run();
 
         if ($this->active &&
             \curl_multi_select($this->_mh, $this->selectTimeout) === -1
@@ -134,7 +134,7 @@ class CurlMultiHandler
      */
     public function execute(): void
     {
-        $queue = P\queue();
+        $queue = PromiseUtils::queue();
 
         while ($this->handles || !$queue->isEmpty()) {
             // If there are no transfers, then sleep for the next delay

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -107,8 +108,8 @@ class MockHandler implements \Countable
         }
 
         $response = $response instanceof \Throwable
-            ? \GuzzleHttp\Promise\rejection_for($response)
-            : \GuzzleHttp\Promise\promise_for($response);
+            ? PromiseUtils::rejectionFor($response)
+            : PromiseUtils::promiseFor($response);
 
         return $response->then(
             function (?ResponseInterface $value) use ($request, $options) {
@@ -137,7 +138,7 @@ class MockHandler implements \Countable
                 if ($this->onRejected) {
                     \call_user_func($this->onRejected, $reason);
                 }
-                return \GuzzleHttp\Promise\rejection_for($reason);
+                return PromiseUtils::rejectionFor($reason);
             }
         );
     }

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -1,6 +1,7 @@
 <?php
 namespace GuzzleHttp;
 
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -80,10 +81,10 @@ class MessageFormatter
                 $result = '';
                 switch ($matches[1]) {
                     case 'request':
-                        $result = Psr7\str($request);
+                        $result = Psr7Utils::str($request);
                         break;
                     case 'response':
-                        $result = $response ? Psr7\str($response) : '';
+                        $result = $response ? Psr7Utils::str($response) : '';
                         break;
                     case 'req_headers':
                         $result = \trim($request->getMethod()

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp;
 use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
@@ -103,7 +104,7 @@ final class Middleware
                             'error'    => $reason,
                             'options'  => $options
                         ];
-                        return \GuzzleHttp\Promise\rejection_for($reason);
+                        return PromiseUtils::rejectionFor($reason);
                     }
                 );
             };
@@ -197,9 +198,9 @@ final class Middleware
                         $response = $reason instanceof RequestException
                             ? $reason->getResponse()
                             : null;
-                        $message = $formatter->format($request, $response, \GuzzleHttp\Promise\exception_for($reason));
+                        $message = $formatter->format($request, $response, PromiseUtils::exceptionFor($reason));
                         $logger->notice($message);
-                        return \GuzzleHttp\Promise\rejection_for($reason);
+                        return PromiseUtils::rejectionFor($reason);
                     }
                 );
             };

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -48,7 +49,7 @@ class Pool implements PromisorInterface
             $opts = [];
         }
 
-        $iterable = \GuzzleHttp\Promise\iter_for($requests);
+        $iterable = PromiseUtils::iterFor($requests);
         $requests = function () use ($iterable, $client, $opts) {
             foreach ($iterable as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp;
 
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -35,7 +36,7 @@ class PrepareBodyMiddleware
         // Add a default content-type if possible.
         if (!$request->hasHeader('Content-Type')) {
             if ($uri = $request->getBody()->getMetadata('uri')) {
-                if ($type = Psr7\mimetype_from_filename($uri)) {
+                if ($type = Psr7Utils::mimetypeFromFilename($uri)) {
                     $modify['set_headers']['Content-Type'] = $type;
                 }
             }
@@ -56,7 +57,7 @@ class PrepareBodyMiddleware
         // Add the expect header if needed.
         $this->addExpectHeader($request, $options, $modify);
 
-        return $fn(Psr7\modify_request($request, $modify), $options);
+        return $fn(Psr7Utils::modifyRequest($request, $modify), $options);
     }
 
     /**

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -4,6 +4,9 @@ namespace GuzzleHttp;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\UriResolver;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -175,7 +178,7 @@ class RedirectMiddleware
         }
 
         $modify['uri'] = $uri;
-        Psr7\rewind_body($request);
+        Psr7Utils::rewindBody($request);
 
         // Add the Referer header if it is told to do so and only
         // add the header if we are not redirecting from https to http.
@@ -193,7 +196,7 @@ class RedirectMiddleware
             $modify['remove_headers'][] = 'Authorization';
         }
 
-        return Psr7\modify_request($request, $modify);
+        return Psr7Utils::modifyRequest($request, $modify);
     }
 
     /**
@@ -204,9 +207,9 @@ class RedirectMiddleware
         ResponseInterface $response,
         array $protocols
     ): UriInterface {
-        $location = Psr7\UriResolver::resolve(
+        $location = UriResolver::resolve(
             $request->getUri(),
-            new Psr7\Uri($response->getHeaderLine('Location'))
+            new Uri($response->getHeaderLine('Location'))
         );
 
         // Ensure that the redirect URI is allowed based on the protocols.

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -2,6 +2,7 @@
 namespace GuzzleHttp;
 
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -96,7 +97,7 @@ class RetryMiddleware
                 null,
                 $reason
             )) {
-                return \GuzzleHttp\Promise\rejection_for($reason);
+                return PromiseUtils::rejectionFor($reason);
             }
             return $this->doRetry($req, $options);
         };

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
@@ -507,7 +507,7 @@ class ClientTest extends TestCase
                 'POST',
                 'http://foo.com',
                 [],
-                new Psr7\MultipartStream(
+                new MultipartStream(
                     [
                         [
                             'name' => 'foo',

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -3,9 +3,11 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlHandler;
+use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use GuzzleHttp\Tests\Server;
 use PHPUnit\Framework\TestCase;
 
@@ -24,7 +26,7 @@ class CurlHandlerTest extends TestCase
         $handler = new CurlHandler();
         $request = new Request('GET', 'http://localhost:123');
 
-        $this->expectException(\GuzzleHttp\Exception\ConnectException::class);
+        $this->expectException(ConnectException::class);
         $this->expectExceptionMessage('cURL');
         $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])->wait();
     }
@@ -36,8 +38,8 @@ class CurlHandlerTest extends TestCase
         Server::enqueue([$response, $response]);
         $a = new CurlHandler();
         $request = new Request('GET', Server::$url);
-        self::assertInstanceOf(\GuzzleHttp\Promise\FulfilledPromise::class, $a($request, []));
-        self::assertInstanceOf(\GuzzleHttp\Promise\FulfilledPromise::class, $a($request, []));
+        self::assertInstanceOf(FulfilledPromise::class, $a($request, []));
+        self::assertInstanceOf(FulfilledPromise::class, $a($request, []));
     }
 
     public function testDoesSleep()
@@ -69,7 +71,7 @@ class CurlHandlerTest extends TestCase
     {
         Server::flush();
         Server::enqueue([new Response()]);
-        $stream = Psr7\stream_for(\str_repeat('.', 1000000));
+        $stream = Psr7Utils::streamFor(\str_repeat('.', 1000000));
         $handler = new CurlHandler();
         $request = new Request(
             'PUT',

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Test\Handler;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\TransferStats;
 use PHPUnit\Framework\TestCase;
 
@@ -101,7 +102,7 @@ class MockHandlerTest extends TestCase
 
     public function testSinkStream()
     {
-        $stream = new \GuzzleHttp\Psr7\Stream(\tmpfile());
+        $stream = new Stream(\tmpfile());
         $res = new Response(200, [], 'TEST CONTENT');
         $mock = new MockHandler([$res]);
         $request = new Request('GET', '/');

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -3,10 +3,10 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\StreamHandler;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
@@ -305,7 +305,7 @@ class StreamHandlerTest extends TestCase
     public function testVerifyCanBeDisabled()
     {
         $handler = $this->getSendResult(['verify' => false]);
-        self::assertInstanceOf(\GuzzleHttp\Psr7\Response::class, $handler);
+        self::assertInstanceOf(Response::class, $handler);
     }
 
     public function testVerifiesCertIfValidPath()
@@ -544,7 +544,7 @@ class StreamHandlerTest extends TestCase
         $req = new Request('GET', Server::$url);
         $got = null;
 
-        $stream = Psr7\stream_for();
+        $stream = Psr7Utils::streamFor();
         $stream = FnStream::decorate($stream, [
             'write' => function ($data) use ($stream, &$got) {
                 self::assertNotNull($got);
@@ -570,8 +570,8 @@ class StreamHandlerTest extends TestCase
     public function testInvokesOnStatsOnSuccess()
     {
         Server::flush();
-        Server::enqueue([new Psr7\Response(200)]);
-        $req = new Psr7\Request('GET', Server::$url);
+        Server::enqueue([new Response(200)]);
+        $req = new Request('GET', Server::$url);
         $gotStats = null;
         $handler = new StreamHandler();
         $promise = $handler($req, [
@@ -595,7 +595,7 @@ class StreamHandlerTest extends TestCase
 
     public function testInvokesOnStatsOnError()
     {
-        $req = new Psr7\Request('GET', 'http://127.0.0.1:123');
+        $req = new Request('GET', 'http://127.0.0.1:123');
         $gotStats = null;
         $handler = new StreamHandler();
         $promise = $handler($req, [
@@ -625,8 +625,8 @@ class StreamHandlerTest extends TestCase
     public function testStreamIgnoresZeroTimeout()
     {
         Server::flush();
-        Server::enqueue([new Psr7\Response(200)]);
-        $req = new Psr7\Request('GET', Server::$url);
+        Server::enqueue([new Response(200)]);
+        $req = new Request('GET', Server::$url);
         $gotStats = null;
         $handler = new StreamHandler();
         $promise = $handler($req, [

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -43,16 +44,16 @@ class MessageFormatterTest extends TestCase
 
     public function formatProvider()
     {
-        $request = new Request('PUT', '/', ['x-test' => 'abc'], Psr7\stream_for('foo'));
-        $response = new Response(200, ['X-Baz' => 'Bar'], Psr7\stream_for('baz'));
+        $request = new Request('PUT', '/', ['x-test' => 'abc'], Psr7Utils::streamFor('foo'));
+        $response = new Response(200, ['X-Baz' => 'Bar'], Psr7Utils::streamFor('baz'));
         $err = new RequestException('Test', $request, $response);
 
         return [
-            ['{request}', [$request], Psr7\str($request)],
-            ['{response}', [$request, $response], Psr7\str($response)],
-            ['{request} {response}', [$request, $response], Psr7\str($request) . ' ' . Psr7\str($response)],
+            ['{request}', [$request], Psr7Utils::str($request)],
+            ['{response}', [$request, $response], Psr7Utils::str($response)],
+            ['{request} {response}', [$request, $response], Psr7Utils::str($request) . ' ' . Psr7Utils::str($response)],
             // Empty response yields no value
-            ['{request} {response}', [$request], Psr7\str($request) . ' '],
+            ['{request} {response}', [$request], Psr7Utils::str($request) . ' '],
             ['{req_headers}', [$request], "PUT / HTTP/1.1\r\nx-test: abc"],
             ['{res_headers}', [$request, $response], "HTTP/1.1 200 OK\r\nX-Baz: Bar"],
             ['{res_headers}', [$request], 'NULL'],

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
@@ -213,7 +214,7 @@ class MiddlewareTest extends TestCase
 
     public function testLogsWithStringError()
     {
-        $h = new MockHandler([\GuzzleHttp\Promise\rejection_for('some problem')]);
+        $h = new MockHandler([PromiseUtils::rejectionFor('some problem')]);
         $stack = new HandlerStack($h);
         $logger = new TestLogger();
         $formatter = new MessageFormatter('{error}');

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
@@ -52,7 +53,7 @@ class PrepareBodyMiddlewareTest extends TestCase
 
     public function testAddsTransferEncodingWhenNoContentLength()
     {
-        $body = FnStream::decorate(Psr7\stream_for('foo'), [
+        $body = FnStream::decorate(Psr7Utils::streamFor('foo'), [
             'getSize' => function () {
                 return null;
             }
@@ -76,7 +77,7 @@ class PrepareBodyMiddlewareTest extends TestCase
 
     public function testAddsContentTypeWhenMissingAndPossible()
     {
-        $bd = Psr7\stream_for(\fopen(__DIR__ . '/../composer.json', 'r'));
+        $bd = Psr7Utils::streamFor(\fopen(__DIR__ . '/../composer.json', 'r'));
         $h = new MockHandler([
             function (RequestInterface $request) {
                 self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
@@ -109,7 +110,7 @@ class PrepareBodyMiddlewareTest extends TestCase
      */
     public function testAddsExpect($value, $result)
     {
-        $bd = Psr7\stream_for(\fopen(__DIR__ . '/../composer.json', 'r'));
+        $bd = Psr7Utils::streamFor(\fopen(__DIR__ . '/../composer.json', 'r'));
 
         $h = new MockHandler([
             function (RequestInterface $request) use ($result) {
@@ -132,7 +133,7 @@ class PrepareBodyMiddlewareTest extends TestCase
 
     public function testIgnoresIfExpectIsPresent()
     {
-        $bd = Psr7\stream_for(\fopen(__DIR__ . '/../composer.json', 'r'));
+        $bd = Psr7Utils::streamFor(\fopen(__DIR__ . '/../composer.json', 'r'));
         $h = new MockHandler([
             function (RequestInterface $request) {
                 self::assertSame(['Foo'], $request->getHeader('Expect'));

--- a/tests/Server.php
+++ b/tests/Server.php
@@ -2,7 +2,7 @@
 namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -94,7 +94,7 @@ class Server
                 if (isset($message['query_string'])) {
                     $uri .= '?' . $message['query_string'];
                 }
-                $response = new Psr7\Request(
+                $response = new Request(
                     $message['http_method'],
                     $uri,
                     $message['headers'],

--- a/tests/TransferStatsTest.php
+++ b/tests/TransferStatsTest.php
@@ -1,7 +1,8 @@
 <?php
 namespace GuzzleHttp\Tests;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\TransferStats;
 use PHPUnit\Framework\TestCase;
 
@@ -9,8 +10,8 @@ class TransferStatsTest extends TestCase
 {
     public function testHasData()
     {
-        $request = new Psr7\Request('GET', 'http://foo.com');
-        $response = new Psr7\Response();
+        $request = new Request('GET', 'http://foo.com');
+        $response = new Response();
         $stats = new TransferStats(
             $request,
             $response,

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -146,8 +146,8 @@ class FunctionsTest extends TestCase
             self::markTestSkipped('intl PHP extension is not loaded');
         }
 
-        $uri = GuzzleHttp\Psr7\uri_for('https://яндекс.рф/images');
-        $uri = GuzzleHttp\_idn_uri_convert($uri);
+        $uri = \GuzzleHttp\Psr7\Utils::uriFor('https://яндекс.рф/images');
+        $uri = \GuzzleHttp\_idn_uri_convert($uri);
         self::assertSame('xn--d1acpjx3f.xn--p1ai', $uri->getHost());
     }
 }


### PR DESCRIPTION
EDIT: The new aim of this PR is avoid the use of global functions provided by our dependencies. This means using their new Utils classes, and bumping their minimum versions (staying within the same major release series).