### PR TITLE
Throw `InvalidArgumentException` when an incorrect `headers` array is provided

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,7 +5,6 @@ namespace GuzzleHttp;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\InvalidArgumentException;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,7 +4,6 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;


### PR DESCRIPTION
As discussed in PR #2916 after it was merged an `InvalidArgumentException` is
more fitting, as passing an invalid `headers` array is a clear programming
error that needs to be fixed and not caught.

This is consistent with the validation of the other options, e.g. when using
`multipart` and `form_params` at the same time.

see #2916
see a2b8dd1ad7e733d50e9c7b80cb375e0883a7088d

/cc @GrahamCampbell; thanks