### PR TITLE
Fix an issue where cookies with an empty string were not stored.

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -392,9 +392,10 @@ class SetCookie
                 . 'following characters: ()<>@,;:\"/?={}';
         }
 
-        // Value must not be empty, but can be 0
+        // Value must not be null. 0 and empty string are valid. Empty strings
+        // are technically against RFC 6265, but known to happen in the wild.
         $value = $this->getValue();
-        if (empty($value) && !\is_numeric($value)) {
+        if ($value === null) {
             return 'The cookie value must not be empty';
         }
 

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -159,8 +159,9 @@ class SetCookieTest extends TestCase
             ['foo', 'baz', 'bar', true],
             ['0', '0', '0', true],
             ['foo[bar]', 'baz', 'bar', true],
+            ['foo', '', 'bar', true],
             ['', 'baz', 'bar', 'The cookie name must not be empty'],
-            ['foo', '', 'bar', 'The cookie value must not be empty'],
+            ['foo', null, 'bar', 'The cookie value must not be empty'],
             ['foo', 'baz', '', 'The cookie domain must not be empty'],
             ["foo\r", 'baz', '0', 'Cookie name must not contain invalid characters: ASCII Control characters (0-31;127), space, tab and the following characters: ()<>@,;:\"/?={}'],
         ];


### PR DESCRIPTION
This is a re-creation of PR #1991, with the requested fix in it and based off master.

Cookies with empty string values are technically a violation of RFC 6265, but this issue is known to occur in the wild (I personally encountered it in dealing with a SAP application server). Browsers handle it property.

Test was also fixed an an additional test for empty string was added.