### PR TITLE
Corrected docs and default connect timeout value to 300 seconds

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -282,7 +282,7 @@ connect_timeout
 ---------------
 
 :Summary: Float describing the number of seconds to wait while trying to connect
-        to a server. Use ``0`` to wait indefinitely (the default behavior).
+        to a server. Use ``0`` to wait 300 seconds (the default behavior).
 :Types: float
 :Default: ``0``
 :Constant: ``GuzzleHttp\RequestOptions::CONNECT_TIMEOUT``

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -224,7 +224,7 @@ class CurlFactory implements CurlFactoryInterface
             \CURLOPT_URL            => (string) $easy->request->getUri()->withFragment(''),
             \CURLOPT_RETURNTRANSFER => false,
             \CURLOPT_HEADER         => false,
-            \CURLOPT_CONNECTTIMEOUT_MS => 300000,
+            \CURLOPT_CONNECTTIMEOUT => 300,
         ];
 
         if (\defined('CURLOPT_PROTOCOLS')) {

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -224,7 +224,7 @@ class CurlFactory implements CurlFactoryInterface
             \CURLOPT_URL            => (string) $easy->request->getUri()->withFragment(''),
             \CURLOPT_RETURNTRANSFER => false,
             \CURLOPT_HEADER         => false,
-            \CURLOPT_CONNECTTIMEOUT => 150,
+            \CURLOPT_CONNECTTIMEOUT_MS => 300000,
         ];
 
         if (\defined('CURLOPT_PROTOCOLS')) {

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -70,7 +70,7 @@ final class RequestOptions
     /**
      * connect_timeout: (float, default=0) Float describing the number of
      * seconds to wait while trying to connect to a server. Use 0 to wait
-     * indefinitely (the default behavior).
+     * 300 seconds (the default behavior).
      */
     public const CONNECT_TIMEOUT = 'connect_timeout';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -66,7 +66,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame('testing', $_SERVER['_curl'][\CURLOPT_POSTFIELDS]);
         self::assertEquals(0, $_SERVER['_curl'][\CURLOPT_RETURNTRANSFER]);
         self::assertEquals(0, $_SERVER['_curl'][\CURLOPT_HEADER]);
-        self::assertSame(300000, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT_MS]);
+        self::assertSame(300, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT]);
         self::assertInstanceOf('Closure', $_SERVER['_curl'][\CURLOPT_HEADERFUNCTION]);
         if (\defined('CURLOPT_PROTOCOLS')) {
             self::assertSame(

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -66,7 +66,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame('testing', $_SERVER['_curl'][\CURLOPT_POSTFIELDS]);
         self::assertEquals(0, $_SERVER['_curl'][\CURLOPT_RETURNTRANSFER]);
         self::assertEquals(0, $_SERVER['_curl'][\CURLOPT_HEADER]);
-        self::assertSame(150, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT]);
+        self::assertSame(300000, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT_MS]);
         self::assertInstanceOf('Closure', $_SERVER['_curl'][\CURLOPT_HEADERFUNCTION]);
         if (\defined('CURLOPT_PROTOCOLS')) {
             self::assertSame(


### PR DESCRIPTION
As per [cURL documentation](https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html) if `CURLOPT_CONNECTTIMEOUT` set to `0` it means 300 seconds timeout:

> Set to zero to switch to the default built-in connection timeout - 300 seconds.

Additionally, curl provides 2 options to set connect timeout:
[CURLOPT_CONNECTTIMEOUT](https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html)
[CURLOPT_CONNECTTIMEOUT_MS](https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT_MS.html)

As mentioned, `If both CURLOPT_CONNECTTIMEOUT and CURLOPT_CONNECTTIMEOUT_MS are set, the value set last will be used.`

Guzzle code sets `CURLOPT_CONNECTTIMEOUT` to default 150, but then uses `CURLOPT_CONNECTTIMEOUT_MS` to overwrite this value.

This PR replaces `CURLOPT_CONNECTTIMEOUT` on `CURLOPT_CONNECTTIMEOUT_MS` and changes the default value for connect timeout from 150 to 300 to get rid of the wrong behaviour.