### PR TITLE
Fail clearly when cURL options cannot be applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
+## 7.10.1 - 2026-05-19
+
+### Fixed
+
+- Fail clearly when cURL options cannot be applied
+
+
 ## 7.10.0 - 2025-08-23
 
 ### Added

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -135,13 +135,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 4
-			path: src/Handler/CurlFactory.php
-
-		-
-			message: '#^Parameter \#1 \$ch of function curl_setopt_array expects resource, CurlHandle\|resource\|false given\.$#'
-			identifier: argument.type
-			count: 1
+			count: 5
 			path: src/Handler/CurlFactory.php
 
 		-
@@ -157,14 +151,14 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: '#^Property GuzzleHttp\\Handler\\CurlFactory\:\:\$handles has unknown class CurlHandle as its type\.$#'
+			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlFactory\:\:applyCurlOptions\(\) has invalid type CurlHandle\.$#'
 			identifier: class.notFound
 			count: 1
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: '#^Property GuzzleHttp\\Handler\\EasyHandle\:\:\$handle \(CurlHandle\|resource\) does not accept CurlHandle\|resource\|false\.$#'
-			identifier: assign.propertyType
+			message: '#^Property GuzzleHttp\\Handler\\CurlFactory\:\:\$handles has unknown class CurlHandle as its type\.$#'
+			identifier: class.notFound
 			count: 1
 			path: src/Handler/CurlFactory.php
 
@@ -383,4 +377,3 @@ parameters:
 			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: src/Utils.php
-

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -78,9 +78,87 @@ class CurlFactory implements CurlFactoryInterface
 
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
         $easy->handle = $this->handles ? \array_pop($this->handles) : \curl_init();
-        curl_setopt_array($easy->handle, $conf);
+
+        try {
+            $this->applyCurlOptions($easy->handle, $conf);
+        } catch (\Throwable $e) {
+            if (PHP_VERSION_ID < 80000) {
+                \curl_close($easy->handle);
+            }
+            unset($easy->handle);
+
+            throw $e;
+        }
 
         return $easy;
