### PR TITLE
[7.1] Deprecate Utils::defaultCaBundle

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -133,6 +133,8 @@ final class Utils
      * Note: the result of this function is cached for subsequent calls.
      *
      * @throws \RuntimeException if no bundle can be found.
+     *
+     * @deprecated Utils::defaultCaBundle will be removed in guzzlehttp/guzzle:8.0. This method is not needed in PHP 5.6+.
      */
     public static function defaultCaBundle(): string
     {

--- a/src/functions.php
+++ b/src/functions.php
@@ -84,7 +84,7 @@ function default_user_agent(): string
  *
  * @throws \RuntimeException if no bundle can be found.
  *
- * @deprecated default_ca_bundle will be removed in guzzlehttp/guzzle:8.0. Use Utils::defaultCaBundle instead.
+ * @deprecated default_ca_bundle will be removed in guzzlehttp/guzzle:8.0. This function is not needed in PHP 5.6+.
  */
 function default_ca_bundle(): string
 {


### PR DESCRIPTION
Requires https://github.com/guzzle/guzzle/pull/2561 to be merged first. Is a follow up to https://github.com/guzzle/guzzle/pull/2560.