### PR TITLE
Add a note to not set the content-type manually

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -636,7 +636,7 @@ multipart
 
 .. note::
 
-    Do not set the `Content-Type` manually when you are using `multipart/form-data`
+    Do not set the `Content-Type` manually when you are using `multipart/form-data`.
 
 The value of ``multipart`` is an array of associative arrays, each containing
 the following key value pairs:

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -634,6 +634,10 @@ multipart
 :Types: array
 :Constant: ``GuzzleHttp\RequestOptions::MULTIPART``
 
+.. note::
+
+    Do not set the `Content-Type` manually when you are using `multipart/form-data`
+
 The value of ``multipart`` is an array of associative arrays, each containing
 the following key value pairs:
 


### PR DESCRIPTION
This PR adds a note in the docs that the Content-Type must not be set manually on multipart/form-data requests.
https://github.com/guzzle/guzzle/issues/1885