### PR TITLE
Don't set stream timeout when fopen() call has failed (#2265)

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -341,7 +341,7 @@ class StreamHandler
                     );
                 }
 
-                if (isset($options['read_timeout'])) {
+                if (false !== $resource && isset($options['read_timeout'])) {
                     $readTimeout = $options['read_timeout'];
                     $sec = (int) $readTimeout;
                     $usec = ($readTimeout - $sec) * 100000;


### PR DESCRIPTION
The connection to the remote crashes with cryptic error:

`stream_set_timeout() expects parameter 1 to be resource, boolean given`

when call to the `fopen()` method has failed for some reason. The root
cause is that code that tries to set timeout on the stream does not
check `fopen()` result for error indication.

Add check that we really do have valid resource before trying to set
timeout on it.