### PR TITLE
Ignore files when exporting package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 .php_cs.dist           export-ignore
 /build/                export-ignore
 /docs/                 export-ignore
+/Dockerfile            export-ignore
 /Makefile              export-ignore
 /phpstan-baseline.neon export-ignore
 /phpstan.neon.dist     export-ignore


### PR DESCRIPTION
This commit is part of a campaign to reduce the amount of data transferred to save global bandwidth and reduce the amount of CO2. See https://github.com/Codeception/Codeception/pull/5527 for more info.