### PR TITLE
Add support for curl_share_init and curl_share_init_persistent

### DIFF
--- a/docs/handlers-and-middleware.rst
+++ b/docs/handlers-and-middleware.rst
@@ -302,3 +302,48 @@ These request options are a subset of request options called
 - :ref:`ssl_key-option`
 - :ref:`stream-option`
 - :ref:`verify-option`
+
+
+Handler Options
+===============
+
+CurlHandler and CurlMultiHandler
+---------------------------------
+
+The ``CurlHandler`` and ``CurlMultiHandler`` accept constructor options that
+configure how cURL handles are created and managed.
+
+share
+~~~~~
+
+:Summary: Array of ``CURL_LOCK_DATA_*`` constants to share between requests via ``curl_share_init()``
+:Types: ``int[]``
+:Default: ``null``
+
+Specify which data types should be shared between cURL handles. Creates a
+cURL share handle that allows multiple cURL handles to share the specified
+data. This can significantly improve performance for applications making
+multiple requests to the same hosts by eliminating redundant DNS lookups
+and SSL handshakes.
+
+share_persistent
+~~~~~~~~~~~~~~~~
+
+:Summary: Array of ``CURL_LOCK_DATA_*`` constants for persistent sharing via ``curl_share_init_persistent()`` (PHP 8.5+)
+:Types: ``int[]``
+:Default: ``null``
+
+In PHP 8.5+, you can specify which data types to share across requests using
+persistent cURL share handles. Persistent share handles survive across multiple
+PHP requests in long-running processes or FPM workers, providing even better
+performance than regular share handles.
+
+If both ``share`` and ``share_persistent`` are specified, ``share_persistent``
+will be used if ``curl_share_init_persistent()`` is available (PHP 8.5+),
+otherwise ``share`` will be used as a fallback.
+
+.. important::
+
+    Do not include ``CURL_LOCK_DATA_COOKIE`` in share handles, as PHP will
+    raise a ``ValueError`` when using persistent share handles. Guzzle manages
+    cookies through middleware, not at the cURL level.

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -38,11 +38,18 @@ class CurlFactory implements CurlFactoryInterface
     private $maxHandles;
 
     /**
-     * @param int $maxHandles Maximum number of idle handles.
+     * @var \CurlShareHandle|\CurlSharePersistentHandle|resource|null
      */
-    public function __construct(int $maxHandles)
+    private $shareHandle;
+
+    /**
+     * @param int                                                       $maxHandles  Maximum number of idle handles.
+     * @param \CurlShareHandle|\CurlSharePersistentHandle|resource|null $shareHandle Optional cURL share handle for sharing data between handles.
+     */
+    public function __construct(int $maxHandles, $shareHandle = null)
     {
         $this->maxHandles = $maxHandles;
+        $this->shareHandle = $shareHandle;
     }
 
     public function create(RequestInterface $request, array $options): EasyHandle
@@ -79,6 +86,11 @@ class CurlFactory implements CurlFactoryInterface
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
         $easy->handle = $this->handles ? \array_pop($this->handles) : \curl_init();
         curl_setopt_array($easy->handle, $conf);
+
+        if ($this->shareHandle !== null) {
+            /** @phpstan-ignore-next-line argument.type (supports resource in PHP 7.x and CurlShareHandle/CurlSharePersistentHandle in PHP 8.x) */
+            curl_setopt($easy->handle, \CURLOPT_SHARE, $this->shareHandle);
+        }
 
         return $easy;
     }

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -22,16 +22,49 @@ class CurlHandler
     private $factory;
 
     /**
+     * @var \CurlShareHandle|\CurlSharePersistentHandle|resource|null
+     *
+     * @phpstan-ignore-next-line property.unusedType (resource is used in PHP 7.x)
+     */
+    private $shareHandle;
+
+    /**
+     * @var bool
+     */
+    private $isPersistentShare = false;
+
+    /**
      * Accepts an associative array of options:
      *
      * - handle_factory: Optional curl factory used to create cURL handles.
+     * - share: Array of CURL_LOCK_DATA_* constants to set on a curl_share_init handle.
+     * - share_persistent: Array of CURL_LOCK_DATA_* constants to set on a curl_share_init_persistent handle (PHP 8.5+).
      *
-     * @param array{handle_factory?: ?CurlFactoryInterface} $options Array of options to use with the handler
+     * If share and share_persistent are both set, share_persistent will be used if the function curl_share_init_persistent is available,
+     * otherwise share will be used if the function curl_share_init is available.
+     *
+     * @param array{handle_factory?: ?CurlFactoryInterface, share?: int[], share_persistent?: int[]} $options Array of options to use with the handler
      */
     public function __construct(array $options = [])
     {
+        if (isset($options['share_persistent']) && \function_exists('curl_share_init_persistent')) {
+            /** @var int[] $sharePersistent */
+            $sharePersistent = $options['share_persistent'];
+            /** @var \CurlSharePersistentHandle $handle */
+            $handle = \curl_share_init_persistent($sharePersistent);
+            $this->shareHandle = $handle;
+            $this->isPersistentShare = true;
+        } elseif (isset($options['share']) && \function_exists('curl_share_init')) {
+            /** @var int[] $share */
+            $share = $options['share'];
+            $this->shareHandle = \curl_share_init();
+            foreach ($share as $lock) {
+                \curl_share_setopt($this->shareHandle, \CURLSHOPT_SHARE, $lock);
+            }
+        }
+
         $this->factory = $options['handle_factory']
-            ?? new CurlFactory(3);
+            ?? new CurlFactory(3, $this->shareHandle);
     }
 
     public function __invoke(RequestInterface $request, array $options): PromiseInterface
