### PR TITLE
Fix "Call to a member function getSize() on null" on HEAD requests

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -805,4 +805,16 @@ class ClientTest extends TestCase
         self::assertSame('https://xn--d1acpjx3f.xn--p1ai/images', (string) $request->getUri());
         self::assertSame('xn--d1acpjx3f.xn--p1ai', (string) $request->getHeaderLine('Host'));
     }
+
+    /**
+     * https://github.com/guzzle/guzzle/issues/2799
+     */
+    public function testGuzzleHeadRequestWithAcceptEncodingHeader(): void
+    {
+        $client = new Client(['headers' => ['accept-encoding' => 'gzip, deflate, br']]);
+
+        $response = $client->head('https://www.youtube.com/watch?v=kiHojsMTBeA');
+
+        self::assertSame(200, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
Related to #2799
Introduced by https://github.com/guzzle/guzzle/commit/4552f37ba6027812d044aa4cdd8f8744b833bff4 (https://github.com/guzzle/guzzle/pull/2778)

A simple test to show that we get an error when attaching `accept-encoding` header to a HEAD request.

The fix is not implemented.

The error is:

````
Error: Call to a member function getSize() on null

/Users/hedii/code/guzzle/src/Handler/EasyHandle.php:89
/Users/hedii/code/guzzle/src/Handler/CurlFactory.php:594
/Users/hedii/code/guzzle/src/Handler/CurlHandler.php:44
/Users/hedii/code/guzzle/src/Handler/Proxy.php:32
/Users/hedii/code/guzzle/src/Handler/Proxy.php:55
/Users/hedii/code/guzzle/src/PrepareBodyMiddleware.php:35
/Users/hedii/code/guzzle/src/Middleware.php:31
/Users/hedii/code/guzzle/src/RedirectMiddleware.php:71
/Users/hedii/code/guzzle/src/Middleware.php:61
/Users/hedii/code/guzzle/src/HandlerStack.php:75
/Users/hedii/code/guzzle/src/Client.php:331
/Users/hedii/code/guzzle/src/Client.php:168
/Users/hedii/code/guzzle/src/Client.php:187
/Users/hedii/code/guzzle/src/ClientTrait.php:61
/Users/hedii/code/guzzle/tests/ClientTest.php:816
````
