### PR TITLE
Use RequestOptions constants in Client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -376,12 +376,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $options['_conditional']['Content-Type'] = 'application/json';
         }
 
-        if (!empty($options['decode_content'])
-            && $options['decode_content'] !== true
+        if (!empty($options[RequestOptions::DECODE_CONTENT])
+            && $options[RequestOptions::DECODE_CONTENT] !== true
         ) {
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\Utils::caselessRemove(['Accept-Encoding'], $options['_conditional']);
-            $modify['set_headers']['Accept-Encoding'] = $options['decode_content'];
+            $modify['set_headers']['Accept-Encoding'] = $options[RequestOptions::DECODE_CONTENT];
         }
 
         if (isset($options[RequestOptions::BODY])) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -414,8 +414,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             }
         }
 
-        if (isset($options['query'])) {
-            $value = $options['query'];
+        if (isset($options[RequestOptions::QUERY])) {
+            $value = $options[RequestOptions::QUERY];
             if (\is_array($value)) {
                 $value = \http_build_query($value, '', '&', \PHP_QUERY_RFC3986);
             }
@@ -423,7 +423,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                 throw new InvalidArgumentException('query must be a string or array');
             }
             $modify['query'] = $value;
-            unset($options['query']);
+            unset($options[RequestOptions::QUERY]);
         }
 
         // Ensure that sink is not an invalid value.

--- a/src/Client.php
+++ b/src/Client.php
@@ -368,9 +368,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             unset($options['multipart']);
         }
 
