### PR TITLE
 Enable php-cs-fixer binary_operator_spaces (ignoring double-arrows)

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -5,6 +5,7 @@ $config = PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'binary_operator_spaces' => ['operators' => ['=>' => null]],
         'blank_line_after_opening_tag' => true,
         'compact_nullable_typehint' => true,
         'concat_space' => ['spacing' => 'one'],

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -254,7 +254,7 @@ class CookieJar implements CookieJarInterface
     private function getCookiePathFromRequest(RequestInterface $request): string
     {
         $uriPath = $request->getUri()->getPath();
-        if (''  === $uriPath) {
+        if ('' === $uriPath) {
             return '/';
         }
         if (0 !== \strpos($uriPath, '/')) {

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -216,7 +216,7 @@ class CurlFactory implements CurlFactoryInterface
     private function getDefaultConf(EasyHandle $easy): array
     {
         $conf = [
-            '_headers'             => $easy->request->getHeaders(),
+            '_headers'              => $easy->request->getHeaders(),
             \CURLOPT_CUSTOMREQUEST  => $easy->request->getMethod(),
             \CURLOPT_URL            => (string) $easy->request->getUri()->withFragment(''),
             \CURLOPT_RETURNTRANSFER => false,

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -478,7 +478,7 @@ class CurlFactory implements CurlFactoryInterface
                 }
             }
 
-            $sslKey = $sslKey?? $options['ssl_key'];
+            $sslKey = $sslKey ?? $options['ssl_key'];
 
             if (!\file_exists($sslKey)) {
                 throw new \InvalidArgumentException(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -624,7 +624,7 @@ class ClientTest extends TestCase
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['base_uri' => 'http://127.0.0.1:8585', 'handler' => $mockHandler]);
-        $request = new Request('GET', '/test', ['Host'=>'foo.com']);
+        $request = new Request('GET', '/test', ['Host' => 'foo.com']);
 
         $client->send($request);
 
@@ -635,7 +635,7 @@ class ClientTest extends TestCase
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['base_uri' => 'http://foo2.com', 'handler' => $mockHandler]);
-        $request = new Request('GET', '/test', ['Host'=>'foo.com']);
+        $request = new Request('GET', '/test', ['Host' => 'foo.com']);
 
         $client->send($request);
 
@@ -664,7 +664,7 @@ class ClientTest extends TestCase
     public function testOnlyAddSchemeWhenHostIsPresent()
     {
         $mockHandler = new MockHandler([new Response()]);
-        $client = new Client(['handler'  => $mockHandler]);
+        $client = new Client(['handler' => $mockHandler]);
 
         $client->request('GET', 'baz');
         self::assertSame(

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -419,11 +419,11 @@ class SetCookieTest extends TestCase
                 true,
             ],
             [
-                'FOO=bar; expires=' . \date(\DateTime::RFC1123, \time()+10) . ';',
+                'FOO=bar; expires=' . \date(\DateTime::RFC1123, \time() + 10) . ';',
                 false,
             ],
             [
-                'FOO=bar; expires=' . \date(\DateTime::RFC1123, \time()-10) . ';',
+                'FOO=bar; expires=' . \date(\DateTime::RFC1123, \time() - 10) . ';',
                 true,
             ],
             [

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -297,7 +297,7 @@ class CurlFactoryTest extends TestCase
         if ($withEncoding) {
             $headers['Content-Encoding'] = 'gzip';
         }
-        $response  = new Psr7\Response(200, $headers, $content);
+        $response = new Psr7\Response(200, $headers, $content);
         Server::flush();
         Server::enqueue([$response]);
         return $content;

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -35,7 +35,7 @@ class FunctionsTest extends TestCase
          * @see https://xdebug.org/docs/display#overload_var_dump
          */
         if (extension_loaded('xdebug')) {
-            $originalOverload =  ini_get('xdebug.overload_var_dump');
+            $originalOverload = ini_get('xdebug.overload_var_dump');
             ini_set('xdebug.overload_var_dump', 0);
         }
 


### PR DESCRIPTION
https://github.com/guzzle/guzzle/pull/2682#discussion_r439739193