### PR TITLE
Prepare release RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ## UNRELEASED
 
-## 7.0.0-rc1 - 2020-06-11
+## 7.0.0-rc1 - 2020-06-15
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+## 7.0.0-rc1 - 2012-06-11
+
+### Changed
+
 * Use error level for logging errors in Middleware [#2629](https://github.com/guzzle/guzzle/pull/2629)
 * Disabled IDN support by default and require ext-intl to use it [#2675](https://github.com/guzzle/guzzle/pull/2675)
 
@@ -32,8 +36,8 @@
 
 ## 7.0.0-beta1 - 2019-12-30
 
-The diff might look very big but 95% of Guzzle users will be able to upgrade without modification. 
-Please see [the upgrade document](UPGRADING.md) that describes all BC breaking changes.   
+The diff might look very big but 95% of Guzzle users will be able to upgrade without modification.
+Please see [the upgrade document](UPGRADING.md) that describes all BC breaking changes.
 
 ### Added
 
@@ -51,7 +55,7 @@ Please see [the upgrade document](UPGRADING.md) that describes all BC breaking c
 * Dont allow passing `null` as URI to `Client::request()` and `Client::requestAsync()` [#2461](https://github.com/guzzle/guzzle/pull/2461)
 * Widen the exception argument to throwable [#2495](https://github.com/guzzle/guzzle/pull/2495)
 
-### Fixed 
+### Fixed
 
 * Logging when Promise rejected with a string [#2311](https://github.com/guzzle/guzzle/pull/2311)
 
@@ -83,7 +87,7 @@ Please see [the upgrade document](UPGRADING.md) that describes all BC breaking c
 
 ## 6.4.1 - 2019-10-23
 
-* No `guzzle.phar` was created in 6.4.0 due expired API token. This release will fix that 
+* No `guzzle.phar` was created in 6.4.0 due expired API token. This release will fix that
 * Added `parent::__construct()` to `FileCookieJar` and `SessionCookieJar`
 
 ## 6.4.0 - 2019-10-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## UNRELEASED
 
-## 7.0.0-rc1 - 2012-06-11
+## 7.0.0-rc1 - 2020-06-11
 
 ### Changed
 
 * Use error level for logging errors in Middleware [#2629](https://github.com/guzzle/guzzle/pull/2629)
 * Disabled IDN support by default and require ext-intl to use it [#2675](https://github.com/guzzle/guzzle/pull/2675)
 
-## 7.0.0-beta2 - 2012-05-25
+## 7.0.0-beta2 - 2020-05-25
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ composer require guzzlehttp/guzzle
 | 3.x     | EOL        | `guzzle/guzzle`     | `Guzzle`     | [v3][guzzle-3-repo] | [v3][guzzle-3-docs] | No    | >= 5.3.3    |
 | 4.x     | EOL        | `guzzlehttp/guzzle` | `GuzzleHttp` | [v4][guzzle-4-repo] | N/A                 | No    | >= 5.4      |
 | 5.x     | EOL        | `guzzlehttp/guzzle` | `GuzzleHttp` | [v5][guzzle-5-repo] | [v5][guzzle-5-docs] | No    | >= 5.4      |
-| 6.x     | bugfixes   | `guzzlehttp/guzzle` | `GuzzleHttp` | [v6][guzzle-6-repo] | [v6][guzzle-6-docs] | Yes   | >= 5.5      |
+| 6.x     | Bugfixes   | `guzzlehttp/guzzle` | `GuzzleHttp` | [v6][guzzle-6-repo] | [v6][guzzle-6-docs] | Yes   | >= 5.5      |
 | 7.x     | Latest     | `guzzlehttp/guzzle` | `GuzzleHttp` | [v7][guzzle-7-repo] | [v7][guzzle-7-docs] | Yes   | >= 7.2      |
 
 [guzzle-3-repo]: https://github.com/guzzle/guzzle3

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         "curl",
         "client",
         "HTTP client",
-        "psr7",
-        "psr18"
+        "PSR-7",
+        "PSR-18"
     ],
     "homepage": "http://guzzlephp.org/",
     "license": "MIT",


### PR DESCRIPTION
Two significant changes has happened since Beta2. 

We disabled IDN support by default and we changed the log level on our logging middleware. 