### PR TITLE
Update Curl is_resource() to work with PHP 8 CurlHandle and CurlMultiHandle objects

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,9 +6,99 @@ parameters:
 			path: src/Client.php
 
 		-
+			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlFactory\\:\\:\\$handles has unknown class CurlHandle as its type\\.$#"
+			count: 1
+			path: src/Handler/CurlFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$ch of function curl_setopt_array expects resource, CurlHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$ch of function curl_close expects resource, CurlHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$ch of function curl_setopt expects resource, CurlHandle\\|resource given\\.$#"
+			count: 4
+			path: src/Handler/CurlFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$ch of function curl_reset expects resource, CurlHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$ch of function curl_getinfo expects resource, CurlHandle\\|resource given\\.$#"
+			count: 4
+			path: src/Handler/CurlFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$ch of function curl_error expects resource, CurlHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlFactory.php
+
+		-
 			message: "#^Parameter \\#1 \\$str1 of function strcasecmp expects string, int\\|string given\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$ch of function curl_exec expects resource, CurlHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$ch of function curl_errno expects resource, CurlHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlHandler.php
+
+		-
+			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:\\$active has unknown class CurlMultiHandle as its type\\.$#"
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: "#^Return typehint of method GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:__get\\(\\) has invalid type CurlMultiHandle\\.$#"
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$mh of function curl_multi_close expects resource, CurlMultiHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$mh of function curl_multi_add_handle expects resource, CurlMultiHandle\\|resource given\\.$#"
+			count: 2
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$mh of function curl_multi_select expects resource, CurlMultiHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$mh of function curl_multi_exec expects resource, CurlMultiHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$mh of function curl_multi_remove_handle expects resource, CurlMultiHandle\\|resource given\\.$#"
+			count: 2
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$mh of function curl_multi_info_read expects resource, CurlMultiHandle\\|resource given\\.$#"
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: "#^Property GuzzleHttp\\\\Handler\\\\EasyHandle\\:\\:\\$handle has unknown class CurlHandle as its type\\.$#"
+			count: 1
+			path: src/Handler/EasyHandle.php
 
 		-
 			message: "#^Argument of an invalid type \\(array\\|null\\) supplied for foreach, only iterables are supported\\.$#"
@@ -19,3 +109,4 @@ parameters:
 			message: "#^Result of && is always false\\.$#"
 			count: 2
 			path: src/Middleware.php
+

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.11.5@3c60609c218d4d4b3b257728b8089094e5c6c6c2">
+<files psalm-version="3.16@d03e5ef057d6adc656c0ff7e166c50b73b4f48f3">
   <file src="src/Client.php">
-    <NullArgument occurrences="1">
-      <code>null</code>
-    </NullArgument>
     <PossiblyUndefinedVariable occurrences="1">
       <code>$options</code>
     </PossiblyUndefinedVariable>
@@ -22,28 +19,59 @@
     </ImplicitToStringCast>
   </file>
   <file src="src/Handler/CurlFactory.php">
-    <ImplicitToStringCast occurrences="1">
-      <code>$easy-&gt;request-&gt;getUri()</code>
-    </ImplicitToStringCast>
+    <PossiblyInvalidArgument occurrences="12">
+      <code>$easy-&gt;handle</code>
+      <code>$easy-&gt;handle</code>
+      <code>$easy-&gt;handle</code>
+      <code>$easy-&gt;handle</code>
+      <code>$easy-&gt;handle</code>
+      <code>$easy-&gt;handle</code>
+      <code>$resource</code>
+      <code>$resource</code>
+      <code>$resource</code>
+      <code>$resource</code>
+      <code>$resource</code>
+      <code>$resource</code>
+    </PossiblyInvalidArgument>
     <TypeDoesNotContainType occurrences="1">
       <code>$timeoutRequiresNoSignal &amp;&amp; \strtoupper(\substr(\PHP_OS, 0, 3)) !== 'WIN'</code>
     </TypeDoesNotContainType>
+    <UndefinedDocblockClass occurrences="2">
+      <code>private $handles = [];</code>
+      <code>resource[]|\CurlHandle[]</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Handler/CurlHandler.php">
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$easy-&gt;handle</code>
+      <code>$easy-&gt;handle</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Handler/CurlMultiHandler.php">
-    <InvalidArgument occurrences="1">
-      <code>$this-&gt;active</code>
-    </InvalidArgument>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;active</code>
     </InvalidPropertyAssignmentValue>
