### PR TITLE
Add GitHub Actions builds for PHP 8 in experimental mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,15 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       max-parallel: 10
       matrix:
         php: ['7.2', '7.3', '7.4']
+        experimental: [false]
+        include:
+          - php: 8.0
+            experimental: true
 
     steps:
       - name: Set up PHP
@@ -66,7 +71,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download dependencies
+        if: matrix.php != '8.0'
         run: composer update --no-interaction --prefer-dist
+
+      - name: Download dependencies (ignore-platform-req)
+        if: matrix.php == '8.0'
+        run: composer update --no-interaction --prefer-dist --ignore-platform-req=php
 
       - name: Run tests
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Download dependencies
-        if: matrix.php != '8.0'
         run: composer update --no-interaction --prefer-dist
-
-      - name: Download dependencies (ignore-platform-req)
-        if: matrix.php == '8.0'
-        run: composer update --no-interaction --prefer-dist --ignore-platform-req=php
 
       - name: Run tests
         run: make test


### PR DESCRIPTION
Related: #2702

Guzzle currently fails to run tests on PHP 8 due to [`CurlHandle` migration](https://php.watch/versions/8.0/resource-CurlHandle) and `method_exists()` function throwing a `\TypeError` exception due to [internal functions enforcing types](https://php.watch/versions/8.0/internal-function-exceptions). 

This PR:

- Update composer.json PHP version requirements to allow PHP 8
- Update GitHub Actions to allow experimental PHP 8 builds
  - Update the PHP version matrix to include PHP 8 builds
  - Add a PHP8-only task that runs `composer install` with [`--ignore-platform-req=php`](https://php.watch/articles/composer-ignore-platform-req) flag.
  - Add a new experimental true/false matrix to allow overall build status to pass even if PHP 8 builds fail.