### PR TITLE
Allow omitting Domain attribute in SetCookie per RFC 6265

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -482,8 +482,11 @@ class SetCookie
 
         // Domains must not be empty, but can be 0. "0" is not a valid internet
         // domain, but may be used as server name in a private network.
+        // A null domain is allowed per RFC 6265 Section 4.1.2.3 — when the
+        // Domain attribute is omitted, the cookie becomes a "host-only" cookie
+        // that is returned only to the origin server.
         $domain = $this->getDomain();
-        if ($domain === null || $domain === '') {
+        if ($domain !== null && $domain === '') {
             return 'The cookie domain must not be empty';
         }
 

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -500,6 +500,21 @@ class CookieJarTest extends TestCase
         self::assertCount($matches ? 1 : 0, $this->jar->toArray());
     }
 
+        /**
+     * @see https://github.com/guzzle/guzzle/issues/3315
+     */
+    public function testAcceptsCookieWithoutDomain(): void
+    {
+        $jar = new CookieJar(true);
+        $cookie = new SetCookie([
+            'Name' => 'test',
+            'Value' => 'value',
+        ]);
+        self::assertTrue($jar->setCookie($cookie));
+        self::assertCount(1, $jar);
+        self::assertNull($jar->toArray()[0]['Domain']);
+    }
+
     private function futureExpirationDate()
     {
         return (new DateTimeImmutable())->add(new DateInterval('P1D'))->format(DateTime::COOKIE);

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -163,6 +163,7 @@ class SetCookieTest extends TestCase
             ['', 'baz', 'bar', 'The cookie name must not be empty'],
             ['foo', null, 'bar', 'The cookie value must not be empty'],
             ['foo', 'baz', '', 'The cookie domain must not be empty'],
+            ['foo', 'baz', null, true],
             ["foo\r", 'baz', '0', 'Cookie name must not contain invalid characters: ASCII Control characters (0-31;127), space, tab and the following characters: ()<>@,;:\"/?={}'],
         ];
     }


### PR DESCRIPTION
## Summary

Per [RFC 6265 Section 4.1.2.3](https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.2.3), when the Domain attribute is omitted from a Set-Cookie header, the cookie becomes a **host-only** cookie returned only to the origin server. This is distinct from explicitly setting the Domain to the origin, which also allows subdomains.

## Problem

Currently, `SetCookie::validate()` rejects cookies with a `null` Domain, throwing:

> RuntimeException: Invalid cookie: The cookie domain must not be empty

This makes it impossible to store host-only cookies in the `CookieJar` when creating cookies manually (without going through `extractCookies()`).

## Solution

Allow `null` Domain in `validate()` while still rejecting empty string (`''`) domains. The `matchesDomain()` method already handles `null` domains correctly (returns `true`).

## Changes

- **`src/Cookie/SetCookie.php`**: Updated `validate()` to allow `null` domain (host-only cookie)
- **`tests/Cookie/SetCookieTest.php`**: Added test case for null domain validation
- **`tests/Cookie/CookieJarTest.php`**: Added test verifying CookieJar accepts cookies without Domain

Fixes #3315