### PR TITLE
[7.8] Correct Guzzle 7 IDN default value in docs

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -582,12 +582,11 @@ http_errors
 idn_conversion
 --------------
 
-:Summary: Internationalized Domain Name (IDN) support (enabled by default if
-    ``intl`` extension is available).
+:Summary: Internationalized Domain Name (IDN) support.
 :Types:
     - bool
     - int
-:Default: ``true`` if ``intl`` extension is available (and ICU library is 4.6+ for PHP 7.2+), ``false`` otherwise
+:Default: ``false``
 :Constant: ``GuzzleHttp\RequestOptions::IDN_CONVERSION``
 
 .. code-block:: php


### PR DESCRIPTION
Since Guzzle 7, the default has been to have this disabled. See https://github.com/guzzle/guzzle/pull/2675.