### PR TITLE
Avoid "functions" from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ## UNRELEASED
 
+### Changed
+
+* Avoid "functions" from dependencies [#2712](https://github.com/guzzle/guzzle/pull/2712)
+
 ## 7.1.1 - 2020-09-30
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
-        "guzzlehttp/promises": "^1.0",
-        "guzzlehttp/psr7": "^1.6.1",
+        "guzzlehttp/promises": "^1.4",
+        "guzzlehttp/psr7": "^1.7",
         "psr/http-client": "^1.0"
     },
     "provide": {

--- a/docs/psr7.rst
+++ b/docs/psr7.rst
@@ -106,7 +106,7 @@ headers:
         'Link' => '<http:/.../front.jpeg>; rel="front"; type="image/jpeg"'
     ]);
 
-    $parsed = Psr7\parse_header($request->getHeader('Link'));
+    $parsed = Psr7\Header::parse($request->getHeader('Link'));
     var_export($parsed);
 
 Will output:
@@ -147,9 +147,9 @@ a message in a stream that uses PHP temp streams. When the size of the body
 exceeds 2 MB, the stream will automatically switch to storing data on disk
 rather than in memory (protecting your application from memory exhaustion).
 
-The easiest way to create a body for a message is using the ``stream_for``
-function from the ``GuzzleHttp\Psr7`` namespace --
-``GuzzleHttp\Psr7\stream_for``. This function accepts strings, resources,
+The easiest way to create a body for a message is using the ``streamFor``
+method from the ``GuzzleHttp\Psr7\Utils`` class --
+``Utils::streamFor``. This method accepts strings, resources,
 callables, iterators, other streamables, and returns an instance of
 ``Psr\Http\Message\StreamInterface``.
 
@@ -372,8 +372,8 @@ stream resource, and stream decorators can be found in the
 Creating Streams
 ----------------
 
-The best way to create a stream is using the ``GuzzleHttp\Psr7\stream_for``
-function. This function accepts strings, resources returned from ``fopen()``,
+The best way to create a stream is using the ``GuzzleHttp\Psr7\Utils::streamFor``
+method. This method accepts strings, resources returned from ``fopen()``,
 an object that implements ``__toString()``, iterators, callables, and instances
 of ``Psr\Http\Message\StreamInterface``.
 
@@ -381,7 +381,7 @@ of ``Psr\Http\Message\StreamInterface``.
 
     use GuzzleHttp\Psr7;
 
-    $stream = Psr7\stream_for('string data');
+    $stream = Psr7\Utils::streamFor('string data');
     echo $stream;
     // string data
     echo $stream->read(3);
@@ -408,7 +408,7 @@ requested by a stream consumer will be buffered until a subsequent read.
     };
 
     $iter = $generator(1024);
-    $stream = Psr7\stream_for($iter);
+    $stream = Psr7\Utils::streamFor($iter);
     echo $stream->read(3); // ...
 
 
@@ -425,7 +425,7 @@ and can optionally expose other custom data.
     use GuzzleHttp\Psr7;
 
     $resource = fopen('/path/to/file', 'r');
-    $stream = Psr7\stream_for($resource);
+    $stream = Psr7\Utils::streamFor($resource);
     echo $stream->getMetadata('uri');
     // /path/to/file
     var_export($stream->isReadable());

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -185,14 +185,14 @@ requests.
 
     // Wait for the requests to complete; throws a ConnectException
     // if any of the requests fail
-    $responses = Promise\unwrap($promises);
+    $responses = Promise\Utils::unwrap($promises);
     
     // You can access each response using the key of the promise
     echo $responses['image']->getHeader('Content-Length')[0];
     echo $responses['png']->getHeader('Content-Length')[0];
 
     // Wait for the requests to complete, even if some of them fail
-    $responses = Promise\settle($promises)->wait();
+    $responses = Promise\Utils::settle($promises)->wait();
 
     // Values returned above are wrapped in an array with 2 keys: "state" (either fulfilled or rejected) and "value" (contains the response)
     echo $responses['image']['state']; // returns "fulfilled"
@@ -351,8 +351,8 @@ resource returned from ``fopen``, or an instance of a
     $body = fopen('/path/to/file', 'r');
     $r = $client->request('POST', 'http://httpbin.org/post', ['body' => $body]);
 
