### PR TITLE
fixes #3273: SetCookie read bool pieces as non-bool bugfix

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -47,7 +47,7 @@ class SetCookie
         foreach ($pieces as $part) {
             $cookieParts = \explode('=', $part, 2);
             $key = \trim($cookieParts[0]);
-            $value = isset($cookieParts[1])
+            $value = isset($cookieParts[1]) && !is_bool($data[$key] ?? null)
                 ? \trim($cookieParts[1], " \n\r\t\0\x0B")
                 : true;
 


### PR DESCRIPTION
fixes #3273 by checking the default value for boolness. Bool in defaults -> must be `true` if it exists.