### PR TITLE
[6.5] Remove obsolete statement in `handler` option docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -67,8 +67,7 @@ The client constructor accepts an associative array of options:
     function is called with a ``Psr7\Http\Message\RequestInterface`` and array
     of transfer options, and must return a
     ``GuzzleHttp\Promise\PromiseInterface`` that is fulfilled with a
-    ``Psr7\Http\Message\ResponseInterface`` on success. ``handler`` is a
-    constructor only option that cannot be overridden in per/request options.
+    ``Psr7\Http\Message\ResponseInterface`` on success.
 
 ``...``
     (mixed) All other options passed to the constructor are used as default

--- a/src/Client.php
+++ b/src/Client.php
@@ -47,9 +47,8 @@ class Client implements ClientInterface
      *   wire. The function is called with a Psr7\Http\Message\RequestInterface
      *   and array of transfer options, and must return a
      *   GuzzleHttp\Promise\PromiseInterface that is fulfilled with a
-     *   Psr7\Http\Message\ResponseInterface on success. "handler" is a
-     *   constructor only option that cannot be overridden in per/request
-     *   options. If no handler is provided, a default handler will be created
+     *   Psr7\Http\Message\ResponseInterface on success.
+     *   If no handler is provided, a default handler will be created
      *   that enables all of the request options below by attaching all of the
      *   default middleware to the handler.
      * - base_uri: (string|UriInterface) Base URI of the client that is merged


### PR DESCRIPTION
Fixes https://github.com/guzzle/guzzle/pull/1852#issuecomment-501727140

(Of course you can also decide to change the code to deprecate/forbid per-request override of  `handler`, but that would be a BC break, thus not before 7.0/8.0)