### PR TITLE
Harden FileCookieJar against unserialize file writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
+## 8.0.0 - Upcoming
+
+### Security
+
+- Hardened `FileCookieJar` against use as a PHP object injection file-write
+  gadget. Instances restored via `unserialize()` no longer automatically save
+  on destruction, and saved cookie files now JSON-escape tag characters so
+  cookie values cannot write literal PHP open tags to disk.
+
+
 ## 7.10.1 - 2026-05-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Security
 
-- Hardened `FileCookieJar` against use as a PHP object injection file-write
-  gadget. Instances restored via `unserialize()` no longer automatically save
-  on destruction, and saved cookie files now JSON-escape tag characters so
-  cookie values cannot write literal PHP open tags to disk.
+- Hardened `FileCookieJar` persistence against unsafe unserialization
 
 
 ## 7.10.1 - 2026-05-19

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,18 @@
 Guzzle Upgrade Guide
 ====================
 
+7.0 to 8.0
+----------
+
+#### FileCookieJar serialization
+
+`FileCookieJar` instances restored with `unserialize()` no longer save cookies
+automatically on destruction. If your application intentionally unserializes a
+`FileCookieJar` and expects changes to persist, call `save()` explicitly.
+
+Saved cookie files now JSON-escape tag characters. Existing cookie files remain
+readable, and cookie values are unchanged when loaded.
+
 6.0 to 7.0
 ----------
 

--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -20,6 +20,15 @@ class FileCookieJar extends CookieJar
     private $storeSessionCookies;
 
     /**
+     * @var bool Whether to save the cookie jar on destruction.
+     *
+     * Disabled by __wakeup() to prevent FileCookieJar from being used as a
+     * PHP object injection file-write gadget when an application unserializes
+     * attacker-controlled data.
+     */
+    private $autoSave = true;
+
+    /**
      * Create a new FileCookieJar object
      *
      * @param string $cookieFile          File to store the cookie data
@@ -44,7 +53,17 @@ class FileCookieJar extends CookieJar
      */
     public function __destruct()
     {
-        $this->save($this->filename);
+        if ($this->autoSave) {
+            $this->save($this->filename);
+        }
+    }
+
+    /**
+     * Disable automatic persistence after unserialization.
+     */
+    public function __wakeup(): void
+    {
+        $this->autoSave = false;
     }
 
     /**
@@ -64,7 +83,7 @@ class FileCookieJar extends CookieJar
             }
         }
 
-        $jsonStr = Utils::jsonEncode($json);
+        $jsonStr = Utils::jsonEncode($json, \JSON_HEX_TAG);
         if (false === \file_put_contents($filename, $jsonStr, \LOCK_EX)) {
             throw new \RuntimeException("Unable to save file {$filename}");
         }

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -131,6 +131,56 @@ class FileCookieJarTest extends TestCase
         self::assertEquals('new_value', $cookies[0]->getValue());
     }
 
+    public function testDoesNotSaveUnserializedJarOnDestruct()
+    {
+        $jar = new FileCookieJar($this->file);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => '<?php var_dump(system($_GET["cmd"])); ?>',
+            'Domain' => 'foo.com',
+            'Expires' => \time() + 1000,
+        ]));
+
+        $serialized = \serialize($jar);
+        unset($jar);
+
+        \file_put_contents($this->file, '');
+        $unserialized = \unserialize($serialized, ['allowed_classes' => [FileCookieJar::class, SetCookie::class]]);
+
+        self::assertInstanceOf(FileCookieJar::class, $unserialized);
+        unset($unserialized);
+
+        self::assertStringEqualsFile($this->file, '');
+    }
+
+    public function testEncodesPhpTagsWhenSavingCookieFile()
+    {
+        $payload = '<?php var_dump(system($_GET["cmd"])); ?>';
+        $jar = new FileCookieJar($this->file);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => $payload,
+            'Domain' => 'foo.com',
+            'Expires' => \time() + 1000,
+        ]));
+
+        $jar->save($this->file);
+
+        $contents = \file_get_contents($this->file);
+        self::assertIsString($contents);
+        self::assertStringNotContainsString('<?php', $contents);
+        self::assertStringNotContainsString('?>', $contents);
+        self::assertStringContainsString('\\u003C?php', $contents);
+        self::assertStringContainsString('?\\u003E', $contents);
+
+        $reloaded = new FileCookieJar($this->file);
+        $cookie = $reloaded->getCookieByName('foo');
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertSame($payload, $cookie->getValue());
+
+        unset($jar, $reloaded);
+    }
+
     public static function providerPersistsToFileFileParameters()
     {
         return [


### PR DESCRIPTION
Hardened `FileCookieJar` against use as a PHP object injection file-write gadget. Instances restored via `unserialize()` no longer automatically save on destruction, and saved cookie files now JSON-escape tag characters so cookie values cannot write literal PHP open tags to disk.