### PR TITLE
Fix everything that php-cs-fixer complains about

### DIFF
--- a/src/Exception/BadResponseException.php
+++ b/src/Exception/BadResponseException.php
@@ -15,7 +15,7 @@ class BadResponseException extends RequestException
         RequestInterface $request,
         ResponseInterface $response,
         ?\Throwable $previous = null,
-        array $handlerContext = []
+        array $handlerContext = [],
     ) {
         parent::__construct($message, $request, $response, $previous, $handlerContext);
     }

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -26,7 +26,7 @@ class ConnectException extends TransferException implements NetworkExceptionInte
         string $message,
         RequestInterface $request,
         ?\Throwable $previous = null,
-        array $handlerContext = []
+        array $handlerContext = [],
     ) {
         parent::__construct($message, 0, $previous);
         $this->request = $request;

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -33,7 +33,7 @@ class RequestException extends TransferException implements RequestExceptionInte
         RequestInterface $request,
         ?ResponseInterface $response = null,
         ?\Throwable $previous = null,
-        array $handlerContext = []
+        array $handlerContext = [],
     ) {
         // Set the code of the exception if the response is set and not future.
         $code = $response ? $response->getStatusCode() : 0;
@@ -65,7 +65,7 @@ class RequestException extends TransferException implements RequestExceptionInte
         ?ResponseInterface $response = null,
         ?\Throwable $previous = null,
         array $handlerContext = [],
-        ?BodySummarizerInterface $bodySummarizer = null
+        ?BodySummarizerInterface $bodySummarizer = null,
     ): self {
         if (!$response) {
             return new self(

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -201,7 +201,7 @@ class MockHandler implements \Countable
         RequestInterface $request,
         array $options,
         ?ResponseInterface $response = null,
-        $reason = null
+        $reason = null,
     ): void {
         if (isset($options['on_stats'])) {
             $transferTime = $options['transfer_time'] ?? 0;

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -96,7 +96,7 @@ class StreamHandler
         RequestInterface $request,
         ?float $startTime,
         ?ResponseInterface $response = null,
-        ?\Throwable $error = null
+        ?\Throwable $error = null,
     ): void {
         if (isset($options['on_stats'])) {
             $stats = new TransferStats($request, $response, Utils::currentTime() - $startTime, $error, []);

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -211,7 +211,7 @@ class RedirectMiddleware
     private static function redirectUri(
         RequestInterface $request,
         ResponseInterface $response,
-        array $protocols
+        array $protocols,
     ): UriInterface {
         $location = Psr7\UriResolver::resolve(
             $request->getUri(),

--- a/src/TransferStats.php
+++ b/src/TransferStats.php
@@ -49,7 +49,7 @@ final class TransferStats
         ?ResponseInterface $response = null,
         ?float $transferTime = null,
         $handlerErrorData = null,
-        array $handlerStats = []
+        array $handlerStats = [],
     ) {
         $this->request = $request;
         $this->response = $response;

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -488,7 +488,7 @@ class RedirectMiddlewareTest extends TestCase
      */
     public function testModifyRequestFollowRequestMethodAndBody(
         RequestInterface $request,
-        $expectedFollowRequestMethod
+        $expectedFollowRequestMethod,
     ) {
         $redirectMiddleware = new RedirectMiddleware(static function () {
         });


### PR DESCRIPTION
The php-cs-fixer policy doesn't seem to be enforced, though it's checked in CI. This PR simply fixes everything that it complains about, so it will no longer report any issues, providing a clean baseline for future changes.