### PR TITLE
Added  wording for the timeout

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -1030,7 +1030,7 @@ SSL certificates can be found on the
 timeout
 -------
 
-:Summary: Float describing the timeout of the request in seconds. Use ``0``
+:Summary: Float describing the total timeout of the request in seconds. Use ``0``
         to wait indefinitely (the default behavior).
 :Types: float
 :Default: ``0``


### PR DESCRIPTION
For me it gives a better meaning that this timeout also includes the `connection` time and it is not only the time waiting for a request after the connection has been established.