### PR TITLE
Fix test randomly fails on Windows

### DIFF
--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -414,7 +414,7 @@ class CurlFactoryTest extends TestCase
         ]);
         $response->wait();
         self::assertStringEqualsFile($tmpfile, 'test');
-        \unlink($tmpfile);
+        @\unlink($tmpfile);
     }
 
     public function testDoesNotAddMultipleContentLengthHeaders()


### PR DESCRIPTION
This test seams to fail 50% of the times because we cannot cleanup after ourselves. 