### PR TITLE
Link to the correct RFC for 'Basic' authentication

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -142,7 +142,7 @@ auth
 The built-in authentication types are as follows:
 
 basic
-    Use `basic HTTP authentication <http://www.ietf.org/rfc/rfc2069.txt>`_
+    Use `basic HTTP authentication <http://www.ietf.org/rfc/rfc7617.txt>`_
     in the ``Authorization`` header (the default setting used if none is
     specified).
 


### PR DESCRIPTION
Currently, the reference link for 'Basic' authentication points to the 'Digest' authentication RFC on IETF. I updated it to point to the correct RFC 7167.