@@ -45,5 +78,16 @@ class CurlHandler
         $easy->errno = \curl_errno($easy->handle);
 
         return CurlFactory::finish($this, $easy, $this->factory);
+    }
+
+    public function __destruct()
+    {
+        // Only close non-persistent share handles
+        // Persistent handles are managed by PHP and should not be closed
+        // curl_share_close has no effect in PHP version >= 8.0.0
+        if ($this->shareHandle !== null && !$this->isPersistentShare && PHP_VERSION_ID < 80000) {
+            /** @phpstan-ignore-next-line */
+            \curl_share_close($this->shareHandle);
+        }
     }
 }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -26,6 +26,18 @@ class CurlMultiHandler
     private $factory;
 
     /**
+     * @var \CurlShareHandle|\CurlSharePersistentHandle|resource|null
+     *
+     * @phpstan-ignore-next-line property.unusedType (resource is used in PHP 7.x)
+     */
+    private $shareHandle;
+
+    /**
+     * @var bool
+     */
+    private $isPersistentShare = false;
+
+    /**
      * @var int
      */
     private $selectTimeout;
@@ -65,10 +77,31 @@ class CurlMultiHandler
      *   out while selecting curl handles. Defaults to 1 second.
      * - options: An associative array of CURLMOPT_* options and
      *   corresponding values for curl_multi_setopt()
+     * - share: Array of CURL_LOCK_DATA_* constants to set on a curl_share_init handle.
+     * - share_persistent: Array of CURL_LOCK_DATA_* constants to set on a curl_share_init_persistent handle (PHP 8.5+).
+     *
+     * If share and share_persistent are both set, share_persistent will be used if the function curl_share_init_persistent is available,
+     * otherwise share will be used if the function curl_share_init is available.
      */
     public function __construct(array $options = [])
     {
-        $this->factory = $options['handle_factory'] ?? new CurlFactory(50);
+        if (isset($options['share_persistent']) && \function_exists('curl_share_init_persistent')) {
+            /** @var int[] $sharePersistent */
+            $sharePersistent = $options['share_persistent'];
+            /** @var \CurlSharePersistentHandle $handle */
+            $handle = \curl_share_init_persistent($sharePersistent);
+            $this->shareHandle = $handle;
+            $this->isPersistentShare = true;
+        } elseif (isset($options['share']) && \function_exists('curl_share_init')) {
+            /** @var int[] $share */
+            $share = $options['share'];
+            $this->shareHandle = \curl_share_init();
+            foreach ($share as $lock) {
+                \curl_share_setopt($this->shareHandle, \CURLSHOPT_SHARE, $lock);
+            }
+        }
+
+        $this->factory = $options['handle_factory'] ?? new CurlFactory(50, $this->shareHandle);
 
         if (isset($options['select_timeout'])) {
             $this->selectTimeout = $options['select_timeout'];
@@ -121,6 +154,14 @@ class CurlMultiHandler
         if (isset($this->_mh)) {
             \curl_multi_close($this->_mh);
             unset($this->_mh);
+        }
+
+        // Only close non-persistent share handles
+        // Persistent handles are managed by PHP and should not be closed
+        // curl_share_close has no effect in PHP version >= 8.0.0
+        if ($this->shareHandle !== null && !$this->isPersistentShare && PHP_VERSION_ID < 80000) {
+            /** @phpstan-ignore-next-line */
+            \curl_share_close($this->shareHandle);
         }
     }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -957,4 +957,65 @@ class CurlFactoryTest extends TestCase
 
         $a(new Psr7\Request('GET', Server::$url.'guzzle-server/bad-status'), [])->wait();
     }
