### PR TITLE
Ability to pass callable as logLevel to Middleware::log()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
+## 7.6.0 - XXXX-XX-XX
+
+### Added
+
+- Ability to pass callable as `logLevel` to `Middleware::log()` to choice a level for each Request/Response pair
+
 ## 7.5.0 - 2022-08-28
 
 ### Added

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,9 +5,6 @@ includes:
 parameters:
     level: max
     checkMissingIterableValueType: false
-    typeAliases:
-        LogLevelConstant: '\Psr\Log\LogLevel::*'
-        LogLevelResolver: 'callable(\Psr\Http\Message\RequestInterface, \Psr\Http\Message\ResponseInterface): LogLevelConstant'
     paths:
         - src
     bootstrapFiles:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,9 @@ includes:
 parameters:
     level: max
     checkMissingIterableValueType: false
+    typeAliases:
+        LogLevelConstant: '\Psr\Log\LogLevel::*'
+        LogLevelResolver: 'callable(\Psr\Http\Message\RequestInterface, \Psr\Http\Message\ResponseInterface): LogLevelConstant'
     paths:
         - src
     bootstrapFiles:

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -183,7 +183,7 @@ final class Middleware
      * Middleware that logs requests, responses, and errors using a message
      * formatter.
      *
-     * @phpstan-param \Psr\Log\LogLevel::*|callable(RequestInterface, ResponseInterface):\Psr\Log\LogLevel::* $logLevel  Level at which to log requests.
+     * @phpstan-param LogLevelConstant|LogLevelResolver $logLevel  Level at which to log requests.
      *
      * @param LoggerInterface                            $logger    Logs messages.
      * @param MessageFormatterInterface|MessageFormatter $formatter Formatter used to create message strings.

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -183,6 +183,8 @@ final class Middleware
      * Middleware that logs requests, responses, and errors using a message
      * formatter.
      *
+     * @phpstan-type LogLevelConstant \Psr\Log\LogLevel::*
+     * @phpstan-type LogLevelResolver callable(RequestInterface, \ResponseInterface): LogLevelConstant
      * @phpstan-param LogLevelConstant|LogLevelResolver $logLevel  Level at which to log requests.
      *
      * @param LoggerInterface                            $logger    Logs messages.

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -184,7 +184,7 @@ final class Middleware
      * formatter.
      *
      * @phpstan-type LogLevelConstant \Psr\Log\LogLevel::*
-     * @phpstan-type LogLevelResolver callable(RequestInterface, \ResponseInterface): LogLevelConstant
+     * @phpstan-type LogLevelResolver callable(RequestInterface, ResponseInterface): LogLevelConstant
      * @phpstan-param LogLevelConstant|LogLevelResolver $logLevel  Level at which to log requests.
      *
      * @param LoggerInterface                            $logger    Logs messages.

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -228,7 +228,7 @@ class MiddlewareTest extends TestCase
 
     public function testLogsRequestsAndResponsesLevelCallback()
     {
-        $logLevelResolver = static function (RequestInterface $req, ResponseInterface  $res): string {
+        $logLevelResolver = static function (RequestInterface $req, ResponseInterface $res): string {
             return LogLevel::ALERT;
         };
 


### PR DESCRIPTION
Hi!

Sometimes we want to choice different levels for different Requests/Response pair. 
Especially for different response status codes.

This PR brings an ability to pass `callable` as `logLevel` param of `Middleware::log()`. 