### PR TITLE
Removed outdated version number.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -28,7 +28,7 @@ Creating a Client
         'timeout'  => 2.0,
     ]);
 
-Clients are immutable in Guzzle 6, which means that you cannot change the defaults used by a client after it's created.
+Clients are immutable in Guzzle, which means that you cannot change the defaults used by a client after it's created.
 
 The client constructor accepts an associative array of options:
 


### PR DESCRIPTION
Having the version number here is superfluous (because it's implicit from the branch, and generated docs pages will use the branch to tell the user the version they are reading about) and adds to maintainability burden (it's wrong in the docs for Guzzle 7!).