+    }
+
+    /**
+     * @param resource|\CurlHandle $handle
+     * @param array<int|string, mixed> $conf
+     */
+    private function applyCurlOptions($handle, array $conf): void
+    {
+        foreach ($conf as $option => $value) {
+            if (!\is_int($option)) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Invalid cURL option %s.',
+                    self::formatCurlOption($option)
+                ));
+            }
+
+            try {
+                $success = curl_setopt($handle, $option, $value);
+            } catch (\Throwable $e) {
+                throw new \InvalidArgumentException(
+                    \sprintf(
+                        'Unable to set cURL option %s: %s',
+                        self::formatCurlOption($option),
+                        $e->getMessage()
+                    ),
+                    0,
+                    $e
+                );
+            }
+
+            if (!$success) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Unable to set cURL option %s.',
+                    self::formatCurlOption($option)
+                ));
+            }
+        }
+    }
+
+    /**
+     * @param int|string $option
+     */
+    private static function formatCurlOption($option): string
+    {
+        if (!\is_int($option)) {
+            return \sprintf('"%s"', $option);
+        }
+
+        static $names = null;
+
+        if (null === $names) {
+            $names = [];
+            foreach (\get_defined_constants(true)['curl'] ?? [] as $name => $value) {
+                if (
+                    \is_int($value)
+                    && \strpos($name, 'CURLOPT_') === 0
+                    && !isset($names[$value])
+                ) {
+                    $names[$value] = $name;
+                }
+            }
+        }
+
+        if (isset($names[$option])) {
+            return \sprintf('%s (%d)', $names[$option], $option);
+        }
+
+        return (string) $option;
     }
 
     private static function supportsHttp2(): bool

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -77,13 +77,17 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
-        $easy->handle = $this->handles ? \array_pop($this->handles) : \curl_init();
+        $handle = $this->handles ? \array_pop($this->handles) : \curl_init();
+        if (false === $handle) {
+            throw new \RuntimeException('Can not initialize cURL handle.');
+        }
+        $easy->handle = $handle;
 
         try {
-            $this->applyCurlOptions($easy->handle, $conf);
+            $this->applyCurlOptions($handle, $conf);
         } catch (\Throwable $e) {
-            if (PHP_VERSION_ID < 80000) {
-                \curl_close($easy->handle);
+            if (PHP_VERSION_ID < 80000 && \is_resource($handle)) {
+                \curl_close($handle);
             }
             unset($easy->handle);
 
@@ -94,7 +98,7 @@ class CurlFactory implements CurlFactoryInterface
     }
 
     /**
-     * @param resource|\CurlHandle $handle
+     * @param resource|\CurlHandle     $handle
      * @param array<int|string, mixed> $conf
      */
     private function applyCurlOptions($handle, array $conf): void
@@ -144,11 +148,7 @@ class CurlFactory implements CurlFactoryInterface
         if (null === $names) {
             $names = [];
             foreach (\get_defined_constants(true)['curl'] ?? [] as $name => $value) {
-                if (
-                    \is_int($value)
-                    && \strpos($name, 'CURLOPT_') === 0
-                    && !isset($names[$value])
-                ) {
+                if (\is_int($value) && \strpos($name, 'CURLOPT_') === 0 && !isset($names[$value])) {
                     $names[$value] = $name;
                 }
             }

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -28,7 +28,7 @@ class CurlFactoryTest extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        unset($_SERVER['_curl'], $_SERVER['curl_test']);
+        unset($_SERVER['_curl'], $_SERVER['curl_test'], $_SERVER['curl_setopt_fail']);
     }
 
     public function testCreatesCurlHandle()
@@ -124,6 +124,37 @@ class CurlFactoryTest extends TestCase
         $req = new Psr7\Request('GET', Server::$url);
         $a($req, ['curl' => [\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_1_0]]);
         self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+    }
+
+    public function testThrowsWhenCurlOptionCannotBeApplied()
+    {
+        $_SERVER['curl_setopt_fail'] = \CURLOPT_LOW_SPEED_LIMIT;
+        $f = new CurlFactory(3);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Unable to set cURL option CURLOPT_LOW_SPEED_LIMIT');
+
+            $f->create(
+                new Psr7\Request('GET', Server::$url),
+                ['curl' => [\CURLOPT_LOW_SPEED_LIMIT => 10]]
+            );
+        } finally {
+            unset($_SERVER['curl_setopt_fail']);
+        }
+    }
+
+    public function testThrowsWhenCurlOptionNameIsInvalid()
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid cURL option "not-a-curl-option".');
+
+        $f->create(
+            new Psr7\Request('GET', Server::$url),
+            ['curl' => ['not-a-curl-option' => true]]
+        );
     }
 
     public function testValidatesVerify()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,9 @@ namespace GuzzleHttp\Handler {
     function curl_setopt($handle, int $option, $value)
     {
         if (!empty($_SERVER['curl_test'])) {
+            if ($option === \CURLOPT_CUSTOMREQUEST) {
+                $_SERVER['_curl'] = [];
+            }
             $_SERVER['_curl'][$option] = $value;
         } else {
             unset($_SERVER['_curl']);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,9 +15,24 @@ namespace GuzzleHttp\Test {
     });
 }
 
-// Override curl_setopt_array() and curl_multi_setopt() to get the last set curl options
+// Override curl_setopt(), curl_setopt_array(), and curl_multi_setopt() to get the last set curl options
 
 namespace GuzzleHttp\Handler {
+    function curl_setopt($handle, int $option, $value)
+    {
+        if (!empty($_SERVER['curl_test'])) {
+            $_SERVER['_curl'][$option] = $value;
+        } else {
+            unset($_SERVER['_curl']);
+        }
+
+        if (isset($_SERVER['curl_setopt_fail']) && (int) $_SERVER['curl_setopt_fail'] === $option) {
+            return false;
+        }
+
+        return \curl_setopt($handle, $option, $value);
+    }
+
     function curl_setopt_array($handle, array $options)
     {
         if (!empty($_SERVER['curl_test'])) {


### PR DESCRIPTION
Apply cURL options individually so unsupported options fail immediately with a clear InvalidArgumentException instead of silently skipping later options.

Fixes #3340.