### PR TITLE
[Bugfix] Use Host header if it is present in the default config

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,6 +181,12 @@ parameters:
 			path: src/Client.php
 
 		-
+			message: '#^Cannot access offset ''Host'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: src/Client.php
+
+		-
 			message: '#^Parameter \#1 \$data of class GuzzleHttp\\Cookie\\SetCookie constructor expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Client.php
+++ b/src/Client.php
@@ -162,6 +162,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         if (\is_array($body)) {
             throw $this->invalidBody();
         }
+        // Special case for the Host header
+        if (!isset($headers['Host']) && isset($this->config['headers']['Host'])) {
+            $headers['Host'] = $this->config['headers']['Host'];
+        }
         $request = new Psr7\Request($method, $uri, $headers, $body, $version);
         // Remove the option so that they are not doubly-applied.
         unset($options['headers'], $options['body'], $options['version']);


### PR DESCRIPTION
When a Client object is created, if the `Host` header is passed as a default header it is ignored.

This is because default headers are kept apart, and only set at a later stage in `applyOptions`. However when the Psr7\Request is created without any headers a default Host based on the `base_uri` might be inserted as default, therefore the desired default value won't be set later in `applyOptions` because a Host header already exists in the request object.

This behavior makes `Host` a special case. Therefore if it is present as a default header but not present in the request options, we force the desired header value.