### PR TITLE
CurlFactory: Move logic for creating and storing curl handles to interface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -487,12 +487,6 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: '#^Parameter \#1 \$ch of function curl_close expects resource, CurlHandle\|resource given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Handler/CurlFactory.php
-
-		-
 			message: '#^Parameter \#1 \$ch of function curl_error expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 1
@@ -500,18 +494,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$ch of function curl_getinfo expects resource, CurlHandle\|resource given\.$#'
-			identifier: argument.type
-			count: 4
-			path: src/Handler/CurlFactory.php
-
-		-
-			message: '#^Parameter \#1 \$ch of function curl_reset expects resource, CurlHandle\|resource given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
-			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 4
 			path: src/Handler/CurlFactory.php
@@ -619,12 +601,6 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: '#^Property GuzzleHttp\\Handler\\CurlFactory\:\:\$handles has unknown class CurlHandle as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
 			message: '#^Property GuzzleHttp\\Handler\\EasyHandle\:\:\$handle \(CurlHandle\|resource\) does not accept CurlHandle\|resource\|false\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -635,6 +611,54 @@ parameters:
 			identifier: callable.nonCallable
 			count: 1
 			path: src/Handler/CurlFactory.php
+
+		-
+			message: '#^Method GuzzleHttp\\Handler\\CurlHandlePool\:\:get\(\) has invalid return type CurlHandle\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlHandlePool.php
+
+		-
+			message: '#^Parameter \#1 \$ch of function curl_close expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Handler/CurlHandlePool.php
+
+		-
+			message: '#^Parameter \#1 \$ch of function curl_reset expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Handler/CurlHandlePool.php
+
+		-
+			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/Handler/CurlHandlePool.php
+
+		-
+			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlHandlePool\:\:put\(\) has invalid type CurlHandle\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlHandlePool.php
+
+		-
+			message: '#^Property GuzzleHttp\\Handler\\CurlHandlePool\:\:\$handles has unknown class CurlHandle as its type\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlHandlePool.php
+
+		-
+			message: '#^Method GuzzleHttp\\Handler\\CurlHandlePoolInterface\:\:get\(\) has invalid return type CurlHandle\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlHandlePoolInterface.php
+
+		-
+			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlHandlePoolInterface\:\:put\(\) has invalid type CurlHandle\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlHandlePoolInterface.php
 
 		-
 			message: '#^Binary operation "\*" between mixed and 1000 results in an error\.$#'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -53,6 +53,9 @@
     <PossiblyFalseOperand>
       <code><![CDATA[$timeoutRequiresNoSignal]]></code>
     </PossiblyFalseOperand>
+    <PossiblyFalsePropertyAssignmentValue>
+      <code><![CDATA[$this->handlePool->get()]]></code>
+    </PossiblyFalsePropertyAssignmentValue>
     <PossiblyInvalidArgument>
       <code><![CDATA[$easy->handle]]></code>
       <code><![CDATA[$easy->handle]]></code>
@@ -60,25 +63,29 @@
       <code><![CDATA[$easy->handle]]></code>
       <code><![CDATA[$easy->handle]]></code>
       <code><![CDATA[$easy->handle]]></code>
-      <code><![CDATA[$handle]]></code>
-      <code><![CDATA[$resource]]></code>
-      <code><![CDATA[$resource]]></code>
-      <code><![CDATA[$resource]]></code>
-      <code><![CDATA[$resource]]></code>
-      <code><![CDATA[$resource]]></code>
-      <code><![CDATA[$resource]]></code>
       <code><![CDATA[$sslKey]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$sslKey]]></code>
     </PossiblyInvalidCast>
+    <UndefinedVariable>
+      <code><![CDATA[$startingResponse]]></code>
+    </UndefinedVariable>
+  </file>
+  <file src="src/Handler/CurlHandlePool.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$handle]]></code>
+    </PossiblyInvalidArgument>
     <UndefinedDocblockClass>
       <code><![CDATA[private $handles = [];]]></code>
       <code><![CDATA[resource[]|\CurlHandle[]]]></code>
     </UndefinedDocblockClass>
-    <UndefinedVariable>
-      <code><![CDATA[$startingResponse]]></code>
-    </UndefinedVariable>
+  </file>
+  <file src="src/Handler/CurlHandlePoolInterface.php">
+    <UndefinedDocblockClass>
+      <code><![CDATA[resource|\CurlHandle]]></code>
+      <code><![CDATA[resource|\CurlHandle|false]]></code>
+    </UndefinedDocblockClass>
   </file>
   <file src="src/Handler/CurlHandler.php">
     <PossiblyInvalidArgument>

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -28,21 +28,18 @@ class CurlFactory implements CurlFactoryInterface
     public const LOW_CURL_VERSION_NUMBER = '7.21.2';
 
     /**
-     * @var resource[]|\CurlHandle[]
+     * @var CurlHandlePoolInterface
      */
-    private $handles = [];
+    private $handlePool;
 
     /**
-     * @var int Total number of idle handles to keep in cache
+     * @param int|CurlHandlePoolInterface $maxHandles Maximum number of idle handles.
      */
-    private $maxHandles;
-
-    /**
-     * @param int $maxHandles Maximum number of idle handles.
-     */
-    public function __construct(int $maxHandles)
+    public function __construct($maxHandles)
     {
-        $this->maxHandles = $maxHandles;
+        $this->handlePool = $maxHandles instanceof CurlHandlePoolInterface
+            ? $maxHandles
+            : new CurlHandlePool($maxHandles);
     }
 
     public function create(RequestInterface $request, array $options): EasyHandle
