### PR TITLE
Throw exception if you are using all wrong headers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace GuzzleHttp;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\InvalidArgumentException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -344,6 +345,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         ];
 
         if (isset($options['headers'])) {
+            if (array_keys($options['headers']) === range(0, count($options['headers']) - 1)) {
+                throw new RequestException('The headers array must have header name as keys.', $request);
+            }
             $modify['set_headers'] = $options['headers'];
             unset($options['headers']);
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -611,6 +612,26 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->send(new Request('GET', 'http://foo.com'));
         self::assertTrue($mock->getLastOptions()['synchronous']);
+    }
+
+    public function testSendWithInvalidHeader()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $request = new Request('GET', 'http://foo.com');
+
+        $this->expectException(RequestException::class);
+        $client->send($request, ['headers'=>['X-Foo: Bar']]);
+    }
+
+    public function testSendWithInvalidHeaders()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $request = new Request('GET', 'http://foo.com');
+
+        $this->expectException(RequestException::class);
+        $client->send($request, ['headers'=>['X-Foo: Bar', 'X-Test: Fail']]);
     }
 
     public function testCanSetCustomHandler()


### PR DESCRIPTION
This will fix #2911

Note that this only thrown an exception if you are using all wrong headers. Ie, it check if you send a list or a map. 