### PR TITLE
Change to ArgumentCountError for magic methods

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -72,7 +72,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     public function __call($method, $args)
     {
         if (\count($args) < 1) {
-            throw new InvalidArgumentException('Magic request methods require a URI and optional options array');
+            throw new \ArgumentCountError(
+                \sprintf('Magic request method %s require a URI and optional options array', $method)
+            );
         }
 
         $uri = $args[0];

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -29,8 +29,8 @@ class ClientTest extends TestCase
     {
         $client = new Client();
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Magic request methods require a URI and optional options array');
+        $this->expectException(\ArgumentCountError::class);
+        $this->expectExceptionMessage('Magic request method options require a URI and optional options array');
         $client->options();
     }
 


### PR DESCRIPTION
This PR changes the behavior of magic methods trying to simulate in a better form PHP 7.

Before in cases the arguments were missing we used to throw an `Exception`. Now it will throw an `Error`