### PR TITLE
fix(docs): add RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "2.7"
+
+sphinx:
+    configuration: docs/conf.py
+
+python:
+   install:
+     - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Latest Version](https://img.shields.io/github/release/guzzle/guzzle.svg?style=flat-square)](https://github.com/guzzle/guzzle/releases)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/guzzle/guzzle/ci.yml?label=ci%20build&style=flat-square)](https://github.com/guzzle/guzzle/actions?query=workflow%3ACI)
 [![Total Downloads](https://img.shields.io/packagist/dt/guzzlehttp/guzzle.svg?style=flat-square)](https://packagist.org/packages/guzzlehttp/guzzle)
+[![Build Status](https://readthedocs.org/projects/guzzle/badge/?version=latest&style=flat-square)](https://app.readthedocs.org/projects/guzzle/)
 
 Guzzle is a PHP HTTP client that makes it easy to send HTTP requests and
 trivial to integrate with web services.


### PR DESCRIPTION
### Change

Add **required** readthedocs configuration. Otherwise no documentation build will be started.

Configuration options can be found here:
https://docs.readthedocs.com/platform/stable/config-file/index.html

### Reference

Fixes #3266
