### PR TITLE
Ensure link can be read before checking it is a directory (PHPStan Error)

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -359,8 +359,14 @@ class CurlFactory implements CurlFactoryInterface
                     }
                     // If it's a directory or a link to a directory use CURLOPT_CAPATH.
                     // If not, it's probably a file, or a link to a file, so use CURLOPT_CAINFO.
-                    if (\is_dir($options['verify']) ||
-                        (\is_link($options['verify']) && \is_dir(\readlink($options['verify'])))) {
+                    if (
+                        \is_dir($options['verify']) ||
+                        (
+                            \is_link($options['verify']) === true &&
+                            ($verifyLink = \readlink($options['verify'])) !== false &&
+                            \is_dir($verifyLink)
+                        )
+                    ) {
                         $conf[CURLOPT_CAPATH] = $options['verify'];
                     } else {
                         $conf[CURLOPT_CAINFO] = $options['verify'];


### PR DESCRIPTION
Fixes PHPStan error affecting checks on open PRs

```
 ------ ------------------------------------------------------------------------------- 
  Line   Handler/CurlFactory.php                                                        
 ------ ------------------------------------------------------------------------------- 
  366    Parameter #1 $filename of function is_dir expects string, string|false given.  
 ------ ------------------------------------------------------------------------------- 
```

Happy to close this PR if you'd prefer to ignore the PHPStan error

I'll remove this fix from https://github.com/guzzle/guzzle/pull/2589 if this is merged (or if this error is ignored in a separate PR)

### Fixed
- Ensure link can be read before checking it is a directory