### PR TITLE
[7.9] Adjust minimum curl version from 7.34.0 to 7.21.2

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -87,7 +87,7 @@ final class Utils
     {
         $handler = null;
 
-        if (\defined('CURLOPT_CUSTOMREQUEST') && \function_exists('curl_version') && version_compare(curl_version()['version'], '7.34') >= 0) {
+        if (\defined('CURLOPT_CUSTOMREQUEST') && \function_exists('curl_version') && version_compare(curl_version()['version'], '7.21.2') >= 0) {
             if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
                 $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
             } elseif (\function_exists('curl_exec')) {


### PR DESCRIPTION
Fixes #3240, but re-breaks #3219. Probably we can delay the bump to 7.34.0 for Guzzle 8.