### PR TITLE
[7.9] #3244: Add `BASE_URI` constant to `RequestOptions` for `base_uri` parameter.

### DIFF
--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -271,4 +271,9 @@ final class RequestOptions
      * force_ip_resolve: (bool) Force client to use only ipv4 or ipv6 protocol
      */
     public const FORCE_IP_RESOLVE = 'force_ip_resolve';
+
+    /**
+     * base_uri: (string) Base URI for the request.
+     */
+    public const BASE_URI = 'base_uri';
 }


### PR DESCRIPTION
**Related Ticket:** #3244

**Description:**

This pull request adds a `BASE_URI` constant to the `RequestOptions` class in Guzzle. This constant represents the `base_uri` parameter used in Guzzle requests.

**Motivation:**

Having a `BASE_URI` constant improves code readability and maintainability by providing a standard way to refer to the `base_uri` parameter. This addition aligns with other existing constants in the `RequestOptions` class and helps developers avoid hardcoding strings in their code.

**Changes:**

- Added `BASE_URI` constant to `src/RequestOptions.php`.

**Example Usage:**

Currently, developers use the `base_uri` parameter as a string:

```php
$client = new \GuzzleHttp\Client([
    'base_uri' => 'https://api.example.com',
]);
```

With the proposed `BASE_URI` constant, it can be written as:

```php
use GuzzleHttp\RequestOptions;

$client = new \GuzzleHttp\Client([
    RequestOptions::BASE_URI => 'https://api.example.com',
]);
```

**Benefits:**

- **Consistency:** Aligns with other request options constants.
- **Readability:** Makes the code easier to read and understand.
- **Maintainability:** Reduces the risk of typos and string duplication.
