### PR TITLE
proposal timeout type on CurlFactory.php

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -417,7 +417,7 @@ class CurlFactory implements CurlFactoryInterface
         $timeoutRequiresNoSignal = false;
         if (isset($options['timeout'])) {
             $timeoutRequiresNoSignal |= $options['timeout'] < 1;
-            $conf[\CURLOPT_TIMEOUT_MS] = $options['timeout'] * 1000;
+            $conf[\CURLOPT_TIMEOUT_MS] = (int)$options['timeout'] * 1000;
         }
 
         // CURL default value is CURL_IPRESOLVE_WHATEVER


### PR DESCRIPTION
could you please consider about my proposal commit!
cause when I  use this library on my project.
I had trouble about the error of [2024-06-19 19:55:02] local.ERROR: TypeError: Unsupported operand types: string * int in /var/www/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:420