### PR TITLE
precise phpdoc typing of array

### DIFF
--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -19,9 +19,9 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string              $method  HTTP method.
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string               $method  HTTP method.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -34,8 +34,8 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -51,8 +51,8 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -68,8 +68,8 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -85,8 +85,8 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -102,8 +102,8 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -119,8 +119,8 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -137,9 +137,9 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string              $method  HTTP method
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string               $method  HTTP method
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      */
     abstract public function requestAsync(string $method, $uri, array $options = []): PromiseInterface;
 
@@ -151,8 +151,8 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      */
     public function getAsync($uri, array $options = []): PromiseInterface
     {
@@ -167,8 +167,8 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      */
     public function headAsync($uri, array $options = []): PromiseInterface
     {
@@ -183,8 +183,8 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      */
     public function putAsync($uri, array $options = []): PromiseInterface
     {
@@ -199,8 +199,8 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      */
     public function postAsync($uri, array $options = []): PromiseInterface
     {
@@ -215,8 +215,8 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      */
     public function patchAsync($uri, array $options = []): PromiseInterface
     {
@@ -231,8 +231,8 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface  $uri     URI object or string.
+     * @param array<string, mixed> $options Request options to apply.
      */
     public function deleteAsync($uri, array $options = []): PromiseInterface
     {


### PR DESCRIPTION
So that phpstan and similar tools catch when you do typo like 

`["body" ,  $body"]` instead of `["body" => $body]`