### PR TITLE
[7.0] Fix multiply defined functions fatal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ## UNRELEASED
 
+## 7.0.1 - 2020-06-27
+
+* Fix multiply defined functions fatal error [#2699](https://github.com/guzzle/guzzle/pull/2699)
+
 ## 7.0.0 - 2020-06-27
 
 No changes since 7.0.0-rc1.

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,6 +1,6 @@
 <?php
 
 // Don't redefine the functions if included multiple times.
-if (!\function_exists('GuzzleHttp\_current_time')) {
+if (!\function_exists('GuzzleHttp\describe_type')) {
     require __DIR__ . '/functions.php';
 }


### PR DESCRIPTION
I think we need to cut a 7.0 branch for this, and release as 7.0.1 ASAP.