### PR TITLE
Pass `int` to `&$still_running` of `curl_multi_exec`

### DIFF
--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -20,7 +20,7 @@ class CurlMultiHandler
     /** @var CurlFactoryInterface */
     private $factory;
     private $selectTimeout;
-    private $active;
+    private $active = 0;
     private $handles = [];
     private $delays = [];
     private $options = [];


### PR DESCRIPTION
Fix originally done here: https://github.com/guzzle/guzzle/pull/2991