-    // Use the stream_for() function to create a PSR-7 stream.
-    $body = \GuzzleHttp\Psr7\stream_for('hello!');
+    // Use the Utils::streamFor method to create a PSR-7 stream.
+    $body = \GuzzleHttp\Psr7\Utils::streamFor('hello!');
     $r = $client->request('POST', 'http://httpbin.org/post', ['body' => $body]);
 
 An easy way to upload JSON data and set the appropriate header is using the
@@ -557,9 +557,9 @@ Guzzle throws exceptions for errors that occur during a transfer.
       try {
           $client->request('GET', 'https://github.com/_abc_123_404');
       } catch (RequestException $e) {
-          echo Psr7\str($e->getRequest());
+          echo Psr7\Message::toString($e->getRequest());
           if ($e->hasResponse()) {
-              echo Psr7\str($e->getResponse());
+              echo Psr7\Message::toString($e->getResponse());
           }
       }
 
@@ -581,8 +581,8 @@ Guzzle throws exceptions for errors that occur during a transfer.
       try {
           $client->request('GET', 'https://github.com/_abc_123_404');
       } catch (ClientException $e) {
-          echo Psr7\str($e->getRequest());
-          echo Psr7\str($e->getResponse());
+          echo Psr7\Message::toString($e->getRequest());
+          echo Psr7\Message::toString($e->getResponse());
       }
 
 - A ``GuzzleHttp\Exception\ServerException`` is thrown for 500 level

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -211,7 +211,7 @@ This setting can be set to any of the following types:
   .. code-block:: php
 
       // You can send requests that use a Guzzle stream object as the body
-      $stream = GuzzleHttp\Psr7\stream_for('contents...');
+      $stream = GuzzleHttp\Psr7\Utils::streamFor('contents...');
       $client->request('POST', '/post', ['body' => $stream]);
 
 .. note::
@@ -916,7 +916,7 @@ body to an open PSR-7 stream.
 .. code-block:: php
 
     $resource = fopen('/path/to/file', 'w');
-    $stream = GuzzleHttp\Psr7\stream_for($resource);
+    $stream = GuzzleHttp\Psr7\Utils::streamFor($resource);
     $client->request('GET', '/stream/20', ['save_to' => $stream]);
 
 .. note::

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -102,7 +102,7 @@ class RequestException extends TransferException implements RequestExceptionInte
             $response->getReasonPhrase()
         );
 
