### PR TITLE
Fix deprecated curl_close() for PHP 8.5

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -729,7 +729,11 @@ class CurlFactory implements CurlFactoryInterface
     public function __destruct()
     {
         foreach ($this->handles as $id => $handle) {
-            \curl_close($handle);
+            if (PHP_VERSION_ID < 80500) {
+                \curl_close($handle);
+            } else {
+                $handle = null;
+            }
             unset($this->handles[$id]);
         }
     }


### PR DESCRIPTION
fixes #3297