-        if (isset($options['json'])) {
-            $options[RequestOptions::BODY] = Utils::jsonEncode($options['json']);
-            unset($options['json']);
+        if (isset($options[RequestOptions::JSON])) {
+            $options[RequestOptions::BODY] = Utils::jsonEncode($options[RequestOptions::JSON]);
+            unset($options[RequestOptions::JSON]);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\Utils::caselessRemove(['Content-Type'], $options['_conditional']);
             $options['_conditional']['Content-Type'] = 'application/json';

--- a/src/Client.php
+++ b/src/Client.php
@@ -155,7 +155,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         // Remove request modifying parameter because it can be done up-front.
         $headers = $options[RequestOptions::HEADERS] ?? [];
         $body = $options[RequestOptions::BODY] ?? null;
-        $version = $options['version'] ?? '1.1';
+        $version = $options[RequestOptions::VERSION] ?? '1.1';
         // Merge the URI into the base URI.
         $uri = $this->buildUri(Psr7\Utils::uriFor($uri), $options);
         if (\is_array($body)) {
@@ -163,7 +163,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
         $request = new Psr7\Request($method, $uri, $headers, $body, $version);
         // Remove the option so that they are not doubly-applied.
-        unset($options[RequestOptions::HEADERS], $options[RequestOptions::BODY], $options['version']);
+        unset($options[RequestOptions::HEADERS], $options[RequestOptions::BODY], $options[RequestOptions::VERSION]);
 
         return $this->transfer($request, $options);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -365,7 +365,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
         if (isset($options[RequestOptions::MULTIPART])) {
             $options[RequestOptions::BODY] = new Psr7\MultipartStream($options[RequestOptions::MULTIPART]);
-            unset($options[RequestOptions::MULTIPART]);
+            unset($options['multipart']);
         }
 
         if (isset($options[RequestOptions::JSON])) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -348,7 +348,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             unset($options['headers']);
         }
 
-        if (isset($options['form_params'])) {
+        if (isset($options[RequestOptions::FORM_PARAMS])) {
             if (isset($options['multipart'])) {
                 throw new InvalidArgumentException('You cannot use '
                     . 'form_params and multipart at the same time. Use the '
@@ -356,8 +356,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     . 'x-www-form-urlencoded requests, and the multipart '
                     . 'option to send multipart/form-data requests.');
             }
-            $options[RequestOptions::BODY] = \http_build_query($options['form_params'], '', '&');
-            unset($options['form_params']);
+            $options[RequestOptions::BODY] = \http_build_query($options[RequestOptions::FORM_PARAMS], '', '&');
+            unset($options[RequestOptions::FORM_PARAMS]);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\Utils::caselessRemove(['Content-Type'], $options['_conditional']);
             $options['_conditional']['Content-Type'] = 'application/x-www-form-urlencoded';

--- a/src/Client.php
+++ b/src/Client.php
@@ -154,7 +154,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         $options = $this->prepareDefaults($options);
         // Remove request modifying parameter because it can be done up-front.
         $headers = $options['headers'] ?? [];
-        $body = $options['body'] ?? null;
+        $body = $options[RequestOptions::BODY] ?? null;
         $version = $options['version'] ?? '1.1';
         // Merge the URI into the base URI.
         $uri = $this->buildUri(Psr7\Utils::uriFor($uri), $options);
@@ -163,7 +163,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
         $request = new Psr7\Request($method, $uri, $headers, $body, $version);
         // Remove the option so that they are not doubly-applied.
-        unset($options['headers'], $options['body'], $options['version']);
+        unset($options['headers'], $options[RequestOptions::BODY], $options['version']);
 
         return $this->transfer($request, $options);
     }
@@ -356,7 +356,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     . 'x-www-form-urlencoded requests, and the multipart '
                     . 'option to send multipart/form-data requests.');
             }
-            $options['body'] = \http_build_query($options['form_params'], '', '&');
+            $options[RequestOptions::BODY] = \http_build_query($options['form_params'], '', '&');
             unset($options['form_params']);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\Utils::caselessRemove(['Content-Type'], $options['_conditional']);
@@ -364,12 +364,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         if (isset($options['multipart'])) {
-            $options['body'] = new Psr7\MultipartStream($options['multipart']);
+            $options[RequestOptions::BODY] = new Psr7\MultipartStream($options['multipart']);
             unset($options['multipart']);
         }
 
         if (isset($options['json'])) {
-            $options['body'] = Utils::jsonEncode($options['json']);
+            $options[RequestOptions::BODY] = Utils::jsonEncode($options['json']);
             unset($options['json']);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\Utils::caselessRemove(['Content-Type'], $options['_conditional']);
@@ -384,12 +384,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $modify['set_headers']['Accept-Encoding'] = $options['decode_content'];
         }
 
-        if (isset($options['body'])) {
-            if (\is_array($options['body'])) {
+        if (isset($options[RequestOptions::BODY])) {
+            if (\is_array($options[RequestOptions::BODY])) {
                 throw $this->invalidBody();
             }
-            $modify['body'] = Psr7\Utils::streamFor($options['body']);
-            unset($options['body']);
+            $modify['body'] = Psr7\Utils::streamFor($options[RequestOptions::BODY]);
+            unset($options[RequestOptions::BODY]);
         }
 
         if (!empty($options[RequestOptions::AUTH]) && \is_array($options[RequestOptions::AUTH])) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -153,7 +153,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     {
         $options = $this->prepareDefaults($options);
         // Remove request modifying parameter because it can be done up-front.
-        $headers = $options['headers'] ?? [];
+        $headers = $options[RequestOptions::HEADERS] ?? [];
         $body = $options[RequestOptions::BODY] ?? null;
         $version = $options['version'] ?? '1.1';
         // Merge the URI into the base URI.
@@ -163,7 +163,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
         $request = new Psr7\Request($method, $uri, $headers, $body, $version);
         // Remove the option so that they are not doubly-applied.
-        unset($options['headers'], $options[RequestOptions::BODY], $options['version']);
+        unset($options[RequestOptions::HEADERS], $options[RequestOptions::BODY], $options['version']);
 
         return $this->transfer($request, $options);
     }
@@ -292,10 +292,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         // conditional headers and as headers passed to a request ctor.
         if (\array_key_exists('headers', $options)) {
             // Allows default headers to be unset.
-            if ($options['headers'] === null) {
+            if ($options[RequestOptions::HEADERS] === null) {
                 $defaults['_conditional'] = [];
-                unset($options['headers']);
-            } elseif (!\is_array($options['headers'])) {
+                unset($options[RequestOptions::HEADERS]);
+            } elseif (!\is_array($options[RequestOptions::HEADERS])) {
                 throw new InvalidArgumentException('headers must be an array');
             }
         }
@@ -343,9 +343,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             'set_headers' => [],
         ];
 
-        if (isset($options['headers'])) {
-            $modify['set_headers'] = $options['headers'];
-            unset($options['headers']);
+        if (isset($options[RequestOptions::HEADERS])) {
+            $modify['set_headers'] = $options[RequestOptions::HEADERS];
+            unset($options[RequestOptions::HEADERS]);
         }
 
         if (isset($options[RequestOptions::FORM_PARAMS])) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -349,7 +349,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         if (isset($options[RequestOptions::FORM_PARAMS])) {
-            if (isset($options['multipart'])) {
+            if (isset($options[RequestOptions::MULTIPART])) {
                 throw new InvalidArgumentException('You cannot use '
                     . 'form_params and multipart at the same time. Use the '
                     . 'form_params option if you want to send application/'
@@ -363,9 +363,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $options['_conditional']['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
-        if (isset($options['multipart'])) {
-            $options[RequestOptions::BODY] = new Psr7\MultipartStream($options['multipart']);
-            unset($options['multipart']);
+        if (isset($options[RequestOptions::MULTIPART])) {
+            $options[RequestOptions::BODY] = new Psr7\MultipartStream($options[RequestOptions::MULTIPART]);
+            unset($options[RequestOptions::MULTIPART]);
         }
 
         if (isset($options[RequestOptions::JSON])) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -427,9 +427,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         // Ensure that sink is not an invalid value.
-        if (isset($options['sink'])) {
+        if (isset($options[RequestOptions::SINK])) {
             // TODO: Add more sink validation?
-            if (\is_bool($options['sink'])) {
+            if (\is_bool($options[RequestOptions::SINK])) {
                 throw new InvalidArgumentException('sink must not be a boolean');
             }
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -392,8 +392,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             unset($options['body']);
         }
 
-        if (!empty($options['auth']) && \is_array($options['auth'])) {
-            $value = $options['auth'];
+        if (!empty($options[RequestOptions::AUTH]) && \is_array($options[RequestOptions::AUTH])) {
+            $value = $options[RequestOptions::AUTH];
             $type = isset($value[2]) ? \strtolower($value[2]) : 'basic';
             switch ($type) {
                 case 'basic':


### PR DESCRIPTION
Replacing `GuzzleHttp\Client` occurrences of `$options[<key>]` with `$options[RequestOptions::*]`.

Fixes #2836