### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,5 @@
 /psalm.xml             export-ignore
 /tests/                export-ignore
 /vendor-bin/           export-ignore
+/CHANGELOG.md          export-ignore
+/UPGRADING.md          export-ignore


### PR DESCRIPTION
Make the vendor 140kb smaller, 
is it possible or is there any reason not to do it?