### PR TITLE
only close curl handle if it's done

### DIFF
--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -221,6 +221,10 @@ class CurlMultiHandler
     private function processMessages(): void
     {
         while ($done = \curl_multi_info_read($this->_mh)) {
+            if ($done['msg'] !== CURLMSG_DONE) {
+                // if it's not done, then it would be premature to remove the handle, right?
+                continue;
+            }
             $id = (int) $done['handle'];
             \curl_multi_remove_handle($this->_mh, $done['handle']);
 


### PR DESCRIPTION
if a handle happens to create another message than "done", then we shouldn't remove the handle yet, right?

notably, there are no other message types in upstream libcurl *yet*, 
but this will help future-proof Guzzle so 2021 versions of Guzzle may run better on future versions of libcurl.