### PR TITLE
Update readme for PHP8 workaround because of phpunit/phpunit not supp

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@
 Guzzle is a PHP HTTP client that makes it easy to send HTTP requests and
 trivial to integrate with web services.
 
-- Simple interface for building query strings, POST requests, streaming large
-  uploads, streaming large downloads, using HTTP cookies, uploading JSON data,
-  etc...
-- Can send both synchronous and asynchronous requests using the same interface.
-- Uses PSR-7 interfaces for requests, responses, and streams. This allows you
-  to utilize other PSR-7 compatible libraries with Guzzle.
-- Supports PSR-18 allowing interoperability between other PSR-18 HTTP Clients.
-- Abstracts away the underlying HTTP transport, allowing you to write
-  environment and transport agnostic code; i.e., no hard dependency on cURL,
-  PHP streams, sockets, or non-blocking event loops.
-- Middleware system allows you to augment and compose client behavior.
+-   Simple interface for building query strings, POST requests, streaming large
+    uploads, streaming large downloads, using HTTP cookies, uploading JSON data,
+    etc...
+-   Can send both synchronous and asynchronous requests using the same interface.
+-   Uses PSR-7 interfaces for requests, responses, and streams. This allows you
+    to utilize other PSR-7 compatible libraries with Guzzle.
+-   Supports PSR-18 allowing interoperability between other PSR-18 HTTP Clients.
+-   Abstracts away the underlying HTTP transport, allowing you to write
+    environment and transport agnostic code; i.e., no hard dependency on cURL,
+    PHP streams, sockets, or non-blocking event loops.
+-   Middleware system allows you to augment and compose client behavior.
 
 ```php
 $client = new \GuzzleHttp\Client();
@@ -42,11 +42,10 @@ $promise->wait();
 
 We use GitHub issues only to discuss bugs and new features. For support please refer to:
 
-- [Documentation](http://guzzlephp.org/)
-- [Stack Overflow](http://stackoverflow.com/questions/tagged/guzzle)
-- [#guzzle](https://app.slack.com/client/T0D2S9JCT/CE6UAAKL4) channel on [PHP-HTTP Slack](http://slack.httplug.io/)
-- [Gitter](https://gitter.im/guzzle/guzzle)
-
+-   [Documentation](http://guzzlephp.org/)
+-   [Stack Overflow](http://stackoverflow.com/questions/tagged/guzzle)
+-   [#guzzle](https://app.slack.com/client/T0D2S9JCT/CE6UAAKL4) channel on [PHP-HTTP Slack](http://slack.httplug.io/)
+-   [Gitter](https://gitter.im/guzzle/guzzle)
 
 ## Installing Guzzle
 
@@ -54,19 +53,23 @@ The recommended way to install Guzzle is through
 [Composer](https://getcomposer.org/).
 
 ```bash
+# PHP7
 composer require guzzlehttp/guzzle
+# PHP8
+# If you run on PHP 8+ you have to ignore invalid php version
+# bacause of lib "phpunit/phpunit" not support PHP8+ jet.
+composer require guzzlehttp/guzzle --ignore-platform-req=php
 ```
-
 
 ## Version Guidance
 
-| Version | Status     | Packagist           | Namespace    | Repo                | Docs                | PSR-7 | PHP Version |
-|---------|------------|---------------------|--------------|---------------------|---------------------|-------|-------------|
-| 3.x     | EOL        | `guzzle/guzzle`     | `Guzzle`     | [v3][guzzle-3-repo] | [v3][guzzle-3-docs] | No    | >= 5.3.3    |
-| 4.x     | EOL        | `guzzlehttp/guzzle` | `GuzzleHttp` | [v4][guzzle-4-repo] | N/A                 | No    | >= 5.4      |
-| 5.x     | EOL        | `guzzlehttp/guzzle` | `GuzzleHttp` | [v5][guzzle-5-repo] | [v5][guzzle-5-docs] | No    | >= 5.4      |
+| Version | Status         | Packagist           | Namespace    | Repo                | Docs                | PSR-7 | PHP Version |
+| ------- | -------------- | ------------------- | ------------ | ------------------- | ------------------- | ----- | ----------- |
+| 3.x     | EOL            | `guzzle/guzzle`     | `Guzzle`     | [v3][guzzle-3-repo] | [v3][guzzle-3-docs] | No    | >= 5.3.3    |
+| 4.x     | EOL            | `guzzlehttp/guzzle` | `GuzzleHttp` | [v4][guzzle-4-repo] | N/A                 | No    | >= 5.4      |
+| 5.x     | EOL            | `guzzlehttp/guzzle` | `GuzzleHttp` | [v5][guzzle-5-repo] | [v5][guzzle-5-docs] | No    | >= 5.4      |
 | 6.x     | Security fixes | `guzzlehttp/guzzle` | `GuzzleHttp` | [v6][guzzle-6-repo] | [v6][guzzle-6-docs] | Yes   | >= 5.5      |
-| 7.x     | Latest     | `guzzlehttp/guzzle` | `GuzzleHttp` | [v7][guzzle-7-repo] | [v7][guzzle-7-docs] | Yes   | >= 7.2      |
+| 7.x     | Latest         | `guzzlehttp/guzzle` | `GuzzleHttp` | [v7][guzzle-7-repo] | [v7][guzzle-7-docs] | Yes   | >= 7.2      |
 
 [guzzle-3-repo]: https://github.com/guzzle/guzzle3
 [guzzle-4-repo]: https://github.com/guzzle/guzzle/tree/4.x


### PR DESCRIPTION
PHP8 doues not work proper becaus of phpunit/phpunit dos nut support it jet. 
![guzzle_php8_not_supported](https://user-images.githubusercontent.com/76826910/120717652-3795ce80-c4c8-11eb-8738-62cc05140849.jpg)