+    <PossiblyInvalidArgument occurrences="7">
+      <code>$this-&gt;_mh</code>
+      <code>$this-&gt;_mh</code>
+      <code>$this-&gt;_mh</code>
+      <code>$this-&gt;_mh</code>
+      <code>$this-&gt;_mh</code>
+      <code>$this-&gt;_mh</code>
+      <code>$this-&gt;_mh</code>
+    </PossiblyInvalidArgument>
+    <UndefinedDocblockClass occurrences="2">
+      <code>resource|\CurlMultiHandle</code>
+      <code>resource|\CurlMultiHandle|null</code>
+    </UndefinedDocblockClass>
     <UndefinedThisPropertyAssignment occurrences="1">
       <code>$this-&gt;_mh</code>
     </UndefinedThisPropertyAssignment>
   </file>
-  <file src="src/Handler/MockHandler.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>$options['delay'] * 1000</code>
-    </InvalidScalarArgument>
+  <file src="src/Handler/EasyHandle.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>resource|\CurlHandle</code>
+    </UndefinedDocblockClass>
   </file>
   <file src="src/Handler/StreamHandler.php">
     <ImplicitToStringCast occurrences="1">
@@ -80,8 +108,5 @@
     <ForbiddenCode occurrences="1">
       <code>\var_dump($input)</code>
     </ForbiddenCode>
-    <PossiblyNullArgument occurrences="1">
-      <code>$info</code>
-    </PossiblyNullArgument>
   </file>
 </files>

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -27,7 +27,7 @@ class CurlFactory implements CurlFactoryInterface
     public const LOW_CURL_VERSION_NUMBER = '7.21.2';
 
     /**
-     * @var resource[]
+     * @var resource[]|\CurlHandle[]
      */
     private $handles = [];
 

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\RequestInterface;
  * associative array of curl option constants mapping to values in the
  * **curl** key of the provided request options.
  *
- * @property resource $_mh Internal use only. Lazy loaded multi-handle.
+ * @property resource|\CurlMultiHandle $_mh Internal use only. Lazy loaded multi-handle.
  *
  * @final
  */
@@ -32,7 +32,7 @@ class CurlMultiHandler
     private $selectTimeout;
 
     /**
-     * @var resource|null the currently executing resource in `curl_multi_exec`.
+     * @var resource|\CurlMultiHandle|null the currently executing resource in `curl_multi_exec`.
      */
     private $active;
 
@@ -83,7 +83,7 @@ class CurlMultiHandler
     /**
      * @param string $name
      *
-     * @return resource
+     * @return resource|\CurlMultiHandle
      *
      * @throws \BadMethodCallException when another field as `_mh` will be gotten
      * @throws \RuntimeException       when curl can not initialize a multi handle

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\StreamInterface;
 final class EasyHandle
 {
     /**
-     * @var resource cURL resource
+     * @var resource|\CurlHandle cURL resource
      */
     public $handle;
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -49,7 +49,11 @@ class CurlFactoryTest extends TestCase
         $f = new Handler\CurlFactory(3);
         $result = $f->create($request, ['sink' => $stream]);
         self::assertInstanceOf(EasyHandle::class, $result);
-        self::assertIsResource($result->handle);
+        if (\PHP_VERSION_ID >= 80000) {
+            self::assertInstanceOf(\CurlHandle::class, $result->handle);
+        } else {
+            self::assertIsResource($result->handle);
+        }
         self::assertIsArray($result->headers);
         self::assertSame($stream, $result->sink);
         \curl_close($result->handle);


### PR DESCRIPTION
Updates `is_resource()` calls for curl handlers to properly work with PHP 8's `\CurlHandle` and `\CurlMultiHandle` objects.
See https://php.watch/versions/8.0/resource-CurlHandle

PHPDoc comments are updated to indicate that the variable/property can be either a resource or a Curl object.
In PHP 8, `curl_close()` calls are no-op, and and explicit `unset()` call is added to ensure the `\CurlHandle` object is destroyed.

---

This PR depends on #2714 (to enable tests). 
Related: #2702

---

On manual/forced PHP 8 [tests](https://github.com/Ayesh/guzzle/runs/816178711#step:8:336), there are two failures related to this repo (and 10 errors related to `promises`).

```
There were 2 failures:

1) GuzzleHttp\Test\Handler\CurlFactoryTest::testCreatesCurlHandle
Failed asserting that CurlHandle Object &00000000184dcf9b000000006cc08298 () is of type "resource".

##[error]/home/runner/work/guzzle/guzzle/tests/Handler/CurlFactoryTest.php:49

2) GuzzleHttp\Test\Handler\CurlFactoryTest::testEmitsProgressToFunction
Failed asserting that actual size 5 matches expected size 4.

##[error]/home/runner/work/guzzle/guzzle/tests/Handler/CurlFactoryTest.php:289

ERRORS!
Tests: 486, Assertions: 2092, Errors: 10, Failures: 2, Skipped: 5.
```

This PR fixes the two failures related to this repo:

```
Tests: 486, Assertions: 2120, Errors: 10, Skipped: 5.
```