### PR TITLE
Use robust, consistent `Psr7\Utils::tryFopen` where possible

### DIFF
--- a/docs/psr7.rst
+++ b/docs/psr7.rst
@@ -424,7 +424,7 @@ and can optionally expose other custom data.
 
     use GuzzleHttp\Psr7;
 
-    $resource = fopen('/path/to/file', 'r');
+    $resource = Psr7\Utils::tryFopen('/path/to/file', 'r');
     $stream = Psr7\Utils::streamFor($resource);
     echo $stream->getMetadata('uri');
     // /path/to/file

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -342,17 +342,19 @@ resource returned from ``fopen``, or an instance of a
 
 .. code-block:: php
 
+    use GuzzleHttp\Psr7;
+
     // Provide the body as a string.
     $r = $client->request('POST', 'http://httpbin.org/post', [
         'body' => 'raw data'
     ]);
 
     // Provide an fopen resource.
-    $body = fopen('/path/to/file', 'r');
+    $body = Psr7\Utils::tryFopen('/path/to/file', 'r');
     $r = $client->request('POST', 'http://httpbin.org/post', ['body' => $body]);
 
     // Use the Utils::streamFor method to create a PSR-7 stream.
-    $body = \GuzzleHttp\Psr7\Utils::streamFor('hello!');
+    $body = Psr7\Utils::streamFor('hello!');
     $r = $client->request('POST', 'http://httpbin.org/post', ['body' => $body]);
 
 An easy way to upload JSON data and set the appropriate header is using the
@@ -406,6 +408,8 @@ associative arrays, where each associative array contains the following keys:
 
 .. code-block:: php
 
+    use GuzzleHttp\Psr7;
+
     $response = $client->request('POST', 'http://httpbin.org/post', [
         'multipart' => [
             [
@@ -414,7 +418,7 @@ associative arrays, where each associative array contains the following keys:
             ],
             [
                 'name'     => 'file_name',
-                'contents' => fopen('/path/to/file', 'r')
+                'contents' => Psr7\Utils::tryFopen('/path/to/file', 'r')
             ],
             [
                 'name'     => 'other_file',

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -203,7 +203,7 @@ This setting can be set to any of the following types:
   .. code-block:: php
 
       // You can send requests that use a stream resource as the body.
-      $resource = fopen('http://httpbin.org', 'r');
+      $resource = \GuzzleHttp\Psr7\Utils::tryFopen('http://httpbin.org', 'r');
       $client->request('PUT', '/put', ['body' => $resource]);
 
 - ``Psr\Http\Message\StreamInterface``
@@ -646,6 +646,8 @@ the following key value pairs:
 
 .. code-block:: php
 
+    use GuzzleHttp\Psr7;
+
     $client->request('POST', '/post', [
         'multipart' => [
             [
@@ -655,11 +657,11 @@ the following key value pairs:
             ],
             [
                 'name'     => 'baz',
-                'contents' => fopen('/path/to/file', 'r')
+                'contents' => Psr7\Utils::tryFopen('/path/to/file', 'r')
             ],
             [
                 'name'     => 'qux',
-                'contents' => fopen('/path/to/file', 'r'),
+                'contents' => Psr7\Utils::tryFopen('/path/to/file', 'r'),
                 'filename' => 'custom_filename.txt'
             ],
         ]
@@ -907,7 +909,7 @@ Pass a resource returned from ``fopen()`` to write the response to a PHP stream:
 
 .. code-block:: php
 
-    $resource = fopen('/path/to/file', 'w');
+    $resource = \GuzzleHttp\Psr7\Utils::tryFopen('/path/to/file', 'w');
     $client->request('GET', '/stream/20', ['sink' => $resource]);
 
 Pass a ``Psr\Http\Message\StreamInterface`` object to stream the response
@@ -915,8 +917,8 @@ body to an open PSR-7 stream.
 
 .. code-block:: php
 
-    $resource = fopen('/path/to/file', 'w');
-    $stream = GuzzleHttp\Psr7\Utils::streamFor($resource);
+    $resource = \GuzzleHttp\Psr7\Utils::tryFopen('/path/to/file', 'w');
+    $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
     $client->request('GET', '/stream/20', ['save_to' => $stream]);
 
 .. note::

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -393,7 +393,7 @@ class CurlFactory implements CurlFactoryInterface
 
         if (!isset($options['sink'])) {
             // Use a default temp stream if no sink was set.
-            $options['sink'] = \fopen('php://temp', 'w+');
+            $options['sink'] = \GuzzleHttp\Psr7\Utils::tryFopen('php://temp', 'w+');
         }
         $sink = $options['sink'];
         if (!\is_string($sink)) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -141,7 +141,7 @@ class StreamHandler
             return $stream;
         }
 
-        $sink = $options['sink'] ?? \fopen('php://temp', 'r+');
+        $sink = $options['sink'] ?? Psr7\Utils::tryFopen('php://temp', 'r+');
 
         return \is_string($sink) ? new Psr7\LazyOpenStream($sink, 'w+') : Psr7\Utils::streamFor($sink);
     }
@@ -304,7 +304,7 @@ class StreamHandler
 
         return $this->createResource(
             function () use ($uri, &$http_response_header, $contextResource, $context, $options, $request) {
-                $resource = \fopen((string) $uri, 'r', false, $contextResource);
+                $resource = @\fopen((string) $uri, 'r', false, $contextResource);
                 $this->lastHeaders = $http_response_header;
 
                 if (false === $resource) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -71,12 +71,7 @@ final class Utils
             return \STDOUT;
         }
 
-        $resource = \fopen('php://output', 'w');
-        if (false === $resource) {
-            throw new \RuntimeException('Can not open php output for writing to debug the resource.');
-        }
-
-        return $resource;
+        return \GuzzleHttp\Psr7\Utils::tryFopen('php://output', 'w');
     }
 
     /**


### PR DESCRIPTION
Replaces #2689.