### PR TITLE
Fix progress parameter type compatibility between cURL and StreamHandler

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -517,7 +517,9 @@ class StreamHandler
             $params,
             static function ($code, $a, $b, $c, $transferred, $total) use ($value) {
                 if ($code == \STREAM_NOTIFY_PROGRESS) {
-                    $value($total, $transferred, null, null);
+                    // The upload progress cannot be determined. Use 0 for cURL compatibility:
+                    // https://curl.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html
+                    $value($total, $transferred, 0, 0);
                 }
             }
         );


### PR DESCRIPTION
Unknown values of the progress called are filled with `0` by cURL and in fact
the `CURLOPT_PROGRESSFUNCTION` parameters are explicitly typed `int` in
CurlFactory.

StreamHandler always provided `null` as the upload progress, because the
progress is not known there. Adjust this to `0` for consistent behavior.