### PR TITLE
Improve invalid response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
+## 7.11.0 - Upcoming
+
+### Fixed
+
+- Improve invalid response handling across handlers
+
+
 ## 7.10.1 - Upcoming
 
 ### Fixed

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -779,7 +779,8 @@ class CurlFactory implements CurlFactoryInterface
                 $startingResponse = true;
                 try {
                     $easy->createResponse();
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
+                    $easy->response = null;
                     $easy->createResponseException = $e;
 
                     return -1;
@@ -787,7 +788,7 @@ class CurlFactory implements CurlFactoryInterface
                 if ($onHeaders !== null) {
                     try {
                         $onHeaders($easy->response);
-                    } catch (\Exception $e) {
+                    } catch (\Throwable $e) {
                         // Associate the exception with the handle and trigger
                         // a curl header write error by returning 0.
                         $easy->onHeadersException = $e;

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -56,7 +56,7 @@ final class EasyHandle
     public $onHeadersException;
 
     /**
-     * @var \Exception|null Exception during createResponse (if any)
+     * @var \Throwable|null Exception during createResponse (if any)
      */
     public $createResponseException;
 

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -24,6 +24,8 @@ final class HeaderProcessor
             throw new \RuntimeException('Expected a non-empty array of header data');
         }
 
+        $headers = self::getLastHeaderBlock($headers);
+
         $parts = \explode(' ', \array_shift($headers), 3);
         $version = \explode('/', $parts[0])[1] ?? null;
 
@@ -37,6 +39,28 @@ final class HeaderProcessor
             throw new \RuntimeException('HTTP status code missing from header data');
         }
 
+        if (!\preg_match('/^\d{3}$/', $status)) {
+            throw new \RuntimeException('HTTP status code is invalid');
+        }
+
         return [$version, (int) $status, $parts[2] ?? null, Utils::headersFromLines($headers)];
+    }
+
+    /**
+     * @param string[] $headers
+     *
+     * @return string[]
+     */
+    private static function getLastHeaderBlock(array $headers): array
+    {
+        $lastStatusLine = null;
+
+        foreach ($headers as $index => $line) {
+            if (\preg_match('/^HTTP\/\S+\s+/i', $line)) {
+                $lastStatusLine = $index;
+            }
+        }
+
+        return $lastStatusLine === null ? $headers : \array_slice($headers, $lastStatusLine);
     }
 }

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -24,9 +24,14 @@ final class HeaderProcessor
             throw new \RuntimeException('Expected a non-empty array of header data');
         }
 
-        $headers = self::getLastHeaderBlock($headers);
+        $headers = self::getLastHeaderBlock(\array_values($headers));
 
-        $parts = \explode(' ', \array_shift($headers), 3);
+        $statusLine = \array_shift($headers);
+        if ($statusLine === null) {
+            throw new \RuntimeException('Expected a non-empty array of header data');
+        }
+
+        $parts = \explode(' ', $statusLine, 3);
         $version = \explode('/', $parts[0])[1] ?? null;
 
         if ($version === null) {
@@ -47,13 +52,13 @@ final class HeaderProcessor
     }
 
     /**
-     * @param string[] $headers
+     * @param non-empty-list<string> $headers
      *
-     * @return string[]
+     * @return list<string>
      */
     private static function getLastHeaderBlock(array $headers): array
     {
-        $lastStatusLine = null;
+        $lastStatusLine = 0;
 
         foreach ($headers as $index => $line) {
             if (\preg_match('/^HTTP\/\S+\s+/i', $line)) {
@@ -61,6 +66,6 @@ final class HeaderProcessor
             }
         }
 
-        return $lastStatusLine === null ? $headers : \array_slice($headers, $lastStatusLine);
+        return \array_slice($headers, $lastStatusLine);
     }
 }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -352,7 +352,7 @@ class StreamHandler
 
                 // See https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable
                 if (function_exists('http_get_last_response_headers')) {
-                    /** @var array|null */
+                    /** @var list<string>|null */
                     $http_response_header = \http_get_last_response_headers();
                 }
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -352,7 +352,6 @@ class StreamHandler
 
                 // See https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable
                 if (function_exists('http_get_last_response_headers')) {
-                    /** @var list<string>|null */
                     $http_response_header = \http_get_last_response_headers();
                 }
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -114,10 +114,8 @@ class StreamHandler
 
         try {
             [$ver, $status, $reason, $headers] = HeaderProcessor::parseHeaders($hdrs);
-        } catch (\Exception $e) {
-            return P\Create::rejectionFor(
-                new RequestException('An error was encountered while creating the response', $request, null, $e)
-            );
+        } catch (\Throwable $e) {
+            return $this->rejectResponseCreation($options, $request, $startTime, $e);
         }
 
         [$stream, $headers] = $this->checkDecode($options, $headers, $stream);
@@ -130,16 +128,14 @@ class StreamHandler
 
         try {
             $response = new Psr7\Response($status, $headers, $sink, $ver, $reason);
-        } catch (\Exception $e) {
-            return P\Create::rejectionFor(
-                new RequestException('An error was encountered while creating the response', $request, null, $e)
-            );
+        } catch (\Throwable $e) {
+            return $this->rejectResponseCreation($options, $request, $startTime, $e);
         }
 
         if (isset($options['on_headers'])) {
             try {
                 $options['on_headers']($response);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 return P\Create::rejectionFor(
                     new RequestException('An error was encountered during the on_headers event', $request, $response, $e)
                 );
@@ -155,6 +151,24 @@ class StreamHandler
         $this->invokeStats($options, $request, $startTime, $response, null);
 
         return new FulfilledPromise($response);
+    }
+
+    private function rejectResponseCreation(
+        array $options,
+        RequestInterface $request,
+        ?float $startTime,
+        \Throwable $previous
+    ): PromiseInterface {
+        $reason = new RequestException(
+            'An error was encountered while creating the response',
+            $request,
+            null,
+            $previous
+        );
+
+        $this->invokeStats($options, $request, $startTime, null, $reason);
+
+        return P\Create::rejectionFor($reason);
     }
 
     private function createSink(StreamInterface $stream, array $options): StreamInterface

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -864,6 +864,32 @@ class CurlFactoryTest extends TestCase
         $promise->wait();
     }
 
