### PR TITLE
Fix `SetCookie::fromString` MaxAge deprecation warning and skip invalid MaxAge values

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -58,7 +58,13 @@ class SetCookie
             } else {
                 foreach (\array_keys(self::$defaults) as $search) {
                     if (!\strcasecmp($search, $key)) {
-                        $data[$search] = $value;
+                        if ($search === 'Max-Age') {
+                            if (is_numeric($value)) {
+                                $data[$search] = (int) $value;
+                            }
+                        } else {
+                            $data[$search] = $value;
+                        }
                         continue 2;
                     }
                 }

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -375,6 +375,36 @@ class SetCookieTest extends TestCase
                     'SameSite' => 'None',
                 ],
             ],
+            [
+                'SESS3a6f27284c4d8b34b6f4ff98cb87703e=Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH; expires=Wed, 07-Jun-2023 15:56:35 GMT; Max-Age=2000000; path=/; domain=.example.com; HttpOnly; SameSite=Lax',
+                [
+                    'Name' => 'SESS3a6f27284c4d8b34b6f4ff98cb87703e',
+                    'Value' => 'Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH',
+                    'Domain' => '.example.com',
+                    'Path' => '/',
+                    'Expires' => 'Wed, 07-Jun-2023 15:56:35 GMT',
+                    'Secure' => false,
+                    'Discard' => false,
+                    'Max-Age' => 2000000,
+                    'HttpOnly' => true,
+                    'SameSite' => 'Lax',
+                ],
+            ],
+            [
+                'SESS3a6f27284c4d8b34b6f4ff98cb87703e=Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH; expires=Wed, 07-Jun-2023 15:56:35 GMT; Max-Age=qwerty; path=/; domain=.example.com; HttpOnly; SameSite=Lax',
+                [
+                    'Name' => 'SESS3a6f27284c4d8b34b6f4ff98cb87703e',
+                    'Value' => 'Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH',
+                    'Domain' => '.example.com',
+                    'Path' => '/',
+                    'Expires' => 'Wed, 07-Jun-2023 15:56:35 GMT',
+                    'Secure' => false,
+                    'Discard' => false,
+                    'Max-Age' => null,
+                    'HttpOnly' => true,
+                    'SameSite' => 'Lax',
+                ],
+            ],
         ];
     }
 

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -370,7 +370,7 @@ class SetCookieTest extends TestCase
                     'Expires' => \time() + 604800,
                     'Secure' => true,
                     'Discard' => false,
-                    'Max-Age' => 604800,
+                    'Max-Age' => null,
                     'HttpOnly' => true,
                     'SameSite' => 'None',
                 ],

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -367,7 +367,7 @@ class SetCookieTest extends TestCase
                     'Value' => 'synced',
                     'Domain' => '.example.com',
                     'Path' => '/',
-                    'Expires' => \time() + 604800,
+                    'Expires' => null,
                     'Secure' => true,
                     'Discard' => false,
                     'Max-Age' => null,


### PR DESCRIPTION
Closes #3137. Closes #3138.