### PR TITLE
Add attribute to avoid deprection warnings on PHP 8.1

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -217,11 +217,13 @@ class CookieJar implements CookieJarInterface
         return true;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->cookies);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator(array_values($this->cookies));

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -81,6 +81,7 @@ class SetCookie
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         $str = $this->data['Name'] . '=' . $this->data['Value'] . '; ';

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -170,6 +170,7 @@ class MockHandler implements \Countable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->queue);

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -76,6 +76,7 @@ class HandlerStack
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         $depth = 0;


### PR DESCRIPTION
PHP 8.1 considers missing return typehints different from the interfaces.