+    public function testRejectsPromiseWhenOnHeadersThrowsThrowable()
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, ['X-Foo' => 'bar'], 'abc 123'),
+        ]);
+        $req = new Psr7\Request('GET', Server::$url);
+        $handler = new Handler\CurlHandler();
+        $promise = $handler($req, [
+            'on_headers' => static function (): void {
+                throw new \Error('test');
+            },
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringContainsString(
+                'An error was encountered during the on_headers event',
+                $e->getMessage()
+            );
+            self::assertInstanceOf(\Error::class, $e->getPrevious());
+        }
+    }
+
     public function testSuccessfullyCallsOnHeadersBeforeWritingToSink()
     {
         Server::flush();

--- a/tests/Handler/HeaderProcessorTest.php
+++ b/tests/Handler/HeaderProcessorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace GuzzleHttp\Tests\Handler;
+
+use GuzzleHttp\Handler\HeaderProcessor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Handler\HeaderProcessor
+ */
+class HeaderProcessorTest extends TestCase
+{
+    public function testParsesLastHeaderBlock(): void
+    {
+        [$version, $status, $reason, $headers] = HeaderProcessor::parseHeaders([
+            'HTTP/1.1 100 Continue',
+            'Ignored: header',
+            'HTTP/1.1 200 OK',
+            'X-Foo: bar',
+        ]);
+
+        self::assertSame('1.1', $version);
+        self::assertSame(200, $status);
+        self::assertSame('OK', $reason);
+        self::assertSame(['X-Foo' => ['bar']], $headers);
+    }
+
+    public function testRejectsMalformedStatusCode(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HTTP status code is invalid');
+
+        HeaderProcessor::parseHeaders([
+            'HTTP/1.1 200abc Weird',
+        ]);
+    }
+}

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -645,6 +645,32 @@ class StreamHandlerTest extends TestCase
         $promise->wait();
     }
 
+    public function testRejectsPromiseWhenOnHeadersThrowsThrowable()
+    {
+        Server::flush();
+        Server::enqueue([
+            new Response(200, ['X-Foo' => 'bar'], 'abc 123'),
+        ]);
+        $req = new Request('GET', Server::$url);
+        $handler = new StreamHandler();
+        $promise = $handler($req, [
+            'on_headers' => static function (): void {
+                throw new \Error('test');
+            },
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringContainsString(
+                'An error was encountered during the on_headers event',
+                $e->getMessage()
+            );
+            self::assertInstanceOf(\Error::class, $e->getPrevious());
+        }
+    }
+
     public function testSuccessfullyCallsOnHeadersBeforeWritingToSink()
     {
         Server::flush();
@@ -811,6 +837,7 @@ class StreamHandlerTest extends TestCase
     {
         $handler = new StreamHandler();
         $called = false;
+        $stats = null;
 
         try {
             $handler(
@@ -819,6 +846,9 @@ class StreamHandlerTest extends TestCase
                     RequestOptions::STREAM => true,
                     'on_headers' => static function () use (&$called): void {
                         $called = true;
+                    },
+                    'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                        $stats = $transferStats;
                     },
                 ]
             )->wait();
@@ -832,6 +862,10 @@ class StreamHandlerTest extends TestCase
             self::assertFalse($e->hasResponse());
             self::assertNull($e->getResponse());
             self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+            self::assertInstanceOf(TransferStats::class, $stats);
+            self::assertFalse($stats->hasResponse());
+            self::assertNull($stats->getResponse());
+            self::assertSame($e, $stats->getHandlerErrorData());
         }
     }
 

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -4,12 +4,15 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
@@ -181,6 +184,40 @@ class PoolTest extends TestCase
         $p->promise()->wait();
         self::assertCount(3, $keys);
         self::assertSame($keys, \array_keys($requests));
+    }
+
+    public function testPoolHandlesInvalidResponseStatusAsResponseLessRejection()
+    {
+        $client = new Client([
+            'handler' => HandlerStack::create(new CurlMultiHandler()),
+        ]);
+        $requests = [
+            new Request('GET', Server::$url.'guzzle-server/bad-status'),
+            new Request('GET', Server::$url.'guzzle-server/bad-status'),
+        ];
+        $fulfilled = 0;
+        $rejected = [];
+
+        $pool = new Pool($client, $requests, [
+            'concurrency' => 2,
+            'fulfilled' => static function () use (&$fulfilled): void {
+                ++$fulfilled;
+            },
+            'rejected' => static function ($reason) use (&$rejected): void {
+                $rejected[] = $reason;
+            },
+        ]);
+
+        $pool->promise()->wait();
+
+        self::assertSame(0, $fulfilled);
+        self::assertCount(2, $rejected);
+
+        foreach ($rejected as $reason) {
+            self::assertInstanceOf(RequestException::class, $reason);
+            self::assertFalse($reason->hasResponse());
+            self::assertNull($reason->getResponse());
+        }
     }
 
     private function getClient($total = 1)


### PR DESCRIPTION
Handles response creation and on_headers throwables consistently, tightens response status parsing, invokes stream stats for response creation failures, and documents the change for 7.11.0.