### PR TITLE
Break up MessageFormatter's format into multiple methods

### DIFF
--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -381,7 +381,8 @@ class MessageFormatter implements MessageFormatterInterface
     protected function formatUnexpectedMatch(
         string $match,
         RequestInterface $request,
-        ?ResponseInterface $response = null): string
+        ?ResponseInterface $response = null
+    ): string
     {
         // handle prefixed dynamic headers
         if (\strpos($match, 'req_header_') === 0) {

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -283,7 +283,7 @@ class MessageFormatter implements MessageFormatterInterface
     /**
      * Formats a request's protocol version.
      *
-     * @param RequestInterface|null $request Request that was sent
+     * @param RequestInterface $request Request that was sent
      */
     protected function formatRequestVersion(RequestInterface $request): string
     {

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -398,7 +398,7 @@ class MessageFormatter implements MessageFormatterInterface
     /**
      * Get headers from message as string
      */
-    private function headers(MessageInterface $message): string
+    protected function headers(MessageInterface $message): string
     {
         $result = '';
         foreach ($message->getHeaders() as $name => $values) {

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -317,7 +317,7 @@ class MessageFormatter implements MessageFormatterInterface
      */
     protected function formatHostname(): string
     {
-        return \gethostname();
+        return (string) \gethostname();
     }
 
     /**
@@ -327,7 +327,7 @@ class MessageFormatter implements MessageFormatterInterface
      */
     protected function formatCode(?ResponseInterface $response = null): string
     {
-        return $response ? strval($response->getStatusCode()) : 'NULL';
+        return $response ? (string) ($response->getStatusCode()) : 'NULL';
     }
 
     /**

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -100,6 +100,7 @@ class MessageFormatter implements MessageFormatterInterface
      * @param RequestInterface       $request  Request that was sent
      * @param ResponseInterface|null $response Response that was received
      * @param \Throwable|null        $error    Exception that was received
+     *
      * @return string
      */
     protected function handleFormatMatch(
@@ -157,7 +158,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a request object.
      *
      * @param RequestInterface $request Request that was sent
-     * @return string
      */
     protected function formatRequest(RequestInterface $request): string
     {
@@ -168,7 +168,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a response object.
      *
      * @param ResponseInterface|null $response Response that was received
-     * @return string
      */
     protected function formatResponse(?ResponseInterface $response = null): string
     {
@@ -179,7 +178,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a request object's headers.
      *
      * @param RequestInterface $request Request that was sent
-     * @return string
      */
     protected function formatRequestHeaders(RequestInterface $request): string
     {
@@ -193,7 +191,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a response object's headers.
      *
      * @param ResponseInterface|null $response Response that was received
-     * @return string
      */
     protected function formatResponseHeaders(?ResponseInterface $response = null): string
     {
@@ -211,7 +208,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a request body.
      *
      * @param RequestInterface $request Request that was sent
-     * @return string
      */
     protected function formatRequestBody(RequestInterface $request): string
     {
@@ -222,7 +218,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a response body.
      *
      * @param ResponseInterface|null $response Response that was received
-     * @return string
      */
     protected function formatResponseBody(?ResponseInterface $response = null): string
     {
@@ -241,8 +236,6 @@ class MessageFormatter implements MessageFormatterInterface
 
     /**
      * Formats a timestamp.
-     *
-     * @return string
      */
     protected function formatTimestamp(): string
     {
@@ -251,8 +244,6 @@ class MessageFormatter implements MessageFormatterInterface
 
     /**
      * Formats a date common log.
-     *
-     * @return string
      */
     protected function formatDateCommonLog(): string
     {
@@ -263,7 +254,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a request method.
      *
      * @param RequestInterface $request Request that was sent
-     * @return string
      */
     protected function formatMethod(RequestInterface $request): string
     {
@@ -274,7 +264,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a request uri.
      *
      * @param RequestInterface $request Request that was sent
-     * @return string
      */
     protected function formatUri(RequestInterface $request): string
     {
@@ -285,7 +274,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a request's target.
      *
      * @param RequestInterface $request Request that was sent
-     * @return string
      */
     protected function formatTarget(RequestInterface $request): string
     {
@@ -296,7 +284,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a request's protocol version.
      *
      * @param RequestInterface|null $request Request that was sent
-     * @return string
      */
     protected function formatRequestVersion(RequestInterface $request = null): string
     {
@@ -307,7 +294,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a response's protocol version.
      *
      * @param ResponseInterface|null $response Response that was received
-     * @return string
      */
     protected function formatResponseVersion(?ResponseInterface $response = null): string
     {
@@ -320,7 +306,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a request's Host header.
      *
      * @param RequestInterface $request Request that was sent
-     * @return string
      */
     protected function formatHost(RequestInterface $request): string
     {
@@ -329,8 +314,6 @@ class MessageFormatter implements MessageFormatterInterface
 
     /**
      * Formats a hostname.
-     *
-     * @return string
      */
     protected function formatHostname(): string
     {
@@ -341,7 +324,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a response's status code.
      *
      * @param ResponseInterface|null $response Response that was received
-     * @return string
      */
     protected function formatCode(?ResponseInterface $response = null): string
     {
@@ -352,7 +334,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats a response's reason phrase.
      *
      * @param ResponseInterface|null $response Response that was received
-     * @return string
      */
     protected function formatPhrase(?ResponseInterface $response = null): string
     {
@@ -363,7 +344,6 @@ class MessageFormatter implements MessageFormatterInterface
      * Formats an error.
      *
      * @param \Throwable|null $error Exception that was received
-     * @return string
      */
     protected function formatError(?\Throwable $error = null): string
     {
@@ -376,14 +356,12 @@ class MessageFormatter implements MessageFormatterInterface
      * @param string                 $match    Match string
      * @param RequestInterface       $request  Request that was sent
      * @param ResponseInterface|null $response Response that was received
-     * @return string
      */
     protected function formatUnexpectedMatch(
         string $match,
         RequestInterface $request,
         ?ResponseInterface $response = null
-    ): string
-    {
+    ): string {
         // handle prefixed dynamic headers
         if (\strpos($match, 'req_header_') === 0) {
             return $request->getHeaderLine(\substr($match, 11));

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -285,7 +285,7 @@ class MessageFormatter implements MessageFormatterInterface
      *
      * @param RequestInterface|null $request Request that was sent
      */
-    protected function formatRequestVersion(RequestInterface $request = null): string
+    protected function formatRequestVersion(RequestInterface $request): string
     {
         return $request->getProtocolVersion();
     }
@@ -327,7 +327,7 @@ class MessageFormatter implements MessageFormatterInterface
      */
     protected function formatCode(?ResponseInterface $response = null): string
     {
-        return $response ? $response->getStatusCode() : 'NULL';
+        return $response ? strval($response->getStatusCode()) : 'NULL';
     }
 
     /**

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -79,111 +79,320 @@ class MessageFormatter implements MessageFormatterInterface
         return \preg_replace_callback(
             '/{\s*([A-Za-z_\-\.0-9]+)\s*}/',
             function (array $matches) use ($request, $response, $error, &$cache) {
-                if (isset($cache[$matches[1]])) {
-                    return $cache[$matches[1]];
+                $match = $matches[1];
+                if (isset($cache[$match])) {
+                    return $cache[$match];
                 }
 
-                $result = '';
-                switch ($matches[1]) {
-                    case 'request':
-                        $result = Psr7\Message::toString($request);
-                        break;
-                    case 'response':
-                        $result = $response ? Psr7\Message::toString($response) : '';
-                        break;
-                    case 'req_headers':
-                        $result = \trim($request->getMethod()
-                                . ' ' . $request->getRequestTarget())
-                            . ' HTTP/' . $request->getProtocolVersion() . "\r\n"
-                            . $this->headers($request);
-                        break;
-                    case 'res_headers':
-                        $result = $response ?
-                            \sprintf(
-                                'HTTP/%s %d %s',
-                                $response->getProtocolVersion(),
-                                $response->getStatusCode(),
-                                $response->getReasonPhrase()
-                            ) . "\r\n" . $this->headers($response)
-                            : 'NULL';
-                        break;
-                    case 'req_body':
-                        $result = $request->getBody()->__toString();
-                        break;
-                    case 'res_body':
-                        if (!$response instanceof ResponseInterface) {
-                            $result = 'NULL';
-                            break;
-                        }
+                $result = $this->handleFormatMatch($match, $request, $response, $error);
+                $cache[$match] = $result;
 
-                        $body = $response->getBody();
-
-                        if (!$body->isSeekable()) {
-                            $result = 'RESPONSE_NOT_LOGGEABLE';
-                            break;
-                        }
-
-                        $result = $response->getBody()->__toString();
-                        break;
-                    case 'ts':
-                    case 'date_iso_8601':
-                        $result = \gmdate('c');
-                        break;
-                    case 'date_common_log':
-                        $result = \date('d/M/Y:H:i:s O');
-                        break;
-                    case 'method':
-                        $result = $request->getMethod();
-                        break;
-                    case 'version':
-                        $result = $request->getProtocolVersion();
-                        break;
-                    case 'uri':
-                    case 'url':
-                        $result = $request->getUri();
-                        break;
-                    case 'target':
-                        $result = $request->getRequestTarget();
-                        break;
-                    case 'req_version':
-                        $result = $request->getProtocolVersion();
-                        break;
-                    case 'res_version':
-                        $result = $response
-                            ? $response->getProtocolVersion()
-                            : 'NULL';
-                        break;
-                    case 'host':
-                        $result = $request->getHeaderLine('Host');
-                        break;
-                    case 'hostname':
-                        $result = \gethostname();
-                        break;
-                    case 'code':
-                        $result = $response ? $response->getStatusCode() : 'NULL';
-                        break;
-                    case 'phrase':
-                        $result = $response ? $response->getReasonPhrase() : 'NULL';
-                        break;
-                    case 'error':
-                        $result = $error ? $error->getMessage() : 'NULL';
-                        break;
-                    default:
-                        // handle prefixed dynamic headers
-                        if (\strpos($matches[1], 'req_header_') === 0) {
-                            $result = $request->getHeaderLine(\substr($matches[1], 11));
-                        } elseif (\strpos($matches[1], 'res_header_') === 0) {
-                            $result = $response
-                                ? $response->getHeaderLine(\substr($matches[1], 11))
-                                : 'NULL';
-                        }
-                }
-
-                $cache[$matches[1]] = $result;
                 return $result;
             },
             $this->template
         );
+    }
+
+    /**
+     * Handles a match when formatting based off of a given template.
+     *
+     * @param string                 $match    Match string
+     * @param RequestInterface       $request  Request that was sent
+     * @param ResponseInterface|null $response Response that was received
+     * @param \Throwable|null        $error    Exception that was received
+     * @return string
+     */
+    protected function handleFormatMatch(
+        string $match,
+        RequestInterface $request,
+        ?ResponseInterface $response = null,
+        ?\Throwable $error = null
+    ) {
+        switch ($match) {
+            case 'request':
+                return $this->formatRequest($request);
+            case 'response':
+                return $this->formatResponse($response);
+            case 'req_headers':
+                return $this->formatRequestHeaders($request);
+            case 'res_headers':
+                return $this->formatResponseHeaders($response);
+            case 'req_body':
+                return $this->formatRequestBody($request);
+            case 'res_body':
+                return $this->formatResponseBody($response);
+            case 'ts':
+            case 'date_iso_8601':
+                return $this->formatTimestamp();
+            case 'date_common_log':
+                return $this->formatDateCommonLog();
+            case 'method':
+                return $this->formatMethod($request);
+            case 'uri':
+            case 'url':
+                return $this->formatUri($request);
+            case 'target':
+                return $this->formatTarget($request);
+            case 'version':
+            case 'req_version':
+                return $this->formatRequestVersion($request);
+            case 'res_version':
+                return $this->formatResponseVersion($response);
+            case 'host':
+                return $this->formatHost($request);
+            case 'hostname':
+                return $this->formatHostname();
+            case 'code':
+                return $this->formatCode($response);
+            case 'phrase':
+                return $this->formatPhrase($response);
+            case 'error':
+                return $this->formatError($error);
+            default:
+                return $this->formatUnexpectedMatch($match, $request, $response);
+        }
+    }
+
+    /**
+     * Formats a request object.
+     *
+     * @param RequestInterface $request Request that was sent
+     * @return string
+     */
+    protected function formatRequest(RequestInterface $request): string
+    {
+        return Psr7\Message::toString($request);
+    }
+
+    /**
+     * Formats a response object.
+     *
+     * @param ResponseInterface|null $response Response that was received
+     * @return string
+     */
+    protected function formatResponse(?ResponseInterface $response = null): string
+    {
+        return $response ? Psr7\Message::toString($response) : '';
+    }
+
+    /**
+     * Formats a request object's headers.
+     *
+     * @param RequestInterface $request Request that was sent
+     * @return string
+     */
+    protected function formatRequestHeaders(RequestInterface $request): string
+    {
+        return \trim($request->getMethod()
+                . ' ' . $request->getRequestTarget())
+            . ' HTTP/' . $request->getProtocolVersion() . "\r\n"
+            . $this->headers($request);
+    }
+
+    /**
+     * Formats a response object's headers.
+     *
+     * @param ResponseInterface|null $response Response that was received
+     * @return string
+     */
+    protected function formatResponseHeaders(?ResponseInterface $response = null): string
+    {
+        return $response ?
+            \sprintf(
+                'HTTP/%s %d %s',
+                $response->getProtocolVersion(),
+                $response->getStatusCode(),
+                $response->getReasonPhrase()
+            ) . "\r\n" . $this->headers($response)
+            : 'NULL';
+    }
+
+    /**
+     * Formats a request body.
+     *
+     * @param RequestInterface $request Request that was sent
+     * @return string
+     */
+    protected function formatRequestBody(RequestInterface $request): string
+    {
+        return $request->getBody()->__toString();
+    }
+
+    /**
+     * Formats a response body.
+     *
+     * @param ResponseInterface|null $response Response that was received
+     * @return string
+     */
+    protected function formatResponseBody(?ResponseInterface $response = null): string
+    {
+        if (!$response instanceof ResponseInterface) {
+            return 'NULL';
+        }
+
+        $body = $response->getBody();
+
+        if (!$body->isSeekable()) {
+            return 'RESPONSE_NOT_LOGGEABLE';
+        }
+
+        return $response->getBody()->__toString();
+    }
+
+    /**
+     * Formats a timestamp.
+     *
+     * @return string
+     */
+    protected function formatTimestamp(): string
+    {
+        return \gmdate('c');
+    }
+
+    /**
+     * Formats a date common log.
+     *
+     * @return string
+     */
+    protected function formatDateCommonLog(): string
+    {
+        return \date('d/M/Y:H:i:s O');
+    }
+
+    /**
+     * Formats a request method.
+     *
+     * @param RequestInterface $request Request that was sent
+     * @return string
+     */
+    protected function formatMethod(RequestInterface $request): string
+    {
+        return $request->getMethod();
+    }
+
+    /**
+     * Formats a request uri.
+     *
+     * @param RequestInterface $request Request that was sent
+     * @return string
+     */
+    protected function formatUri(RequestInterface $request): string
+    {
+        return $request->getUri();
+    }
+
+    /**
+     * Formats a request's target.
+     *
+     * @param RequestInterface $request Request that was sent
+     * @return string
+     */
+    protected function formatTarget(RequestInterface $request): string
+    {
+        return $request->getRequestTarget();
+    }
+
+    /**
+     * Formats a request's protocol version.
+     *
+     * @param RequestInterface|null $request Request that was sent
+     * @return string
+     */
+    protected function formatRequestVersion(RequestInterface $request = null): string
+    {
+        return $request->getProtocolVersion();
+    }
+
+    /**
+     * Formats a response's protocol version.
+     *
+     * @param ResponseInterface|null $response Response that was received
+     * @return string
+     */
+    protected function formatResponseVersion(?ResponseInterface $response = null): string
+    {
+        return $response
+            ? $response->getProtocolVersion()
+            : 'NULL';
+    }
+
+    /**
+     * Formats a request's Host header.
+     *
+     * @param RequestInterface $request Request that was sent
+     * @return string
+     */
+    protected function formatHost(RequestInterface $request): string
+    {
+        return $request->getHeaderLine('Host');
+    }
+
+    /**
+     * Formats a hostname.
+     *
+     * @return string
+     */
+    protected function formatHostname(): string
+    {
+        return \gethostname();
+    }
+
+    /**
+     * Formats a response's status code.
+     *
+     * @param ResponseInterface|null $response Response that was received
+     * @return string
+     */
+    protected function formatCode(?ResponseInterface $response = null): string
+    {
+        return $response ? $response->getStatusCode() : 'NULL';
+    }
+
+    /**
+     * Formats a response's reason phrase.
+     *
+     * @param ResponseInterface|null $response Response that was received
+     * @return string
+     */
+    protected function formatPhrase(?ResponseInterface $response = null): string
+    {
+        return $response ? $response->getReasonPhrase() : 'NULL';
+    }
+
+    /**
+     * Formats an error.
+     *
+     * @param \Throwable|null $error Exception that was received
+     * @return string
+     */
+    protected function formatError(?\Throwable $error = null): string
+    {
+        return $error ? $error->getMessage() : 'NULL';
+    }
+
+    /**
+     * Formats a "default" or unexpected match.
+     *
+     * @param string                 $match    Match string
+     * @param RequestInterface       $request  Request that was sent
+     * @param ResponseInterface|null $response Response that was received
+     * @return string
+     */
+    protected function formatUnexpectedMatch(
+        string $match,
+        RequestInterface $request,
+        ?ResponseInterface $response = null): string
+    {
+        // handle prefixed dynamic headers
+        if (\strpos($match, 'req_header_') === 0) {
+            return $request->getHeaderLine(\substr($match, 11));
+        } elseif (\strpos($match, 'res_header_') === 0) {
+            return $response
+                ? $response->getHeaderLine(\substr($match, 11))
+                : 'NULL';
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
The `MessageFormatter` has a large method, `format`, that handles formatting everything in a `preg_replace_callback` closure.

This PR breaks that up into separate methods for each formatting, as well as `handleFormatMatch`, which is the switch statement to handle ALL matches. This allows a developer to extend this class and override specific formatting or switches - i.e. they could change what formats are expected, or change how they're formatted.