### PR TITLE
Allow Bearer Authentication with cURL handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
+### Added
+
+- Add support for Bearer tokens
+
 ## 7.10.0 - 2025-08-23
 
 ### Added

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -194,7 +194,7 @@ bearer
 
 .. note::
 
-    This is currently only supported when using the cURL handler.
+    This is currently only supported when using the cURL handler with cURL version 7.61.0 or higher and PHP version 7.3 or higher
 
 
 body

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -131,7 +131,9 @@ auth
 :Summary: Pass an array of HTTP authentication parameters to use with the
         request. The array must contain the username in index [0], the password in
         index [1], and you can optionally provide a built-in authentication type in
-        index [2]. Pass ``null`` to disable authentication for a request.
+        index [2]. In the case of ``bearer`` authentication, the token will be in
+        index [0], and index [1] contains the empty string.
+        Pass ``null`` to disable authentication for a request.
 :Types:
         - array
         - string
@@ -174,6 +176,20 @@ ntlm
 
     $client->request('GET', '/get', [
         'auth' => ['username', 'password', 'ntlm']
+    ]);
+
+.. note::
+
+    This is currently only supported when using the cURL handler.
+
+bearer
+    Use `Bearer authentication <https://datatracker.ietf.org/doc/html/rfc6750>`_
+    (must be supported by the HTTP handler).
+
+.. code-block:: php
+
+    $client->request('GET', '/get', [
+        'auth' => ['token', '', 'bearer']
     ]);
 
 .. note::

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,9 +37,15 @@ parameters:
 			path: src/Client.php
 
 		-
+			message: '#^Cannot access offset 10220 on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Client.php
+
+		-
 			message: '#^Cannot access offset 107 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 3
 			path: src/Client.php
 
 		-
@@ -957,7 +963,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 2 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 2
 			path: src/Handler/StreamHandler.php
 
 		-
@@ -1220,6 +1226,12 @@ parameters:
 
 		-
 			message: '#^Cannot access offset ''track_redirects'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/RedirectMiddleware.php
+
+		-
+			message: '#^Cannot access offset 10220 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/RedirectMiddleware.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -416,6 +416,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_NTLM;
                     $options['curl'][\CURLOPT_USERPWD] = "$value[0]:$value[1]";
                     break;
+                case 'bearer':
+                    $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_BEARER;
+                    $options['curl'][\CURLOPT_XOAUTH2_BEARER] = $value[0];
+                    break;
             }
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -417,8 +417,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     $options['curl'][\CURLOPT_USERPWD] = "$value[0]:$value[1]";
                     break;
                 case 'bearer':
-                    $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_BEARER;
-                    $options['curl'][\CURLOPT_XOAUTH2_BEARER] = $value[0];
+                    if (defined('CURLAUTH_BEARER')) {
+                        $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_BEARER;
+                        $options['curl'][\CURLOPT_XOAUTH2_BEARER] = $value[0];
+                    } else {
+                        throw new InvalidArgumentException('Bearer authentication only supported with curl handler from version 7.61.0 and PHP from version 7.3');
+                    }
                     break;
             }
         }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -324,6 +324,11 @@ class StreamHandler
             throw new \InvalidArgumentException('Microsoft NTLM authentication only supported with curl handler');
         }
 
