### PR TITLE
[Fix] MessageFormatter makes the response body empty

### DIFF
--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -87,6 +87,11 @@ class MessageFormatter implements MessageFormatterInterface
                         break;
                     case 'response':
                         $result = $response ? Psr7\Message::toString($response) : '';
+
+                        if ($response !== null) {
+                            $response->getBody()->rewind();
+                        }
+
                         break;
                     case 'req_headers':
                         $result = \trim($request->getMethod()

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -97,4 +97,18 @@ class MessageFormatterTest extends TestCase
         $f = new MessageFormatter($template);
         self::assertSame((string) $result, $f->format(...$args));
     }
+
+    public function testResponseFormat(): void
+    {
+        $contents = '{"aza":root@myaza.info}';
+
+        $stream = Psr7\Utils::streamFor($contents);
+        $request = new Request('GET', '/');
+        $formatter = new MessageFormatter('{response}');
+        $response = new Response(200, [], $stream);
+
+        $formatter->format($request, $response);
+
+        self::assertEquals($response->getBody()->getContents(), $contents);
+    }
 }


### PR DESCRIPTION
[Issue #2863](https://github.com/guzzle/guzzle/issues/2863)