### PR TITLE
Add Request to on_headers callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.9.3 - 2025
+
+### Changed
+
+- Add `RequestInterface` as a second argument to `on_headers` callback
+
 ## 7.9.2 - 2024-07-24
 
 ### Fixed

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -733,7 +733,7 @@ on_headers
 :Types: - callable
 :Constant: ``GuzzleHttp\RequestOptions::ON_HEADERS``
 
-The callable accepts a ``Psr\Http\Message\ResponseInterface`` object. If an exception
+The callable accepts a ``Psr\Http\Message\ResponseInterface`` and ``Psr\Http\Message\RequestInterface`` objects. If an exception
 is thrown by the callable, then the promise associated with the response will
 be rejected with a ``GuzzleHttp\Exception\RequestException`` that wraps the
 exception that was thrown.
@@ -745,9 +745,9 @@ can be written to the sink.
 
     // Reject responses that are greater than 1024 bytes.
     $client->request('GET', 'http://httpbin.org/stream/1024', [
-        'on_headers' => function (ResponseInterface $response) {
+        'on_headers' => function (ResponseInterface $response, RequestInterface $request) {
             if ($response->getHeaderLine('Content-Length') > 1024) {
-                throw new \Exception('The file is too big!');
+                throw new \Exception('The file is too big! URL: ' . (string)$request->getUri());
             }
         }
     ]);

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -706,7 +706,7 @@ class CurlFactory implements CurlFactoryInterface
                 }
                 if ($onHeaders !== null) {
                     try {
-                        $onHeaders($easy->response);
+                        $onHeaders($easy->response, $easy->request);
                     } catch (\Exception $e) {
                         // Associate the exception with the handle and trigger
                         // a curl header write error by returning 0.

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -96,7 +96,7 @@ class MockHandler implements \Countable
                 throw new \InvalidArgumentException('on_headers must be callable');
             }
             try {
-                $options['on_headers']($response);
+                $options['on_headers']($response, $request);
             } catch (\Exception $e) {
                 $msg = 'An error was encountered during the on_headers event';
                 $response = new RequestException($msg, $request, $response, $e);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -132,7 +132,7 @@ class StreamHandler
 
         if (isset($options['on_headers'])) {
             try {
-                $options['on_headers']($response);
+                $options['on_headers']($response, $request);
             } catch (\Exception $e) {
                 return P\Create::rejectionFor(
                     new RequestException('An error was encountered during the on_headers event', $request, $response, $e)

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -815,7 +815,7 @@ class CurlFactoryTest extends TestCase
         $promise = $handler($req, [
             'on_headers' => static function (ResponseInterface $res, RequestInterface $req) {
                 self::assertInstanceOf(RequestInterface::class, $req);
-                self::assertSame(Server::$url, (string)$req->getUri());
+                self::assertSame(Server::$url, (string) $req->getUri());
             },
         ]);
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Tests\Helpers;
 use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -800,6 +801,25 @@ class CurlFactoryTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('bar', $response->getHeaderLine('X-Foo'));
         self::assertSame('abc 123', (string) $response->getBody());
+    }
+
+    public function testOnHeadersRequestArgument()
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, ['X-Foo' => 'bar'], 'abc 123'),
+        ]);
+        $req = new Psr7\Request('GET', Server::$url);
+
+        $handler = new Handler\CurlHandler();
+        $promise = $handler($req, [
+            'on_headers' => static function (ResponseInterface $res, RequestInterface $req) {
+                self::assertInstanceOf(RequestInterface::class, $req);
+                self::assertSame(Server::$url, (string)$req->getUri());
+            },
+        ]);
+
+        $promise->wait();
     }
 
     public function testInvokesOnStatsOnSuccess()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -653,7 +653,7 @@ class StreamHandlerTest extends TestCase
         $promise = $handler($req, [
             'on_headers' => static function (ResponseInterface $res, RequestInterface $req) {
                 self::assertInstanceOf(RequestInterface::class, $req);
-                self::assertSame(Server::$url, (string)$req->getUri());
+                self::assertSame(Server::$url, (string) $req->getUri());
             },
         ]);
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Tests\Server;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -638,6 +639,25 @@ class StreamHandlerTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('bar', $response->getHeaderLine('X-Foo'));
         self::assertSame('abc 123', (string) $response->getBody());
+    }
+
+    public function testOnHeadersRequestArgument()
+    {
+        Server::flush();
+        Server::enqueue([
+            new Response(200, ['X-Foo' => 'bar'], 'abc 123'),
+        ]);
+        $req = new Request('GET', Server::$url);
+
+        $handler = new StreamHandler();
+        $promise = $handler($req, [
+            'on_headers' => static function (ResponseInterface $res, RequestInterface $req) {
+                self::assertInstanceOf(RequestInterface::class, $req);
+                self::assertSame(Server::$url, (string)$req->getUri());
+            },
+        ]);
+
+        $promise->wait();
     }
 
     public function testInvokesOnStatsOnSuccess()


### PR DESCRIPTION
When using a Guzzle Pool, there is no way to understand which response arrived for `on_headers` callback. This pull request
addresses this issue by passing a request as a second argument to the `on_headers` callback function, and thus we can
understand to which request this response belongs.

There was a previous attempt to do the same, but PR was closed because it was stale https://github.com/guzzle/guzzle/pull/2828 . Here is an example of code:
```php
require __DIR__ . '/../vendor/autoload.php';

use GuzzleHttp\Client;
use GuzzleHttp\Exception\RequestException;
use GuzzleHttp\Pool;
use GuzzleHttp\Psr7\Request;
use GuzzleHttp\Psr7\Response;
use Psr\Http\Message\ResponseInterface;

$client = new Client();

$requests = static function ($total) {
    for ($i = 1; $i < $total; $i++) {
        yield $i => new Request('GET', 'http://httpbin.org/redirect/' . $i);
    }
};

$pool = new Pool($client, $requests(5), [
    'concurrency' => 5,
    'options' => [
        'fulfilled' => function (Response $response, $index) {
            // this is delivered each successful response
            var_dump($index);
        },
        'rejected' => function (RequestException $reason, $index) {
            // this is delivered each failed request
            var_dump($index);
        },
        'on_headers' => static function (ResponseInterface $response, Request $request) {
            var_dump((string)$request->getUri());
        },
    ],
]);

// Initiate the transfers and create a promise
$promise = $pool->promise();

// Force the pool of requests to complete.
$promise->wait();
```