### PR TITLE
replace allow_redirects to \GuzzleHttp\RequestOptions::ALLOW_REDIRECTS

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -25,7 +25,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     $client = new Client([
      *         'base_uri'        => 'http://www.foo.com/1.0/',
      *         'timeout'         => 0,
-     *         'allow_redirects' => false,
+     *         \GuzzleHttp\RequestOptions::ALLOW_REDIRECTS => false,
      *         'proxy'           => '192.168.16.1:10'
      *     ]);
      *
@@ -216,7 +216,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     private function configureDefaults(array $config): void
     {
         $defaults = [
-            'allow_redirects' => RedirectMiddleware::$defaultSettings,
+            RequestOptions::ALLOW_REDIRECTS => RedirectMiddleware::$defaultSettings,
             'http_errors'     => true,
             'decode_content'  => true,
             'verify'          => true,

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -39,7 +39,7 @@ class HandlerStack
     {
         $stack = new self($handler ?: Utils::chooseHandler());
         $stack->push(Middleware::httpErrors(), 'http_errors');
-        $stack->push(Middleware::redirect(), 'allow_redirects');
+        $stack->push(Middleware::redirect(), RequestOptions::ALLOW_REDIRECTS);
         $stack->push(Middleware::cookies(), 'cookies');
         $stack->push(Middleware::prepareBody(), 'prepare_body');
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -131,7 +131,7 @@ class ClientTest extends TestCase
         $client = new Client(['headers' => ['User-agent' => 'foo']]);
         $config = Helpers::readObjectAttribute($client, 'config');
         self::assertSame(['User-agent' => 'foo'], $config['headers']);
-        self::assertIsArray($config['allow_redirects']);
+        self::assertIsArray($config[RequestOptions::ALLOW_REDIRECTS]);
         self::assertTrue($config['http_errors']);
         self::assertTrue($config['decode_content']);
         self::assertTrue($config['verify']);
@@ -188,8 +188,8 @@ class ClientTest extends TestCase
         $mock = new MockHandler([new Response(200, [], 'foo')]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('http://foo.com', ['allow_redirects' => true]);
-        self::assertIsArray($mock->getLastOptions()['allow_redirects']);
+        $client->get('http://foo.com', [RequestOptions::ALLOW_REDIRECTS => true]);
+        self::assertIsArray($mock->getLastOptions()[RequestOptions::ALLOW_REDIRECTS]);
     }
 
     public function testValidatesAllowRedirects()
@@ -200,7 +200,7 @@ class ClientTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('allow_redirects must be true, false, or array');
-        $client->get('http://foo.com', ['allow_redirects' => 'foo']);
+        $client->get('http://foo.com', [RequestOptions::ALLOW_REDIRECTS => 'foo']);
     }
 
     public function testThrowsHttpErrorsByDefault()

--- a/tests/HandlerStackTest.php
+++ b/tests/HandlerStackTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\TestCase;
 
 class HandlerStackTest extends TestCase
@@ -162,7 +163,7 @@ class HandlerStackTest extends TestCase
         $request = new Request('GET', 'http://foo.com/bar');
         $jar = new CookieJar();
         $response = $handler($request, [
-            'allow_redirects' => true,
+            RequestOptions::ALLOW_REDIRECTS => true,
             'cookies' => $jar
         ])->wait();
         self::assertSame(200, $response->getStatusCode());

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RedirectMiddleware;
+use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
@@ -51,7 +52,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com?a=b');
         $promise = $handler($request, [
-            'allow_redirects' => ['max' => 2]
+            RequestOptions::ALLOW_REDIRECTS => ['max' => 2]
         ]);
         $response = $promise->wait();
         self::assertSame(200, $response->getStatusCode());
@@ -69,7 +70,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com?a=b');
         $promise = $handler($request, [
-            'allow_redirects' => ['max' => 2]
+            RequestOptions::ALLOW_REDIRECTS => ['max' => 2]
         ]);
         $response = $promise->wait();
         self::assertSame(200, $response->getStatusCode());
@@ -88,7 +89,7 @@ class RedirectMiddlewareTest extends TestCase
         $stack->push(Middleware::redirect());
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com');
-        $promise = $handler($request, ['allow_redirects' => ['max' => 3]]);
+        $promise = $handler($request, [RequestOptions::ALLOW_REDIRECTS => ['max' => 3]]);
 
         $this->expectException(\GuzzleHttp\Exception\TooManyRedirectsException::class);
         $this->expectExceptionMessage('Will not follow more than 3 redirects');
@@ -107,7 +108,7 @@ class RedirectMiddlewareTest extends TestCase
 
         $this->expectException(\GuzzleHttp\Exception\BadResponseException::class);
         $this->expectExceptionMessage('Redirect URI,');
-        $handler($request, ['allow_redirects' => ['max' => 3]])->wait();
+        $handler($request, [RequestOptions::ALLOW_REDIRECTS => ['max' => 3]])->wait();
     }
 
     public function testAddsRefererHeader()
@@ -121,7 +122,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com?a=b');
         $promise = $handler($request, [
-            'allow_redirects' => ['max' => 2, 'referer' => true]
+            RequestOptions::ALLOW_REDIRECTS => ['max' => 2, 'referer' => true]
         ]);
         $promise->wait();
         self::assertSame(
@@ -141,7 +142,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://foo:bar@example.com?a=b');
         $promise = $handler($request, [
-            'allow_redirects' => ['max' => 2, 'referer' => true]
+            RequestOptions::ALLOW_REDIRECTS => ['max' => 2, 'referer' => true]
         ]);
         $promise->wait();
         self::assertSame(
@@ -164,7 +165,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com?a=b');
         $promise = $handler($request, [
-            'allow_redirects' => ['track_redirects' => true]
+            RequestOptions::ALLOW_REDIRECTS => ['track_redirects' => true]
         ]);
         $response = $promise->wait(true);
         self::assertSame(
@@ -192,7 +193,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com?a=b');
         $promise = $handler($request, [
-            'allow_redirects' => ['track_redirects' => true]
+            RequestOptions::ALLOW_REDIRECTS => ['track_redirects' => true]
         ]);
         $response = $promise->wait(true);
         self::assertSame(
@@ -217,7 +218,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'https://example.com?a=b');
         $promise = $handler($request, [
-            'allow_redirects' => ['max' => 2, 'referer' => true]
+            RequestOptions::ALLOW_REDIRECTS => ['max' => 2, 'referer' => true]
         ]);
         $promise->wait();
         self::assertFalse($mock->getLastRequest()->hasHeader('Referer'));
@@ -235,7 +236,7 @@ class RedirectMiddlewareTest extends TestCase
         $request = new Request('GET', 'http://example.com?a=b');
         $call = false;
         $promise = $handler($request, [
-            'allow_redirects' => [
+            RequestOptions::ALLOW_REDIRECTS => [
                 'max' => 2,
                 'on_redirect' => function ($request, $response, $uri) use (&$call) {
                     self::assertSame(302, $response->getStatusCode());


### PR DESCRIPTION
\GuzzleHttp\RequestOptions class contains 30 constants, but in project code still use string literals instead of constants. I decided to try replace allow_redirects with a constant to see reaction of project maintainers. If PR will be merged i want to continue replace other strings to constants.