### PR TITLE
initial idea for adding protection against file write gadget chain

### DIFF
--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -56,7 +56,7 @@ class FileCookieJar extends CookieJar
      */
     public function save(string $filename): void
     {
-        $json = [];
+        $json = ['_comment' => "//<?php die('Security');?>"];
         /** @var SetCookie $cookie */
         foreach ($this as $cookie) {
             if (CookieJar::shouldPersist($cookie, $this->storeSessionCookies)) {
@@ -91,6 +91,7 @@ class FileCookieJar extends CookieJar
 
         $data = Utils::jsonDecode($json, true);
         if (\is_array($data)) {
+            unset($data['_comment']);
             foreach ($data as $cookie) {
                 $this->setCookie(new SetCookie($cookie));
             }


### PR DESCRIPTION
Context: https://github.com/guzzle/guzzle/issues/3271

Here's a simple (/crude) way to avoid this class being used to write out a file containing malicious PHP.

The idea is similar to what joomla does here (edit - fixed link):

https://github.com/joomla/joomla-cms/blob/6.1.0/libraries/src/Log/Logger/FormattedtextLogger.php#L250

This wouldn't prevent the arbitrary file write, but should mean that the file cannot easily be used to execute a malicious PHP payload.

https://stackoverflow.com/questions/244777/can-comments-be-used-in-json for context (/ bikeshedding) on how to add a comment to a json file.