### PR TITLE
Handle createResponse()-exceptions in curl-header-function correctly

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -562,16 +562,16 @@ class CurlFactory implements CurlFactoryInterface
             $value = trim($h);
             if ($value === '') {
                 $startingResponse = true;
-                $easy->createResponse();
-                if ($onHeaders !== null) {
-                    try {
+                try {
+                    $easy->createResponse();
+                    if ($onHeaders !== null) {
                         $onHeaders($easy->response);
-                    } catch (\Exception $e) {
-                        // Associate the exception with the handle and trigger
-                        // a curl header write error by returning 0.
-                        $easy->onHeadersException = $e;
-                        return -1;
                     }
+                } catch (\Exception $e) {
+                    // Associate the exception with the handle and trigger
+                    // a curl header write error by returning 0.
+                    $easy->onHeadersException = $e;
+                    return -1;
                 }
             } elseif ($startingResponse) {
                 $startingResponse = false;


### PR DESCRIPTION
Invalid status codes like "404:" (with a colon) are accepted by curl, but createResponse() throws an exception, that should not break the curl event loop.

I fixed it by extending the try/catch block around createResponse(). Then the exception is thrown as "An error was encountered during the on_headers event".

This fixes #2266 