### PR TITLE
Be explicit and replace string casting with __toString function

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -7,6 +7,7 @@ $config = PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'binary_operator_spaces' => ['operators' => ['=>' => null]],
         'blank_line_after_opening_tag' => true,
+        'cast_spaces' => ['space' => 'single'],
         'class_attributes_separation' => ['elements' => ['method']],
         'compact_nullable_typehint' => true,
         'concat_space' => ['spacing' => 'one'],

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -196,7 +196,7 @@ class CurlFactory implements CurlFactoryInterface
             $ctx['error'],
             'see https://curl.haxx.se/libcurl/c/libcurl-errors.html'
         );
-        $uriString = (string) $easy->request->getUri();
+        $uriString = $easy->request->getUri()->__toString();
         if ($uriString !== '' && false === \strpos($ctx['error'], $uriString)) {
             $message .= \sprintf(' for %s', $uriString);
         }
@@ -217,7 +217,7 @@ class CurlFactory implements CurlFactoryInterface
         $conf = [
             '_headers'              => $easy->request->getHeaders(),
             \CURLOPT_CUSTOMREQUEST  => $easy->request->getMethod(),
-            \CURLOPT_URL            => (string) $easy->request->getUri()->withFragment(''),
+            \CURLOPT_URL            => $easy->request->getUri()->withFragment('')->__toString(),
             \CURLOPT_RETURNTRANSFER => false,
             \CURLOPT_HEADER         => false,
             \CURLOPT_CONNECTTIMEOUT => 150,
@@ -277,7 +277,7 @@ class CurlFactory implements CurlFactoryInterface
         if (($size !== null && $size < 1000000) ||
             !empty($options['_body_as_string'])
         ) {
-            $conf[\CURLOPT_POSTFIELDS] = (string) $request->getBody();
+            $conf[\CURLOPT_POSTFIELDS] = $request->getBody()->__toString();
             // Don't duplicate the Content-Length header
             $this->removeHeader('Content-Length', $conf);
             $this->removeHeader('Transfer-Encoding', $conf);

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -121,7 +121,7 @@ class MockHandler implements \Countable
                 }
 
                 if ($value !== null && isset($options['sink'])) {
-                    $contents = (string) $value->getBody();
+                    $contents = $value->getBody()->__toString();
                     $sink = $options['sink'];
 
                     if (\is_resource($sink)) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -327,12 +327,12 @@ class StreamHandler
 
         return $this->createResource(
             function () use ($uri, &$http_response_header, $contextResource, $context, $options, $request) {
-                $resource = \fopen((string) $uri, 'r', false, $contextResource);
+                $resource = \fopen($uri->__toString(), 'r', false, $contextResource);
                 $this->lastHeaders = $http_response_header;
 
                 if (false === $resource) {
                     throw new ConnectException(
-                        sprintf('Connection refused for URI %s', $uri),
+                        sprintf('Connection refused for URI %s', $uri->__toString()),
                         $request,
                         null,
                         $context
@@ -406,7 +406,7 @@ class StreamHandler
             ],
         ];
 
-        $body = (string) $request->getBody();
+        $body = $request->getBody()->__toString();
 
         if (!empty($body)) {
             $context['http']['content'] = $body;

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -103,7 +103,7 @@ class RedirectMiddleware
         if (!empty($options['allow_redirects']['track_redirects'])) {
             return $this->withTracking(
                 $promise,
-                (string) $nextRequest->getUri(),
+                $nextRequest->getUri()->__toString(),
                 $response->getStatusCode()
             );
         }
@@ -190,7 +190,7 @@ class RedirectMiddleware
             && $modify['uri']->getScheme() === $request->getUri()->getScheme()
         ) {
             $uri = $request->getUri()->withUserInfo('');
-            $modify['set_headers']['Referer'] = (string) $uri;
+            $modify['set_headers']['Referer'] = $uri->__toString();
         } else {
             $modify['remove_headers'][] = 'Referer';
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -85,7 +85,7 @@ class ClientTest extends TestCase
         $client->get('baz');
         self::assertSame(
             'http://foo.com/bar/baz',
-            (string)$mock->getLastRequest()->getUri()
+            $mock->getLastRequest()->getUri()->__toString()
         );
     }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -310,8 +310,8 @@ class CurlFactoryTest extends TestCase
         $request = new Psr7\Request('GET', Server::$url);
         $response = $handler($request, ['decode_content' => true]);
         $response = $response->wait();
-        self::assertEquals('test', (string) $response->getBody());
-        self::assertEquals('', $_SERVER['_curl'][\CURLOPT_ENCODING]);
+        self::assertSame('test', $response->getBody()->__toString());
+        self::assertSame('', $_SERVER['_curl'][\CURLOPT_ENCODING]);
         $sent = Server::received()[0];
         self::assertFalse($sent->hasHeader('Accept-Encoding'));
     }
@@ -343,7 +343,7 @@ class CurlFactoryTest extends TestCase
         self::assertEquals('gzip', $_SERVER['_curl'][\CURLOPT_ENCODING]);
         $sent = Server::received()[0];
         self::assertEquals('gzip', $sent->getHeaderLine('Accept-Encoding'));
-        self::assertEquals('test', (string) $response->getBody());
+        self::assertEquals('test', $response->getBody()->__toString());
         self::assertFalse($response->hasHeader('content-encoding'));
         self::assertTrue(
             !$response->hasHeader('content-length') ||
@@ -360,7 +360,7 @@ class CurlFactoryTest extends TestCase
         $response = $response->wait();
         $sent = Server::received()[0];
         self::assertFalse($sent->hasHeader('Accept-Encoding'));
-        self::assertEquals($content, (string) $response->getBody());
+        self::assertEquals($content, $response->getBody()->__toString());
     }
 
     public function testProtocolVersion()
@@ -523,7 +523,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame('OK', $response->getReasonPhrase());
         self::assertSame('Hello', $response->getHeaderLine('Test'));
         self::assertSame('4', $response->getHeaderLine('Content-Length'));
-        self::assertSame('test', (string) $response->getBody());
+        self::assertSame('test', $response->getBody()->__toString());
     }
 
     public function testCreatesConnectException()
@@ -661,7 +661,7 @@ class CurlFactoryTest extends TestCase
         $response = $promise->wait();
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('bar', $response->getHeaderLine('X-Foo'));
-        self::assertSame('abc 123', (string) $response->getBody());
+        self::assertSame('abc 123', $response->getBody()->__toString());
     }
 
     public function testInvokesOnStatsOnSuccess()

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -56,7 +56,7 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $response = $promise->wait();
         self::assertSame(200, $response->getStatusCode());
-        self::assertSame('http://test.com', (string)$mock->getLastRequest()->getUri());
+        self::assertSame('http://test.com', $mock->getLastRequest()->getUri()->__toString());
     }
 
     public function testRedirectsWithRelativeUri()
