### PR TITLE
Update docs to reflect correct exception when using timeout option

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -1040,7 +1040,7 @@ timeout
 
     // Timeout if a server does not return a response in 3.14 seconds.
     $client->request('GET', '/delay/5', ['timeout' => 3.14]);
-    // PHP Fatal error:  Uncaught exception 'GuzzleHttp\Exception\RequestException'
+    // PHP Fatal error:  Uncaught exception 'GuzzleHttp\Exception\TransferException'
 
 
 .. _version-option:


### PR DESCRIPTION
Per https://github.com/guzzle/guzzle/blob/master/UPGRADING.md 
>Class GuzzleHttp\Exception\ConnectException now extends GuzzleHttp\Exception\TransferException instead of GuzzleHttp\Exception\RequestException.

Updating docs to reflect this.