### PR TITLE
[7.0] Updated old hyperlinks to their new locations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://editorconfig.org/
 
 # top-most EditorConfig file
 root = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -386,7 +386,7 @@ object).
   * Note: This has been changed in 5.0.3 to now encode query string values by
     default unless the `rawString` argument is provided when setting the query
     string on a URL: Now allowing many more characters to be present in the
-    query string without being percent encoded. See http://tools.ietf.org/html/rfc3986#appendix-A
+    query string without being percent encoded. See https://tools.ietf.org/html/rfc3986#appendix-A
 
 ## 5.0.1 - 2014-10-16
 
@@ -428,7 +428,7 @@ interfaces.
   responses, `GuzzleHttp\Collection`, `GuzzleHttp\Url`,
   `GuzzleHttp\Query`, `GuzzleHttp\Post\PostBody`, and
   `GuzzleHttp\Cookie\SetCookie`. This blog post provides a good outline of
-  why I did this: http://ocramius.github.io/blog/fluent-interfaces-are-evil/.
+  why I did this: https://ocramius.github.io/blog/fluent-interfaces-are-evil/.
   This also makes the Guzzle message interfaces compatible with the current
   PSR-7 message proposal.
 * Removed "functions.php", so that Guzzle is truly PSR-4 compliant. Except
@@ -614,8 +614,6 @@ interfaces.
 
 ## 4.0.0 - 2014-03-29
 
-* For more information on the 4.0 transition, see:
-  http://mtdowling.com/blog/2014/03/15/guzzle-4-rc/
 * For information on changes and upgrading, see:
   https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#3x-to-40
 * Added `GuzzleHttp\batch()` as a convenience function for sending requests in
@@ -924,7 +922,7 @@ interfaces.
 
 ## 3.4.0 - 2013-04-11
 
-* Bug fix: URLs are now resolved correctly based on http://tools.ietf.org/html/rfc3986#section-5.2. #289
+* Bug fix: URLs are now resolved correctly based on https://tools.ietf.org/html/rfc3986#section-5.2. #289
 * Bug fix: Absolute URLs with a path in a service description will now properly override the base URL. #289
 * Bug fix: Parsing a query string with a single PHP array value will now result in an array. #263
 * Bug fix: Better normalization of the User-Agent header to prevent duplicate headers. #264.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $promise->wait();
 ## Installing Guzzle
 
 The recommended way to install Guzzle is through
