### PR TITLE
avoid depreciation issues in php8.1

### DIFF
--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -178,7 +178,7 @@ class CurlMultiHandler
         while ($this->handles || !$queue->isEmpty()) {
             // If there are no transfers, then sleep for the next delay
             if (!$this->active && $this->delays) {
-                \usleep($this->timeToNext());
+                \usleep(intval($this->timeToNext()));
             }
             $this->tick();
         }


### PR DESCRIPTION
**Description:**
wrapped `$this->timeToNext()` with `intval()` to avoid implicit conversion from float to int since this is depricated in php8.1.

