### PR TITLE
Add Windows CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,44 @@ jobs:
 
       - name: Run tests
         run: make test
+
+  build-windows:
+    name: Build on Windows
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 10
+      matrix:
+        php: ['7.2', '7.3', '7.4']
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: mbstring, intl
+          tools: composer:v2
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Setup Problem Matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download dependencies
+        run: composer update --no-interaction --prefer-dist
+
+      - name: Start test servers
+        shell: bash
+        run: |
+          node tests/server.js &
+          # See https://github.com/php-http/client-integration-tests/issues/46 for the background of the line below.
+          php -S 127.0.0.1:10000 -t "vendor/php-http/client-integration-tests/fixture" &
+
+      - name: Run tests
+        run: vendor/bin/phpunit.bat

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -15,7 +15,7 @@ class FileCookieJarTest extends TestCase
 
     public function setUp(): void
     {
-        $this->file = \tempnam('/tmp', 'file-cookies');
+        $this->file = \tempnam(\sys_get_temp_dir(), 'file-cookies');
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -258,7 +258,7 @@ class CurlFactoryTest extends TestCase
 
     public function testEmitsDebugInfoToStream()
     {
-        $res = \fopen('php://memory', 'r+');
+        $res = \fopen('php://temp', 'r+');
         Server::flush();
         Server::enqueue([new Psr7\Response()]);
         $a = new Handler\CurlMultiHandler();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -118,7 +118,7 @@ class StreamHandlerTest extends TestCase
 
     public function testDrainsResponseIntoSaveToBodyAtPath()
     {
-        $tmpfname = \tempnam('/tmp', 'save_to_path');
+        $tmpfname = \tempnam(\sys_get_temp_dir(), 'save_to_path');
         $this->queueRes();
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
@@ -132,7 +132,7 @@ class StreamHandlerTest extends TestCase
 
     public function testDrainsResponseIntoSaveToBodyAtNonExistentPath()
     {
-        $tmpfname = \tempnam('/tmp', 'save_to_path');
+        $tmpfname = \tempnam(\sys_get_temp_dir(), 'save_to_path');
         \unlink($tmpfname);
         $this->queueRes();
         $handler = new StreamHandler();


### PR DESCRIPTION
As discussed in https://github.com/guzzle/guzzle/pull/2741#issuecomment-696907947 this adds Windows CI based on GitHub Actions. <strike>A single curl test fails. I did not yet look into it in detail. It might or might not be some limitation of the Windows platform.</strike>

I also added an uglyish workaround for https://github.com/php-http/client-integration-tests/issues/46 to get things started. That one should probably be cleaned up. It looks like @Nyholm also is a contributor to the client-integration-tests package, maybe he can help getting the script fixed?

Feel free to push into the windows-ci-clean branch of my fork. I left the "Allow edits by maintainers" checkbox enabled 😄 