### PR TITLE
Improve the comment regarding `CURLOPT_ENCODING` handling

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -385,8 +385,11 @@ class CurlFactory implements CurlFactoryInterface
             if ($accept) {
                 $conf[\CURLOPT_ENCODING] = $accept;
             } else {
+                // The empty string enables all available decoders and implicitly
+                // sets a matching 'Accept-Encoding' header.
                 $conf[\CURLOPT_ENCODING] = '';
-                // Don't let curl send the header over the wire
+                // But as the user did not specify any acceptable encodings we need
+                // to overwrite this implicit header with an empty one.
                 $conf[\CURLOPT_HTTPHEADER][] = 'Accept-Encoding:';
             }
         }


### PR DESCRIPTION
While researching how the `decode_content` option is meant to be used and
looking into the Guzzle source code I stumbled over this part of the code,
because it was non-obvious to me that providing an empty string to
`CURLOPT_ENCODING` does not *disable* the decoding, but instead enables *all*
decoders.