### PR TITLE
Ensure RequestException always has response

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -34,7 +34,6 @@ class RequestException extends TransferException implements RequestExceptionInte
         \Throwable $previous = null,
         array $handlerContext = []
     ) {
-        // Set the code of the exception if the response is set and not future.
         parent::__construct($message, $response->getStatusCode(), $previous);
         $this->request = $request;
         $this->response = $response;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -174,7 +174,7 @@ class CurlFactory implements CurlFactoryInterface
 
         // If an exception was encountered during the onHeaders event, then
         // return a rejected promise that wraps that exception.
-        if ($easy->onHeadersException) {
+        if ($easy->response && $easy->onHeadersException) {
             return \GuzzleHttp\Promise\rejection_for(
                 new RequestException(
                     'An error was encountered during the on_headers event',

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -202,7 +202,7 @@ class CurlFactory implements CurlFactoryInterface
             );
         }
 
-        // Create a connection exception if it was a specific error code.
+        // Create a connection exception if it was a specific error code or the response is not available.
         $error = isset($connectionErrors[$easy->errno]) || $easy->response === null
             ? new ConnectException($message, $easy->request, null, $ctx)
             : new RequestException($message, $easy->request, $easy->response, null, $ctx);

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -203,7 +203,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         // Create a connection exception if it was a specific error code.
-        $error = isset($connectionErrors[$easy->errno])
+        $error = isset($connectionErrors[$easy->errno]) || $easy->response === null
             ? new ConnectException($message, $easy->request, null, $ctx)
             : new RequestException($message, $easy->request, $easy->response, null, $ctx);
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -67,8 +67,6 @@ class StreamHandler
                 || false !== \strpos($message, "connection attempt failed")
             ) {
                 $e = new ConnectException($e->getMessage(), $request, $e);
-            } else {
-                $e = RequestException::wrapException($request, $e);
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -58,18 +58,8 @@ class StreamHandler
         } catch (\InvalidArgumentException $e) {
             throw $e;
         } catch (\Exception $e) {
-            // Determine if the error was a networking error.
-            $message = $e->getMessage();
-            // This list can probably get more comprehensive.
-            if (false !== \strpos($message, 'getaddrinfo') // DNS lookup failed
-                || false !== \strpos($message, 'Connection refused')
-                || false !== \strpos($message, "couldn't connect to host") // error on HHVM
-                || false !== \strpos($message, "connection attempt failed")
-            ) {
-                $e = new ConnectException($e->getMessage(), $request, $e);
-            }
+            $e = new ConnectException($e->getMessage(), $request, $e);
             $this->invokeStats($options, $request, $startTime, null, $e);
-
             return \GuzzleHttp\Promise\rejection_for($e);
         }
     }
@@ -466,7 +456,7 @@ class StreamHandler
         if (\is_string($value)) {
             $options['ssl']['cafile'] = $value;
             if (!\file_exists($value)) {
-                throw new \RuntimeException("SSL CA bundle not found: $value");
+                throw new \InvalidArgumentException("SSL CA bundle not found: $value");
             }
         } elseif ($value !== true) {
             throw new \InvalidArgumentException('Invalid verify request option');
@@ -488,7 +478,7 @@ class StreamHandler
         }
 
         if (!\file_exists($value)) {
-            throw new \RuntimeException("SSL certificate not found: {$value}");
+            throw new \InvalidArgumentException("SSL certificate not found: {$value}");
         }
 
         $options['ssl']['local_cert'] = $value;

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -86,7 +86,7 @@ class RedirectMiddleware
             return $response;
         }
 
-        $this->guardMax($request, $options);
+        $this->guardMax($request, $response, $options);
         $nextRequest = $this->modifyRequest($request, $options, $response);
 
         if (isset($options['allow_redirects']['on_redirect'])) {
@@ -137,7 +137,7 @@ class RedirectMiddleware
      *
      * @throws TooManyRedirectsException Too many redirects.
      */
-    private function guardMax(RequestInterface $request, array &$options): void
+    private function guardMax(RequestInterface $request, ResponseInterface $response, array &$options): void
     {
         $current = $options['__redirect_count']
             ?? 0;
@@ -147,7 +147,8 @@ class RedirectMiddleware
         if ($options['__redirect_count'] > $max) {
             throw new TooManyRedirectsException(
                 "Will not follow more than {$max} redirects",
-                $request
+                $request,
+                $response
             );
         }
     }

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -28,13 +28,6 @@ class RequestExceptionTest extends TestCase
         self::assertSame('foo', $e->getMessage());
     }
 