-        $summary = \GuzzleHttp\Psr7\get_message_body_summary($response);
+        $summary = \GuzzleHttp\Psr7\Message::bodySummary($response);
 
         if ($summary !== null) {
             $message .= ":\n{$summary}\n";

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\LazyOpenStream;
@@ -180,7 +181,7 @@ class CurlFactory implements CurlFactoryInterface
         // If an exception was encountered during the onHeaders event, then
         // return a rejected promise that wraps that exception.
         if ($easy->onHeadersException) {
-            return \GuzzleHttp\Promise\rejection_for(
+            return P\Create::rejectionFor(
                 new RequestException(
                     'An error was encountered during the on_headers event',
                     $easy->request,
@@ -207,7 +208,7 @@ class CurlFactory implements CurlFactoryInterface
             ? new ConnectException($message, $easy->request, null, $ctx)
             : new RequestException($message, $easy->request, $easy->response, null, $ctx);
 
-        return \GuzzleHttp\Promise\rejection_for($error);
+        return P\Create::rejectionFor($error);
     }
 
     /**

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -154,7 +154,7 @@ class CurlMultiHandler
         }
 
         // Step through the task queue which may add additional requests.
-        P\queue()->run();
+        P\Utils::queue()->run();
 
         if ($this->active &&
             \curl_multi_select($this->_mh, $this->selectTimeout) === -1
@@ -174,7 +174,7 @@ class CurlMultiHandler
      */
     public function execute(): void
     {
-        $queue = P\queue();
+        $queue = P\Utils::queue();
 
         while ($this->handles || !$queue->isEmpty()) {
             // If there are no transfers, then sleep for the next delay

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Utils;
@@ -113,8 +114,8 @@ class MockHandler implements \Countable
         }
 
         $response = $response instanceof \Throwable
-            ? \GuzzleHttp\Promise\rejection_for($response)
-            : \GuzzleHttp\Promise\promise_for($response);
+            ? P\Create::rejectionFor($response)
+            : P\Create::promiseFor($response);
 
         return $response->then(
             function (?ResponseInterface $value) use ($request, $options) {
@@ -143,7 +144,7 @@ class MockHandler implements \Countable
                 if ($this->onRejected) {
                     ($this->onRejected)($reason);
                 }
-                return \GuzzleHttp\Promise\rejection_for($reason);
+                return P\Create::rejectionFor($reason);
             }
         );
     }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
@@ -74,7 +75,7 @@ class StreamHandler
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
 
-            return \GuzzleHttp\Promise\rejection_for($e);
+            return P\Create::rejectionFor($e);
         }
     }
 
@@ -114,7 +115,7 @@ class StreamHandler
         $reason = $parts[2] ?? null;
         $headers = Utils::headersFromLines($hdrs);
         [$stream, $headers] = $this->checkDecode($options, $headers, $stream);
-        $stream = Psr7\stream_for($stream);
+        $stream = Psr7\Utils::streamFor($stream);
         $sink = $stream;
 
         if (\strcasecmp('HEAD', $request->getMethod())) {
@@ -129,7 +130,7 @@ class StreamHandler
             } catch (\Exception $e) {
                 $msg = 'An error was encountered during the on_headers event';
                 $ex = new RequestException($msg, $request, $response, $e);
-                return \GuzzleHttp\Promise\rejection_for($ex);
+                return P\Create::rejectionFor($ex);
             }
         }
 
@@ -159,7 +160,7 @@ class StreamHandler
 
         return \is_string($sink)
             ? new Psr7\LazyOpenStream($sink, 'w+')
-            : Psr7\stream_for($sink);
+            : Psr7\Utils::streamFor($sink);
     }
 
     /**
@@ -174,7 +175,7 @@ class StreamHandler
                 $encoding = $headers[$normalizedKeys['content-encoding']];
                 if ($encoding[0] === 'gzip' || $encoding[0] === 'deflate') {
                     $stream = new Psr7\InflateStream(
-                        Psr7\stream_for($stream)
+                        Psr7\Utils::streamFor($stream)
                     );
                     $headers['x-encoded-content-encoding']
                         = $headers[$normalizedKeys['content-encoding']];
@@ -216,7 +217,7 @@ class StreamHandler
         // that number of bytes has been read. This can prevent infinitely
         // reading from a stream when dealing with servers that do not honor
         // Connection: Close headers.
-        Psr7\copy_to_stream(
+        Psr7\Utils::copyToStream(
             $source,
             $sink,
             (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -86,10 +86,10 @@ class MessageFormatter implements MessageFormatterInterface
                 $result = '';
                 switch ($matches[1]) {
                     case 'request':
-                        $result = Psr7\str($request);
+                        $result = Psr7\Message::toString($request);
                         break;
                     case 'response':
-                        $result = $response ? Psr7\str($response) : '';
+                        $result = $response ? Psr7\Message::toString($response) : '';
                         break;
                     case 'req_headers':
                         $result = \trim($request->getMethod()

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -104,7 +105,7 @@ final class Middleware
                             'error'    => $reason,
                             'options'  => $options
                         ];
-                        return \GuzzleHttp\Promise\rejection_for($reason);
+                        return P\Create::rejectionFor($reason);
                     }
                 );
             };
@@ -205,9 +206,9 @@ final class Middleware
                         $response = $reason instanceof RequestException
                             ? $reason->getResponse()
                             : null;
-                        $message = $formatter->format($request, $response, \GuzzleHttp\Promise\exception_for($reason));
+                        $message = $formatter->format($request, $response, P\Create::exceptionFor($reason));
                         $logger->error($message);
-                        return \GuzzleHttp\Promise\rejection_for($reason);
+                        return P\Create::rejectionFor($reason);
                     }
                 );
             };

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -2,6 +2,7 @@
 
 namespace GuzzleHttp;
 
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
@@ -53,7 +54,7 @@ class Pool implements PromisorInterface
             $opts = [];
         }
 
-        $iterable = \GuzzleHttp\Promise\iter_for($requests);
+        $iterable = P\Create::iterFor($requests);
         $requests = static function () use ($iterable, $client, $opts) {
             foreach ($iterable as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -40,7 +40,7 @@ class PrepareBodyMiddleware
         // Add a default content-type if possible.
         if (!$request->hasHeader('Content-Type')) {
             if ($uri = $request->getBody()->getMetadata('uri')) {
-                if (is_string($uri) && $type = Psr7\mimetype_from_filename($uri)) {
+                if (is_string($uri) && $type = Psr7\MimeType::fromFilename($uri)) {
                     $modify['set_headers']['Content-Type'] = $type;
                 }
             }
@@ -61,7 +61,7 @@ class PrepareBodyMiddleware
         // Add the expect header if needed.
         $this->addExpectHeader($request, $options, $modify);
 
-        return $fn(Psr7\modify_request($request, $modify), $options);
+        return $fn(Psr7\Utils::modifyRequest($request, $modify), $options);
     }
 
     /**

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -184,7 +184,7 @@ class RedirectMiddleware
         }
 
         $modify['uri'] = $uri;
-        Psr7\rewind_body($request);
+        Psr7\Message::rewindBody($request);
 
         // Add the Referer header if it is told to do so and only
         // add the header if we are not redirecting from https to http.
@@ -202,7 +202,7 @@ class RedirectMiddleware
             $modify['remove_headers'][] = 'Authorization';
         }
 
-        return Psr7\modify_request($request, $modify);
+        return Psr7\Utils::modifyRequest($request, $modify);
     }
 
     /**

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace GuzzleHttp;
 
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -103,7 +104,7 @@ class RetryMiddleware
                 null,
                 $reason
             )) {
-                return \GuzzleHttp\Promise\rejection_for($reason);
+                return P\Create::rejectionFor($reason);
             }
             return $this->doRetry($req, $options);
         };

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -2,7 +2,9 @@
 
 namespace GuzzleHttp\Tests\Exception;
 
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
@@ -32,7 +34,7 @@ class RequestExceptionTest extends TestCase
     {
         $e = RequestException::create(new Request('GET', '/'));
         self::assertSame('Error completing request', $e->getMessage());
-        self::assertInstanceOf(\GuzzleHttp\Exception\RequestException::class, $e);
+        self::assertInstanceOf(RequestException::class, $e);
     }
 
     public function testCreatesClientErrorResponseException()
@@ -46,7 +48,7 @@ class RequestExceptionTest extends TestCase
             '400 Bad Request',
             $e->getMessage()
         );
-        self::assertInstanceOf(\GuzzleHttp\Exception\ClientException::class, $e);
+        self::assertInstanceOf(ClientException::class, $e);
     }
 
     public function testCreatesServerErrorResponseException()
@@ -60,7 +62,7 @@ class RequestExceptionTest extends TestCase
             '500 Internal Server Error',
             $e->getMessage()
         );
-        self::assertInstanceOf(\GuzzleHttp\Exception\ServerException::class, $e);
+        self::assertInstanceOf(ServerException::class, $e);
     }
 
     public function testCreatesGenericErrorResponseException()
@@ -74,7 +76,7 @@ class RequestExceptionTest extends TestCase
             '300 ',
             $e->getMessage()
         );
-        self::assertInstanceOf(\GuzzleHttp\Exception\RequestException::class, $e);
+        self::assertInstanceOf(RequestException::class, $e);
     }
 
     public function testThrowsInvalidArgumentExceptionOnOutOfBoundsResponseCode()
@@ -112,7 +114,7 @@ class RequestExceptionTest extends TestCase
             $content,
             $e->getMessage()
         );
-        self::assertInstanceOf(\GuzzleHttp\Exception\RequestException::class, $e);
+        self::assertInstanceOf(RequestException::class, $e);
     }
 
     public function testCreatesExceptionWithTruncatedSummary()
@@ -141,7 +143,7 @@ class RequestExceptionTest extends TestCase
         $e = new \Exception('foo');
         $r = new Request('GET', 'http://www.oo.com');
         $ex = RequestException::wrapException($r, $e);
-        self::assertInstanceOf(\GuzzleHttp\Exception\RequestException::class, $ex);
+        self::assertInstanceOf(RequestException::class, $ex);
         self::assertSame($e, $ex->getPrevious());
     }
 

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlHandler;
+use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -26,7 +27,7 @@ class CurlHandlerTest extends TestCase
         $handler = new CurlHandler();
         $request = new Request('GET', 'http://localhost:123');
 
-        $this->expectException(\GuzzleHttp\Exception\ConnectException::class);
+        $this->expectException(ConnectException::class);
         $this->expectExceptionMessage('cURL');
         $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])->wait();
     }
@@ -38,8 +39,8 @@ class CurlHandlerTest extends TestCase
         Server::enqueue([$response, $response]);
         $a = new CurlHandler();
         $request = new Request('GET', Server::$url);
-        self::assertInstanceOf(\GuzzleHttp\Promise\FulfilledPromise::class, $a($request, []));
-        self::assertInstanceOf(\GuzzleHttp\Promise\FulfilledPromise::class, $a($request, []));
+        self::assertInstanceOf(FulfilledPromise::class, $a($request, []));
+        self::assertInstanceOf(FulfilledPromise::class, $a($request, []));
     }
 
     public function testDoesSleep()
@@ -71,7 +72,7 @@ class CurlHandlerTest extends TestCase
     {
         Server::flush();
         Server::enqueue([new Response()]);
-        $stream = Psr7\stream_for(\str_repeat('.', 1000000));
+        $stream = Psr7\Utils::streamFor(\str_repeat('.', 1000000));
         $handler = new CurlHandler();
         $request = new Request(
             'PUT',

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -2,7 +2,9 @@
 
 namespace GuzzleHttp\Tests\Handler;
 
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Tests\Helpers;
@@ -48,7 +50,7 @@ class CurlMultiHandlerTest extends TestCase
     {
         $a = new CurlMultiHandler();
 
-        $this->expectException(\GuzzleHttp\Exception\ConnectException::class);
+        $this->expectException(ConnectException::class);
         $this->expectExceptionMessage('cURL error');
         $a(new Request('GET', 'http://localhost:123'), [])->wait();
     }
@@ -73,7 +75,7 @@ class CurlMultiHandlerTest extends TestCase
         }
 
         foreach ($responses as $r) {
-            self::assertSame('rejected', $r->getState());
+            self::assertTrue(P\Is::rejected($r));
         }
     }
 
@@ -85,7 +87,7 @@ class CurlMultiHandlerTest extends TestCase
         $response = $a(new Request('GET', Server::$url), []);
         $response->wait();
         $response->cancel();
-        self::assertSame('fulfilled', $response->getState());
+        self::assertTrue(P\Is::fulfilled($response));
     }
 
     public function testDelaysConcurrently()

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -2,9 +2,12 @@
 
 namespace GuzzleHttp\Test\Handler;
 
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\TransferStats;
 use PHPUnit\Framework\TestCase;
 
@@ -102,7 +105,7 @@ class MockHandlerTest extends TestCase
 
     public function testSinkStream()
     {
-        $stream = new \GuzzleHttp\Psr7\Stream(\tmpfile());
+        $stream = new Stream(\tmpfile());
         $res = new Response(200, [], 'TEST CONTENT');
         $mock = new MockHandler([$res]);
         $request = new Request('GET', '/');
@@ -146,7 +149,7 @@ class MockHandlerTest extends TestCase
             }
         ]);
 
-        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+        $this->expectException(RequestException::class);
         $this->expectExceptionMessage('An error was encountered during the on_headers event');
         $promise->wait();
     }
@@ -189,7 +192,7 @@ class MockHandlerTest extends TestCase
         $mock = MockHandler::createWithMiddleware([$r]);
         $request = new Request('GET', 'http://example.com');
 
-        $this->expectException(\GuzzleHttp\Exception\BadResponseException::class);
+        $this->expectException(BadResponseException::class);
         $mock($request, ['http_errors' => true])->wait();
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\StreamHandler;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
@@ -55,7 +56,7 @@ class StreamHandlerTest extends TestCase
     {
         $handler = new StreamHandler();
 
-        $this->expectException(\GuzzleHttp\Exception\ConnectException::class);
+        $this->expectException(ConnectException::class);
         $handler(
             new Request('GET', 'http://localhost:123'),
             ['timeout' => 0.01]
@@ -262,7 +263,7 @@ class StreamHandlerTest extends TestCase
 
     public function testAddsProxy()
     {
-        $this->expectException(\GuzzleHttp\Exception\ConnectException::class);
+        $this->expectException(ConnectException::class);
         $this->expectExceptionMessage('Connection refused');
 
         $this->getSendResult(['proxy' => '127.0.0.1:8125']);
@@ -298,7 +299,7 @@ class StreamHandlerTest extends TestCase
 
     public function testVerifiesVerifyIsValidIfPath()
     {
-        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+        $this->expectException(RequestException::class);
         $this->expectExceptionMessage('SSL CA bundle not found: /does/not/exist');
 
         $this->getSendResult(['verify' => '/does/not/exist']);
@@ -307,12 +308,12 @@ class StreamHandlerTest extends TestCase
     public function testVerifyCanBeDisabled()
     {
         $handler = $this->getSendResult(['verify' => false]);
-        self::assertInstanceOf(\GuzzleHttp\Psr7\Response::class, $handler);
+        self::assertInstanceOf(Response::class, $handler);
     }
 
     public function testVerifiesCertIfValidPath()
     {
-        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+        $this->expectException(RequestException::class);
         $this->expectExceptionMessage('SSL certificate not found: /does/not/exist');
 
         $this->getSendResult(['cert' => '/does/not/exist']);
@@ -527,7 +528,7 @@ class StreamHandlerTest extends TestCase
             }
         ]);
 
-        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+        $this->expectException(RequestException::class);
         $this->expectExceptionMessage('An error was encountered during the on_headers event');
         $promise->wait();
     }
@@ -541,7 +542,7 @@ class StreamHandlerTest extends TestCase
         $req = new Request('GET', Server::$url);
         $got = null;
 
-        $stream = Psr7\stream_for();
+        $stream = Psr7\Utils::streamFor();
         $stream = FnStream::decorate($stream, [
             'write' => static function ($data) use ($stream, &$got) {
                 self::assertNotNull($got);

--- a/tests/InternalUtilsTest.php
+++ b/tests/InternalUtilsTest.php
@@ -18,7 +18,7 @@ class InternalUtilsTest extends TestCase
      */
     public function testIdnConvert()
     {
-        $uri = Psr7\uri_for('https://яндекс.рф/images');
+        $uri = Psr7\Utils::uriFor('https://яндекс.рф/images');
         $uri = Utils::idnUriConvert($uri);
         self::assertSame('xn--d1acpjx3f.xn--p1ai', $uri->getHost());
     }

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -44,16 +44,16 @@ class MessageFormatterTest extends TestCase
 
     public function formatProvider()
     {
-        $request = new Request('PUT', '/', ['x-test' => 'abc'], Psr7\stream_for('foo'));
-        $response = new Response(200, ['X-Baz' => 'Bar'], Psr7\stream_for('baz'));
+        $request = new Request('PUT', '/', ['x-test' => 'abc'], Psr7\Utils::streamFor('foo'));
+        $response = new Response(200, ['X-Baz' => 'Bar'], Psr7\Utils::streamFor('baz'));
         $err = new RequestException('Test', $request, $response);
 
         return [
-            ['{request}', [$request], Psr7\str($request)],
-            ['{response}', [$request, $response], Psr7\str($response)],
-            ['{request} {response}', [$request, $response], Psr7\str($request) . ' ' . Psr7\str($response)],
+            ['{request}', [$request], Psr7\Message::toString($request)],
+            ['{response}', [$request, $response], Psr7\Message::toString($response)],
+            ['{request} {response}', [$request, $response], Psr7\Message::toString($request) . ' ' . Psr7\Message::toString($response)],
             // Empty response yields no value
-            ['{request} {response}', [$request], Psr7\str($request) . ' '],
+            ['{request} {response}', [$request], Psr7\Message::toString($request) . ' '],
             ['{req_headers}', [$request], "PUT / HTTP/1.1\r\nx-test: abc"],
             ['{res_headers}', [$request, $response], "HTTP/1.1 200 OK\r\nX-Baz: Bar"],
             ['{res_headers}', [$request], 'NULL'],

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -54,7 +54,7 @@ class PrepareBodyMiddlewareTest extends TestCase
 
     public function testAddsTransferEncodingWhenNoContentLength()
     {
-        $body = FnStream::decorate(Psr7\stream_for('foo'), [
+        $body = FnStream::decorate(Psr7\Utils::streamFor('foo'), [
             'getSize' => static function () {
                 return null;
             }
@@ -78,7 +78,7 @@ class PrepareBodyMiddlewareTest extends TestCase
 
     public function testAddsContentTypeWhenMissingAndPossible()
     {
-        $bd = Psr7\stream_for(\fopen(__DIR__ . '/../composer.json', 'r'));
+        $bd = Psr7\Utils::streamFor(\fopen(__DIR__ . '/../composer.json', 'r'));
         $h = new MockHandler([
             static function (RequestInterface $request) {
                 self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
@@ -111,7 +111,7 @@ class PrepareBodyMiddlewareTest extends TestCase
      */
     public function testAddsExpect($value, $result)
     {
-        $bd = Psr7\stream_for(\fopen(__DIR__ . '/../composer.json', 'r'));
+        $bd = Psr7\Utils::streamFor(\fopen(__DIR__ . '/../composer.json', 'r'));
 
         $h = new MockHandler([
             static function (RequestInterface $request) use ($result) {
@@ -134,7 +134,7 @@ class PrepareBodyMiddlewareTest extends TestCase
 
     public function testIgnoresIfExpectIsPresent()
     {
-        $bd = Psr7\stream_for(\fopen(__DIR__ . '/../composer.json', 'r'));
+        $bd = Psr7\Utils::streamFor(\fopen(__DIR__ . '/../composer.json', 'r'));
         $h = new MockHandler([
             static function (RequestInterface $request) {
                 self::assertSame(['Foo'], $request->getHeader('Expect'));

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -3,6 +3,8 @@
 namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -91,7 +93,7 @@ class RedirectMiddlewareTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $promise = $handler($request, ['allow_redirects' => ['max' => 3]]);
 
-        $this->expectException(\GuzzleHttp\Exception\TooManyRedirectsException::class);
+        $this->expectException(TooManyRedirectsException::class);
         $this->expectExceptionMessage('Will not follow more than 3 redirects');
         $promise->wait();
     }
@@ -106,7 +108,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com');
 
-        $this->expectException(\GuzzleHttp\Exception\BadResponseException::class);
+        $this->expectException(BadResponseException::class);
         $this->expectExceptionMessage('Redirect URI,');
         $handler($request, ['allow_redirects' => ['max' => 3]])->wait();
     }


### PR DESCRIPTION
The aim of this PR is to avoid the use of functions provided by our dependencies. This means using their new Utils classes, and bumping their minimum versions (`guzzlehttp/promises:^1.4`; `guzzlehttp/psr7:^1.7`). Note that similar changes were already implemented for Guzzle 7.0 itself, but not its dependencies, which we are going to address now, for Guzzle 7.1.

### TODO:

- [x] Implement upstream `guzzlehttp/promises` changes (https://github.com/guzzle/promises/pull/113)
- [x] Implement upstream `guzzlehttp/psr7` changes (https://github.com/guzzle/psr7/pull/345)
- [x] Merge https://github.com/guzzle/guzzle/pull/2720 and perform 6.5 -> 7.1 merge
- [x] Update `composer.json` with `^1.4` and `^1.7`
- [x] Replace all uses of functions with their static method replacements
- [x] Update documentation and examples
- [x] Tag `guzzlehttp/promises` 1.4.0 and remove `@dev`
- [x] Tag `guzzlehttp/psr7` 1.7.0 and remove `@dev`
- [x] Update change log

### Mappings:

| Original Function | Replacement Method |
|----------------|----------------|
| `GuzzleHttp\Promise\queue` | `GuzzleHttp\Promise\Utils::queue` |
| `GuzzleHttp\Promise\task` | `GuzzleHttp\Promise\Utils::task` |
| `GuzzleHttp\Promise\promise_for` | `GuzzleHttp\Promise\Create::promiseFor` |
| `GuzzleHttp\Promise\rejection_for` | `GuzzleHttp\Promise\Create::rejectionFor` |
| `GuzzleHttp\Promise\exception_for` | `GuzzleHttp\Promise\Create::exceptionFor` |
| `GuzzleHttp\Promise\iter_for` | `GuzzleHttp\Promise\Create::iterFor` |
| `GuzzleHttp\Promise\inspect` | `GuzzleHttp\Promise\Utils::inspect` |
| `GuzzleHttp\Promise\inspect_all` | `GuzzleHttp\Promise\Utils::inspectAll` |
| `GuzzleHttp\Promise\unwrap` | `GuzzleHttp\Promise\Utils::unwrap` |
| `GuzzleHttp\Promise\all` | `GuzzleHttp\Promise\Utils::all` |
| `GuzzleHttp\Promise\some` | `GuzzleHttp\Promise\Utils::some` |
| `GuzzleHttp\Promise\any` | `GuzzleHttp\Promise\Utils::any` |
| `GuzzleHttp\Promise\settle` | `GuzzleHttp\Promise\Utils::settle` |
| `GuzzleHttp\Promise\each` | `GuzzleHttp\Promise\Each::of` |
| `GuzzleHttp\Promise\each_limit` | `GuzzleHttp\Promise\Each::ofLimit` |
| `GuzzleHttp\Promise\each_limit_all` | `GuzzleHttp\Promise\Each::ofLimitAll` |
| `!GuzzleHttp\Promise\is_fulfilled` | `GuzzleHttp\Promise\Is::pending` |
| `GuzzleHttp\Promise\is_fulfilled` | `GuzzleHttp\Promise\Is::fulfilled` |
| `GuzzleHttp\Promise\is_rejected` | `GuzzleHttp\Promise\Is::rejected` |
| `GuzzleHttp\Promise\is_settled` | `GuzzleHttp\Promise\Is::settled` |
| `GuzzleHttp\Promise\coroutine` | `GuzzleHttp\Promise\Coroutine::of` |
| `GuzzleHttp\Psr7\str` | `GuzzleHttp\Psr7\Message::toString` |
| `GuzzleHttp\Psr7\uri_for` | `GuzzleHttp\Psr7\Utils::uriFor` |
| `GuzzleHttp\Psr7\stream_for` | `GuzzleHttp\Psr7\Utils::streamFor` |
| `GuzzleHttp\Psr7\parse_header` | `GuzzleHttp\Psr7\Header::parse` |
| `GuzzleHttp\Psr7\normalize_header` | `GuzzleHttp\Psr7\Header::normalize` |
| `GuzzleHttp\Psr7\modify_request` | `GuzzleHttp\Psr7\Utils::modifyRequest` |
| `GuzzleHttp\Psr7\rewind_body` | `GuzzleHttp\Psr7\Message::rewindBody` |
| `GuzzleHttp\Psr7\try_fopen` | `GuzzleHttp\Psr7\Utils::tryFopen` |
| `GuzzleHttp\Psr7\copy_to_string` | `GuzzleHttp\Psr7\Utils::copyToString` |
| `GuzzleHttp\Psr7\copy_to_stream` | `GuzzleHttp\Psr7\Utils::copyToStream` |
| `GuzzleHttp\Psr7\hash` | `GuzzleHttp\Psr7\Utils::hash` |
| `GuzzleHttp\Psr7\readline` | `GuzzleHttp\Psr7\Utils::readLine` |
| `GuzzleHttp\Psr7\parse_request` | `GuzzleHttp\Psr7\Message::parseRequest` |
| `GuzzleHttp\Psr7\parse_response` | `GuzzleHttp\Psr7\Message::parseResponse` |
| `GuzzleHttp\Psr7\parse_query` | `GuzzleHttp\Psr7\Query::parse` |
| `GuzzleHttp\Psr7\build_query` | `GuzzleHttp\Psr7\Query::build` |
| `GuzzleHttp\Psr7\mimetype_from_filename` | `GuzzleHttp\Psr7\MimeType::fromFilename` |
| `GuzzleHttp\Psr7\mimetype_from_extension` | `GuzzleHttp\Psr7\MimeType::fromExtension` |
| `GuzzleHttp\Psr7\_parse_message` | `GuzzleHttp\Psr7\Message::parseMessage` |
| `GuzzleHttp\Psr7\_parse_request_uri` | `GuzzleHttp\Psr7\Message::parseRequestUri` |
| `GuzzleHttp\Psr7\get_message_body_summary` | `GuzzleHttp\Psr7\Message::bodySummary` |
| `GuzzleHttp\Psr7\_caseless_remove` | `GuzzleHttp\Psr7\Utils::caselessRemove` |

---

Closes #2740.