### PR TITLE
Removed PHP 5 work arounds and fix PHP 8 call_user_* issues

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
+			message: "#^Argument of an invalid type \\(array\\|null\\) supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Handler/StreamHandler.php
+
+		-
 			message: "#^Result of && is always false\\.$#"
 			count: 2
 			path: src/Middleware.php

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -497,13 +497,8 @@ class CurlFactory implements CurlFactoryInterface
                 );
             }
             $conf[\CURLOPT_NOPROGRESS] = false;
-            $conf[\CURLOPT_PROGRESSFUNCTION] = static function () use ($progress) {
-                $args = \func_get_args();
-                // PHP 5.5 pushed the handle onto the start of the args
-                if (\is_resource($args[0])) {
-                    \array_shift($args);
-                }
-                \call_user_func_array($progress, $args);
+            $conf[\CURLOPT_PROGRESSFUNCTION] = static function ($resource, int $downloadSize, int $downloaded, int $uploadSize, int $uploaded) use ($progress) {
+                $progress($downloadSize, $downloaded, $uploadSize, $uploaded);
             };
         }
 

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -77,7 +77,8 @@ class MockHandler implements \Countable
         $this->onRejected = $onRejected;
 
         if ($queue) {
-            \call_user_func_array([$this, 'append'], $queue);
+            // array_values included for BC
+            $this->append(...array_values($queue));
         }
     }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -279,8 +279,8 @@ class CurlFactoryTest extends TestCase
         $called = [];
         $request = new Psr7\Request('HEAD', Server::$url);
         $response = $a($request, [
-            'progress' => static function () use (&$called) {
-                $called[] = \func_get_args();
+            'progress' => static function (...$args) use (&$called) {
+                $called[] = $args;
             },
         ]);
         $response->wait();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -389,8 +389,8 @@ class StreamHandlerTest extends TestCase
         $called = [];
         $this->queueRes();
         $this->getSendResult([
-            'progress' => static function () use (&$called) {
-                $called[] = \func_get_args();
+            'progress' => static function (...$args) use (&$called) {
+                $called[] = $args;
             },
         ]);
         self::assertNotEmpty($called);
@@ -405,8 +405,8 @@ class StreamHandlerTest extends TestCase
         $buffer = \fopen('php://memory', 'w+');
         $this->getSendResult([
             'debug'    => $buffer,
-            'progress' => static function () use (&$called) {
-                $called[] = \func_get_args();
+            'progress' => static function (...$args) use (&$called) {
+                $called[] = $args;
             },
         ]);
         self::assertNotEmpty($called);

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -34,7 +34,7 @@ class MessageFormatterTest extends TestCase
     /**
      * @dataProvider dateProvider
      */
-    public function testFormatsTimestamps($format, $pattern)
+    public function testFormatsTimestamps(string $format, string $pattern)
     {
         $f = new MessageFormatter($format);
         $request = new Request('GET', '/');
@@ -86,9 +86,9 @@ class MessageFormatterTest extends TestCase
     /**
      * @dataProvider formatProvider
      */
-    public function testFormatsMessages($template, $args, $result)
+    public function testFormatsMessages(string $template, array $args, $result)
     {
         $f = new MessageFormatter($template);
-        self::assertSame((string) $result, \call_user_func_array([$f, 'format'], $args));
+        self::assertSame((string) $result, $f->format(...$args));
     }
 }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -16,8 +16,8 @@ class RetryMiddlewareTest extends TestCase
     {
         $delayCalls = 0;
         $calls = [];
-        $decider = static function ($retries, $request, $response, $error) use (&$calls) {
-            $calls[] = \func_get_args();
+        $decider = static function (...$args) use (&$calls) {
+            $calls[] = $args;
             return \count($calls) < 3;
         };
         $delay = static function ($retries, $response) use (&$delayCalls) {
@@ -52,9 +52,9 @@ class RetryMiddlewareTest extends TestCase
     public function testCanRetryExceptions()
     {
         $calls = [];
-        $decider = static function ($retries, $request, $response, $error) use (&$calls) {
-            $calls[] = \func_get_args();
-            return $error instanceof \Exception;
+        $decider = static function (...$args) use (&$calls) {
+            $calls[] = $args;
+            return $args[3] instanceof \Exception;
         };
         $m = Middleware::retry($decider);
         $h = new MockHandler([new \Exception(), new Response(201)]);


### PR DESCRIPTION
// cc @gmponos this safely removes `call_user_func_array` too