### PR TITLE
Update Client.php to allow for HTTP_PROXY

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -244,6 +244,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $defaults['proxy']['http'] = $proxy;
         }
 
+        if ($proxy = Utils::getenv('HTTP_PROXY')) {
+            $defaults['proxy']['http'] = $proxy;
+        }
+        
         if ($proxy = Utils::getenv('HTTPS_PROXY')) {
             $defaults['proxy']['https'] = $proxy;
         }


### PR DESCRIPTION
When operating behind our proxy, we were getting a CURL error 7 trying to connect to Google Analytics.  Adding the extra environment check for HTTP_PROXY resolved the issue with no impact to other functionality.

production.ERROR: cURL error 7: Failed connect to www.google-analytics.com:80; Operation now in progress (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://www.google-analytics.com/collect?v=1&tid=UA-123456-1&cid=123456&t=pageview&dt=API%20Request&dp=api%2Fv3%2Fevents {"exception":"[object] (GuzzleHttp\\Exception
ConnectException(code: 0): cURL error 7: Failed connect to www.google-analytics.com:80; Operation now in progress (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://www.google-analytics.com/collect?v=1&tid=UA-123456-1&cid=123456&t=pageview&dt=API%20Request&dp=api%2Fv3%2Fevents at /var/www/html/xxxxx/html/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:210)