### PR TITLE
Add Psalm/IDE type docs for Client::__construct() config (fixes #3194)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -105,7 +105,13 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$uri of static method GuzzleHttp\\Psr7\\Utils\:\:uriFor\(\) expects Psr\\Http\\Message\\UriInterface\|string, mixed given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
+			path: src/Client.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
 			path: src/Client.php
 
 		-

--- a/src/Client.php
+++ b/src/Client.php
@@ -13,6 +13,8 @@ use Psr\Http\Message\UriInterface;
 
 /**
  * @final
+ *
+ * @psalm-import-type OptionsArray from \GuzzleHttp\RequestOptions
  */
 class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 {
@@ -51,6 +53,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * - **: any request option
      *
      * @param array $config Client configuration settings.
+     *
+     * @psalm-param OptionsArray $config
      *
      * @see RequestOptions for a list of available request options.
      */

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -6,6 +6,43 @@ namespace GuzzleHttp;
  * This class contains a list of built-in Guzzle request options.
  *
  * @see https://docs.guzzlephp.org/en/latest/request-options.html
+ *
+ * @psalm-type OptionsArray = array{
+ *     handler?: callable,
+ *     base_uri?: string|\Psr\Http\Message\UriInterface,
+ *     allow_redirects?: bool|array,
+ *     auth?: array{0: string, 1: string, 2?: string}|null,
+ *     body?: resource|string|null|int|float|\Psr\Http\Message\StreamInterface|callable|\Iterator,
+ *     cert?: string|array,
+ *     connect_timeout?: float,
+ *     cookies?: bool|\GuzzleHttp\Cookie\CookieJarInterface,
+ *     crypto_method?: int,
+ *     debug?: bool|resource,
+ *     decode_content?: bool|string,
+ *     delay?: int|float,
+ *     expect?: bool|int,
+ *     form_params?: array<string, string|array<string>>,
+ *     headers?: array<string, string|array<string>>,
+ *     http_errors?: bool,
+ *     idn_conversion?: bool|int,
+ *     json?: mixed,
+ *     multipart?: array<int, array{name: string, contents: mixed, headers?: array, filename?: string}>,
+ *     on_headers?: callable,
+ *     on_stats?: callable,
+ *     progress?: callable,
+ *     proxy?: string|array,
+ *     query?: array|string,
+ *     read_timeout?: float,
+ *     sink?: resource|string|\Psr\Http\Message\StreamInterface,
+ *     ssl_key?: array|string,
+ *     stream?: bool,
+ *     synchronous?: bool,
+ *     timeout?: float,
+ *     verify?: bool|string,
+ *     version?: float,
+ *     force_ip_resolve?: string,
+ *     ...
+ * }
  */
 final class RequestOptions
 {


### PR DESCRIPTION
- Add @psalm-type OptionsArray in RequestOptions with full option shape
- Add @psalm-import-type and @psalm-param OptionsArray in Client::__construct()
- Align option types with official docs (decode_content, delay, force_ip_resolve)
- Update PHPStan baseline for new typing (uriFor count, booleanNot.alwaysFalse)