### PR TITLE
Update GuzzleException.php

### DIFF
--- a/src/Exception/GuzzleException.php
+++ b/src/Exception/GuzzleException.php
@@ -1,23 +1,15 @@
 <?php
 namespace GuzzleHttp\Exception;
 
-use Throwable;
-
-if (interface_exists(Throwable::class)) {
-    interface GuzzleException extends Throwable
-    {
-    }
-} else {
-    /**
-     * @method string getMessage()
-     * @method \Throwable|null getPrevious()
-     * @method mixed getCode()
-     * @method string getFile()
-     * @method int getLine()
-     * @method array getTrace()
-     * @method string getTraceAsString()
-     */
-    interface GuzzleException
-    {
-    }
+/**
+ * @method string getMessage()
+ * @method \Throwable|null getPrevious()
+ * @method mixed getCode()
+ * @method string getFile()
+ * @method int getLine()
+ * @method array getTrace()
+ * @method string getTraceAsString()
+ */
+interface GuzzleException
+{
 }


### PR DESCRIPTION
The version must be compatible with PHP5.6, but the interface Throwable only's present on a PHP7 enviroment.
The system's taht run's on PHP5.6 enviroment don't works.