### PR TITLE
[7.0] Remove dead PHP 5 code

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -1015,32 +1015,6 @@ verify
     // Disable validation entirely (don't do this!).
     $client->request('GET', '/', ['verify' => false]);
 
-Not all system's have a known CA bundle on disk. For example, Windows and
-OS X do not have a single common location for CA bundles. When setting
-"verify" to ``true``, Guzzle will do its best to find the most appropriate
-CA bundle on your system. When using cURL or the PHP stream wrapper on PHP
-versions >= 5.6, this happens by default. When using the PHP stream
-wrapper on versions < 5.6, Guzzle tries to find your CA bundle in the
-following order:
-
-1. Check if ``openssl.cafile`` is set in your php.ini file.
-2. Check if ``curl.cainfo`` is set in your php.ini file.
-3. Check if ``/etc/pki/tls/certs/ca-bundle.crt`` exists (Red Hat, CentOS,
-   Fedora; provided by the ca-certificates package)
-4. Check if ``/etc/ssl/certs/ca-certificates.crt`` exists (Ubuntu, Debian;
-   provided by the ca-certificates package)
-5. Check if ``/usr/local/share/certs/ca-root-nss.crt`` exists (FreeBSD;
-   provided by the ca_root_nss package)
-6. Check if ``/usr/local/etc/openssl/cert.pem`` (OS X; provided by homebrew)
-7. Check if ``C:\windows\system32\curl-ca-bundle.crt`` exists (Windows)
-8. Check if ``C:\windows\curl-ca-bundle.crt`` exists (Windows)
-
-The result of this lookup is cached in memory so that subsequent calls
-in the same process will return very quickly. However, when sending only
-a single request per-process in something like Apache, you should consider
-setting the ``openssl.cafile`` environment variable to the path on disk
-to the file so that this entire process is skipped.
-
 If you do not need a specific certificate bundle, then Mozilla provides a
 commonly used CA bundle which can be downloaded
 `here <https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt>`_

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -433,22 +433,19 @@ class StreamHandler
 
     private function add_verify(RequestInterface $request, array &$options, $value, array &$params): void
     {
-        if ($value === true) {
-            // PHP 5.6 or greater will find the system cert by default. When
-            // < 5.6, use the Guzzle bundled cacert.
-            if (PHP_VERSION_ID < 50600) {
-                $options['ssl']['cafile'] = Utils::defaultCaBundle();
-            }
-        } elseif (\is_string($value)) {
+        if ($value === false) {
+            $options['ssl']['verify_peer'] = false;
+            $options['ssl']['verify_peer_name'] = false;
+
+            return;
+        }
+
+        if (\is_string($value)) {
             $options['ssl']['cafile'] = $value;
             if (!\file_exists($value)) {
                 throw new \RuntimeException("SSL CA bundle not found: $value");
             }
-        } elseif ($value === false) {
-            $options['ssl']['verify_peer'] = false;
-            $options['ssl']['verify_peer_name'] = false;
-            return;
-        } else {
+        } elseif ($value !== true) {
             throw new \InvalidArgumentException('Invalid verify request option');
         }
 


### PR DESCRIPTION
This PR removes dead code from the internals of the stream handler. We should probably also deprecate `default_ca_bundle` in 7.1.0, and remove it in 8.0.0, since it's only relevant for PHP 5 code, however  people probably blanket call it anyway (like composer does in its internals (not guzzle's implementation, but their own)).