### PR TITLE
Void return

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -491,7 +491,7 @@ class CurlFactory implements CurlFactoryInterface
                 throw new \InvalidArgumentException('progress client option must be callable');
             }
             $conf[\CURLOPT_NOPROGRESS] = false;
-            $conf[\CURLOPT_PROGRESSFUNCTION] = static function ($resource, int $downloadSize, int $downloaded, int $uploadSize, int $uploaded) use ($progress) {
+            $conf[\CURLOPT_PROGRESSFUNCTION] = static function ($resource, int $downloadSize, int $downloaded, int $uploadSize, int $uploaded) use ($progress): void {
                 $progress($downloadSize, $downloaded, $uploadSize, $uploaded);
             };
         }

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -104,7 +104,7 @@ final class EasyHandle
      *
      * @throws \BadMethodCallException
      */
-    public function __get($name)
+    public function __get($name): void
     {
         $msg = $name === 'handle' ? 'The EasyHandle has been released' : 'Invalid property: ' . $name;
         throw new \BadMethodCallException($msg);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -522,7 +522,7 @@ class StreamHandler
     {
         self::addNotification(
             $params,
-            static function ($code, $a, $b, $c, $transferred, $total) use ($value) {
+            static function ($code, $a, $b, $c, $transferred, $total) use ($value): void {
                 if ($code == \STREAM_NOTIFY_PROGRESS) {
                     // The upload progress cannot be determined. Use 0 for cURL compatibility:
                     // https://curl.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html
@@ -584,7 +584,7 @@ class StreamHandler
 
     private static function callArray(array $functions): callable
     {
-        return static function (...$args) use ($functions) {
+        return static function (...$args) use ($functions): void {
             foreach ($functions as $fn) {
                 $fn(...$args);
             }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -111,12 +111,12 @@ class Pool implements PromisorInterface
     private static function cmpCallback(array &$options, string $name, array &$results): void
     {
         if (!isset($options[$name])) {
-            $options[$name] = static function ($v, $k) use (&$results) {
+            $options[$name] = static function ($v, $k) use (&$results): void {
                 $results[$k] = $v;
             };
         } else {
             $currentFn = $options[$name];
-            $options[$name] = static function ($v, $k) use (&$results, $currentFn) {
+            $options[$name] = static function ($v, $k) use (&$results, $currentFn): void {
                 $currentFn($v, $k);
                 $results[$k] = $v;
             };


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.