### PR TITLE
[7.9] Improve `Accept-Encoding` documentation

### DIFF
--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -400,6 +400,28 @@ header of the request.
     // Pass "gzip" as the Accept-Encoding header.
     $client->request('GET', '/foo.js', ['decode_content' => 'gzip']);
 
+.. warning::
+
+    The ``Accept-Encoding`` header will not be sent unless you provide it
+    explicitly, or pass a string value to ``decode_content``. That is
+    `equivalent <https://www.rfc-editor.org/rfc/rfc9110#field.accept-encoding>`
+    to sending ``Accept-Encoding: *``. Most servers will probably
+    return an uncompressed body in response to that but some might opt
+    to use a compression method that is not supported by your system.
+
+    In order to enable compression, and to ensure that only supported
+    encoding methods will be used, you should let curl send
+    the ``Accept-Encoding`` header:
+
+    .. code-block:: php
+
+        // Delegate choosing compression method to curl
+        $client->request('GET', '/foo.js', [
+            'curl' => [
+                \CURLOPT_ENCODING => '',
+            ],
+        ]);
+
 
 .. _delay-option:
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -390,8 +390,10 @@ class CurlFactory implements CurlFactoryInterface
                 // The empty string enables all available decoders and implicitly
                 // sets a matching 'Accept-Encoding' header.
                 $conf[\CURLOPT_ENCODING] = '';
-                // But as the user did not specify any acceptable encodings we need
-                // to overwrite this implicit header with an empty one.
+                // But as the user did not specify any encoding preference,
+                // let’s leave it up to server by preventing curl from sending
+                // the header, which will be interpreted as 'Accept-Encoding: *'.
+                // https://www.rfc-editor.org/rfc/rfc9110#field.accept-encoding
                 $conf[\CURLOPT_HTTPHEADER][] = 'Accept-Encoding:';
             }
         }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -391,7 +391,7 @@ class CurlFactory implements CurlFactoryInterface
                 // sets a matching 'Accept-Encoding' header.
                 $conf[\CURLOPT_ENCODING] = '';
                 // But as the user did not specify any encoding preference,
-                // let’s leave it up to server by preventing curl from sending
+                // let's leave it up to server by preventing curl from sending
                 // the header, which will be interpreted as 'Accept-Encoding: *'.
                 // https://www.rfc-editor.org/rfc/rfc9110#field.accept-encoding
                 $conf[\CURLOPT_HTTPHEADER][] = 'Accept-Encoding:';


### PR DESCRIPTION
https://github.com/guzzle/guzzle/commit/1d46cec19f74f57fe8be671214b4ecf183e5d63f tried to improve the comment but the new content implies an empty header will be sent.

That is not the case. Quoting from <https://curl.se/libcurl/c/CURLOPT_HTTPHEADER.html>:

> If you add a header with no content as in 'Accept:' (no data on the right side of the colon), the internally used header is disabled/removed.

Let’s clarify the point is removing the header to get the default '*'
<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding#sect2>:

> `*`: Matches any content encoding not already listed in the header. This is the default value if the header is not present. This directive does not suggest that any algorithm is supported but indicates that no preference is expressed.

As was probably intended by the original change that introduced this: https://github.com/guzzle/guzzle/commit/1a9ad6b55368283aaf73672a519e5177530991fb
