### PR TITLE
Fix CURLOPT_HTTPAUTH defined() checks on cross-origin redirects

### DIFF
--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -89,7 +89,10 @@ class RedirectMiddleware
         $nextRequest = $this->modifyRequest($request, $options, $response);
 
         // If authorization is handled by curl, unset it if URI is cross-origin.
-        if (Psr7\UriComparator::isCrossOrigin($request->getUri(), $nextRequest->getUri()) && defined('\CURLOPT_HTTPAUTH')) {
+        if (
+            Psr7\UriComparator::isCrossOrigin($request->getUri(), $nextRequest->getUri())
+            && defined('CURLOPT_HTTPAUTH')
+        ) {
             unset(
                 $options['curl'][\CURLOPT_HTTPAUTH],
                 $options['curl'][\CURLOPT_USERPWD]

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -278,7 +278,7 @@ class RedirectMiddlewareTest extends TestCase
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossHost($auth)
     {
-        if (!defined('\CURLOPT_HTTPAUTH')) {
+        if (!defined('CURLOPT_HTTPAUTH')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -308,7 +308,7 @@ class RedirectMiddlewareTest extends TestCase
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossPort($auth)
     {
-        if (!defined('\CURLOPT_HTTPAUTH')) {
+        if (!defined('CURLOPT_HTTPAUTH')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -338,7 +338,7 @@ class RedirectMiddlewareTest extends TestCase
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossScheme($auth)
     {
-        if (!defined('\CURLOPT_HTTPAUTH')) {
+        if (!defined('CURLOPT_HTTPAUTH')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -368,7 +368,7 @@ class RedirectMiddlewareTest extends TestCase
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossSchemeSamePort($auth)
     {
-        if (!defined('\CURLOPT_HTTPAUTH')) {
+        if (!defined('CURLOPT_HTTPAUTH')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -398,7 +398,7 @@ class RedirectMiddlewareTest extends TestCase
      */
     public function testNotRemoveCurlAuthorizationOptionsOnRedirect($auth)
     {
-        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_USERPWD')) {
+        if (!defined('CURLOPT_HTTPAUTH') || !defined('CURLOPT_USERPWD')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 


### PR DESCRIPTION
This PR fixes an incorrect use of defined() when checking for curl authentication constants during cross-origin redirects.

Previously, the code was calling `defined('\CURLOPT_HTTPAUTH')`, which treats the backslash-prefixed string as a different constant name. As a result, the condition could evaluate to false even when the curl extension was available, preventing the intended removal of curl authentication options on cross-origin redirects.

This change ensures that curl auth options are correctly removed when a redirect crosses origin boundaries, restoring the intended and documented behaviour.

- What was changed
    - Replaced defined('\CURLOPT_HTTPAUTH') with defined('CURLOPT_HTTPAUTH')
    - Ensured related logic is evaluated correctly when curl is available
    - Updated existing tests to reflect the corrected constant check and avoid false negatives

- Tests

    - Updated redirect middleware tests to use the correct defined('CURLOPT_HTTPAUTH') guard
    - All existing redirect behaviour tests remain unchanged
    - No new test cases were required, as existing coverage already exercised the affected code paths

- test results
<img width="734" height="600" alt="スクリーンショット 2025-12-25 22 33 56" src="https://github.com/user-attachments/assets/3f5e70a7-68b4-4d37-b0d7-4d754f5f2de0" />
