### PR TITLE
Replace the abandoned `php-http/message-factory` package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "ext-curl": "*",
         "bamarni/composer-bin-plugin": "^1.8.1",
         "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
-        "php-http/message-factory": "^1.1",
+        "psr/http-factory": "^1.0",
         "phpunit/phpunit": "^8.5.29 || ^9.5.23",
         "psr/log": "^1.1 || ^2.0 || ^3.0"
     },


### PR DESCRIPTION
This package is abandoned and no longer maintained. The author suggests using the [psr/http-factory](https://packagist.org/packages/psr/http-factory) package instead.