### PR TITLE
No singleline whitespace before semicolons

### DIFF
--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -122,7 +122,7 @@ class HandlerStack
      */
     public function hasHandler(): bool
     {
-        return $this->handler !== null ;
+        return $this->handler !== null;
     }
 
     /**


### PR DESCRIPTION
Single-line whitespace before closing semicolon are prohibited.