### PR TITLE
Fix formatting of Exception hierarchy in quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -534,7 +534,7 @@ on each other.
 
     . \RuntimeException
     └── TransferException (implements GuzzleException)
-        └── ConnectException (implements NetworkExceptionInterface)
+        ├── ConnectException (implements NetworkExceptionInterface)
         └── RequestException
             ├── BadResponseException
             │   ├── ServerException


### PR DESCRIPTION
Introduced in 25486bffcf6fcdb0aceae5a51c31e8f4b2c13c5f.