### PR TITLE
Fix typo in the abandoned request option name (UPGRADING.md)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,7 +27,7 @@ Please make sure:
 - Function `GuzzleHttp\Exception\RequestException::getResponseBodySummary` is removed.
   Use `\GuzzleHttp\Psr7\get_message_body_summary` as an alternative.
 - Function `GuzzleHttp\Cookie\CookieJar::getCookieValue` is removed.
-- Request option `exception` is removed. Please use `http_errors`.
+- Request option `exceptions` is removed. Please use `http_errors`.
 - Request option `save_to` is removed. Please use `sink`.
 - Pool option `pool_size` is removed. Please use `concurrency`.
 - We now look for environment variables in the `$_SERVER` super global, due to thread safety issues with `getenv`. We continue to fallback to `getenv` in CLI environments, for maximum compatibility.


### PR DESCRIPTION
The file `UPGRADING.md` contains typo in the `exceptions` option.