### PR TITLE
Fixed to set the default protocol version if the request has an empty-letter protocol version.

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -53,6 +53,8 @@ class CurlFactory implements CurlFactoryInterface
             if (!self::supportsHttp2()) {
                 throw new ConnectException('HTTP/2 is supported by the cURL handler, however libcurl is built without HTTP/2 support.', $request);
             }
+        } elseif ('' === $protocolVersion) {
+            throw new ConnectException('Protocol version is not set for the cURL handler.', $request);
         } elseif ('1.0' !== $protocolVersion && '1.1' !== $protocolVersion) {
             throw new ConnectException(sprintf('HTTP/%s is not supported by the cURL handler.', $protocolVersion), $request);
         }

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -493,6 +493,21 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
     }
 
+    /**
+     * https://github.com/guzzle/guzzle/issues/3250
+     */
+    public function testFailsWhenEmptyProtocolVersion()
+    {
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('Protocol version is not set for the cURL handler.');
+
+        $emptyProtocolVersion = '';
+        $request = new Psr7\Request('GET', Server::$url, [], null, $emptyProtocolVersion);
+        $factory = new CurlFactory(3);
+
+        $factory->create($request, []);
+    }
+
     public function testSavesToStream()
     {
         $stream = \fopen('php://memory', 'r+');

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -496,16 +496,16 @@ class CurlFactoryTest extends TestCase
     /**
      * https://github.com/guzzle/guzzle/issues/3250
      */
-    public function testFailsWhenEmptyProtocolVersion()
+    public function testTreatAsDefaultProtocolVersionWhenEmpty()
     {
-        $this->expectException(ConnectException::class);
-        $this->expectExceptionMessage('Protocol version is not set for the cURL handler.');
-
         $emptyProtocolVersion = '';
-        $request = new Psr7\Request('GET', Server::$url, [], null, $emptyProtocolVersion);
+        $request = new Psr7\Request('GET', 'http://foo.com', [], null, $emptyProtocolVersion);
         $factory = new CurlFactory(3);
 
-        $factory->create($request, []);
+        $result = $factory->create($request, []);
+
+        self::assertEquals('1.0', $result->request->getProtocolVersion());
+        self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
     }
 
     public function testSavesToStream()


### PR DESCRIPTION
Added exception handling so that CurlFactory can return appropriate error messages.
The issue on which this pull request is based is #3250.

When using the create method in CurlFactory, if the first argument, $request, was set to an empty protocol version, a slightly confusing error message was displayed, "HTTP/ is not supported by the cURL handler.".

With this fix, if an empty protocol version is set, it now returns the error message "Protocol version is not set for the cURL handler".

---

_This text was translated from Japanese to English at DeepL._