### PR TITLE
[8.0] Fix Utils::json*() for native `\JSON_THROW_ON_ERROR` option

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -273,12 +273,11 @@ EOT
      */
     public static function jsonDecode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
     {
-        $data = \json_decode($json, $assoc, $depth, $options);
-        if (\JSON_ERROR_NONE !== \json_last_error()) {
-            throw new InvalidArgumentException('json_decode error: '.\json_last_error_msg());
+        try {
+            return \json_decode($json, $assoc, $depth, $options | \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new InvalidArgumentException('json_decode error: '.$e->getMessage(), 0, $e);
         }
-
-        return $data;
     }
 
     /**
@@ -294,13 +293,11 @@ EOT
      */
     public static function jsonEncode($value, int $options = 0, int $depth = 512): string
     {
-        $json = \json_encode($value, $options, $depth);
-        if (\JSON_ERROR_NONE !== \json_last_error()) {
-            throw new InvalidArgumentException('json_encode error: '.\json_last_error_msg());
+        try {
+            return \json_encode($value, $options | \JSON_THROW_ON_ERROR, $depth);
+        } catch (\JsonException $e) {
+            throw new InvalidArgumentException('json_encode error: '.$e->getMessage(), 0, $e);
         }
-
-        /** @var string */
-        return $json;
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -168,6 +168,13 @@ class UtilsTest extends TestCase
         \GuzzleHttp\json_encode("\x99");
     }
 
+    public function testEncodesJsonAndThrowsOnErrorWithNativeOption()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Utils::jsonEncode("\x99", \JSON_THROW_ON_ERROR);
+    }
+
     public function testDecodesJson()
     {
         self::assertTrue(Utils::jsonDecode('true'));
@@ -186,6 +193,13 @@ class UtilsTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         \GuzzleHttp\json_decode('{{]]');
+    }
+
+    public function testDecodesJsonAndThrowsOnErrorWithNativeOption()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Utils::jsonDecode('{{]]', false, 512, \JSON_THROW_ON_ERROR);
     }
 }
 


### PR DESCRIPTION
If a user passes the native `\JSON_THROW_ON_ERROR` option, these functions would throw a `\JsonException` instead of the expected `\InvalidArgumentException`.