### PR TITLE
[RFC] Follow experiment friendly PHP constraint 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": ">=7.2.5",
         "ext-json": "*",
         "guzzlehttp/promises": "^1.0",
         "guzzlehttp/psr7": "^1.6.1",


### PR DESCRIPTION
... as suggested by @nicolas-grekas

After reading all comments on https://github.com/symfony/symfony/pull/36876 I found the arguments listed there sufficient enough to open this PR to also attempt discussing this for Guzzle.

Feel free to close this PR once the discussion is inconclusive.

## Why?

see https://twitter.com/nicolasgrekas/status/1263023258938548225

also see https://github.com/symfony/symfony/pull/36876

> 1. it's either planned obsolescence xor a strong promise to maintain in the long run. None is sustainable.
> 2. if you actually end up maintaining in the long run (not by promise but by fact), your latest versions will work with PHP 8 by definition.
> 3. meanwhile, "^7.x" prevented all your ecosystem from experimenting with PHP 8, which means they increased the workload on you the core maintainer.
