### PR TITLE
Add MessageFormatterInterface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12,7 +12,7 @@ parameters:
 
 		-
 			message: "#^Result of && is always false\\.$#"
-			count: 1
+			count: 2
 			path: src/Middleware.php
 
 		-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,7 +4,6 @@ includes:
 parameters:
     level: max
     checkMissingIterableValueType: false
-    reportUnmatchedIgnoredErrors: false
     paths:
         - src
     bootstrapFiles:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,7 @@ includes:
 parameters:
     level: max
     checkMissingIterableValueType: false
+    reportUnmatchedIgnoredErrors: false
     paths:
         - src
     bootstrapFiles:

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -43,8 +43,6 @@ class MessageFormatter implements MessageFormatterInterface
      * @link https://httpd.apache.org/docs/2.4/logs.html#common
      *
      * @var string
-     *
-     * @deprecated log format constants will be moved into MessageFormatterInterface in guzzlehttp/guzzle:8.0.
      */
     public const CLF = "{hostname} {req_header_User-Agent} - [{date_common_log}] \"{method} {target} HTTP/{version}\" {code} {res_header_Content-Length}";
     public const DEBUG = ">>>>>>>>\n{request}\n<<<<<<<<\n{response}\n--------\n{error}";

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -38,6 +38,19 @@ use Psr\Http\Message\ResponseInterface;
 class MessageFormatter implements MessageFormatterInterface
 {
     /**
+     * Apache Common Log Format.
+     *
+     * @link https://httpd.apache.org/docs/2.4/logs.html#common
+     *
+     * @var string
+     *
+     * @deprecated log format constants will be moved into MessageFormatterInterface in guzzlehttp/guzzle:8.0.
+     */
+    public const CLF = "{hostname} {req_header_User-Agent} - [{date_common_log}] \"{method} {target} HTTP/{version}\" {code} {res_header_Content-Length}";
+    public const DEBUG = ">>>>>>>>\n{request}\n<<<<<<<<\n{response}\n--------\n{error}";
+    public const SHORT = '[{ts}] "{method} {target} HTTP/{version}" {code}';
+
+    /**
      * @var string Template used to format log messages
      */
     private $template;

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -32,20 +32,11 @@ use Psr\Http\Message\ResponseInterface;
  * - {res_headers}:    Response headers
  * - {req_body}:       Request body
  * - {res_body}:       Response body
+ *
+ * @final
  */
-class MessageFormatter
+class MessageFormatter implements MessageFormatterInterface
 {
-    /**
-     * Apache Common Log Format.
-     *
-     * @link https://httpd.apache.org/docs/2.4/logs.html#common
-     *
-     * @var string
-     */
-    public const CLF = "{hostname} {req_header_User-Agent} - [{date_common_log}] \"{method} {target} HTTP/{version}\" {code} {res_header_Content-Length}";
-    public const DEBUG = ">>>>>>>>\n{request}\n<<<<<<<<\n{response}\n--------\n{error}";
-    public const SHORT = '[{ts}] "{method} {target} HTTP/{version}" {code}';
-
     /**
      * @var string Template used to format log messages
      */

--- a/src/MessageFormatterInterface.php
+++ b/src/MessageFormatterInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace GuzzleHttp;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface MessageFormatterInterface
+{
+    /**
+     * Apache Common Log Format.
+     *
+     * @link https://httpd.apache.org/docs/2.4/logs.html#common
+     *
+     * @var string
+     */
+    public const CLF = "{hostname} {req_header_User-Agent} - [{date_common_log}] \"{method} {target} HTTP/{version}\" {code} {res_header_Content-Length}";
+    public const DEBUG = ">>>>>>>>\n{request}\n<<<<<<<<\n{response}\n--------\n{error}";
+    public const SHORT = '[{ts}] "{method} {target} HTTP/{version}" {code}';
+
+    /**
+     * Returns a formatted message string.
+     *
+     * @param RequestInterface       $request  Request that was sent
+     * @param ResponseInterface|null $response Response that was received
+     * @param \Throwable|null        $error    Exception that was received
+     */
+    public function format(
+        RequestInterface $request,
+        ?ResponseInterface $response = null,
+        ?\Throwable $error = null
+    ): string;
+}

--- a/src/MessageFormatterInterface.php
+++ b/src/MessageFormatterInterface.php
@@ -8,17 +8,6 @@ use Psr\Http\Message\ResponseInterface;
 interface MessageFormatterInterface
 {
     /**
-     * Apache Common Log Format.
-     *
-     * @link https://httpd.apache.org/docs/2.4/logs.html#common
-     *
-     * @var string
-     */
-    public const CLF = "{hostname} {req_header_User-Agent} - [{date_common_log}] \"{method} {target} HTTP/{version}\" {code} {res_header_Content-Length}";
-    public const DEBUG = ">>>>>>>>\n{request}\n<<<<<<<<\n{response}\n--------\n{error}";
-    public const SHORT = '[{ts}] "{method} {target} HTTP/{version}" {code}';
-
-    /**
      * Returns a formatted message string.
      *
      * @param RequestInterface       $request  Request that was sent

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -180,14 +180,19 @@ final class Middleware
      *
      * @phpstan-param \Psr\Log\LogLevel::* $logLevel  Level at which to log requests.
      *
-     * @param LoggerInterface           $logger    Logs messages.
-     * @param MessageFormatterInterface $formatter Formatter used to create message strings.
-     * @param string                    $logLevel  Level at which to log requests.
+     * @param LoggerInterface                            $logger    Logs messages.
+     * @param MessageFormatterInterface|MessageFormatter $formatter Formatter used to create message strings.
+     * @param string                                     $logLevel  Level at which to log requests.
      *
      * @return callable Returns a function that accepts the next handler.
      */
-    public static function log(LoggerInterface $logger, MessageFormatterInterface $formatter, string $logLevel = 'info'): callable
+    public static function log(LoggerInterface $logger, $formatter, string $logLevel = 'info'): callable
     {
+        // To be compatible with Guzzle 7.1.x we need to allow users to pass a MessageFormatter
+        if (!$formatter instanceof MessageFormatter && !$formatter instanceof MessageFormatterInterface) {
+            throw new \LogicException(sprintf('Argument 2 to %s::log() must be of type %s', self::class, MessageFormatterInterface::class));
+        }
+
         return static function (callable $handler) use ($logger, $formatter, $logLevel): callable {
             return static function (RequestInterface $request, array $options = []) use ($handler, $logger, $formatter, $logLevel) {
                 return $handler($request, $options)->then(

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -180,13 +180,13 @@ final class Middleware
      *
      * @phpstan-param \Psr\Log\LogLevel::* $logLevel  Level at which to log requests.
      *
-     * @param LoggerInterface  $logger    Logs messages.
-     * @param MessageFormatter $formatter Formatter used to create message strings.
-     * @param string           $logLevel  Level at which to log requests.
+     * @param LoggerInterface           $logger    Logs messages.
+     * @param MessageFormatterInterface $formatter Formatter used to create message strings.
+     * @param string                    $logLevel  Level at which to log requests.
      *
      * @return callable Returns a function that accepts the next handler.
      */
-    public static function log(LoggerInterface $logger, MessageFormatter $formatter, string $logLevel = 'info'): callable
+    public static function log(LoggerInterface $logger, MessageFormatterInterface $formatter, string $logLevel = 'info'): callable
     {
         return static function (callable $handler) use ($logger, $formatter, $logLevel): callable {
             return static function (RequestInterface $request, array $options = []) use ($handler, $logger, $formatter, $logLevel) {


### PR DESCRIPTION
`MessageFormatterInterface` allow custom formatting implementations discussed in [#PR2726](https://github.com/guzzle/guzzle/pull/2726).

One question - move log formats to MessageFormatterInterface? Imho it is ok.