### PR TITLE
[Docs] Add clarification on redirects and PSR-18

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -120,6 +120,10 @@ pairs:
     by default when a client is created with no handler, and is added by
     default when creating a handler with ``GuzzleHttp\HandlerStack::create``.
 
+.. warning::
+
+    This option has **no** effect when making requests using ``GuzzleHttp\Client::sendRequest()``. In order to stay compliant with PSR-18 any redirect response is returned as is.
+
 
 auth
 ----

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -120,7 +120,7 @@ pairs:
     by default when a client is created with no handler, and is added by
     default when creating a handler with ``GuzzleHttp\HandlerStack::create``.
 
-.. warning::
+.. note::
 
     This option has **no** effect when making requests using ``GuzzleHttp\Client::sendRequest()``. In order to stay compliant with PSR-18 any redirect response is returned as is.
 


### PR DESCRIPTION
Using ``GuzzleHttp\Client::sendRequest()`` ignores the `allow_redirects` configuration option. This is discussed in [#2584][0].

I ran into this issue while upgrading from Guzzle 6 with HttPlug to Guzzle 7. This different behavior is not documented properly in my opinion. I only found out why the redirects are not followed by going through closed issues on the repository. 

If the wording is not in line with the rest of the document feel free to rewrite or reject. This is merely an attempt to help others :)  

[0]: https://github.com/guzzle/guzzle/issues/2584