### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/branch-alias.yml
+++ b/.github/workflows/branch-alias.yml
@@ -4,8 +4,13 @@ on:
   push:
     tags: ['*']
 
+permissions: {}
 jobs:
   branch-alias:
+    permissions:
+      contents: write  #  to create branch (peter-evans/create-pull-request)
+      pull-requests: write  #  to create a PR (peter-evans/create-pull-request)
+
     name: Update branch alias
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   composer-normalize:
     name: Composer Normalize

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read  #  to clone the repos and get release assets (shivammathur/setup-php)
+
 jobs:
   build-lowest-version:
     name: Build lowest version

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   phpstan:
     name: PHPStan


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.