### PR TITLE
Change link due repository deprecation

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -1017,7 +1017,7 @@ verify
 
 If you do not need a specific certificate bundle, then Mozilla provides a
 commonly used CA bundle which can be downloaded
-`here <https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt>`_
+`here <https://curl.haxx.se/ca/cacert.pem>`_
 (provided by the maintainer of cURL). Once you have a CA bundle available on
 disk, you can set the "openssl.cafile" PHP ini setting to point to the path to
 the file, allowing you to omit the "verify" request option. Much more detail on

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -180,7 +180,7 @@ supply the path on disk to a certificate bundle to the 'verify' request
 option: http://docs.guzzlephp.org/en/latest/clients.html#verify. If you do not
 need a specific certificate bundle, then Mozilla provides a commonly used CA
 bundle which can be downloaded here (provided by the maintainer of cURL):
-https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt. Once
+https://curl.haxx.se/ca/cacert.pem. Once
 you have a CA bundle available on disk, you can set the 'openssl.cafile' PHP
 ini setting to point to the path to the file, allowing you to omit the 'verify'
 request option. See https://curl.haxx.se/docs/sslcerts.html for more


### PR DESCRIPTION
- https://github.com/bagder/ca-bundle#deprecated

Do you consider original URL also? https://tls-observatory.services.mozilla.com/api/v1/truststore?store=mozilla&format=pem