### PR TITLE
Add another `base_uri` example in documentation

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -58,6 +58,7 @@ The client constructor accepts an associative array of options:
     ``http://foo.com/foo``   ``/bar``            ``http://foo.com/bar``
     ``http://foo.com/foo``   ``bar``             ``http://foo.com/bar``
     ``http://foo.com/foo/``  ``bar``             ``http://foo.com/foo/bar``
+    ``http://foo.com/foo/``  ``/bar``            ``http://foo.com/bar``
     ``http://foo.com``       ``http://baz.com``  ``http://baz.com``
     ``http://foo.com/?bar``  ``bar``             ``http://foo.com/bar``
     =======================  ==================  ===============================


### PR DESCRIPTION
It's not that intuitive that `http://api.com/v1/` + `/resources` would result in `http://api.com/resources` so I think it's good to mention it.

It could actually be merged in an older branch but I didn't know which one to choose, tell me if I should change the target branch.