### PR TITLE
fix: minimum ringphp version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/ringphp": "^1.1",
+        "guzzlehttp/ringphp": "^1.1.1",
         "react/promise": "^2.2"
     },
     "require-dev": {


### PR DESCRIPTION
When using `--prefer-lowest` flag (which is useful for verifying your `composer.json` is properly configured) [on PHP 8](https://github.com/googleapis/google-api-php-client/pull/2021/checks?check_run_id=1596687099) (and presumably other versions as well), guzzle throws the error 

```
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

vendor/guzzlehttp/ringphp/src/Client/CurlFactory.php:363
```

This is fixed in [`guzzlehttp/ringphp:v1.1.1`](https://github.com/guzzle/RingPHP/blob/1.1.1/src/Client/CurlFactory.php#L363), but this branch allows for `v1.1.0`.

As this is a warning and not an error, it may not be important enough to cut a new version. I leave that up to the repo maintainers!