### PR TITLE
feat(HandlerStack): add hasMiddleware function (context: async requests with multiple guzzle clients)

### DIFF
--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -126,6 +126,20 @@ class HandlerStack
     }
 
     /**
+     * Returns true if a middleware has already been pushed with this name.
+     */
+    public function hasMiddleware(string $name): bool
+    {
+        foreach ($this->stack as $k => $v) {
+            if ($v[1] === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Unshift a middleware to the bottom of the stack.
      *
      * @param callable(callable): callable $middleware Middleware function


### PR DESCRIPTION
## Context
To make parallel async requests between different Guzzle clients, I had to make these Guzzle clients all share a same `handler`... 

```php
$stack = new HandlerStack();
$stack->setHandler(new CurlMultiHandler());

$client1 = new Client(['handler' => $stack]);
$client2 = new Client(['handler' => $stack]);

GuzzleHttp\Promise\Utils::all([
    $client1->requestAsync(/*...*/),
    $client1->requestAsync(/*...*/),
    $client2->requestAsync(/*...*/),
    $client2->requestAsync(/*...*/),
])->wait();
```

## Issue
The problem with that is that sharing a same `handler` also mean that all `middlewares` will be shared across clients...

Example: 
```php
$stack = new HandlerStack();
$stack->setHandler(new CurlMultiHandler());
$client1 = new Client(['handler' => $stack]);
$client2 = new Client(['handler' => $stack]);

// some function which register a middleware on each Guzzle clients
foreach ($clients as $client) {
    $handler = $client->getConfig('handler');
    $handler->push(MyMiddleware, 'foo');
}

// => MyMiddleware has been pushed twice /o\
```

## Proposal
In order to avoid registering a same middleware multiple times, I would like to introduce a new `hasMiddleware` function.

Example: 
```php
$stack = new HandlerStack();
$stack->setHandler(new CurlMultiHandler());
$client1 = new Client(['handler' => $stack]);
$client2 = new Client(['handler' => $stack]);

// some function which register a middleware on each Guzzle clients
foreach ($clients as $client) {
    $handler = $client->getConfig('handler');
    if ($handler->hasMiddleware('foo')) {
        $handler->push(MyMiddleware, 'foo');
    }
}

// => MyMiddleware has been pushed once \o/
```

## Note
If you have a better idea about how we can make async requests using multiple Guzzle clients, without sharing a same handlerstack, feel free to tell me 🙏 