### PR TITLE
Pass response to TooManyRedirectsException

### DIFF
--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -88,7 +88,7 @@ class RedirectMiddleware
             return $response;
         }
 
-        $this->guardMax($request, $options);
+        $this->guardMax($request, $response, $options);
         $nextRequest = $this->modifyRequest($request, $options, $response);
 
         if (isset($options['allow_redirects']['on_redirect'])) {
@@ -139,7 +139,7 @@ class RedirectMiddleware
      *
      * @throws TooManyRedirectsException Too many redirects.
      */
-    private function guardMax(RequestInterface $request, array &$options): void
+    private function guardMax(RequestInterface $request, ResponseInterface $response, array &$options): void
     {
         $current = $options['__redirect_count']
             ?? 0;
@@ -149,7 +149,8 @@ class RedirectMiddleware
         if ($options['__redirect_count'] > $max) {
             throw new TooManyRedirectsException(
                 "Will not follow more than {$max} redirects",
-                $request
+                $request,
+                $response
             );
         }
     }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -96,6 +96,26 @@ class RedirectMiddlewareTest extends TestCase
         $promise->wait();
     }
 
+    public function testTooManyRedirectsExceptionHasResponse()
+    {
+        $mock = new MockHandler([
+            new Response(301, ['Location' => 'http://test.com']),
+            new Response(302, ['Location' => 'http://test.com'])
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('GET', 'http://example.com');
+        $promise = $handler($request, ['allow_redirects' => ['max' => 1]]);
+
+        try {
+            $promise->wait();
+            self::fail();
+        } catch (\GuzzleHttp\Exception\TooManyRedirectsException $e) {
+            self::assertSame(302, $e->getResponse()->getStatusCode());
+        }
+    }
+
     public function testEnsuresProtocolIsValid()
     {
         $mock = new MockHandler([


### PR DESCRIPTION
### Fixed
- `TooManyRedirectsException` now has response 

> Note: https://github.com/guzzle/guzzle/pull/2589 includes additional breaking changes to ensure `RequestException` always has a response, which will be considered for version `8.0.0`
>
> If you'd prefer this fix to remain as part of https://github.com/guzzle/guzzle/pull/2589 I'll close this PR