### PR TITLE
Bumped branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "7.1-dev"
+            "dev-master": "7.3-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
The next version will be 7.3.0 on this branch, and no, we shouldn't change this to 7.x-dev. 7.3-dev gives more information to composer.