### PR TITLE
PHPStan 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vendor/
 /phpstan.neon
 /phpunit.xml
 
+.idea/
 build/
 artifacts/
 docs/_build

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Result of && is always false\\.$#"
-			count: 3
-			path: src/Cookie/SetCookie.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between null and null will always evaluate to false\\.$#"
-			count: 3
-			path: src/Cookie/SetCookie.php
-
-		-
 			message: "#^Parameter \\#1 \\$ch of function curl_close expects resource, CurlHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php
@@ -94,14 +84,4 @@ parameters:
 			message: "#^Property GuzzleHttp\\\\Handler\\\\EasyHandle\\:\\:\\$handle has unknown class CurlHandle as its type\\.$#"
 			count: 1
 			path: src/Handler/EasyHandle.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: src/HandlerStack.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 2
-			path: src/Middleware.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$str of function strtolower expects string, int\\|string given\\.$#"
-			count: 1
-			path: src/Client.php
-
-		-
 			message: "#^Result of && is always false\\.$#"
 			count: 3
 			path: src/Cookie/SetCookie.php
@@ -14,16 +9,6 @@ parameters:
 			message: "#^Strict comparison using \\!\\=\\= between null and null will always evaluate to false\\.$#"
 			count: 3
 			path: src/Cookie/SetCookie.php
-
-		-
-			message: "#^Cannot access offset 'version' on array\\|false\\.$#"
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
-			message: "#^Cannot call method getBody\\(\\) on Psr\\\\Http\\\\Message\\\\ResponseInterface\\|null\\.$#"
-			count: 1
-			path: src/Handler/CurlFactory.php
 
 		-
 			message: "#^Parameter \\#1 \\$ch of function curl_close expects resource, CurlHandle\\|resource given\\.$#"
@@ -56,11 +41,6 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$str1 of function strcasecmp expects string, int\\|string given\\.$#"
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
 			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlFactory\\:\\:\\$handles has unknown class CurlHandle as its type\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php
@@ -74,6 +54,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$ch of function curl_exec expects resource, CurlHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlHandler.php
+
+		-
+			message: "#^Method GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:__get\\(\\) has invalid return type CurlMultiHandle\\.$#"
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
 
 		-
 			message: "#^Parameter \\#1 \\$mh of function curl_multi_add_handle expects resource, CurlMultiHandle\\|resource given\\.$#"
@@ -102,16 +87,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$mh of function curl_multi_select expects resource, CurlMultiHandle\\|resource given\\.$#"
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
-			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:\\$active has unknown class CurlMultiHandle as its type\\.$#"
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
-			message: "#^Return typehint of method GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:__get\\(\\) has invalid type CurlMultiHandle\\.$#"
 			count: 1
 			path: src/Handler/CurlMultiHandler.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,7 @@ includes:
 parameters:
     level: max
     checkMissingIterableValueType: false
+    treatPhpDocTypesAsCertain: false
     paths:
         - src
     bootstrapFiles:

--- a/src/Client.php
+++ b/src/Client.php
@@ -120,6 +120,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     public function send(RequestInterface $request, array $options = []): ResponseInterface
     {
         $options[RequestOptions::SYNCHRONOUS] = true;
+
+        /** @var ResponseInterface */
         return $this->sendAsync($request, $options)->wait();
     }
 
@@ -134,6 +136,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         $options[RequestOptions::ALLOW_REDIRECTS] = false;
         $options[RequestOptions::HTTP_ERRORS] = false;
 
+        /** @var ResponseInterface */
         return $this->sendAsync($request, $options)->wait();
     }
 
@@ -184,6 +187,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     public function request(string $method, $uri = '', array $options = []): ResponseInterface
     {
         $options[RequestOptions::SYNCHRONOUS] = true;
+
+        /** @var ResponseInterface */
         return $this->requestAsync($method, $uri, $options)->wait();
     }
 
@@ -264,6 +269,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $this->config['headers'] = ['User-Agent' => Utils::defaultUserAgent()];
         } else {
             // Add the User-Agent header if one was not already set.
+
+            /** @var string $name */
             foreach (\array_keys($this->config['headers']) as $name) {
                 if (\strtolower($name) === 'user-agent') {
                     return;

--- a/src/Cookie/SessionCookieJar.php
+++ b/src/Cookie/SessionCookieJar.php
@@ -70,7 +70,7 @@ class SessionCookieJar extends CookieJar
             foreach ($data as $cookie) {
                 $this->setCookie(new SetCookie($cookie));
             }
-        } elseif (\is_string($data) && \strlen($data)) {
+        } elseif (!\is_string($data) && \strlen($data)) {
             throw new \RuntimeException("Invalid cookie data");
         }
     }

--- a/src/Cookie/SessionCookieJar.php
+++ b/src/Cookie/SessionCookieJar.php
@@ -70,7 +70,7 @@ class SessionCookieJar extends CookieJar
             foreach ($data as $cookie) {
                 $this->setCookie(new SetCookie($cookie));
             }
-        } elseif (\strlen($data)) {
+        } elseif (\is_string($data) && \strlen($data)) {
             throw new \RuntimeException("Invalid cookie data");
         }
     }

