### PR TITLE
Add "Bearer" as an auth option

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -405,6 +405,11 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     $options['curl'][CURLOPT_HTTPAUTH] = CURLAUTH_NTLM;
                     $options['curl'][CURLOPT_USERPWD] = "$value[0]:$value[1]";
                     break;
+                case 'bearer':
+                    // Ensure that we don't have the Authorization header in
+                    // different case and set the new value wih the token
+                    $modify['set_headers'] = Psr7\_caseless_remove(['Authorization'], $modify['set_headers']);
+                    $modify['set_headers']['Authorization'] = 'Bearer ' . $value[0];
             }
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -399,6 +399,29 @@ class ClientTest extends TestCase
         ], $last['curl']);
     }
 
+    public function testAuthCanBeArrayForBearerAuth()
+    {
+        /**
+         * For Providing Bearer as Auth Option,
+         * Supply token as first argument and
+         * set type to 'bearer' (ignoring-case)
+         * $client->get($uri, ['auth' => ['<token>', null, 'bearer']])
+         */
+        $bearerToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+            . 'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.'
+            . 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+        $expectedAuthorizationHeader = 'Bearer ' . $bearerToken;
+
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->get('http://foo.com', [
+            RequestOptions::AUTH => [$bearerToken, null, 'bearer']
+        ]);
+
+        $last = $mock->getLastRequest();
+        self::assertSame($expectedAuthorizationHeader, $last->getHeaderLine('Authorization'));
+    }
+
     public function testAuthCanBeCustomType()
     {
         $mock = new MockHandler([new Response()]);


### PR DESCRIPTION
- This PR addresses issue #1919 
- Adds Bearer Token Authorization to Client Requests.
- Added needed test.