### PR TITLE
Add request to delay closure params

### DIFF
--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -109,7 +109,7 @@ class RetryMiddleware
 
     private function doRetry(RequestInterface $request, array $options, ResponseInterface $response = null): PromiseInterface
     {
-        $options['delay'] = ($this->delay)(++$options['retries'], $response);
+        $options['delay'] = ($this->delay)(++$options['retries'], $response, $request);
 
         return $this($request, $options);
     }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -20,10 +20,11 @@ class RetryMiddlewareTest extends TestCase
             $calls[] = $args;
             return \count($calls) < 3;
         };
-        $delay = static function ($retries, $response) use (&$delayCalls) {
+        $delay = static function ($retries, $response, $request) use (&$delayCalls) {
             $delayCalls++;
             self::assertSame($retries, $delayCalls);
             self::assertInstanceOf(Response::class, $response);
+            self::assertInstanceOf(Request::class, $request);
             return 1;
         };
         $m = Middleware::retry($decider, $delay);


### PR DESCRIPTION
This PR adds the `$request` object to the delay closure, this would be useful when you want to delay the request based on specific logic which is my case. 