### PR TITLE
Get class to class keyword

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -23,7 +23,7 @@ final class Utils
     {
         switch (\gettype($input)) {
             case 'object':
-                return 'object(' . \get_class($input) . ')';
+                return 'object(' . $input::class . ')';
             case 'array':
                 return 'array(' . \count($input) . ')';
             default:


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.