+        // Bearer authentication only supported with curl handler
+        if (isset($options['auth'][2]) && 'bearer' === $options['auth'][2]) {
+            throw new \InvalidArgumentException('Bearer authentication only supported with curl handler');
+        }
+
         $uri = $this->resolveHost($request, $options);
 
         $contextResource = $this->createResource(

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -92,9 +92,13 @@ class RedirectMiddleware
         if (Psr7\UriComparator::isCrossOrigin($request->getUri(), $nextRequest->getUri()) && defined('\CURLOPT_HTTPAUTH')) {
             unset(
                 $options['curl'][\CURLOPT_HTTPAUTH],
-                $options['curl'][\CURLOPT_USERPWD],
-                $options['curl'][\CURLOPT_XOAUTH2_BEARER]
+                $options['curl'][\CURLOPT_USERPWD]
             );
+            if (defined('CURLOPT_XOAUTH2_BEARER')) {
+                unset(
+                    $options['curl'][\CURLOPT_XOAUTH2_BEARER]
+                );
+            }
         }
 
         if (isset($options['allow_redirects']['on_redirect'])) {

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -92,7 +92,8 @@ class RedirectMiddleware
         if (Psr7\UriComparator::isCrossOrigin($request->getUri(), $nextRequest->getUri()) && defined('\CURLOPT_HTTPAUTH')) {
             unset(
                 $options['curl'][\CURLOPT_HTTPAUTH],
-                $options['curl'][\CURLOPT_USERPWD]
+                $options['curl'][\CURLOPT_USERPWD],
+                $options['curl'][\CURLOPT_XOAUTH2_BEARER]
             );
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -405,6 +405,9 @@ class ClientTest extends TestCase
 
     public function testAuthCanBeArrayForBearerAuth()
     {
+        if (PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('This test requires PHP version 7.3 or higher.');
+        }
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', '', 'bearer']]);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -403,6 +403,18 @@ class ClientTest extends TestCase
         ], $last['curl']);
     }
 
+    public function testAuthCanBeArrayForBearerAuth()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->get('http://foo.com', ['auth' => ['a', '', 'bearer']]);
+        $last = $mock->getLastOptions();
+        self::assertSame([
+            \CURLOPT_HTTPAUTH => 64,
+            \CURLOPT_XOAUTH2_BEARER => 'a',
+        ], $last['curl']);
+    }
+
     public function testAuthCanBeArrayForNtlmAuth()
     {
         $mock = new MockHandler([new Response()]);

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -465,7 +465,7 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('http://example.com?a=b', ['auth' => ['testtoken', '', $auth]]);
     }
 
     public static function crossOriginRedirectProvider()

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -275,7 +275,6 @@ class RedirectMiddlewareTest extends TestCase
     /**
      * @testWith ["digest"]
      *           ["ntlm"]
-     *           ["bearer"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossHost($auth)
     {
@@ -294,6 +293,30 @@ class RedirectMiddlewareTest extends TestCase
                     isset($options['curl'][\CURLOPT_USERPWD]),
                     'curl options still contain CURLOPT_USERPWD entry'
                 );
+
+                return new Response(200);
+            },
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+    }
+
+    public function testRemoveCurlBarerAuthorizationOptionsOnRedirectCrossHost()
+    {
+        if (PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('This test requires PHP version 7.3 or higher.');
+        }
+        if (!defined('\CURLOPT_HTTPAUTH')) {
+            self::markTestSkipped('ext-curl is required for this test');
+        }
+        if (!defined('\CURLAUTH_BEARER')) {
+            self::markTestSkipped('curl version 7.61.0 or higher is required for this test');
+        }
+
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com']),
+            static function (RequestInterface $request, $options) {
                 self::assertFalse(
                     isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
                     'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
@@ -304,13 +327,12 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('http://example.com?a=b', ['auth' => ['testtoken', '', 'bearer']]);
     }
 
     /**
      * @testWith ["digest"]
      *           ["ntlm"]
-     *           ["bearer"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossPort($auth)
     {
@@ -329,6 +351,30 @@ class RedirectMiddlewareTest extends TestCase
                     isset($options['curl'][\CURLOPT_USERPWD]),
                     'curl options still contain CURLOPT_USERPWD entry'
                 );
+
+                return new Response(200);
+            },
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+    }
+
+    public function testRemoveCurlBearerAuthorizationOptionsOnRedirectCrossPort()
+    {
+        if (PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('This test requires PHP version 7.3 or higher.');
+        }
+        if (!defined('\CURLOPT_HTTPAUTH')) {
+            self::markTestSkipped('ext-curl is required for this test');
+        }
+        if (!defined('\CURLAUTH_BEARER')) {
+            self::markTestSkipped('curl version 7.61.0 or higher is required for this test');
+        }
+
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com:81/']),
+            static function (RequestInterface $request, $options) {
                 self::assertFalse(
                     isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
                     'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
@@ -339,13 +385,12 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('http://example.com?a=b', ['auth' => ['testtoken', '', 'bearer']]);
     }
 
     /**
      * @testWith ["digest"]
      *           ["ntlm"]
-     *           ["bearer"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossScheme($auth)
     {
@@ -364,6 +409,30 @@ class RedirectMiddlewareTest extends TestCase
                     isset($options['curl'][\CURLOPT_USERPWD]),
                     'curl options still contain CURLOPT_USERPWD entry'
                 );
+
+                return new Response(200);
+            },
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $client->get('https://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+    }
+
+    public function testRemoveCurlBearerAuthorizationOptionsOnRedirectCrossScheme()
+    {
+        if (PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('This test requires PHP version 7.3 or higher.');
+        }
+        if (!defined('\CURLOPT_HTTPAUTH')) {
+            self::markTestSkipped('ext-curl is required for this test');
+        }
+        if (!defined('\CURLAUTH_BEARER')) {
+            self::markTestSkipped('curl version 7.61.0 or higher is required for this test');
+        }
+
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com?a=b']),
+            static function (RequestInterface $request, $options) {
                 self::assertFalse(
                     isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
                     'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
@@ -374,13 +443,12 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('https://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('https://example.com?a=b', ['auth' => ['testtoken', '', 'bearer']]);
     }
 
     /**
      * @testWith ["digest"]
      *           ["ntlm"]
-     *           ["bearer"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossSchemeSamePort($auth)
     {
@@ -410,6 +478,34 @@ class RedirectMiddlewareTest extends TestCase
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
         $client->get('https://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+    }
+
+    public function testRemoveCurlBearerAuthorizationOptionsOnRedirectCrossSchemeSamePort()
+    {
+        if (PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('This test requires PHP version 7.3 or higher.');
+        }
+        if (!defined('\CURLOPT_HTTPAUTH')) {
+            self::markTestSkipped('ext-curl is required for this test');
+        }
+        if (!defined('\CURLAUTH_BEARER')) {
+            self::markTestSkipped('curl version 7.61.0 or higher is required for this test');
+        }
+
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com:80?a=b']),
+            static function (RequestInterface $request, $options) {
+                self::assertFalse(
+                    isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
+                    'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
+                );
+
+                return new Response(200);
+            },
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $client->get('https://example.com?a=b', ['auth' => ['testtoken', '', 'bearer']]);
     }
 
     /**
@@ -442,14 +538,16 @@ class RedirectMiddlewareTest extends TestCase
         $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
     }
 
-    /**
-     * @testWith ["bearer"]
-     *
-     */
-    public function testNotRemoveCurlBearerAuthorizationOptionsOnRedirect($auth)
+    public function testNotRemoveCurlBearerAuthorizationOptionsOnRedirect()
     {
-        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_XOAUTH2_BEARER')) {
+        if (PHP_VERSION_ID < 70300) {
+            $this->markTestSkipped('This test requires PHP version 7.3 or higher.');
+        }
+        if (!defined('\CURLOPT_HTTPAUTH')) {
             self::markTestSkipped('ext-curl is required for this test');
+        }
+        if (!defined('\CURLAUTH_BEARER')) {
+            self::markTestSkipped('curl version 7.61.0 or higher is required for this test');
         }
 
         $mock = new MockHandler([
@@ -465,7 +563,7 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('http://example.com?a=b', ['auth' => ['testtoken', '', $auth]]);
+        $client->get('http://example.com?a=b', ['auth' => ['testtoken', '', 'bearer']]);
     }
 
     public static function crossOriginRedirectProvider()

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -275,6 +275,7 @@ class RedirectMiddlewareTest extends TestCase
     /**
      * @testWith ["digest"]
      *           ["ntlm"]
+     *           ["bearer"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossHost($auth)
     {
@@ -293,6 +294,10 @@ class RedirectMiddlewareTest extends TestCase
                     isset($options['curl'][\CURLOPT_USERPWD]),
                     'curl options still contain CURLOPT_USERPWD entry'
                 );
+                self::assertFalse(
+                    isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
+                    'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
+                );
 
                 return new Response(200);
             },
@@ -305,6 +310,7 @@ class RedirectMiddlewareTest extends TestCase
     /**
      * @testWith ["digest"]
      *           ["ntlm"]
+     *           ["bearer"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossPort($auth)
     {
@@ -323,6 +329,10 @@ class RedirectMiddlewareTest extends TestCase
                     isset($options['curl'][\CURLOPT_USERPWD]),
                     'curl options still contain CURLOPT_USERPWD entry'
                 );
+                self::assertFalse(
+                    isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
+                    'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
+                );
 
                 return new Response(200);
             },
@@ -335,6 +345,7 @@ class RedirectMiddlewareTest extends TestCase
     /**
      * @testWith ["digest"]
      *           ["ntlm"]
+     *           ["bearer"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossScheme($auth)
     {
@@ -353,6 +364,10 @@ class RedirectMiddlewareTest extends TestCase
                     isset($options['curl'][\CURLOPT_USERPWD]),
                     'curl options still contain CURLOPT_USERPWD entry'
                 );
+                self::assertFalse(
+                    isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
+                    'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
+                );
 
                 return new Response(200);
             },
@@ -365,6 +380,7 @@ class RedirectMiddlewareTest extends TestCase
     /**
      * @testWith ["digest"]
      *           ["ntlm"]
+     *           ["bearer"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossSchemeSamePort($auth)
     {
@@ -382,6 +398,10 @@ class RedirectMiddlewareTest extends TestCase
                 self::assertFalse(
                     isset($options['curl'][\CURLOPT_USERPWD]),
                     'curl options still contain CURLOPT_USERPWD entry'
+                );
+                self::assertFalse(
+                    isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
+                    'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
                 );
 
                 return new Response(200);
@@ -412,6 +432,32 @@ class RedirectMiddlewareTest extends TestCase
                 self::assertTrue(
                     isset($options['curl'][\CURLOPT_USERPWD]),
                     'curl options does not contain expected CURLOPT_USERPWD entry'
+                );
+
+                return new Response(200);
+            },
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+    }
+
+    /**
+     * @testWith ["bearer"]
+     *
+     */
+    public function testNotRemoveCurlBearerAuthorizationOptionsOnRedirect($auth)
+    {
+        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_XOAUTH2_BEARER')) {
+            self::markTestSkipped('ext-curl is required for this test');
+        }
+
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com/2']),
+            static function (RequestInterface $request, $options) {
+                self::assertTrue(
+                    isset($options['curl'][\CURLOPT_XOAUTH2_BEARER]),
+                    'curl options still contain CURLOPT_XOAUTH2_BEARER entry'
                 );
 
                 return new Response(200);


### PR DESCRIPTION
Here we add a new authentication type for Bearer auth.

Fixes #3311