+
+    public function testAcceptsShareHandle()
+    {
+        if (!\function_exists('curl_share_init')) {
+            self::markTestSkipped('curl_share_init is not available');
+        }
+
+        $sh = \curl_share_init();
+        \curl_share_setopt($sh, \CURLSHOPT_SHARE, \CURL_LOCK_DATA_DNS);
+
+        $f = new CurlFactory(3, $sh);
+        $request = new Psr7\Request('GET', Server::$url);
+        $easy = $f->create($request, []);
+
+        // Verify the share handle was set via the test bootstrap's curl_setopt override
+        self::assertEquals($sh, $_SERVER['_curl'][\CURLOPT_SHARE] ?? null);
+
+        if (PHP_VERSION_ID < 80000) {
+            \curl_close($easy->handle);
+            \curl_share_close($sh);
+        }
+    }
+
+    public function testAppliesShareHandleToCreatedHandles()
+    {
+        $mockShare = 'mock_share_handle';
+        $f = new CurlFactory(3, $mockShare);
+        $request = new Psr7\Request('GET', Server::$url);
+
+        $easy = $f->create($request, []);
+
+        self::assertEquals($mockShare, $_SERVER['_curl'][\CURLOPT_SHARE] ?? null);
+
+        if (PHP_VERSION_ID < 80000) {
+            \curl_close($easy->handle);
+        }
+    }
+
+    public function testReappliesShareHandleAfterHandleReuse()
+    {
+        $mockShare = 'mock_share_handle';
+        $f = new CurlFactory(3, $mockShare);
+        $request = new Psr7\Request('GET', Server::$url);
+
+        $easy1 = $f->create($request, []);
+        $handle1 = $easy1->handle;
+        self::assertEquals($mockShare, $_SERVER['_curl'][\CURLOPT_SHARE] ?? null);
+
+        $f->release($easy1);
+
+        $_SERVER['_curl'] = [];
+
+        $easy2 = $f->create($request, []);
+
+        self::assertSame($handle1, $easy2->handle);
+        self::assertEquals($mockShare, $_SERVER['_curl'][\CURLOPT_SHARE] ?? null);
+
+        if (PHP_VERSION_ID < 80000) {
+            \curl_close($easy2->handle);
+        }
+    }
 }

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -98,4 +98,40 @@ class CurlHandlerTest extends TestCase
         self::assertEquals(1000000, $received->getHeaderLine('Content-Length'));
         self::assertFalse($received->hasHeader('Transfer-Encoding'));
     }
+
+    public function testAcceptsShareOption()
+    {
+        if (!\function_exists('curl_share_init')) {
+            self::markTestSkipped('curl_share_init is not available');
+        }
+
+        $handler = new CurlHandler([
+            'share' => [\CURL_LOCK_DATA_DNS, \CURL_LOCK_DATA_SSL_SESSION],
+        ]);
+
+        Server::flush();
+        Server::enqueue([new Response()]);
+        $request = new Request('GET', Server::$url);
+        $handler($request, [])->wait();
+
+        $this->assertTrue(true);
+    }
+
+    public function testAcceptsSharePersistentOption()
+    {
+        if (!\function_exists('curl_share_init_persistent')) {
+            self::markTestSkipped('curl_share_init_persistent is not available (PHP 8.5+)');
+        }
+
+        $handler = new CurlHandler([
+            'share_persistent' => [\CURL_LOCK_DATA_DNS],
+        ]);
+
+        Server::flush();
+        Server::enqueue([new Response()]);
+        $request = new Request('GET', Server::$url);
+        $handler($request, [])->wait();
+
+        $this->assertTrue(true);
+    }
 }

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -127,4 +127,40 @@ class CurlMultiHandlerTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
         $h->foo;
     }
