### PR TITLE
Add guzzle version to user agent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
+        "composer/package-versions-deprecated": "^1.8",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.6.1",
         "psr/http-client": "^1.0",
-        "symfony/polyfill-intl-idn": "^1.11",
-        "composer/package-versions-deprecated": "^1.8"
+        "symfony/polyfill-intl-idn": "^1.11"
     },
     "provide": {
         "psr/http-client-implementation": "1.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.6.1",
         "psr/http-client": "^1.0",
-        "symfony/polyfill-intl-idn": "^1.11"
+        "symfony/polyfill-intl-idn": "^1.11",
+        "composer/package-versions-deprecated": "^1.8"
     },
     "provide": {
         "psr/http-client-implementation": "1.0"

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -6,6 +6,8 @@ use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Handler\StreamHandler;
+use OutOfBoundsException;
+use PackageVersions\Versions;
 use Psr\Http\Message\UriInterface;
 
 final class Utils
@@ -109,7 +111,13 @@ final class Utils
         static $defaultAgent = '';
 
         if (!$defaultAgent) {
-            $defaultAgent = 'GuzzleHttp/Guzzle';
+            try {
+                $version = Versions::getVersion("guzzlehttp/guzzle");
+                $version = substr($version, 0, strpos($version,"@"));
+            } catch (OutOfBoundsException $e) {
+                $version = 'Guzzle';
+            }
+            $defaultAgent = 'GuzzleHttp/' . $version;
             if (\extension_loaded('curl') && \function_exists('curl_version')) {
                 $defaultAgent .= ' curl/' . \curl_version()['version'];
             }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -113,7 +113,7 @@ final class Utils
         if (!$defaultAgent) {
             try {
                 $version = Versions::getVersion("guzzlehttp/guzzle");
-                $version = substr($version, 0, strpos($version,"@"));
+                $version = substr($version, 0, \strpos($version, "@") ?: \strlen($version));
             } catch (OutOfBoundsException $e) {
                 $version = 'Guzzle';
             }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -113,7 +113,7 @@ final class Utils
         if (!$defaultAgent) {
             try {
                 $version = Versions::getVersion("guzzlehttp/guzzle");
-                $version = substr($version, 0, \strpos($version, "@") ?: \strlen($version));
+                $version = \substr($version, 0, \strpos($version, "@") ?: \strlen($version));
             } catch (OutOfBoundsException $e) {
                 $version = 'Guzzle';
             }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Handler\StreamHandler;
-use OutOfBoundsException;
 use PackageVersions\Versions;
 use Psr\Http\Message\UriInterface;
 
@@ -114,7 +113,7 @@ final class Utils
             try {
                 $version = Versions::getVersion("guzzlehttp/guzzle");
                 $version = \substr($version, 0, \strpos($version, "@") ?: \strlen($version));
-            } catch (OutOfBoundsException $e) {
+            } catch (\Throwable $e) {
                 $version = 'Guzzle';
             }
             $defaultAgent = 'GuzzleHttp/' . $version;


### PR DESCRIPTION
With Composer2 it's possible to retrieve the version information of an installed package with no overhead. For older composer versions there is a composer plugin which was originally created by ocramius.

The defaultAgent method now reads the the package version, throws away the git hash and adds the version number to the user agent string.

Maybe the catch should be wider if guzzle hasn't been installed with composer as the class may be not there.

This PR has been inspired by the discussion here https://github.com/guzzle/guzzle/pull/2421/files/1965ac6bdd75ae90ad1b95fdfb8b7ecb9a4c95b7#diff-84b928a9905378810b602c8a740b4cba and to avoid parsing the installed.json file