### PR TITLE
Use `http_get_last_response_headers()` in StreamHandler

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1075,6 +1075,12 @@ parameters:
 			path: src/Handler/StreamHandler.php
 
 		-
+			message: '#^Property GuzzleHttp\\Handler\\StreamHandler\:\:\$lastHeaders \(array\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Handler/StreamHandler.php
+
+		-
 			message: '#^Trying to invoke mixed but it''s not a callable\.$#'
 			identifier: callable.nonCallable
 			count: 4

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -335,7 +335,11 @@ class StreamHandler
         return $this->createResource(
             function () use ($uri, &$http_response_header, $contextResource, $context, $options, $request) {
                 $resource = @\fopen((string) $uri, 'r', false, $contextResource);
-                $this->lastHeaders = $http_response_header ?? [];
+                if (\function_exists('http_get_last_response_headers')) {
+                    $this->lastHeaders = \http_get_last_response_headers() ?? [];
+                } else {
+                    $this->lastHeaders = $http_response_header ?? [];
+                }
 
                 if (false === $resource) {
                     throw new ConnectException(sprintf('Connection refused for URI %s', $uri), $request, null, $context);


### PR DESCRIPTION
`http_get_last_response_headers()` was added in PHP 8.4 as a replacement for the magic `$http_response_header` variable. Make use of it for forward compatibility, since the variable is considered for deprecation in PHP 8.5:

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable