### PR TITLE
Redact the userinfo in cURL error exception messages

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: src/Cookie/SetCookie.php
 
 		-
-			message: "#^Unsafe call to private method GuzzleHttp\\\\Exception\\\\RequestException\\:\\:obfuscateUri\\(\\) through static\\:\\:\\.$#"
-			count: 1
-			path: src/Exception/RequestException.php
-
-		-
 			message: "#^Cannot access offset 'version' on array\\|false\\.$#"
 			count: 1
 			path: src/Handler/CurlFactory.php

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -4,10 +4,10 @@ namespace GuzzleHttp\Exception;
 
 use GuzzleHttp\BodySummarizer;
 use GuzzleHttp\BodySummarizerInterface;
+use GuzzleHttp\Utils;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\UriInterface;
 
 /**
  * HTTP Request exception
@@ -91,7 +91,7 @@ class RequestException extends TransferException implements RequestExceptionInte
         }
 
         $uri = $request->getUri();
-        $uri = static::obfuscateUri($uri);
+        $uri = Utils::redactUserinfoInUri($uri);
 
         // Client Error: `GET /` resulted in a `404 Not Found` response:
         // <html> ... (truncated)
@@ -111,20 +111,6 @@ class RequestException extends TransferException implements RequestExceptionInte
         }
 
         return new $className($message, $request, $response, $previous, $handlerContext);
-    }
-
-    /**
-     * Obfuscates URI if there is a username and a password present
-     */
-    private static function obfuscateUri(UriInterface $uri): UriInterface
-    {
-        $userInfo = $uri->getUserInfo();
-
-        if (false !== ($pos = \strpos($userInfo, ':'))) {
-            return $uri->withUserInfo(\substr($userInfo, 0, $pos), '***');
-        }
-
-        return $uri;
     }
 
     /**

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -200,7 +200,7 @@ class CurlFactory implements CurlFactoryInterface
             $ctx['error'],
             'see https://curl.haxx.se/libcurl/c/libcurl-errors.html'
         );
-        $uriString = (string) $easy->request->getUri();
+        $uriString = (string) Utils::redactUserinfoInUri($easy->request->getUri());
         if ($uriString !== '' && false === \strpos($ctx['error'], $uriString)) {
             $message .= \sprintf(' for %s', $uriString);
         }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -381,4 +381,18 @@ EOT
 
         throw new \Error('ext-idn or symfony/polyfill-intl-idn not loaded or too old');
     }
+
+    /**
+     * Redacts the password in the userinfo part of a UriInterface.
+     */
+    public static function redactUserinfoInUri(UriInterface $uri): UriInterface
+    {
+        $userInfo = $uri->getUserInfo();
+
+        if (false !== ($pos = \strpos($userInfo, ':'))) {
+            return $uri->withUserInfo(\substr($userInfo, 0, $pos), '***');
+        }
+
+        return $uri;
+    }
 }

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -32,6 +32,19 @@ class CurlHandlerTest extends TestCase
         $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])->wait();
     }
 
+    public function testRedactsUserInfoInErrors()
+    {
+        $handler = new CurlHandler();
+        $request = new Request('GET', 'http://my_user:secretPass@localhost:123');
+
+        try {
+            $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])->wait();
+            $this->fail('Must throw an Exception.');
+        } catch (\Throwable $e) {
+            $this->assertStringNotContainsString('secretPass', $e->getMessage());
+        }
+    }
+
     public function testReusesHandles()
     {
         Server::flush();

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Test;
 
 use GuzzleHttp;
+use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 
@@ -186,6 +187,13 @@ class UtilsTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         \GuzzleHttp\json_decode('{{]]');
+    }
+
+    public function testRedactsUserInfoInErrors()
+    {
+        $uri = new Uri('http://my_user:secretPass@localhost/');
+
+        self::assertEquals('http://my_user:***@localhost/', Utils::redactUserinfoInUri($uri)->__toString());
     }
 }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -189,7 +189,7 @@ class UtilsTest extends TestCase
         \GuzzleHttp\json_decode('{{]]');
     }
 
-    public function testRedactsUserInfoInErrors()
+    public function testRedactUserinfoInUri()
     {
         $uri = new Uri('http://my_user:secretPass@localhost/');
 


### PR DESCRIPTION
I think this would technically qualify as a security issue, but given that it cannot be actively exploited by an attacker, I'm filing this as a public PR. You might want to consider publishing an advisory nevertheless.