### PR TITLE
Streamline badge style for build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Guzzle, PHP HTTP client
 =======================
 
 [![Latest Version](https://img.shields.io/github/release/guzzle/guzzle.svg?style=flat-square)](https://github.com/guzzle/guzzle/releases)
-![Build Status](https://github.com/guzzle/guzzle/workflows/CI/badge.svg?style=flat-square)
+[![Build Status](https://img.shields.io/github/workflow/status/guzzle/guzzle/CI?label=ci%20build&style=flat-square)](https://github.com/guzzle/guzzle/actions?query=workflow%3ACI)
 [![Total Downloads](https://img.shields.io/packagist/dt/guzzlehttp/guzzle.svg?style=flat-square)](https://packagist.org/packages/guzzlehttp/guzzle)
 
 Guzzle is a PHP HTTP client that makes it easy to send HTTP requests and


### PR DESCRIPTION
Set the same style for the build badge as the other badges use.

Add a link to the build / CI workflow to prevent a impractical link to the image itself.

Before:
![Bildschirmfoto von 2020-04-17 11-48-54](https://user-images.githubusercontent.com/1592995/79556929-04b13100-80a2-11ea-8438-e56381466393.png)

After:
![Bildschirmfoto von 2020-04-17 11-52-41](https://user-images.githubusercontent.com/1592995/79556949-08dd4e80-80a2-11ea-9d0c-f7ae67633ba7.png)

Closes #2614