### PR TITLE
Allow installing guzzlehttp/psr7:2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/promises": "^1.4",
-        "guzzlehttp/psr7": "^1.7",
+        "guzzlehttp/psr7": "^1.7 || ^2.0",
         "psr/http-client": "^1.0"
     },
     "provide": {


### PR DESCRIPTION
We want people to test guzzlehttp/psr7:2.0 before it is released. 