### PR TITLE
Cast to array, preventing unsupported operands error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -301,7 +301,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         // Shallow merge defaults underneath options.
-        $result = $options + $defaults;
+        $result = (array) $options + (array) $defaults;
 
         // Remove null values.
         foreach ($result as $k => $v) {


### PR DESCRIPTION
We've observed cases where options have come through as something other than an array. This change is covered by existing unit tests and offers a sanity check and prevents Unsupported Operands error from being thrown. 