### PR TITLE
Allow running static Actions via Make

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -10,13 +10,13 @@ jobs:
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: PHPStan
-        uses: OskarStark/phpstan-ga@0.12.27
+        uses: OskarStark/phpstan-ga@0.12.28
         env:
           REQUIRE_DEV: true
         with:

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,12 @@ tag:
 package:
 	php build/packager.php
 
+static: static-phpstan static-cs-fixer
+
+static-phpstan:
+	docker run --rm -it -e REQUIRE_DEV=true -v ${PWD}:/app -w /app oskarstark/phpstan-ga:0.12.23 analyze
+
+static-cs-fixer:
+	docker run --rm -it -v ${PWD}:/app -w /app oskarstark/php-cs-fixer-ga:2.16.3.1 --dry-run --diff-format udiff
+
 .PHONY: docs burgomaster coverage-show view-coverage

--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,18 @@ tag:
 package:
 	php build/packager.php
 
-static: static-phpstan static-cs-fixer
+static: static-phpstan static-codestyle-check
 
 static-phpstan:
-	docker run --rm -it -e REQUIRE_DEV=true -v ${PWD}:/app -w /app oskarstark/phpstan-ga:0.12.23 analyze
+	docker run --rm -it -e REQUIRE_DEV=true -v ${PWD}:/app -w /app oskarstark/phpstan-ga:0.12.27 analyze $(PHPSTAN_PARAMS)
 
-static-cs-fixer:
-	docker run --rm -it -v ${PWD}:/app -w /app oskarstark/php-cs-fixer-ga:2.16.3.1 --dry-run --diff-format udiff
+static-phpstan-update-baseline:
+	$(MAKE) static-phpstan PHPSTAN_PARAMS="--generate-baseline"
+
+static-codestyle-fix:
+	docker run --rm -it -v ${PWD}:/app -w /app oskarstark/php-cs-fixer-ga:2.16.3.1 --diff-format udiff $(CS_PARAMS)
+
+static-codestyle-check:
+	$(MAKE) static-codestyle-fix CS_PARAMS="--dry-run"
 
 .PHONY: docs burgomaster coverage-show view-coverage

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ package:
 static: static-phpstan static-codestyle-check
 
 static-phpstan:
-	docker run --rm -it -e REQUIRE_DEV=true -v ${PWD}:/app -w /app oskarstark/phpstan-ga:0.12.27 analyze $(PHPSTAN_PARAMS)
+	docker run --rm -it -e REQUIRE_DEV=true -v ${PWD}:/app -w /app oskarstark/phpstan-ga:0.12.28 analyze $(PHPSTAN_PARAMS)
 
 static-phpstan-update-baseline:
 	$(MAKE) static-phpstan PHPSTAN_PARAMS="--generate-baseline"


### PR DESCRIPTION
Having the image version numbers in an environment file somewhere would allow both the Makefile and the Github action to read them.

As a follow-up on this PR I will start working on reducing the size of `phpstan-baseline.neon`.