### PR TITLE
Remove obsolete reference capturing of `$http_response_header`

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -333,7 +333,7 @@ class StreamHandler
         );
 
         return $this->createResource(
-            function () use ($uri, &$http_response_header, $contextResource, $context, $options, $request) {
+            function () use ($uri, $contextResource, $context, $options, $request) {
                 $resource = @\fopen((string) $uri, 'r', false, $contextResource);
                 $this->lastHeaders = $http_response_header ?? [];
 


### PR DESCRIPTION
This is no longer needed since 6c906cd4388408caa1955e6db1b12e01906ca56d.