### PR TITLE
request no encoding if user does not specify acceptable encodings

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -388,9 +388,9 @@ class CurlFactory implements CurlFactoryInterface
                 // The empty string enables all available decoders and implicitly
                 // sets a matching 'Accept-Encoding' header.
                 $conf[\CURLOPT_ENCODING] = '';
-                // But as the user did not specify any acceptable encodings we need
-                // to overwrite this implicit header with an empty one.
-                $conf[\CURLOPT_HTTPHEADER][] = 'Accept-Encoding:';
+                // But as the user did not specify any acceptable encodings we should
+                // tell the server that no encodings are acceptable..
+                $conf[\CURLOPT_HTTPHEADER][] = 'Accept-Encoding: identity';
             }
         }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -371,7 +371,7 @@ class CurlFactoryTest extends TestCase
         self::assertEquals('test', (string) $response->getBody());
         self::assertEquals('', $_SERVER['_curl'][\CURLOPT_ENCODING]);
         $sent = Server::received()[0];
-        self::assertFalse($sent->hasHeader('Accept-Encoding'));
+        self::assertTrue($sent->hasHeader('Accept-Encoding'));
     }
 
     public function testReportsOriginalSizeAndContentEncodingAfterDecoding()


### PR DESCRIPTION
due to (imo shitty) specs, when the client does not request any encodings, the server is free to pick any encoding it wants. not sending any `Accept-Encoding` headers is equivalent to sending Accept-Encoding: *
(as * - anything - is the default Accept-encoding value)

IMO we shouldn't overwrite curl's Accept-Encoding header at all and the guzzle implementation is stupid, i'd love to hear the guzzle dev's rationale, 
 but at least setting CURLOPT_ENCODING='' + Accept-Encoding: identity is better than CURLOPT_ENCODING='' + Accept-encoding: *  (* is implicit when no accept-encoding is specified)

Lets say for example that curl is compiled with gzip+deflate, and curl *wants* to send `Accept-Encoding: gzip,deflate`, but because Guzzle sets `Accept-Encoding: *` (implicitly), the server opts to use br/brotli, resulting in broken downloads. this wouldn't have happened if guzzle didn't overwrite curl's default accept-encoding, and it wouldn't have happened if guzzle sent `Accept-Encoding: identity`, but it may happen if guzzle sends `Accept-Encoding: *` as it does prior to this patch.