### PR TITLE
Option to force passing Authorization header on redirect (#1272)

### DIFF
--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -25,11 +25,12 @@ class RedirectMiddleware
      * @var array
      */
     public static $defaultSettings = [
-        'max'             => 5,
-        'protocols'       => ['http', 'https'],
-        'strict'          => false,
-        'referer'         => false,
-        'track_redirects' => false,
+        'max'                      => 5,
+        'protocols'                => ['http', 'https'],
+        'strict'                   => false,
+        'referer'                  => false,
+        'track_redirects'          => false,
+        'force_pass_authorization' => false,
     ];
 
     /**
@@ -194,7 +195,9 @@ class RedirectMiddleware
         }
 
         // Remove Authorization header if host is different.
-        if ($request->getUri()->getHost() !== $modify['uri']->getHost()) {
+        if (!$options['allow_redirects']['force_pass_authorization'] &&
+            $request->getUri()->getHost() !== $modify['uri']->getHost()
+        ) {
             $modify['remove_headers'][] = 'Authorization';
         }
 

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -277,4 +277,26 @@ class RedirectMiddlewareTest extends TestCase
         $client = new Client(['handler' => $handler]);
         $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass']]);
     }
+
+    public function testNotRemoveAuthorizationHeaderOnRedirectWhenForced()
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com']),
+            static function (RequestInterface $request) {
+                self::assertTrue($request->hasHeader('Authorization'));
+                return new Response(200);
+            }
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $client->get(
+            'http://example.com?a=b',
+            [
+                'auth' => ['testuser', 'testpass'],
+                'allow_redirects' => [
+                    'force_pass_authorization' => true,
+                ],
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Resolves #1272 by adding an option to force passing Authorization header on redirects.