### PR TITLE
Fix relative URI parsing when a path segment contains a colon

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -158,7 +158,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         $body = $options['body'] ?? null;
         $version = $options['version'] ?? '1.1';
         // Merge the URI into the base URI.
-        $uri = $this->buildUri(Psr7\Utils::uriFor($uri), $options);
+        $uri = $this->buildUri(self::uriForRequest($uri, $options), $options);
         if (\is_array($body)) {
             throw $this->invalidBody();
         }
@@ -221,6 +221,53 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;
+    }
+
+    /**
+     * @param string|UriInterface $uri
+     */
+    private static function uriForRequest($uri, array $config): UriInterface
+    {
+        if (\is_string($uri) && isset($config['base_uri']) && self::isRelativePathReference($uri)) {
+            // Avoid parse_url() treating a relative path segment with ":<port>" later in the path as an authority.
+            return self::uriForRelativePathReference($uri);
+        }
+
+        return Psr7\Utils::uriFor($uri);
+    }
+
+    private static function uriForRelativePathReference(string $uri): UriInterface
+    {
+        // Split query and fragment manually so the remaining value can be used as a path verbatim.
+        $fragment = '';
+        if (false !== $fragmentPos = \strpos($uri, '#')) {
+            $fragment = \substr($uri, $fragmentPos + 1);
+            $uri = \substr($uri, 0, $fragmentPos);
+        }
+
+        $query = '';
+        if (false !== $queryPos = \strpos($uri, '?')) {
+            $query = \substr($uri, $queryPos + 1);
+            $uri = \substr($uri, 0, $queryPos);
+        }
+
+        return (new Psr7\Uri())
+            ->withPath($uri)
+            ->withQuery($query)
+            ->withFragment($fragment);
+    }
+
+    private static function isRelativePathReference(string $uri): bool
+    {
+        if ($uri === '' || $uri[0] === '/' || $uri[0] === '?' || $uri[0] === '#') {
+            return false;
+        }
+
+        // A colon in the first segment denotes a scheme per RFC 3986, not a relative path reference.
+        $firstDelimiter = \strcspn($uri, '/?#');
+        $firstSegment = \substr($uri, 0, $firstDelimiter);
+
+        return \strpos($firstSegment, ':') === false;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -89,6 +89,22 @@ class ClientTest extends TestCase
         );
     }
 
+    public function testCanMergeRelativeUriWithColonInPathSegmentOnBaseUri()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client([
+            'base_uri' => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+            'handler' => $mock,
+        ]);
+
+        $client->post('model/amazon.titan-image-generator-v2:0/invoke');
+
+        self::assertSame(
+            'https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.titan-image-generator-v2:0/invoke',
+            (string) $mock->getLastRequest()->getUri()
+        );
+    }
+
     public function testCanMergeOnBaseUriWithRequest()
     {
         $mock = new MockHandler([new Response(), new Response()]);


### PR DESCRIPTION
## Summary

- A relative URI with a colon in a non-initial path segment (e.g. `model/amazon.titan-image-generator-v2:0/invoke`) was mis-parsed by `parse_url()` as `host=model`, `port=0`, yielding an invalid request URI once merged with `base_uri`.
- For relative-path references (RFC 3986 §4.2) combined with a `base_uri`, we now bypass `parse_url()` and feed the path verbatim into `Uri::withPath()` before letting `UriResolver::resolve()` do the merging. Query and fragment are split off manually first.
- Absolute URIs, absolute-path references (`/foo`), network-path references (`//host/foo`) and references whose first segment contains a colon (treated as scheme per RFC 3986) keep their previous behavior.

## Reproduction (before the fix)

```php
$client = new Client(['base_uri' => 'https://bedrock-runtime.us-east-1.amazonaws.com']);
$client->post('model/amazon.titan-image-generator-v2:0/invoke');
// → request URI was malformed (host=model, port=0)
```

Fixes #3306 

Test plan
 New unit test ClientTest::testCanMergeRelativeUriWithColonInPathSegmentOnBaseUri covering the reported case.
 Full ClientTest suite passes (63 tests).
 Manual edge-case sweep: absolute URI override, absolute path, query-only, fragment-only, empty relative, scheme-prefixed (foo:bar/baz), query + fragment on the relative part.