### PR TITLE
Add support for HTTP/3

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -49,7 +49,11 @@ class CurlFactory implements CurlFactoryInterface
     {
         $protocolVersion = $request->getProtocolVersion();
 
-        if ('2' === $protocolVersion || '2.0' === $protocolVersion) {
+        if ('3' === $protocolVersion || '3.0' === $protocolVersion) {
+            if (!self::supportsHttp3()) {
+                throw new ConnectException('HTTP/3 is supported by the cURL handler, however libcurl is built without HTTP/3 support.', $request);
+            }
+        } elseif ('2' === $protocolVersion || '2.0' === $protocolVersion) {
             if (!self::supportsHttp2()) {
                 throw new ConnectException('HTTP/2 is supported by the cURL handler, however libcurl is built without HTTP/2 support.', $request);
             }
@@ -81,6 +85,29 @@ class CurlFactory implements CurlFactoryInterface
         curl_setopt_array($easy->handle, $conf);
 
         return $easy;
+    }
+
+    private static function supportsHttp3(): bool
+    {
+        static $supportsHttp3 = null;
+
+        if (null === $supportsHttp3) {
+            $curlVersion = curl_version();
+            $http3Flag = 0;
+            if (defined('CURL_VERSION_HTTP3')) {
+                /** @var int $http3FlagConst */
+                $http3FlagConst = \CURL_VERSION_HTTP3;
+                $http3Flag = intval(''.$http3FlagConst);
+            }
+            /** @psalm-suppress RedundantCondition */
+            $supportsHttp3 = self::supportsTls13()
+                && is_array($curlVersion)
+                && isset($curlVersion['features'])
+                && is_int($curlVersion['features'])
+                && ($http3Flag & $curlVersion['features']);
+        }
+
+        return (bool) $supportsHttp3;
     }
 
     private static function supportsHttp2(): bool
@@ -316,7 +343,9 @@ class CurlFactory implements CurlFactoryInterface
 
         $version = $easy->request->getProtocolVersion();
 
-        if ('2' === $version || '2.0' === $version) {
+        if (('3' === $version || '3.0' === $version) && defined('CURL_HTTP_VERSION_3')) {
+            $conf[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_3;
+        } elseif ('2' === $version || '2.0' === $version) {
             $conf[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2_0;
         } elseif ('1.1' === $version) {
             $conf[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_1_1;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -491,6 +491,15 @@ class CurlFactoryTest extends TestCase
         $request = new Psr7\Request('GET', Server::$url, [], null, '1.0');
         $a($request, []);
         self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+        $request = new Psr7\Request('GET', Server::$url, [], null, '2.0');
+        $a($request, []);
+        self::assertEquals(\CURL_HTTP_VERSION_2, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+        // HTTP/3 is only available in PHP 8.4 and curl experimental builds, so check it's available before we try to use it
+        if (\defined('CURL_VERSION_HTTP3') && (\CURL_VERSION_HTTP3 & \curl_version()['features'])) {
+            $request = new Psr7\Request('GET', Server::$url, [], null, '3.0');
+            $a($request, []);
+            self::assertEquals(\CURL_HTTP_VERSION_3, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+        }
     }
 
     public function testSavesToStream()


### PR DESCRIPTION
PHP 8.4 has support for HTTP/3, but it's dependent on the underlying libcurl having support for it, which is not enabled by default; see [curl docs](https://curl.se/docs/http3.html).

Nevertheless, we can add HTTP/3 support so that it will be usable if a PHP build has it enabled.

This PR adds a check for whether HTTP/3 is available (it also requires TLSv1.3), adds support for the `version` option to be `3` or `3.0`, provides integration with PHP's constants, and includes check for the presence of curl HTTP/3 support in both runtime and test configs, so it won't break in old PHP versions.

While I was there, I noticed that HTTP/2 wasn't checked in `\GuzzleHttp\Test\Handler\CurlFactoryTest::testProtocolVersion`, so I added that as well.