@@ -77,7 +74,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
-        $easy->handle = $this->handles ? \array_pop($this->handles) : \curl_init();
+        $easy->handle = $this->handlePool->get();
         curl_setopt_array($easy->handle, $conf);
 
         return $easy;
@@ -124,20 +121,7 @@ class CurlFactory implements CurlFactoryInterface
         $resource = $easy->handle;
         unset($easy->handle);
 
-        if (\count($this->handles) >= $this->maxHandles) {
-            \curl_close($resource);
-        } else {
-            // Remove all callback functions as they can hold onto references
-            // and are not cleaned up by curl_reset. Using curl_setopt_array
-            // does not work for some reason, so removing each one
-            // individually.
-            \curl_setopt($resource, \CURLOPT_HEADERFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_READFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_WRITEFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_PROGRESSFUNCTION, null);
-            \curl_reset($resource);
-            $this->handles[] = $resource;
-        }
+        $this->handlePool->put($resource);
     }
 
     /**
@@ -724,13 +708,5 @@ class CurlFactory implements CurlFactoryInterface
 
             return \strlen($h);
         };
-    }
-
-    public function __destruct()
-    {
-        foreach ($this->handles as $id => $handle) {
-            \curl_close($handle);
-            unset($this->handles[$id]);
-        }
     }
 }

--- a/src/Handler/CurlHandlePool.php
+++ b/src/Handler/CurlHandlePool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace GuzzleHttp\Handler;
+
+class CurlHandlePool implements CurlHandlePoolInterface
+{
+    /**
+     * @var resource[]|\CurlHandle[]
+     */
+    private $handles = [];
+
+    /**
+     * @var int Total number of idle handles to keep in cache
+     */
+    private $maxHandles;
+
+    /**
+     * @param int $maxHandles Maximum number of idle handles.
+     */
+    public function __construct(int $maxHandles)
+    {
+        $this->maxHandles = $maxHandles;
+    }
+
+    public function get()
+    {
+        return $this->handles ? \array_pop($this->handles) : \curl_init();
+    }
+
+    public function put($handle): void
+    {
+        if (\count($this->handles) >= $this->maxHandles) {
+            \curl_close($handle);
+        } else {
+            // Remove all callback functions as they can hold onto references
+            // and are not cleaned up by curl_reset. Using curl_setopt_array
+            // does not work for some reason, so removing each one
+            // individually.
+            \curl_setopt($handle, \CURLOPT_HEADERFUNCTION, null);
+            \curl_setopt($handle, \CURLOPT_READFUNCTION, null);
+            \curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
+            \curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
+            \curl_reset($handle);
+            $this->handles[] = $handle;
+        }
+    }
+
+    public function __destruct()
+    {
+        foreach ($this->handles as $id => $handle) {
+            \curl_close($handle);
+            unset($this->handles[$id]);
+        }
+    }
+}

--- a/src/Handler/CurlHandlePoolInterface.php
+++ b/src/Handler/CurlHandlePoolInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GuzzleHttp\Handler;
+
+interface CurlHandlePoolInterface
+{
+    /**
+     * @return resource|\CurlHandle|false
+     */
+    public function get();
+
+    /**
+     * @param resource|\CurlHandle $handle
+     */
+    public function put($handle): void;
+}

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -711,20 +711,20 @@ class CurlFactoryTest extends TestCase
         $easy = $f->create($req, []);
         $h1 = $easy->handle;
         $f->release($easy);
-        self::assertCount(1, Helpers::readObjectAttribute($f, 'handles'));
+        self::assertCount(1, Helpers::readObjectAttribute(Helpers::readObjectAttribute($f, 'handlePool'), 'handles'));
         $easy = $f->create($req, []);
         self::assertSame($easy->handle, $h1);
         $easy2 = $f->create($req, []);
         $easy3 = $f->create($req, []);
         $easy4 = $f->create($req, []);
         $f->release($easy);
-        self::assertCount(1, Helpers::readObjectAttribute($f, 'handles'));
+        self::assertCount(1, Helpers::readObjectAttribute(Helpers::readObjectAttribute($f, 'handlePool'), 'handles'));
         $f->release($easy2);
-        self::assertCount(2, Helpers::readObjectAttribute($f, 'handles'));
+        self::assertCount(2, Helpers::readObjectAttribute(Helpers::readObjectAttribute($f, 'handlePool'), 'handles'));
         $f->release($easy3);
-        self::assertCount(3, Helpers::readObjectAttribute($f, 'handles'));
+        self::assertCount(3, Helpers::readObjectAttribute(Helpers::readObjectAttribute($f, 'handlePool'), 'handles'));
         $f->release($easy4);
-        self::assertCount(3, Helpers::readObjectAttribute($f, 'handles'));
+        self::assertCount(3, Helpers::readObjectAttribute(Helpers::readObjectAttribute($f, 'handlePool'), 'handles'));
     }
 
     public function testRejectsPromiseWhenCreateResponseFails()


### PR DESCRIPTION
This PR introduces `CurlHandlePool` and `CurlHandlePoolInterface` which gives developer an option to customize logic for creating and storing curl handles.

# Reason
I have concurrency heavy app that powered by Swoole and I want to replace default implementation with basic array with my Swoole specific implementation for better performance and concurrency control.
But with current implementation of `CurlFactory` my only option is to fully reimplement `CurlFactoryInterface` with small edits to storing and creating curl handles