### PR TITLE
Remove unneeded annotation

### DIFF
--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -183,7 +183,6 @@ class MockHandler implements \Countable
     /**
      * Returns the number of remaining items in the queue.
      */
-    #[\ReturnTypeWillChange]
     public function count(): int
     {
         return \count($this->queue);


### PR DESCRIPTION
My bad here! The return type is already int, so fine for PHP 8.1.