### PR TITLE
SetCookie constructor bugfix

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -82,7 +82,7 @@ class SetCookie
 
         $this->data = $replaced;
         // Extract the Expires value and turn it into a UNIX timestamp if needed
-        if (!$this->getExpires() && $this->getMaxAge()) {
+        if (!$this->getExpires() && $this->getMaxAge() && \is_numeric($this->getMaxAge())) {
             // Calculate the Expires date
             $this->setExpires(\time() + $this->getMaxAge());
         } elseif (null !== ($expires = $this->getExpires()) && !\is_numeric($expires)) {


### PR DESCRIPTION
The following issue has been fixed:
When using fromString(), for the following kind of incorrectly formed cookie
```fr=synced; Max-Age=604800 Expires=Mon, 12 Dec 2022 13:27:50 GMT; Domain=.emxdgt.com; Path=/; SameSite=None; Secure; HttpOnly```
it gives ```A non well formed numeric value encountered in /app/proxy/vendor/guzzlehttp/guzzle/src/Cookie/SetCookie.php notice```