### PR TITLE
PHP 8.2 Dynamic Property Compat

### DIFF
--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * @property resource $_mh Internal use only. Lazy loaded multi-handle.
  */
+#[\AllowDynamicProperties]
 class CurlMultiHandler
 {
     /** @var CurlFactoryInterface */


### PR DESCRIPTION
Adds the `\AllowDynamicProperties` annotation to suppress warnings about dynamic property creation on PHP 8.2.

This has also been raised in the `psr7` repository:

https://github.com/guzzle/psr7/pull/547
https://github.com/guzzle/psr7/pull/519

Are there concerns for supporting older versions of PHP that this is incompatible with?