### PR TITLE
Prevent to enable IDN conversion if the intl extension or its polyfill is not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
       max-parallel: 10
       matrix:
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        extensions: ['mbstring, intl']
+        include:
+          - php: '7.4'
+            extensions: 'mbstring'
 
     steps:
       - name: Set up PHP
@@ -50,7 +54,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
-          extensions: mbstring, intl
+          extensions: ${{ matrix.extensions }}
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/src/Client.php
+++ b/src/Client.php
@@ -236,7 +236,7 @@ class Client implements ClientInterface
             'decode_content'  => true,
             'verify'          => true,
             'cookies'         => false,
-            'idn_conversion'  => true,
+            'idn_conversion'  => defined('IDNA_DEFAULT'),
         ];
 
         // Use the standard Linux HTTP_PROXY and HTTPS_PROXY if set.


### PR DESCRIPTION
```shell
Fatal error: Uncaught Error: Undefined constant "GuzzleHttp\IDNA_DEFAULT" in /app/vendor/guzzlehttp/guzzle/src/Client.php:218
```