### PR TITLE
[6.5] Install symfony's intl-idn polyfill

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: PHPStan
         uses: docker://oskarstark/phpstan-ga
+        env:
+          REQUIRE_DEV: true
         with:
           args: analyze --no-progress
 

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": ">=5.5",
         "ext-json": "*",
+        "symfony/polyfill-intl-idn": "^1.11",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.6.1"
     },
@@ -32,8 +33,7 @@
         "psr/log": "^1.1"
     },
     "suggest": {
-        "psr/log": "Required for using the Log middleware",
-        "ext-intl": "Required for Internationalized Domain Name (IDN) support"
+        "psr/log": "Required for using the Log middleware"
     },
     "config": {
         "sort-packages": true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,4 +5,3 @@ parameters:
     level: max
     paths:
       - src
-    bootstrap: tests/bootstrap-phpstan.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -236,18 +236,9 @@ class Client implements ClientInterface
             'http_errors'     => true,
             'decode_content'  => true,
             'verify'          => true,
-            'cookies'         => false
+            'cookies'         => false,
+            'idn_conversion'  => true,
         ];
-
-        // idn_to_ascii() is a part of ext-intl and might be not available
-        $defaults['idn_conversion'] = function_exists('idn_to_ascii')
-            // Old ICU versions don't have this constant, so we are basically stuck (see https://github.com/guzzle/guzzle/pull/2424
-            // and https://github.com/guzzle/guzzle/issues/2448 for details)
-            && (
-                defined('INTL_IDNA_VARIANT_UTS46')
-                ||
-                PHP_VERSION_ID < 70200
-            );
 
         // Use the standard Linux HTTP_PROXY and HTTPS_PROXY if set.
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -756,9 +756,6 @@ class ClientTest extends TestCase
      */
     public function testExceptionOnInvalidIdn()
     {
-        if (!extension_loaded('intl')) {
-            self::markTestSkipped('intl PHP extension is not loaded');
-        }
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -721,18 +721,11 @@ class ClientTest extends TestCase
 
         $config = $client->getConfig();
 
-        if (extension_loaded('intl')) {
-            self::assertTrue($config['idn_conversion']);
-        } else {
-            self::assertFalse($config['idn_conversion']);
-        }
+        self::assertTrue($config['idn_conversion']);
     }
 
     public function testIdnIsTranslatedToAsciiWhenConversionIsEnabled()
     {
-        if (!extension_loaded('intl')) {
-            self::markTestSkipped('intl PHP extension is not loaded');
-        }
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
@@ -778,10 +771,6 @@ class ClientTest extends TestCase
      */
     public function testIdnBaseUri()
     {
-        if (!extension_loaded('intl')) {
-            self::markTestSkipped('intl PHP extension is not loaded');
-        }
-
         $mock = new MockHandler([new Response()]);
         $client = new Client([
             'handler'  => $mock,
@@ -796,9 +785,6 @@ class ClientTest extends TestCase
 
     public function testIdnWithRedirect()
     {
-        if (!extension_loaded('intl')) {
-            self::markTestSkipped('intl PHP extension is not loaded');
-        }
         $mockHandler = new MockHandler([
             new Response(302, ['Location' => 'http://www.tést.com/whatever']),
             new Response()

--- a/tests/InternalUtilsTest.php
+++ b/tests/InternalUtilsTest.php
@@ -14,10 +14,6 @@ class InternalUtilsTest extends TestCase
 
     public function testIdnConvert()
     {
-        if (!extension_loaded('intl')) {
-            self::markTestSkipped('intl PHP extension is not loaded');
-        }
-
         $uri = Psr7\uri_for('https://яндекс.рф/images');
         $uri = Utils::idnUriConvert($uri);
         self::assertSame('xn--d1acpjx3f.xn--p1ai', $uri->getHost());

--- a/tests/bootstrap-phpstan.php
+++ b/tests/bootstrap-phpstan.php
@@ -1,9 +1,0 @@
-<?php
-
-if (!defined('IDNA_DEFAULT')) {
-    define('IDNA_DEFAULT', 0);
-}
-
-if (!defined('INTL_IDNA_VARIANT_UTS46')) {
-    define('INTL_IDNA_VARIANT_UTS46', 1);
-}


### PR DESCRIPTION
Composer will now, instead, suggest `ext-intl` for better performance, instead of suggesting `ext-intl` and having Guzzle crash at runtime with an error people won't understand.