### PR TITLE
Fix handling of HEAD requests with Accept-Encoding header

### DIFF
--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -78,6 +78,7 @@ final class EasyHandle
 
         if (!empty($this->options['decode_content'])
             && isset($normalizedKeys['content-encoding'])
+            && $this->request->getMethod() !== 'HEAD'
         ) {
             $headers['x-encoded-content-encoding']
                 = $headers[$normalizedKeys['content-encoding']];

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -358,6 +358,25 @@ class CurlFactoryTest extends TestCase
         );
     }
 
+    /**
+     * https://github.com/guzzle/guzzle/issues/2799
+     */
+    public function testDecodesGzippedResponsesWithHeaderForHeadRequest()
+    {
+        $this->addDecodeResponse();
+        $handler = new Handler\CurlMultiHandler();
+        $request = new Psr7\Request('HEAD', Server::$url, ['Accept-Encoding' => 'gzip']);
+        $response = $handler($request, ['decode_content' => true]);
+        $response = $response->wait();
+        self::assertEquals('gzip', $_SERVER['_curl'][\CURLOPT_ENCODING]);
+        $sent = Server::received()[0];
+        self::assertEquals('gzip', $sent->getHeaderLine('Accept-Encoding'));
+
+        // We do not receive the body for a HEAD request, thus we can't decode it
+        // and the content-encoding must be preserved.
+        self::assertTrue($response->hasHeader('content-encoding'));
+    }
+
     public function testDoesNotForceDecode()
     {
         $content = $this->addDecodeResponse();


### PR DESCRIPTION
Fixes guzzle/guzzle#2799
Resolves guzzle/guzzle#2800