### PR TITLE
[7.1] Deprecate Client::__call

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -69,6 +69,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * @param array  $args
      *
      * @return PromiseInterface|ResponseInterface
+     *
+     * @deprecated Client::__call will be removed in guzzlehttp/guzzle:8.0.
      */
     public function __call($method, $args)
     {


### PR DESCRIPTION
Follow up to https://github.com/guzzle/guzzle/pull/2529.