### PR TITLE
Updated PHP version in documentation

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -5,7 +5,7 @@ Overview
 Requirements
 ============
 
-#. PHP 5.5.0
+#. PHP 7.2.5
 #. To use the PHP stream handler, ``allow_url_fopen`` must be enabled in your
    system's php.ini.
 #. To use the cURL handler, you must have a recent version of cURL >= 7.19.4


### PR DESCRIPTION
As composer.json and contributing guidelines state, the minimum version is 7.2.5.