### PR TITLE
[8.0] Partially remove `getConfig`

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -200,7 +200,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *
      * @return mixed
      *
-     * @deprecated Client::getConfig will be removed in guzzlehttp/guzzle:8.0.
+     * @deprecated Client::getConfig will be removed in guzzlehttp/guzzle:9.0.
      */
     public function getConfig(?string $option = null)
     {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -66,19 +66,4 @@ interface ClientInterface
      * @param array               $options Request options to apply.
      */
     public function requestAsync(string $method, $uri, array $options = []): PromiseInterface;
-
-    /**
-     * Get a client configuration option.
-     *
-     * These options include default request options of the client, a "handler"
-     * (if utilized by the concrete client), and a "base_uri" if utilized by
-     * the concrete client.
-     *
-     * @param string|null $option The config option to retrieve.
-     *
-     * @return mixed
-     *
-     * @deprecated ClientInterface::getConfig will be removed in guzzlehttp/guzzle:8.0.
-     */
-    public function getConfig(?string $option = null);
 }


### PR DESCRIPTION
Remove `getConfig` from the `ClientInterface` and delay removal from the Client until Guzzle 9.0.