-[Composer](http://getcomposer.org).
+[Composer](https://getcomposer.org/).
 
 ```bash
 composer require guzzlehttp/guzzle

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -48,7 +48,7 @@ For the full diff you can check [here](https://github.com/guzzle/guzzle/compare/
 5.0 to 6.0
 ----------
 
-Guzzle now uses [PSR-7](http://www.php-fig.org/psr/psr-7/) for HTTP messages.
+Guzzle now uses [PSR-7](https://www.php-fig.org/psr/psr-7/) for HTTP messages.
 Due to the fact that these messages are immutable, this prompted a refactoring
 of Guzzle to use a middleware based system rather than an event system. Any
 HTTP message interaction (e.g., `GuzzleHttp\Message\Request`) need to be
@@ -211,7 +211,7 @@ passing a `GuzzleHttp\Adapter\AdapterInterface`, you must now pass a PHP
 
 ## Removed Fluent Interfaces
 
-[Fluent interfaces were removed](http://ocramius.github.io/blog/fluent-interfaces-are-evil)
+[Fluent interfaces were removed](https://ocramius.github.io/blog/fluent-interfaces-are-evil/)
 from the following classes:
 
 - `GuzzleHttp\Collection`
@@ -864,7 +864,7 @@ HeaderInterface (e.g. toArray(), getAll(), etc.).
 3.3 to 3.4
 ----------
 
-Base URLs of a client now follow the rules of http://tools.ietf.org/html/rfc3986#section-5.2.2 when merging URLs.
+Base URLs of a client now follow the rules of https://tools.ietf.org/html/rfc3986#section-5.2.2 when merging URLs.
 
 3.2 to 3.3
 ----------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -7,7 +7,7 @@ Does Guzzle require cURL?
 
 No. Guzzle can use any HTTP handler to send requests. This means that Guzzle
 can be used with cURL, PHP's stream wrapper, sockets, and non-blocking libraries
-like `React <http://reactphp.org/>`_. You just need to configure an HTTP handler
+like `React <https://reactphp.org/>`_. You just need to configure an HTTP handler
 to use a different method of sending requests.
 
 .. note::
@@ -48,7 +48,7 @@ of the returned promise.
 How can I add custom cURL options?
 ==================================
 
-cURL offers a huge number of `customizable options <http://us1.php.net/curl_setopt>`_.
+cURL offers a huge number of `customizable options <https://www.php.net/curl_setopt>`_.
 While Guzzle normalizes many of these options across different handlers, there
 are times when you need to set custom cURL options. This can be accomplished
 by passing an associative array of cURL settings in the **curl** key of a
@@ -86,7 +86,7 @@ additional options can be specified as an associative array in the
 How can I add custom stream context options?
 ============================================
 
-You can pass custom `stream context options <http://www.php.net/manual/en/context.php>`_
+You can pass custom `stream context options <https://www.php.net/manual/en/context.php>`_
 using the **stream_context** key of the request option. The **stream_context**
 array is an associative array where each key is a PHP transport, and each value
 is an associative array of transport options.

--- a/docs/psr7.rst
+++ b/docs/psr7.rst
@@ -226,7 +226,7 @@ When creating a request, you can provide the URI as a string or an instance of
 Scheme
 ------
 
-The `scheme <http://tools.ietf.org/html/rfc3986#section-3.1>`_ of a request
+The `scheme <https://tools.ietf.org/html/rfc3986#section-3.1>`_ of a request
 specifies the protocol to use when sending the request. When using Guzzle, the
 scheme can be set to "http" or "https".
 
@@ -417,7 +417,7 @@ Metadata
 
 Streams expose stream metadata through the ``getMetadata()`` method. This
 method provides the data you would retrieve when calling PHP's
-`stream_get_meta_data() function <http://php.net/manual/en/function.stream-get-meta-data.php>`_,
+`stream_get_meta_data() function <https://www.php.net/manual/en/function.stream-get-meta-data.php>`_,
 and can optionally expose other custom data.
 
 .. code-block:: php

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -37,7 +37,7 @@ The client constructor accepts an associative array of options:
     URIs. Can be a string or instance of UriInterface. When a relative URI
     is provided to a client, the client will combine the base URI with the
     relative URI using the rules described in
-    `RFC 3986, section 2 <http://tools.ietf.org/html/rfc3986#section-5.2>`_.
+    `RFC 3986, section 5.2 <https://tools.ietf.org/html/rfc3986#section-5.2>`_.
 
     .. code-block:: php
 

--- a/src/Cookie/CookieJarInterface.php
+++ b/src/Cookie/CookieJarInterface.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
  * necessary. Subclasses are also responsible for storing and retrieving
  * cookies from a file, database, etc.
  *
- * @link http://docs.python.org/2/library/cookielib.html Inspiration
+ * @link https://docs.python.org/2/library/cookielib.html Inspiration
  */
 interface CookieJarInterface extends \Countable, \IteratorAggregate
 {

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -331,7 +331,7 @@ class SetCookie
     public function matchesDomain(string $domain): bool
     {
         // Remove the leading '.' as per spec in RFC 6265.
-        // http://tools.ietf.org/html/rfc6265#section-5.2.3
+        // https://tools.ietf.org/html/rfc6265#section-5.2.3
         $cookieDomain = \ltrim($this->getDomain(), '.');
 
         // Domain not set or exact match.
@@ -340,7 +340,7 @@ class SetCookie
         }
 
         // Matching the subdomain according to RFC 6265.
-        // http://tools.ietf.org/html/rfc6265#section-5.1.3
+        // https://tools.ietf.org/html/rfc6265#section-5.1.3
         if (\filter_var($domain, FILTER_VALIDATE_IP)) {
             return false;
         }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -246,7 +246,7 @@ class CurlFactory implements CurlFactoryInterface
 
         $method = $easy->request->getMethod();
         if ($method === 'PUT' || $method === 'POST') {
-            // See http://tools.ietf.org/html/rfc7230#section-3.3.2
+            // See https://tools.ietf.org/html/rfc7230#section-3.3.2
             if (!$easy->request->hasHeader('Content-Length')) {
                 $conf[CURLOPT_HTTPHEADER][] = 'Content-Length: 0';
             }

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -37,7 +37,7 @@ class MessageFormatter
     /**
      * Apache Common Log Format.
      *
-     * @link http://httpd.apache.org/docs/2.4/logs.html#common
+     * @link https://httpd.apache.org/docs/2.4/logs.html#common
      *
      * @var string
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -183,7 +183,7 @@ bundle which can be downloaded here (provided by the maintainer of cURL):
 https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt. Once
 you have a CA bundle available on disk, you can set the 'openssl.cafile' PHP
 ini setting to point to the path to the file, allowing you to omit the 'verify'
-request option. See http://curl.haxx.se/docs/sslcerts.html for more
+request option. See https://curl.haxx.se/docs/sslcerts.html for more
 information.
 EOT
         );
@@ -269,7 +269,7 @@ EOT
      *
      * @throws InvalidArgumentException if the JSON cannot be decoded.
      *
-     * @link http://www.php.net/manual/en/function.json-decode.php
+     * @link https://www.php.net/manual/en/function.json-decode.php
      */
     public static function jsonDecode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
     {
@@ -292,7 +292,7 @@ EOT
      *
      * @throws InvalidArgumentException if the JSON cannot be encoded.
      *
-     * @link http://www.php.net/manual/en/function.json-encode.php
+     * @link https://www.php.net/manual/en/function.json-encode.php
      */
     public static function jsonEncode($value, int $options = 0, int $depth = 512): string
     {

--- a/src/functions.php
+++ b/src/functions.php
@@ -121,7 +121,7 @@ function is_host_in_noproxy(string $host, array $noProxyArray): bool
  *
  * @throws Exception\InvalidArgumentException if the JSON cannot be decoded.
  *
- * @link http://www.php.net/manual/en/function.json-decode.php
+ * @link https://www.php.net/manual/en/function.json-decode.php
  */
 function json_decode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
 {
@@ -137,7 +137,7 @@ function json_decode(string $json, bool $assoc = false, int $depth = 512, int $o
  *
  * @throws Exception\InvalidArgumentException if the JSON cannot be encoded.
  *
- * @link http://www.php.net/manual/en/function.json-encode.php
+ * @link https://www.php.net/manual/en/function.json-encode.php
  */
 function json_encode($value, int $options = 0, int $depth = 512): string
 {

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -272,7 +272,7 @@ class SetCookieTest extends TestCase
                     'HttpOnly' => false
                 ]
             ],
-            // Some of the following tests are based on http://framework.zend.com/svn/framework/standard/trunk/tests/Zend/Http/CookieTest.php
+            // Some of the following tests are based on https://github.com/zendframework/zf1/blob/master/tests/Zend/Http/CookieTest.php
             [
                 'justacookie=foo; domain=example.com',
                 [


### PR DESCRIPTION
I've not included any of the changes from https://github.com/guzzle/guzzle/pull/2565, to avoid conflicts.