### PR TITLE
Fix error on quickstart for concurrent requests

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -192,8 +192,8 @@ requests.
     $responses = Promise\settle($promises)->wait();
 
     // You can access each response using the key of the promise
-    echo $responses['image']->getHeader('Content-Length')[0];
-    echo $responses['png']->getHeader('Content-Length')[0];
+    echo $responses['image']['value']->getHeader('Content-Length')[0];
+    echo $responses['png']['value']->getHeader('Content-Length')[0];
 
 You can use the ``GuzzleHttp\Pool`` object when you have an indeterminate
 amount of requests you wish to send.


### PR DESCRIPTION
The example fixed gives an error as it is at the moment:

`Fatal error: Uncaught Error: Call to a member function getHeader() on array`

The fix provides the right code for the example.