### PR TITLE
[7.9] Only select the cURL handler by default if 7.34.0 or higher is linked

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -186,6 +186,11 @@ parameters:
 			path: src/Middleware.php
 
 		-
+			message: "#^Cannot access offset 'version' on array\\|false\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
 			message: "#^Method GuzzleHttp\\\\Utils\\:\\:jsonDecode\\(\\) should return array\\|bool\\|float\\|int\\|object\\|string\\|null but returns mixed\\.$#"
 			count: 1
 			path: src/Utils.php

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -87,7 +87,7 @@ final class Utils
     {
         $handler = null;
 
-        if (\defined('CURLOPT_CUSTOMREQUEST')) {
+        if (\defined('CURLOPT_CUSTOMREQUEST') && \function_exists('curl_version') && version_compare(curl_version()['version'], '7.34') >= 0) {
             if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
                 $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
             } elseif (\function_exists('curl_exec')) {


### PR DESCRIPTION
I don't expect this to impact a lot of people, given how old a version of curl this is. This is not dropping support for curl older than that, this is just not using it by default if it's very too old, in particular, too old to expose if it is TLS 1.2 capable or not.

---

Fixes #3219.