### PR TITLE
Install dependencies for phpstan analysis

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: PHPStan
         uses: docker://oskarstark/phpstan-ga
+        env:
+          REQUIRE_DEV: true
         with:
           args: analyze --no-progress
 


### PR DESCRIPTION
### Changed
- Install dev dependencies when running phpstan analysis

> Makes use of https://github.com/OskarStark/phpstan-ga/releases/tag/0.12.11.1 
> Relates to: https://github.com/OskarStark/phpstan-ga/pull/22