### PR TITLE
Streamline badge style for build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Guzzle, PHP HTTP client
 
 [![Latest Version](https://img.shields.io/github/release/guzzle/guzzle.svg?style=flat-square)](https://github.com/guzzle/guzzle/releases)
-![Build Status](https://github.com/guzzle/guzzle/workflows/CI/badge.svg?style=flat-square)
+[![Build Status](https://img.shields.io/github/workflow/status/guzzle/guzzle/CI?label=ci%20build&style=flat-square)](https://github.com/guzzle/guzzle/actions?query=workflow%3ACI)
 [![Total Downloads](https://img.shields.io/packagist/dt/guzzlehttp/guzzle.svg?style=flat-square)](https://packagist.org/packages/guzzlehttp/guzzle)
 
 Guzzle is a PHP HTTP client that makes it easy to send HTTP requests and


### PR DESCRIPTION
Rebase of #2615

> Set the same style for the build badge as the other badges use.
> 
> Add a link to the build / CI workflow to prevent a impractical
> link to the image itself.

Closes #2614
Fixed #2615