### PR TITLE
HandlerStack: Use nullable `$name` parameter in `unshift` method

### DIFF
--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -129,7 +129,7 @@ class HandlerStack
      * Unshift a middleware to the bottom of the stack.
      *
      * @param callable(callable): callable $middleware Middleware function
-     * @param string                       $name       Name to register for this middleware.
+     * @param ?string                      $name       Name to register for this middleware.
      */
     public function unshift(callable $middleware, ?string $name = null): void
     {


### PR DESCRIPTION
Changed the `$name` parameter type in the `unshift` method from `string` to `?string` to allow null values.