### PR TITLE
PR for #3137: Using `\GuzzleHttp\Cookie\SetCookie::fromString` with a `Max-Age` set will always result in a deprecation warning in `\GuzzleHttp\Cookie\SetCookie::setMaxAge`.

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -60,7 +60,7 @@ class SetCookie
                     if (!\strcasecmp($search, $key)) {
                         if ($search === 'Max-Age') {
                             if (is_numeric($value)) {
-                                $value = (int) $value;
+                                $data[$search] = (int) $value;
                             }
                         } else {
                             $data[$search] = $value;

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -58,10 +58,13 @@ class SetCookie
             } else {
                 foreach (\array_keys(self::$defaults) as $search) {
                     if (!\strcasecmp($search, $key)) {
-                        if ($search === 'Max-Age' && is_numeric($value)) {
-                            $value = (int) $value;
+                        if ($search === 'Max-Age') {
+                            if (is_numeric($value)) {
+                                $value = (int) $value;
+                            }
+                        } else {
+                            $data[$search] = $value;
                         }
-                        $data[$search] = $value;
                         continue 2;
                     }
                 }

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -58,6 +58,9 @@ class SetCookie
             } else {
                 foreach (\array_keys(self::$defaults) as $search) {
                     if (!\strcasecmp($search, $key)) {
+                        if ($search === 'Max-Age' && is_numeric($value)) {
+                            $value = (int) $value;
+                        }
                         $data[$search] = $value;
                         continue 2;
                     }

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -390,6 +390,21 @@ class SetCookieTest extends TestCase
                     'SameSite' => 'Lax',
                 ],
             ],
+            [
+                'SESS3a6f27284c4d8b34b6f4ff98cb87703e=Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH; expires=Wed, 07-Jun-2023 15:56:35 GMT; Max-Age=qwerty; path=/; domain=.example.com; HttpOnly; SameSite=Lax',
+                [
+                    'Name' => 'SESS3a6f27284c4d8b34b6f4ff98cb87703e',
+                    'Value' => 'Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH',
+                    'Domain' => '.example.com',
+                    'Path' => '/',
+                    'Expires' => 'Wed, 07-Jun-2023 15:56:35 GMT',
+                    'Secure' => false,
+                    'Discard' => false,
+                    'Max-Age' => null,
+                    'HttpOnly' => true,
+                    'SameSite' => 'Lax',
+                ],
+            ],
         ];
     }
 

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -375,6 +375,21 @@ class SetCookieTest extends TestCase
                     'SameSite' => 'None',
                 ],
             ],
+            [
+                'SESS3a6f27284c4d8b34b6f4ff98cb87703e=Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH; expires=Wed, 07-Jun-2023 15:56:35 GMT; Max-Age=2000000; path=/; domain=.example.com; HttpOnly; SameSite=Lax',
+                [
+                    'Name' => 'SESS3a6f27284c4d8b34b6f4ff98cb87703e',
+                    'Value' => 'Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH',
+                    'Domain' => '.example.com',
+                    'Path' => '/',
+                    'Expires' => 'Wed, 07-Jun-2023 15:56:35 GMT',
+                    'Secure' => false,
+                    'Discard' => false,
+                    'Max-Age' => 2000000,
+                    'HttpOnly' => true,
+                    'SameSite' => 'Lax',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Attempts to resolve #3137 