### PR TITLE
Lock versions on static analysis checks

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,6 @@ jobs:
         env:
           REQUIRE_DEV: true
         with:
-          entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress
 
   php-cs-fixer:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,10 +16,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PHPStan
-        uses: docker://oskarstark/phpstan-ga
+        uses: OskarStark/phpstan-ga@0.12.23
         env:
           REQUIRE_DEV: true
         with:
+          entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress
 
   php-cs-fixer:
@@ -31,6 +32,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PHP-CS-Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga
+        uses: OskarStark/php-cs-fixer-ga@2.16.3.1
         with:
           args: --dry-run --diff-format udiff


### PR DESCRIPTION
We dont want master to break just because static analysis tools were updated. 