### PR TITLE
[8.0] Remove the getConfig function

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -183,26 +183,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         return $this->requestAsync($method, $uri, $options)->wait();
     }
 
-    /**
-     * Get a client configuration option.
-     *
-     * These options include default request options of the client, a "handler"
-     * (if utilized by the concrete client), and a "base_uri" if utilized by
-     * the concrete client.
-     *
-     * @param string|null $option The config option to retrieve.
-     *
-     * @return mixed
-     *
-     * @deprecated Client::getConfig will be removed in guzzlehttp/guzzle:8.0.
-     */
-    public function getConfig(?string $option = null)
-    {
-        return $option === null
-            ? $this->config
-            : (isset($this->config[$option]) ? $this->config[$option] : null);
-    }
-
     private function buildUri(UriInterface $uri, array $config): UriInterface
     {
         if (isset($config['base_uri'])) {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -66,19 +66,4 @@ interface ClientInterface
      * @param array               $options Request options to apply.
      */
     public function requestAsync(string $method, $uri, array $options = []): PromiseInterface;
-
-    /**
-     * Get a client configuration option.
-     *
-     * These options include default request options of the client, a "handler"
-     * (if utilized by the concrete client), and a "base_uri" if utilized by
-     * the concrete client.
-     *
-     * @param string|null $option The config option to retrieve.
-     *
-     * @return mixed
-     *
-     * @deprecated ClientInterface::getConfig will be removed in guzzlehttp/guzzle:8.0.
-     */
-    public function getConfig(?string $option = null);
 }


### PR DESCRIPTION
This depends on https://github.com/guzzle/guzzle/pull/2516, which in turn depends on https://github.com/guzzle/guzzle/pull/2515.