### PR TITLE
docs: Pin Jinja2 & markupsafe

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 Sphinx>=1.3.0,<1.4.0
 guzzle_sphinx_theme>=0.7.0,<0.8.0
+jinja2<3
+markupsafe<2.1


### PR DESCRIPTION
Hi, I'm the maintainer of [doc2dash](https://doc2dash.readthedocs.io/), a tool to create browsable docsets from Sphinx documentation. One of your users asked for help on my bug tracker about converting your docs and while trying to reproduce, I've noticed that the documentation doesn't build with the pins that you have in your `requirements.txt` because Jinja2 and markupsafe broke some backwards-compatability.

With the two I'm adding here, it works again.

---

I've noticed you're not building your docs in CI, so generally speaking if you have any questions that someone a bit more intimate with Python, docs, and packaging feel free to ask.

Cheers