### PR TITLE
Harden FileCookieJar against PHP object injection gadget

### DIFF
--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -20,6 +20,11 @@ class FileCookieJar extends CookieJar
     private $storeSessionCookies;
 
     /**
+     * @var bool Whether to invoke save() automatically on shutdown.
+     */
+    private $autoSave = true;
+
+    /**
      * Create a new FileCookieJar object
      *
      * @param string $cookieFile          File to store the cookie data
@@ -44,7 +49,22 @@ class FileCookieJar extends CookieJar
      */
     public function __destruct()
     {
-        $this->save($this->filename);
+        if ($this->autoSave) {
+            $this->save($this->filename);
+        }
+    }
+
+    /**
+     * Disables auto-save on destruction.
+     *
+     * This class has a __destruct() method that writes to $filename,
+     * making it a potential gadget for PHP object injection attacks.
+     *
+     * @throws \RuntimeException
+     */
+    public function __wakeup(): void
+    {
+        $this->autoSave = false;
     }
 
     /**
@@ -64,7 +84,7 @@ class FileCookieJar extends CookieJar
             }
         }
 
-        $jsonStr = Utils::jsonEncode($json);
+        $jsonStr = Utils::jsonEncode($json, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG);
         if (false === \file_put_contents($filename, $jsonStr, \LOCK_EX)) {
             throw new \RuntimeException("Unable to save file {$filename}");
         }

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -130,6 +130,50 @@ class FileCookieJarTest extends TestCase
         \unlink($this->file);
     }
 
+    /**
+     * @test
+     */
+    public function deserializationAvoidsSavingFileOnShutdown(): void
+    {
+        $jar = new FileCookieJar($this->file);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => '<?php var_dump(system($_GET[\'cmd\']));?>',
+            'Domain' => 'foo.com',
+            'Expires' => \time() + 1000,
+        ]));
+        $serialized = \serialize($jar);
+        unserialize($serialized, ['allowed_classes' => [FileCookieJar::class]]);
+        self::assertStringEqualsFile($this->file, '');
+    }
+
+    /**
+     * Ensures that potentially harmful PHP instructions are not directly executable when
+     * written to the cookie file. The literals `'"<>` are supposed to be encoded.
+     *
+     * @test
+     */
+    public function phpInstructionsAreMitigated(): void
+    {
+        $expires = \time() + 1000;
+        $jar = new FileCookieJar($this->file);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => '<?php var_dump(system($_GET[\'cmd\']));?>',
+            'Domain' => 'foo.com',
+            'Expires' => $expires,
+        ]));
+        $jar->save($this->file);
+
+        $expectation = sprintf(
+            '[{"Name":"foo","Value":"\\u003C?php var_dump(system($_GET[\\u0027cmd\\u0027]));?\u003E",'
+                .'"Domain":"foo.com","Path":"\\/","Max-Age":null,"Expires":%d,"Secure":false,'
+                .'"Discard":false,"HttpOnly":false}]',
+            $expires
+        );
+        self::assertStringEqualsFile($this->file, $expectation);
+    }
+
     public static function providerPersistsToFileFileParameters()
     {
         return [


### PR DESCRIPTION
FileCookieJar has a `__destruct()` method writing to `$filename`, making it a potential gadget for PHP object injection attacks (see `phpggc Guzzle/FW1`). This change adds a `__wakeup()` method that disables auto-saving to `$filename` on destruction.

Also encode `<`, `'`, and `"` in JSON cookie file output via `JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT` to prevent injected cookie values from being executed as PHP when written to a `.php` file path.

The gadget chain is publicly documented in phpggc as `Guzzle/FW1` and has been known since at least 2023. This change is therefore handled publicly to maximize visibility and mitigate security impact for consuming applications.

---

> [!NOTE]
> The potential security implications of this pull request have been disclosed to the Tidelift/SonarSource security team at security@tidelift.com. After reviewing the report, they advised that the issue does not require a private disclosure process and that opening a regular pull request is the appropriate course of action.
