### PR TITLE
Fix CURLOPT_ENCODING not to be overwritten

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -394,7 +394,7 @@ class CurlFactory implements CurlFactoryInterface
             }
         }
 
-        if (!empty($options['decode_content'])) {
+        if (!isset($options['curl'][\CURLOPT_ENCODING]) && !empty($options['decode_content'])) {
             $accept = $easy->request->getHeaderLine('Accept-Encoding');
             if ($accept) {
                 $conf[\CURLOPT_ENCODING] = $accept;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -272,6 +272,21 @@ class ClientTest extends TestCase
         self::assertSame('gzip', $mock->getLastOptions()['decode_content']);
     }
 
+    public function testAddsAcceptEncodingbyCurl()
+    {
+        $client = new Client(['curl' => [\CURLOPT_ENCODING => '']]);
+
+        Server::flush();
+        Server::enqueue([new Response()]);
+        $client->get(Server::$url);
+        $sent = Server::received()[0];
+        self::assertTrue($sent->hasHeader('Accept-Encoding'));
+
+        $mock = new MockHandler([new Response()]);
+        $client->get('http://foo.com', ['handler' => $mock]);
+        self::assertSame([\CURLOPT_ENCODING => ''], $mock->getLastOptions()['curl']);
+    }
+
     public function testValidatesHeaders()
     {
         $mock = new MockHandler();


### PR DESCRIPTION
This PR fixes an issue where CURLOPT_ENCODING is overwritten when decode_content is true (default is true).

Before this fix, setting only CURLOPT_ENCODING removes the Accept-Encoding header and the server response is not compressed.
After this fix, the Accept-Encoding header is sent and the server response is compressed.

Maybe this will solve that issue #2270