### PR TITLE
Soft mark CURL_VERSION_STR as private

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -19,6 +19,9 @@ use Psr\Http\Message\RequestInterface;
  */
 class CurlFactory implements CurlFactoryInterface
 {
+    /**
+     * @private
+     */
     public const CURL_VERSION_STR = 'curl_version';
 
     /**


### PR DESCRIPTION
To be made private in in 8.0, or just removed and inlined. D'no why this constant was bothered with?