### PR TITLE
only close curl handle if it's done.

### DIFF
--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -225,6 +225,10 @@ class CurlMultiHandler
     private function processMessages(): void
     {
         while ($done = \curl_multi_info_read($this->_mh)) {
+            if ($done['msg'] !== \CURLMSG_DONE) {
+                // if it's not done, then it would be premature to remove the handle. ref https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216
+                continue;
+            }
             $id = (int) $done['handle'];
             \curl_multi_remove_handle($this->_mh, $done['handle']);
 


### PR DESCRIPTION
this is a copy of PR #2892

quoting [bagder](https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216):

>Can I object to the closing of this PR? I'm the main author of libcurl and I wrote this API. It is *clearly* documented to return a `CURLMSG_DONE` for this case and *only then* does it mean that a handle/transfer is complete. Not checking for that value works only by chance and will break in the case libcurl adds another message.

If you're not going to listen to badger, the guy who wrote libcurl, then there's no hope.

that said, another option would be to throw a LogicException instead, something along the line of
```php
            if ($done['msg'] !== \CURLMSG_DONE) {
                throw new \LogicException("unknown message received from libcurl. only CURLMSG_DONE is supported. received ".$msg['msg'] );
            }
```
but.. just ignoring unknown messages is the least destructive approach. 