@@ -74,7 +74,7 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $response = $promise->wait();
         self::assertSame(200, $response->getStatusCode());
-        self::assertSame('http://example.com/foo', (string)$mock->getLastRequest()->getUri());
+        self::assertSame('http://example.com/foo', $mock->getLastRequest()->getUri()->__toString());
     }
 
     public function testLimitsToMaxRedirects()

--- a/tests/Server.php
+++ b/tests/Server.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -58,7 +59,7 @@ class Server
             if (!($response instanceof ResponseInterface)) {
                 throw new \Exception('Invalid response given.');
             }
-            $headers = \array_map(static function ($h) {
+            $headers = \array_map(static function ($h): string {
                 return \implode(' ,', $h);
             }, $response->getHeaders());
 
@@ -66,7 +67,7 @@ class Server
                 'status'  => (string) $response->getStatusCode(),
                 'reason'  => $response->getReasonPhrase(),
                 'headers' => $headers,
-                'body'    => \base64_encode((string) $response->getBody())
+                'body'    => \base64_encode($response->getBody()->__toString())
             ];
         }
 
@@ -78,7 +79,7 @@ class Server
     /**
      * Get all of the received requests
      *
-     * @return ResponseInterface[]
+     * @return RequestInterface[]
      *
      * @throws \RuntimeException
      */


### PR DESCRIPTION
Why?

Let's just for a moment imagine that `$response->getBody()` will return an int for WHATEVER THE HELL reason.. this will still work:

`(string) $response->getBody()`.. So replacing it with `__toString()` makes things strict. 

Do we care? yes they are edge cases what so ever but I think we should promote this.

This PR also includes https://github.com/guzzle/guzzle/issues/2498#issuecomment-657200787
