### PR TITLE
[6.5] Fix "curl error msg for low version"

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\RequestInterface;
 class CurlFactory implements CurlFactoryInterface
 {
     const CURL_VERSION_STR = 'curl_version';
-    const LOW_CURL_VERSION_NUMBER = '7.21.2';
 
     /** @var array */
     private $handles = [];
@@ -178,21 +177,17 @@ class CurlFactory implements CurlFactoryInterface
                 )
             );
         }
-        if (version_compare($ctx[self::CURL_VERSION_STR], self::LOW_CURL_VERSION_NUMBER)) {
-            $message = sprintf(
-                'cURL error %s: %s (%s)',
-                $ctx['errno'],
-                $ctx['error'],
-                'see https://curl.haxx.se/libcurl/c/libcurl-errors.html'
-            );
-        } else {
-            $message = sprintf(
-                'cURL error %s: %s (%s) for %s',
-                $ctx['errno'],
-                $ctx['error'],
-                'see https://curl.haxx.se/libcurl/c/libcurl-errors.html',
-                $easy->request->getUri()
-            );
+
+        $message = sprintf(
+            'cURL error %s: %s (%s)',
+            $ctx['errno'],
+            $ctx['error'],
+            'see https://curl.haxx.se/libcurl/c/libcurl-errors.html'
+        );
+        if ('' !== ($uriStr = (string) $easy->request->getUri())
+            && false === strpos($ctx['error'], $uriStr)
+        ) {
+            $message .= sprintf(' for %s', $uriStr);
         }
 
         // Create a connection exception if it was a specific error code.


### PR DESCRIPTION
My try at https://github.com/guzzle/guzzle/pull/2108#discussion_r405509826: revert the incorrect `version_compare` test and append the URI if not already contained in the error message