### PR TITLE
The CurlMultiHandle causes a busy immediately when the first byte is received

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -117,7 +117,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$mh of function curl_multi_exec expects resource, CurlMultiHandle\\|resource given\\.$#"
-			count: 1
+			count: 2
 			path: src/Handler/CurlMultiHandler.php
 
 		-
@@ -132,7 +132,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$mh of function curl_multi_select expects resource, CurlMultiHandle\\|resource given\\.$#"
-			count: 1
+			count: 3
 			path: src/Handler/CurlMultiHandler.php
 
 		-
@@ -189,4 +189,3 @@ parameters:
 			message: "#^Parameter \\#3 \\$depth of function json_encode expects int\\<1, max\\>, int given\\.$#"
 			count: 1
 			path: src/Utils.php
-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,7 +16,7 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function strtolower expects string, int\\|string given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function strtolower expects string, int\\|string given\\.$#"
 			count: 1
 			path: src/Client.php
 
@@ -51,87 +51,77 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$ch of function curl_close expects resource, CurlHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$handle of function curl_close expects CurlHandle, CurlHandle\\|resource given\\.$#"
 			count: 2
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$ch of function curl_error expects resource, CurlHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$handle of function curl_error expects CurlHandle, CurlHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$ch of function curl_getinfo expects resource, CurlHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$handle of function curl_getinfo expects CurlHandle, CurlHandle\\|resource given\\.$#"
 			count: 4
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$ch of function curl_reset expects resource, CurlHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$handle of function curl_reset expects CurlHandle, CurlHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$ch of function curl_setopt expects resource, CurlHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$handle of function curl_setopt expects CurlHandle, CurlHandle\\|resource given\\.$#"
 			count: 4
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$ch of function curl_setopt_array expects resource, CurlHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$handle of function curl_setopt_array expects CurlHandle, CurlHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$str1 of function strcasecmp expects string, int\\|string given\\.$#"
+			message: "#^Parameter \\#1 \\$string1 of function strcasecmp expects string, int\\|string given\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlFactory\\:\\:\\$handles has unknown class CurlHandle as its type\\.$#"
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
-			message: "#^Parameter \\#1 \\$ch of function curl_errno expects resource, CurlHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$handle of function curl_errno expects CurlHandle, CurlHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$ch of function curl_exec expects resource, CurlHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$handle of function curl_exec expects CurlHandle, CurlHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlHandler.php
 
 		-
-			message: "#^Method GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:__get\\(\\) has invalid return type CurlMultiHandle\\.$#"
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_add_handle expects resource, CurlMultiHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$multi_handle of function curl_multi_add_handle expects CurlMultiHandle, CurlMultiHandle\\|resource given\\.$#"
 			count: 2
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_close expects resource, CurlMultiHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$multi_handle of function curl_multi_close expects CurlMultiHandle, CurlMultiHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_exec expects resource, CurlMultiHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$multi_handle of function curl_multi_exec expects CurlMultiHandle, CurlMultiHandle\\|resource given\\.$#"
 			count: 2
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_info_read expects resource, CurlMultiHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$multi_handle of function curl_multi_info_read expects CurlMultiHandle, CurlMultiHandle\\|resource given\\.$#"
 			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_remove_handle expects resource, CurlMultiHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$multi_handle of function curl_multi_remove_handle expects CurlMultiHandle, CurlMultiHandle\\|resource given\\.$#"
 			count: 2
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$mh of function curl_multi_select expects resource, CurlMultiHandle\\|resource given\\.$#"
+			message: "#^Parameter \\#1 \\$multi_handle of function curl_multi_select expects CurlMultiHandle, CurlMultiHandle\\|resource given\\.$#"
 			count: 3
 			path: src/Handler/CurlMultiHandler.php
 
@@ -141,14 +131,9 @@ parameters:
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: "#^Property GuzzleHttp\\\\Handler\\\\CurlMultiHandler\\:\\:\\$_mh has unknown class CurlMultiHandle as its type\\.$#"
+			message: "#^Strict comparison using \\=\\=\\= between false and CurlMultiHandle will always evaluate to false\\.$#"
 			count: 1
 			path: src/Handler/CurlMultiHandler.php
-
-		-
-			message: "#^Property GuzzleHttp\\\\Handler\\\\EasyHandle\\:\\:\\$handle has unknown class CurlHandle as its type\\.$#"
-			count: 1
-			path: src/Handler/EasyHandle.php
 
 		-
 			message: "#^Trying to invoke mixed but it's not a callable\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -99,6 +99,9 @@
       <code><![CDATA[$this->_mh]]></code>
       <code><![CDATA[$this->_mh]]></code>
       <code><![CDATA[$this->_mh]]></code>
+      <code><![CDATA[$this->_mh]]></code>
+      <code><![CDATA[$this->_mh]]></code>
+      <code><![CDATA[$this->_mh]]></code>
     </PossiblyInvalidArgument>
     <RedundantPropertyInitializationCheck>
       <code><![CDATA[isset($this->_mh)]]></code>


### PR DESCRIPTION
I've provided a patch to the CurlMultiHandler which leverages the event loop. This allows TaskQueue implementations to properly sleep between each invocation of the \curl_multi_exec, and added a curl_multi_select() statement inside the busy wait loop that is meant to "wrap up" things.