### PR TITLE
Avoid exposing stale responses on response creation failure

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -311,7 +311,7 @@ class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'An error was encountered while creating the response',
                     $easy->request,
-                    $easy->response,
+                    null,
                     $easy->createResponseException,
                     $ctx
                 )

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -68,6 +68,8 @@ final class EasyHandle
      */
     public function createResponse(): void
     {
+        $this->response = null;
+
         [$ver, $status, $reason, $headers] = HeaderProcessor::parseHeaders($this->headers);
 
         $normalizedKeys = Utils::normalizeHeaderKeys($headers);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -783,11 +783,57 @@ class CurlFactoryTest extends TestCase
 
         $req = new Psr7\Request('GET', Server::$url);
         $handler = new Handler\CurlHandler();
-        $promise = $handler($req, []);
+        $called = false;
+        $promise = $handler($req, [
+            'on_headers' => static function () use (&$called): void {
+                $called = true;
+            },
+        ]);
 
-        $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('An error was encountered while creating the response');
-        $promise->wait();
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringContainsString(
+                'An error was encountered while creating the response',
+                $e->getMessage()
+            );
+            self::assertFalse($called);
+            self::assertFalse($e->hasResponse());
+            self::assertNull($e->getResponse());
+            self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+        }
+    }
+
+    public function testCreateResponseFailureDoesNotExposeStaleCurlResponse()
+    {
+        $factory = new CurlFactory(1);
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), []);
+        $easy->response = new Psr7\Response(100);
+        $easy->errno = \CURLE_WRITE_ERROR;
+        $easy->createResponseException = new \InvalidArgumentException(
+            'Status code must be an integer value between 1xx and 5xx.'
+        );
+
+        $promise = CurlFactory::finish(
+            static function () {
+            },
+            $easy,
+            $factory
+        );
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringContainsString(
+                'An error was encountered while creating the response',
+                $e->getMessage()
+            );
+            self::assertFalse($e->hasResponse());
+            self::assertNull($e->getResponse());
+            self::assertSame($easy->createResponseException, $e->getPrevious());
+        }
     }
 
     public function testEnsuresOnHeadersIsCallable()
@@ -987,9 +1033,17 @@ class CurlFactoryTest extends TestCase
     {
         $a = new Handler\CurlMultiHandler();
 
-        $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('An error was encountered while creating the response');
-
-        $a(new Psr7\Request('GET', Server::$url.'guzzle-server/bad-status'), [])->wait();
+        try {
+            $a(new Psr7\Request('GET', Server::$url.'guzzle-server/bad-status'), [])->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringContainsString(
+                'An error was encountered while creating the response',
+                $e->getMessage()
+            );
+            self::assertFalse($e->hasResponse());
+            self::assertNull($e->getResponse());
+            self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+        }
     }
 }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -810,16 +810,29 @@ class StreamHandlerTest extends TestCase
     public function testHandlesInvalidStatusCodeGracefully()
     {
         $handler = new StreamHandler();
+        $called = false;
 
-        $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('An error was encountered while creating the response');
-
-        $handler(
-            new Request('GET', Server::$url.'guzzle-server/bad-status'),
-            [
-                RequestOptions::STREAM => true,
-            ]
-        )->wait();
+        try {
+            $handler(
+                new Request('GET', Server::$url.'guzzle-server/bad-status'),
+                [
+                    RequestOptions::STREAM => true,
+                    'on_headers' => static function () use (&$called): void {
+                        $called = true;
+                    },
+                ]
+            )->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringContainsString(
+                'An error was encountered while creating the response',
+                $e->getMessage()
+            );
+            self::assertFalse($called);
+            self::assertFalse($e->hasResponse());
+            self::assertNull($e->getResponse());
+            self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+        }
     }
 
     public function testRejectsNonHttpSchemes()


### PR DESCRIPTION
Prevents response creation failures from attaching a stale cURL response, and strengthens invalid-status handling tests to assert no response is exposed. Invalid responses continue to reject without changing handler context or stats behavior.