-    public function testCreatesGenerateException()
-    {
-        $e = RequestException::create(new Request('GET', '/'));
-        self::assertSame('Error completing request', $e->getMessage());
-        self::assertInstanceOf(\GuzzleHttp\Exception\RequestException::class, $e);
-    }
-
     public function testCreatesClientErrorResponseException()
     {
         $e = RequestException::create(new Request('GET', '/'), new Response(400));
@@ -154,24 +147,27 @@ class RequestExceptionTest extends TestCase
     public function testWrapsRequestExceptions()
     {
         $e = new \Exception('foo');
-        $r = new Request('GET', 'http://www.oo.com');
-        $ex = RequestException::wrapException($r, $e);
+        $req = new Request('GET', 'http://www.oo.com');
+        $res = new Response(200);
+        $ex = RequestException::wrapException($req, $res, $e);
         self::assertInstanceOf(\GuzzleHttp\Exception\RequestException::class, $ex);
         self::assertSame($e, $ex->getPrevious());
     }
 
     public function testDoesNotWrapExistingRequestExceptions()
     {
-        $r = new Request('GET', 'http://www.oo.com');
-        $e = new RequestException('foo', $r);
-        $e2 = RequestException::wrapException($r, $e);
+        $req = new Request('GET', 'http://www.oo.com');
+        $res = new Response(200);
+        $e = new RequestException('foo', $req, $res);
+        $e2 = RequestException::wrapException($req, $res, $e);
         self::assertSame($e, $e2);
     }
 
     public function testCanProvideHandlerContext()
     {
-        $r = new Request('GET', 'http://www.oo.com');
-        $e = new RequestException('foo', $r, null, null, ['bar' => 'baz']);
+        $req = new Request('GET', 'http://www.oo.com');
+        $res = new Response(200);
+        $e = new RequestException('foo', $req, $res, null, ['bar' => 'baz']);
         self::assertSame(['bar' => 'baz'], $e->getHandlerContext());
     }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -456,7 +456,7 @@ class CurlFactoryTest extends TestCase
             return Handler\CurlFactory::finish($fn, $easy, $factory);
         };
 
-        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+        $this->expectException(\GuzzleHttp\Exception\ConnectException::class);
         $this->expectExceptionMessage('but attempting to rewind the request body failed');
         $fn($request, [])->wait();
     }
@@ -503,7 +503,7 @@ class CurlFactoryTest extends TestCase
         $p->wait(false);
         self::assertEquals(3, $call);
 
-        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+        $this->expectException(\GuzzleHttp\Exception\ConnectException::class);
         $this->expectExceptionMessage('The cURL request was retried 3 times');
         $p->wait(true);
     }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -298,7 +298,7 @@ class StreamHandlerTest extends TestCase
 
     public function testVerifiesVerifyIsValidIfPath()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('SSL CA bundle not found: /does/not/exist');
 
         $this->getSendResult(['verify' => '/does/not/exist']);
@@ -312,7 +312,7 @@ class StreamHandlerTest extends TestCase
 
     public function testVerifiesCertIfValidPath()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('SSL certificate not found: /does/not/exist');
 
         $this->getSendResult(['cert' => '/does/not/exist']);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -298,7 +298,7 @@ class StreamHandlerTest extends TestCase
 
     public function testVerifiesVerifyIsValidIfPath()
     {
-        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('SSL CA bundle not found: /does/not/exist');
 
         $this->getSendResult(['verify' => '/does/not/exist']);
@@ -312,7 +312,7 @@ class StreamHandlerTest extends TestCase
 
     public function testVerifiesCertIfValidPath()
     {
-        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('SSL certificate not found: /does/not/exist');
 
         $this->getSendResult(['cert' => '/does/not/exist']);

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -110,7 +110,8 @@ class MiddlewareTest extends TestCase
         $container = [];
         $m = Middleware::history($container);
         $request = new Request('GET', 'http://foo.com');
-        $h = new MockHandler([new RequestException('error', $request)]);
+        $response = new Response(200);
+        $h = new MockHandler([new RequestException('error', $request, $response)]);
         $f = $m($h);
         $f($request, [])->wait(false);
         self::assertCount(1, $container);

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -96,6 +96,26 @@ class RedirectMiddlewareTest extends TestCase
         $promise->wait();
     }
 
+    public function testTooManyRedirectsExceptionHasResponse()
+    {
+        $mock = new MockHandler([
+            new Response(301, ['Location' => 'http://test.com']),
+            new Response(302, ['Location' => 'http://test.com'])
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('GET', 'http://example.com');
+        $promise = $handler($request, ['allow_redirects' => ['max' => 1]]);
+
+        try {
+            $promise->wait();
+            self::fail();
+        } catch (\GuzzleHttp\Exception\TooManyRedirectsException $e) {
+            self::assertSame(302, $e->getResponse()->getStatusCode());
+        }
+    }
+
     public function testEnsuresProtocolIsValid()
     {
         $mock = new MockHandler([


### PR DESCRIPTION
> Attempts to address https://github.com/guzzle/guzzle/pull/2541#issuecomment-586730619 by @Tobion 

### Changed
- `GuzzleHttp\Exception\RequestException` now always has a response

#### I think there are a few possible problems with these changes:
- `RequestException::wrapException()` now requires a response, so exceptions cannot be wrapped in `GuzzleHttp\Handler\StreamHandler::__invoke()`
- `CurlFactory::createRejection()` assumes `ConnectException` when `$easy->response` is `null`