### PR TITLE
Bump minimum versions for PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,8 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "guzzlehttp/promises": "^1.4",
-        "guzzlehttp/psr7": "^1.7 || ^2.0",
+        "guzzlehttp/promises": "^1.5",
+        "guzzlehttp/psr7": "^1.8.3 || ^2.1",
         "psr/http-client": "^1.0",
         "symfony/deprecation-contracts": "^2.2"
     },


### PR DESCRIPTION
Allows someone using `--prefer-lowest` on PHP 8.1 and asking for Guzzle `^7.4` (when 7.4.0 it is released) to get peer dependencies that work on PHP 8.1.

---

Can we tag release 7.4.0 soon, @Nyholm?