### PR TITLE
Timeout exception is added and it needs to be tested

### DIFF
--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception when the timeout exceeds
+ */
+class TimeoutException extends ConnectException
+{
+
+}

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -7,5 +7,4 @@ namespace GuzzleHttp\Exception;
  */
 class TimeoutException extends ConnectException
 {
-
 }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TimeoutException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -189,6 +190,18 @@ class CurlFactory implements CurlFactoryInterface
                     $easy->request,
                     $easy->response,
                     $easy->onHeadersException,
+                    $ctx
+                )
+            );
+        }
+
+        //Message is got from cURL error code: 28 by https://curl.haxx.se/libcurl/c/libcurl-errors.html
+        if ($ctx['errno'] == \CURLE_OPERATION_TIMEOUTED) {
+            return P\Create::rejectionFor(
+                new TimeoutException(
+                    "Operation timeout. The specified time-out period was reached according to the conditions.",
+                    $easy->request,
+                    null,
                     $ctx
                 )
             );

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -28,6 +28,16 @@ class CurlHandlerTest extends TestCase
         $handler = new CurlHandler();
         $request = new Request('GET', 'http://localhost:123');
 
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('cURL');
+        $handler($request)->wait();
+    }
+
+    public function testTimeoutError()
+    {
+        $handler = new CurlHandler();
+        $request = new Request('GET', Server::$url);
+
         $this->expectException(TimeoutException::class);
         $this->expectExceptionMessage('time-out');
         $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])->wait();

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -30,7 +30,7 @@ class CurlHandlerTest extends TestCase
 
         $this->expectException(ConnectException::class);
         $this->expectExceptionMessage('cURL');
-        $handler($request)->wait();
+        $handler($request, ['connect_timeout' => 0.001])->wait();
     }
 
     public function testTimeoutError()

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\TimeoutException;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
@@ -27,8 +28,8 @@ class CurlHandlerTest extends TestCase
         $handler = new CurlHandler();
         $request = new Request('GET', 'http://localhost:123');
 
-        $this->expectException(ConnectException::class);
-        $this->expectExceptionMessage('cURL');
+        $this->expectException(TimeoutException::class);
+        $this->expectExceptionMessage('time-out');
         $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])->wait();
     }
 


### PR DESCRIPTION
Related to https://github.com/guzzle/guzzle/issues/2932 and https://github.com/guzzle/guzzle/issues/2933

I added a new exception named "Timeout". The problem was distinguishing timeout exceptions independently.

For example, I find "timeout" exceptions like the following by using "RequestException".

try {
    //guzzle request
} catch (RequestException $e) {
    if (strpos($e->getMessage(), 'timed out after') !== false) {
    //
    }
}

But we'd like to find these scenarios like the following.
try {
    //guzzle request
} catch (TimeoutException $e) {
    //timeout issue
}


I added some codes but I couldn't be sure how can I test this case by PHPUnit.