### PR TITLE
[6.5] Fix various intl icu issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=5.5",
         "ext-json": "*",
-        "symfony/polyfill-intl-idn": "^1.11",
+        "symfony/polyfill-intl-idn": "^1.17",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.6.1"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -496,6 +496,11 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
+			message: "#^Parameter \\#1 \\$filename of function is_dir expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Handler/CurlFactory.php
+
+		-
 			message: "#^Method GuzzleHttp\\\\Handler\\\\CurlFactory\\:\\:retryFailedRewind\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php
@@ -1309,6 +1314,11 @@ parameters:
 			message: "#^Method GuzzleHttp\\\\UriTemplate\\:\\:isAssoc\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/UriTemplate.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Utils\\:\\:idnToAsci\\(\\) has parameter \\$info with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Utils.php
 
 		-
 			message: "#^Function GuzzleHttp\\\\uri_template\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -72,6 +72,10 @@ final class Utils
      */
     private static function idnToAsci($domain, $options, &$info = [])
     {
+        if (\preg_match('%^[ -~]+$%', $domain) === 1) {
+            return $domain;
+        }
+
         if (\extension_loaded('intl') && defined('INTL_IDNA_VARIANT_UTS46')) {
             return \idn_to_ascii($domain, $options, INTL_IDNA_VARIANT_UTS46, $info);
         }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -3,7 +3,7 @@ namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
-use Symfony\Polyfill\Intl\Idn;
+use Symfony\Polyfill\Intl\Idn\Idn;
 
 final class Utils
 {
@@ -63,6 +63,13 @@ final class Utils
         return $uri;
     }
 
+    /**
+     * @param string $domain
+     * @param int    $options
+     * @param array  $info
+     *
+     * @return string|false
+     */
     private static function idnToAsci($domain, $options, &$info = [])
     {
         if (\extension_loaded('intl') && defined('INTL_IDNA_VARIANT_UTS46')) {


### PR DESCRIPTION
This fixes the following issues:

1. Whenever PHP has been compiled against a too old version of intl icu, we should use the polyfill implementation (Fixes #2620).
2. A minimum version of the polyfill of 1.17.0 should be imposed to fix issues with constants being defined in error (Fixes https://github.com/guzzle/guzzle/pull/2626#issuecomment-627452837).
3. When a domain is only ASCII, we should skip conversion entirely (Fixes #2640).