### PR TITLE
Fix `NO_PROXY` settings

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -444,7 +444,7 @@ class CurlFactory implements CurlFactoryInterface
                 if (isset($options['proxy'][$scheme])) {
                     $host = $easy->request->getUri()->getHost();
                     if (isset($options['proxy']['no']) && Utils::isHostInNoProxy($host, $options['proxy']['no'])) {
-                        $conf[\CURLOPT_PROXY] = '';
+                        unset($conf[\CURLOPT_PROXY]);
                     } else {
                         $conf[\CURLOPT_PROXY] = $options['proxy'][$scheme];
                     }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -443,7 +443,9 @@ class CurlFactory implements CurlFactoryInterface
                 $scheme = $easy->request->getUri()->getScheme();
                 if (isset($options['proxy'][$scheme])) {
                     $host = $easy->request->getUri()->getHost();
-                    if (!isset($options['proxy']['no']) || !Utils::isHostInNoProxy($host, $options['proxy']['no'])) {
+                    if (isset($options['proxy']['no']) && Utils::isHostInNoProxy($host, $options['proxy']['no'])) {
+                        $conf[\CURLOPT_PROXY] = '';
+                    } else {
                         $conf[\CURLOPT_PROXY] = $options['proxy'][$scheme];
                     }
                 }


### PR DESCRIPTION
**Description**
When using the proxy => no request option guzzle fails to ignore the proxy if ENV vars are present on the server i.e. http_proxy or https_proxy.

This is because the no option only applies the CURLOPT_PROXY if the host is not in the list. So when ignoring it doesn't apply the curl option so falling back to the proxy that is set in the ENV var.

Fixes: https://github.com/guzzle/guzzle/issues/3093