### PR TITLE
`testHandlesGarbageHttpServerGracefully`: Split test between PHP <= 8.1 and > 8.1

### DIFF
--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -750,12 +750,33 @@ class StreamHandlerTest extends TestCase
         self::assertFalse(\feof($body));
     }
 
-    public function testHandlesGarbageHttpServerGracefully()
+    /**
+     * @requires PHP <=8.1
+     */
+    public function testHandlesGarbageHttpServerGracefullyLegacy()
     {
         $handler = new StreamHandler();
 
         $this->expectException(RequestException::class);
         $this->expectExceptionMessage('An error was encountered while creating the response');
+
+        $handler(
+            new Request('GET', Server::$url.'guzzle-server/garbage'),
+            [
+                RequestOptions::STREAM => true,
+            ]
+        )->wait();
+    }
+
+    /**
+     * @requires PHP >8.1
+     */
+    public function testHandlesGarbageHttpServerGracefully()
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('Connection refused for URI '.Server::$url);
 
         $handler(
             new Request('GET', Server::$url.'guzzle-server/garbage'),

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -750,11 +750,20 @@ class StreamHandlerTest extends TestCase
         self::assertFalse(\feof($body));
     }
 
-    /**
-     * @requires PHP <=8.1
-     */
+    private static function shouldRunOnThisPhpVersion(): bool
+    {
+        return (PHP_VERSION_ID >= 80132 && PHP_VERSION_ID < 80200)
+            || (PHP_VERSION_ID >= 80228 && PHP_VERSION_ID < 80300)
+            || (PHP_VERSION_ID >= 80319 && PHP_VERSION_ID < 80400)
+            || PHP_VERSION_ID >= 80405;
+    }
+
     public function testHandlesGarbageHttpServerGracefullyLegacy()
     {
+        if (self::shouldRunOnThisPhpVersion()) {
+            $this->markTestSkipped('This test is not relevant for '.PHP_VERSION);
+        }
+
         $handler = new StreamHandler();
 
         $this->expectException(RequestException::class);
@@ -768,11 +777,12 @@ class StreamHandlerTest extends TestCase
         )->wait();
     }
 
-    /**
-     * @requires PHP >8.1
-     */
     public function testHandlesGarbageHttpServerGracefully()
     {
+        if (!self::shouldRunOnThisPhpVersion()) {
+            $this->markTestSkipped('This test is not relevant for '.PHP_VERSION);
+        }
+
         $handler = new StreamHandler();
 
         $this->expectException(ConnectException::class);


### PR DESCRIPTION
## Summary
This fixes the failing tests recently observed, e.g.:
- https://github.com/guzzle/guzzle/actions/runs/13981481062/job/39147439887
- https://github.com/guzzle/guzzle/actions/runs/14036887147/job/39296947529


It seems the behaviour of `fopen()` changed with newer PHP version already returning `false` instead of a resource, presumably due to some HTTP header probing/parsing.

Seeing the behaviour change affects > 8.1, which is the last one to also receive security patches, I guess it's one of the recent security fixes applied.