### PR TITLE
Remove explicit content-length header for GET requests

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -52,12 +52,6 @@ class StreamHandler
             // Does not support the expect header.
             $request = $request->withoutHeader('Expect');
 
-            // Append a content-length header if body size is zero to match
-            // cURL's behavior.
-            if (0 === $request->getBody()->getSize()) {
-                $request = $request->withHeader('Content-Length', '0');
-            }
-
             return $this->createResponse(
                 $request,
                 $options,

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -52,6 +52,18 @@ class StreamHandler
             // Does not support the expect header.
             $request = $request->withoutHeader('Expect');
 
+            // Append a content-length header if body size is zero to match
+            // the behavior of `CurlHandler`
+            if (
+                (
+                    0 === \strcasecmp('PUT', $request->getMethod())
+                    || 0 === \strcasecmp('POST', $request->getMethod())
+                )
+                && 0 === $request->getBody()->getSize()
+            ) {
+                $request = $request->withHeader('Content-Length', '0');
+            }
+
             return $this->createResponse(
                 $request,
                 $options,

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -544,11 +544,31 @@ class StreamHandlerTest extends TestCase
         self::assertEquals(3, $req->getHeaderLine('Content-Length'));
     }
 
-    public function testDontAddContentLengthEvenWhenEmpty()
+    public function testAddsContentLengthForPUTEvenWhenEmpty()
     {
         $this->queueRes();
         $handler = new StreamHandler();
         $request = new Request('PUT', Server::$url, [], '');
+        $handler($request, []);
+        $req = Server::received()[0];
+        self::assertEquals(0, $req->getHeaderLine('Content-Length'));
+    }
+
+    public function testAddsContentLengthForPOSTEvenWhenEmpty()
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('POST', Server::$url, [], '');
+        $handler($request, []);
+        $req = Server::received()[0];
+        self::assertEquals(0, $req->getHeaderLine('Content-Length'));
+    }
+
+    public function testDontAddContentLengthForGETEvenWhenEmpty()
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url, [], '');
         $handler($request, []);
         $req = Server::received()[0];
         self::assertSame('', $req->getHeaderLine('Content-Length'));

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -544,14 +544,14 @@ class StreamHandlerTest extends TestCase
         self::assertEquals(3, $req->getHeaderLine('Content-Length'));
     }
 
-    public function testAddsContentLengthEvenWhenEmpty()
+    public function testDontAddContentLengthEvenWhenEmpty()
     {
         $this->queueRes();
         $handler = new StreamHandler();
         $request = new Request('PUT', Server::$url, [], '');
         $handler($request, []);
         $req = Server::received()[0];
-        self::assertEquals(0, $req->getHeaderLine('Content-Length'));
+        self::assertSame('', $req->getHeaderLine('Content-Length'));
     }
 
     public function testSupports100Continue()


### PR DESCRIPTION
## Summary
Fixes #3277 and reverts #1189

Originally this was introduced in #1189 to fix https://github.com/aws/aws-sdk-php/issues/701

In my case however, I receive a 500 when trying to stream content from media.licdn.com because of this header.

I then went back and tried the example from the aws-sdk-php and removed that header only to learn it works as expected.

My conclusion therefore is that in the past 10 years either AWS server or the SDK changed and this workaround, once needed, no longer is necessary and we can remove it.

### Update
- The final PR only removes the content-length header for `GET` requests, keeps it for `POST` & `PUT`