### PR TITLE
[7.9] Drop PSR7 v1 and redact URI user info in errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,19 +52,10 @@ jobs:
       max-parallel: 10
       matrix:
         php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        psr7: ['^1.9.1', '^2.6.3']
+        psr7: ['^2.7.0']
         include:
           - php: '8.4'
-            psr7: '^2.6.3@dev'
-        exclude:
-          - php: '8.1'
-            psr7: '^1.9.1'
-          - php: '8.2'
-            psr7: '^1.9.1'
-          - php: '8.3'
-            psr7: '^1.9.1'
-          - php: '8.4'
-            psr7: '^1.9.1'
+            psr7: '^2.7.0@dev'
 
     steps:
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
-        "guzzlehttp/psr7": "^1.9.1 || ^2.6.3",
+        "guzzlehttp/psr7": "^2.7.0",
         "psr/http-client": "^1.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: src/Cookie/SetCookie.php
 
 		-
-			message: "#^Unsafe call to private method GuzzleHttp\\\\Exception\\\\RequestException\\:\\:obfuscateUri\\(\\) through static\\:\\:\\.$#"
-			count: 1
-			path: src/Exception/RequestException.php
-
-		-
 			message: "#^Cannot access offset 'features' on array\\|false\\.$#"
 			count: 3
 			path: src/Handler/CurlFactory.php

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -4,10 +4,10 @@ namespace GuzzleHttp\Exception;
 
 use GuzzleHttp\BodySummarizer;
 use GuzzleHttp\BodySummarizerInterface;
+use GuzzleHttp\Utils;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\UriInterface;
 
 /**
  * HTTP Request exception
@@ -90,8 +90,7 @@ class RequestException extends TransferException implements RequestExceptionInte
             $className = __CLASS__;
         }
 
-        $uri = $request->getUri();
-        $uri = static::obfuscateUri($uri);
+        $uri = \GuzzleHttp\Psr7\Utils::redactUserInfo($request->getUri());
 
         // Client Error: `GET /` resulted in a `404 Not Found` response:
         // <html> ... (truncated)
@@ -111,20 +110,6 @@ class RequestException extends TransferException implements RequestExceptionInte
         }
 
         return new $className($message, $request, $response, $previous, $handlerContext);
-    }
-
-    /**
-     * Obfuscates URI if there is a username and a password present
-     */
-    private static function obfuscateUri(UriInterface $uri): UriInterface
-    {
-        $userInfo = $uri->getUserInfo();
-
-        if (false !== ($pos = \strpos($userInfo, ':'))) {
-            return $uri->withUserInfo(\substr($userInfo, 0, $pos), '***');
-        }
-
-        return $uri;
     }
 
     /**

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -4,7 +4,6 @@ namespace GuzzleHttp\Exception;
 
 use GuzzleHttp\BodySummarizer;
 use GuzzleHttp\BodySummarizerInterface;
-use GuzzleHttp\Utils;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -254,15 +254,17 @@ class CurlFactory implements CurlFactoryInterface
 
         $uri = $easy->request->getUri();
 
+        $sanitizedError = self::sanitizeCurlError($ctx['error'] ?? '', $uri);
+
         $message = \sprintf(
             'cURL error %s: %s (%s)',
             $ctx['errno'],
-            self::sanitizeCurlError($ctx['error'] ?? '', $uri),
+            $sanitizedError,
             'see https://curl.haxx.se/libcurl/c/libcurl-errors.html'
         );
 
         $redactedUriString = \GuzzleHttp\Psr7\Utils::redactUserInfo($uri)->__toString();
-        if ($redactedUriString !== '' && false === \strpos($ctx['error'], $redactedUriString)) {
+        if ($redactedUriString !== '' && false === \strpos($sanitizedError, $redactedUriString)) {
             $message .= \sprintf(' for %s', $redactedUriString);
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Creates curl resources from a request

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -263,9 +263,11 @@ class CurlFactory implements CurlFactoryInterface
             'see https://curl.haxx.se/libcurl/c/libcurl-errors.html'
         );
 
-        $redactedUriString = \GuzzleHttp\Psr7\Utils::redactUserInfo($uri)->__toString();
-        if ($redactedUriString !== '' && false === \strpos($sanitizedError, $redactedUriString)) {
-            $message .= \sprintf(' for %s', $redactedUriString);
+        if ('' !== $sanitizedError) {
+            $redactedUriString = \GuzzleHttp\Psr7\Utils::redactUserInfo($uri)->__toString();
+            if ($redactedUriString !== '' && false === \strpos($sanitizedError, $redactedUriString)) {
+                $message .= \sprintf(' for %s', $redactedUriString);
+            }
         }
 
         // Create a connection exception if it was a specific error code.
@@ -278,6 +280,10 @@ class CurlFactory implements CurlFactoryInterface
 
     private static function sanitizeCurlError(string $error, UriInterface $uri): string
     {
+        if ('' === $error) {
+            return $error;
+        }
+
         $baseUri = $uri->withQuery('')->withFragment('');
         $baseUriString = $baseUri->__toString();
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -261,9 +261,8 @@ class CurlFactory implements CurlFactoryInterface
             'see https://curl.haxx.se/libcurl/c/libcurl-errors.html'
         );
 
-        $originalUriString = $uri->__toString();
-        if ($originalUriString !== '' && false === \strpos($ctx['error'], $originalUriString)) {
-            $redactedUriString = \GuzzleHttp\Psr7\Utils::redactUserInfo($uri)->__toString();
+        $redactedUriString = \GuzzleHttp\Psr7\Utils::redactUserInfo($uri)->__toString();
+        if ($redactedUriString !== '' && false === \strpos($ctx['error'], $redactedUriString)) {
             $message .= \sprintf(' for %s', $redactedUriString);
         }
 

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -32,6 +32,19 @@ class CurlHandlerTest extends TestCase
         $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])->wait();
     }
 
+    public function testRedactsUserInfoInErrors()
+    {
+        $handler = new CurlHandler();
+        $request = new Request('GET', 'http://my_user:secretPass@localhost:123');
+
+        try {
+            $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])->wait();
+            $this->fail('Must throw an Exception.');
+        } catch (\Throwable $e) {
+            $this->assertStringNotContainsString('secretPass', $e->getMessage());
+        }
+    }
+
     public function testReusesHandles()
     {
         Server::flush();

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -3,7 +3,6 @@
 namespace GuzzleHttp\Test;
 
 use GuzzleHttp;
-use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Test;
 
 use GuzzleHttp;
+use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
v1 of the psr7 package is EOL, as of the end of the last month, so we don't need to continue supporting it. Closes #3229.