### PR TITLE
Run CI with PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - hhvm
   - nightly
 
@@ -33,7 +32,12 @@ matrix:
   fast_finish: true
   include:
     - php: 5.4
+      dist: trusty
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
 
 before_deploy:
   - make package


### PR DESCRIPTION
and re-arrange Travis for PHP 5.4 and 5.4 to use `trusty` so that those old PHP versions are found.

This demonstrates that unit tests pass on PHP 7.3
That will make people feel happier that `guzzle5` can be used up to PHP  7.3