+
+    public function testAcceptsShareOption()
+    {
+        if (!\function_exists('curl_share_init')) {
+            self::markTestSkipped('curl_share_init is not available');
+        }
+
+        Server::flush();
+        Server::enqueue([new Response()]);
+
+        $handler = new CurlMultiHandler([
+            'share' => [\CURL_LOCK_DATA_DNS, \CURL_LOCK_DATA_SSL_SESSION],
+        ]);
+        $request = new Request('GET', Server::$url);
+        $handler($request, [])->wait();
+
+        $this->assertTrue(true);
+    }
+
+    public function testAcceptsSharePersistentOption()
+    {
+        if (!\function_exists('curl_share_init_persistent')) {
+            self::markTestSkipped('curl_share_init_persistent is not available (PHP 8.5+)');
+        }
+
+        Server::flush();
+        Server::enqueue([new Response()]);
+
+        $handler = new CurlMultiHandler([
+            'share_persistent' => [\CURL_LOCK_DATA_DNS],
+        ]);
+        $request = new Request('GET', Server::$url);
+        $handler($request, [])->wait();
+
+        $this->assertTrue(true);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,26 @@ namespace GuzzleHttp\Handler {
         return \curl_setopt_array($handle, $options);
     }
 
+    function curl_setopt($handle, $option, $value)
+    {
+        if (!empty($_SERVER['curl_test'])) {
+            $_SERVER['_curl'][$option] = $value;
+
+            // Skip setting CURLOPT_SHARE if the value is not a valid cURL share handle
+            // This allows tests to use mock share handles for assertions
+            if ($option === \CURLOPT_SHARE) {
+                $isValidShareHandle = is_resource($value)
+                    || (PHP_VERSION_ID >= 80000 && ($value instanceof \CurlShareHandle || $value instanceof \CurlSharePersistentHandle));
+
+                if (!$isValidShareHandle) {
+                    return true;
+                }
+            }
+        }
+
+        return \curl_setopt($handle, $option, $value);
+    }
+
     function curl_multi_setopt($handle, $option, $value)
     {
         if (!empty($_SERVER['curl_test'])) {


### PR DESCRIPTION
**Motivation:**

Closes #3307 

PHP 8.5 introduces the [curl_share_init_persistent function](https://www.php.net/manual/en/function.curl-share-init-persistent.php), which allows for the creation of named, persistent shared cURL handles. Supporting this in Guzzle would allow callers to take advantage of the performance benefits that come with using a persistent shared curl handle by reducing the overhead of repeated SSL handshakes and DNS lookups. 

**Changes introduced:**
This PR adds the ability to instantiate a CurlHandler or CurlMultiHandler with some added `$options`:
- `share` - an array of CURL_LOCK_DATA_* constants to share between requests via [`curl_share_init()`](https://www.php.net/manual/en/function.curl-share-init.php)
- `share_persistent` - an array of CURL_LOCK_DATA_* constants to share between requests via [`curl_share_init_persistent()`](https://www.php.net/manual/en/function.curl-share-init-persistent.php)

If the `share_persistent` option is specified and the function `curl_share_init_persistent` exists (it was added in PHP 8.5.0), we will create a persistent share handle. If only `share` is present and `curl_share_init` exists, we will create a regular share handle.

Within the `__destruct` method for both CurlHandler and CurlMultiHandler, we will call [`curl_share_close()`](https://www.php.net/manual/en/function.curl-share-close.php) if the share handle is not persistent and the PHP version is < 8.0.0 (at which point the function is a noop, according to the [docs](https://www.php.net/manual/en/function.curl-share-close.php)).

**Example**

I ran a PHP server with the following script (`php -S localhost:8000 examples/server_persistent.php`):

```php
<?php

require __DIR__ . '/../vendor/autoload.php';

use GuzzleHttp\Client;
use GuzzleHttp\HandlerStack;
use GuzzleHttp\Handler\CurlMultiHandler;
use GuzzleHttp\TransferStats;

$handler = new CurlMultiHandler([
    'share_persistent' => [
        CURL_LOCK_DATA_DNS,
        CURL_LOCK_DATA_CONNECT,
        CURL_LOCK_DATA_SSL_SESSION,
    ]
]);

$client = new Client(['handler' => HandlerStack::create($handler)]);
$stats = null;

$response = $client->get('https://example.com/', [
    'on_stats' => function (TransferStats $transferStats) use (&$stats) {
        $curlStats = $transferStats->getHandlerStats();
        $stats = $curlStats;
    }
]);

header('Content-Type: text/plain');
echo sprintf("namelookup_time_us:     %6d\n", ($stats['namelookup_time'] ?? 0) * 1_000_000);
echo sprintf("connect_time_us:        %6d\n", ($stats['connect_time'] ?? 0) * 1_000_000);
echo sprintf("appconnect_time_us:     %6d\n", ($stats['appconnect_time'] ?? 0) * 1_000_000);
echo sprintf("starttransfer_time_us:  %6d\n", ($stats['starttransfer_time'] ?? 0) * 1_000_000);
echo sprintf("total_time_us:          %6d\n", ($stats['total_time'] ?? 0) * 1_000_000);
echo "\n";
```

I then ran `curl localhost:8000` twice to confirm that we are sharing the handle - the second request had negligible namelookup_time, appconnect_time, and connect_time values:
```
➜  guzzle git:(support_curl_share_init_persistent) ✗ curl localhost:8000
namelookup_time_us:      19336
connect_time_us:         31954
appconnect_time_us:     108133
starttransfer_time_us:  126151
total_time_us:          126911

➜  guzzle git:(support_curl_share_init_persistent) ✗ curl localhost:8000
namelookup_time_us:         39
connect_time_us:            39
appconnect_time_us:         39
starttransfer_time_us:   17842
total_time_us:           18326

```