### PR TITLE
Fix PHP <8 support for 7.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
         "guzzlehttp/psr7": "^2.7.0",
         "psr/http-client": "^1.0",
-        "symfony/deprecation-contracts": "^2.2 || ^3.0"
+        "symfony/deprecation-contracts": "^2.5"
     },
     "provide": {
         "psr/http-client-implementation": "1.0"


### PR DESCRIPTION
Guzzle version **7.x** has declared support for PHP versions **>=7.2.5,<8.5**, but due to required versions of _"symfony/deprecation-contracts"_ it doesn't support the range of declared PHP versions.

Due to required versions for the specified package being declared like:
`"symfony/deprecation-contracts": "^2.5 || ^3.0"`

It installs higher version which no longer supports PHP versions under 8.

Changed the required version of the package to use specific minor version with only higher version patches being allowed: 
`"symfony/deprecation-contracts": "^2.5"`

Since the [deprecation-contracts](https://github.com/symfony/deprecation-contracts/blob/3.0/composer.json#L18) package 2.5 version supports PHP >7.1 that makes Guzzle also support the declared PHP versions.

