### PR TITLE
Reject non-HTTP schemes in StreamHandler

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -266,6 +266,10 @@ class StreamHandler
             $methods = \array_flip(\get_class_methods(__CLASS__));
         }
 
+        if (!\in_array($request->getUri()->getScheme(), ['http', 'https'])) {
+            throw new RequestException(\sprintf("The scheme '%s' is not supported.", $request->getUri()->getScheme()), $request);
+        }
+
         // HTTP/1.1 streams using the PHP stream wrapper require a
         // Connection: close header
         if ($request->getProtocolVersion() == '1.1'

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -318,7 +318,7 @@ class StreamHandler
         return $this->createResource(
             function () use ($uri, &$http_response_header, $contextResource, $context, $options, $request) {
                 $resource = @\fopen((string) $uri, 'r', false, $contextResource);
-                $this->lastHeaders = $http_response_header;
+                $this->lastHeaders = $http_response_header ?? [];
 
                 if (false === $resource) {
                     throw new ConnectException(sprintf('Connection refused for URI %s', $uri), $request, null, $context);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -738,4 +738,19 @@ class StreamHandlerTest extends TestCase
             ]
         )->wait();
     }
+
+    public function testHandlesNonHttpSchemesGracefully()
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('An error was encountered while creating the response');
+
+        $handler(
+            new Request('GET', 'file:///etc/passwd'),
+            [
+                RequestOptions::STREAM => true,
+            ]
+        )->wait();
+    }
 }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -739,12 +739,12 @@ class StreamHandlerTest extends TestCase
         )->wait();
     }
 
-    public function testHandlesNonHttpSchemesGracefully()
+    public function testRejectsNonHttpSchemes()
     {
         $handler = new StreamHandler();
 
         $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('An error was encountered while creating the response');
+        $this->expectExceptionMessage("The scheme 'file' is not supported.");
 
         $handler(
             new Request('GET', 'file:///etc/passwd'),


### PR DESCRIPTION
I recommend not to squash this PR when merging, as the commits try to tell a story.

Detailed reasoning can be found in the commit message of each of the both commits.