### PR TITLE
Symfony\Component\Debug\Exception\FatalThrowableError: Unsupported operand types

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -299,7 +299,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                 throw new InvalidArgumentException('headers must be an array');
             }
         }
-        
+
         if (!is_array($options)) {
             $options = [$options];
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -299,6 +299,14 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                 throw new InvalidArgumentException('headers must be an array');
             }
         }
+        
+        if (!is_array($options)) {
+            $options = [$options];
+        }
+
+        if (!is_array($defaults)) {
+            $defaults = [$defaults];
+        }
 
         // Shallow merge defaults underneath options.
         $result = $options + $defaults;


### PR DESCRIPTION
```
if (!is_array($options)) {
    $options = [$options];
}

if (!is_array($defaults)) {
    $defaults = [$defaults];
}
```

Avoid unsupported operand types.