--- a/src/Cookie/SessionCookieJar.php
+++ b/src/Cookie/SessionCookieJar.php
@@ -70,7 +70,7 @@ class SessionCookieJar extends CookieJar
             foreach ($data as $cookie) {
                 $this->setCookie(new SetCookie($cookie));
             }
-        } elseif (!\is_string($data) && \strlen($data)) {
+        } elseif (!\is_string($data) || \strlen($data)) {
             throw new \RuntimeException("Invalid cookie data");
         }
     }

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -91,7 +91,7 @@ class RequestException extends TransferException implements RequestExceptionInte
         }
 
         $uri = $request->getUri();
-        $uri = static::obfuscateUri($uri);
+        $uri = self::obfuscateUri($uri);
 
         // Client Error: `GET /` resulted in a `404 Not Found` response:
         // <html> ... (truncated)

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -145,8 +145,8 @@ class CurlFactory implements CurlFactoryInterface
     private static function finishError(callable $handler, EasyHandle $easy, CurlFactoryInterface $factory): PromiseInterface
     {
         // Get error information and release the handle to the factory.
+        /** @var array<array-key, mixed> $curlStats */
         $curlStats = \curl_getinfo($easy->handle);
-        assert(\is_array($curlStats));
 
         $ctx = [
             'errno' => $easy->errno,
@@ -154,8 +154,8 @@ class CurlFactory implements CurlFactoryInterface
             'appconnect_time' => \curl_getinfo($easy->handle, \CURLINFO_APPCONNECT_TIME),
         ] + $curlStats;
 
+        /** @var array<array-key, mixed> $curlVersion */
         $curlVersion = \curl_version();
-        assert($curlVersion !== false);
 
         $ctx[self::CURL_VERSION_STR] = $curlVersion['version'];
         $factory->release($easy);

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -32,9 +32,9 @@ class CurlMultiHandler
     private $selectTimeout;
 
     /**
-     * @var resource|\CurlMultiHandle|null the currently executing resource in `curl_multi_exec`.
+     * @var 0|1 the currently executing resource in `curl_multi_exec`.
      */
-    private $active;
+    private $active = 0;
 
     /**
      * @var array Request entry handles, indexed by handle id in `addRequest`.
@@ -53,7 +53,7 @@ class CurlMultiHandler
     /**
      * @var array<mixed> An associative array of CURLMOPT_* options and corresponding values for curl_multi_setopt()
      */
-    private $options = [];
+    private $options;
 
     /**
      * This handler accepts the following options:

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -32,7 +32,7 @@ class CurlMultiHandler
     private $selectTimeout;
 
     /**
-     * @var 0|1 the currently executing resource in `curl_multi_exec`.
+     * @var int the currently executing resource in `curl_multi_exec`.
      */
     private $active = 0;
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -517,6 +517,8 @@ class StreamHandler
             $params,
             static function ($code, $a, $b, $c, $transferred, $total) use ($value) {
                 if ($code == \STREAM_NOTIFY_PROGRESS) {
+                    assert(\is_callable($value));
+
                     // The upload progress cannot be determined. Use 0 for cURL compatibility:
                     // https://curl.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html
                     $value($total, $transferred, 0, 0);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -21,10 +21,10 @@ final class Utils
      */
     public static function describeType($input): string
     {
-        switch (\gettype($input)) {
-            case 'object':
+        switch (true) {
+            case \is_object($input):
                 return 'object(' . \get_class($input) . ')';
-            case 'array':
+            case \is_array($input):
                 return 'array(' . \count($input) . ')';
             default:
                 \ob_start();
@@ -270,11 +270,14 @@ EOT
      */
     public static function jsonDecode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
     {
+        assert($depth >= 1);
+
         $data = \json_decode($json, $assoc, $depth, $options);
         if (\JSON_ERROR_NONE !== \json_last_error()) {
             throw new InvalidArgumentException('json_decode error: ' . \json_last_error_msg());
         }
 
+        /** @var object|array|string|int|float|bool|null */
         return $data;
     }
 
@@ -291,6 +294,8 @@ EOT
      */
     public static function jsonEncode($value, int $options = 0, int $depth = 512): string
     {
+        assert($depth >= 1);
+
         $json = \json_encode($value, $options, $depth);
         if (\JSON_ERROR_NONE !== \json_last_error()) {
             throw new InvalidArgumentException('json_encode error: ' . \json_last_error_msg());

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,8 +1,8 @@
 {
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "phpstan/phpstan": "0.12.99",
-        "phpstan/phpstan-deprecation-rules": "0.12.6"
+        "phpstan/phpstan": "1.2.0",
+        "phpstan/phpstan-deprecation-rules": "1.0.0"
     },
     "config": {
         "preferred-install": "dist"


### PR DESCRIPTION
This PR updates PHPStan to 1.2 and fixes a bunch of errors at the same time; The remaining ones are left is related to the PHP 7<>8 stubs which I did not look too deep into.

I did opt for a few expectations, though it did not seem to be the common practice here, especially for the `$depth` parameter on `\json_decode()` which requires `int<1, max>`, though that can be fixed with `@var` tags as an alternative as PHP does not have the concept of signedness when it comes to `int`.

See inline comments for further in-depth thoughts