### PR TITLE
fix: ensure 5.3 cannot be installed for PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^5.4||^7.0",
+        "php": "^5.4|^7.0",
         "guzzlehttp/ringphp": "^1.1",
         "react/promise": "^2.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": "^5.4||^7.0",
         "guzzlehttp/ringphp": "^1.1",
         "react/promise": "^2.2"
     },


### PR DESCRIPTION
See https://github.com/guzzle/guzzle/pull/2833

guzzle 5.3 is not compatible with PHP 8.0. Update `composer.json` to ensure this is taken into account by composer.