### PR TITLE
Harden invalid response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - Hardened `FileCookieJar` persistence against unsafe unserialization
 
+### Changed
+
+- Tighten invalid response handling and avoid exposing response-derived cURL stats
+
 
 ## 7.11.0 - Upcoming
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,9 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ## 8.0.0 - Upcoming
 
-### Security
-
-- Hardened `FileCookieJar` persistence against unsafe unserialization
-
 ### Changed
 
+- Hardened `FileCookieJar` persistence against unsafe unserialization
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
 
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -248,6 +248,14 @@ class CurlFactory implements CurlFactoryInterface
     {
         $curlStats = \curl_getinfo($easy->handle);
         $curlStats['appconnect_time'] = \curl_getinfo($easy->handle, \CURLINFO_APPCONNECT_TIME);
+
+        if ($easy->createResponseException) {
+            $curlStats = [
+                'total_time' => $curlStats['total_time'],
+                'appconnect_time' => $curlStats['appconnect_time'],
+            ];
+        }
+
         $stats = new TransferStats(
             $easy->request,
             $easy->response,
@@ -264,12 +272,7 @@ class CurlFactory implements CurlFactoryInterface
     private static function finishError(callable $handler, EasyHandle $easy, CurlFactoryInterface $factory): PromiseInterface
     {
         // Get error information and release the handle to the factory.
-        $ctx = [
-            'errno' => $easy->errno,
-            'error' => \curl_error($easy->handle),
-            'appconnect_time' => \curl_getinfo($easy->handle, \CURLINFO_APPCONNECT_TIME),
-        ] + \curl_getinfo($easy->handle);
-        $ctx[self::CURL_VERSION_STR] = self::getCurlVersion();
+        $ctx = self::createErrorContext($easy);
         $factory->release($easy);
 
         // Retry when nothing is present or when curl failed to rewind.
@@ -278,6 +281,23 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         return self::createRejection($easy, $ctx);
+    }
+
+    private static function createErrorContext(EasyHandle $easy): array
+    {
+        $ctx = [
+            'errno' => $easy->errno,
+            'error' => \curl_error($easy->handle),
+        ];
+
+        if (!$easy->createResponseException) {
+            $ctx['appconnect_time'] = \curl_getinfo($easy->handle, \CURLINFO_APPCONNECT_TIME);
+            $ctx += \curl_getinfo($easy->handle);
+        }
+
+        $ctx[self::CURL_VERSION_STR] = self::getCurlVersion();
+
+        return $ctx;
     }
 
     private static function getCurlVersion(): string

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -44,7 +44,7 @@ final class HeaderProcessor
             throw new \RuntimeException('HTTP status code missing from header data');
         }
 
-        if (!\preg_match('/^\d{3}$/', $status)) {
+        if (!\preg_match('/^[1-5]\d{2}$/', $status)) {
             throw new \RuntimeException('HTTP status code is invalid');
         }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -784,9 +784,13 @@ class CurlFactoryTest extends TestCase
         $req = new Psr7\Request('GET', Server::$url);
         $handler = new Handler\CurlHandler();
         $called = false;
+        $stats = null;
         $promise = $handler($req, [
             'on_headers' => static function () use (&$called): void {
                 $called = true;
+            },
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
             },
         ]);
 
@@ -801,7 +805,12 @@ class CurlFactoryTest extends TestCase
             self::assertFalse($called);
             self::assertFalse($e->hasResponse());
             self::assertNull($e->getResponse());
-            self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+            self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
+            self::assertResponseInfoWasNotExposed($e->getHandlerContext());
+            self::assertInstanceOf(TransferStats::class, $stats);
+            self::assertFalse($stats->hasResponse());
+            self::assertNull($stats->getResponse());
+            self::assertResponseInfoWasNotExposed($stats->getHandlerStats());
         }
     }
 
@@ -833,6 +842,7 @@ class CurlFactoryTest extends TestCase
             self::assertFalse($e->hasResponse());
             self::assertNull($e->getResponse());
             self::assertSame($easy->createResponseException, $e->getPrevious());
+            self::assertResponseInfoWasNotExposed($e->getHandlerContext());
         }
     }
 
@@ -1069,7 +1079,15 @@ class CurlFactoryTest extends TestCase
             );
             self::assertFalse($e->hasResponse());
             self::assertNull($e->getResponse());
-            self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+            self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
+            self::assertResponseInfoWasNotExposed($e->getHandlerContext());
         }
+    }
+
+    private static function assertResponseInfoWasNotExposed(array $context): void
+    {
+        self::assertArrayNotHasKey('http_code', $context);
+        self::assertArrayNotHasKey('header_size', $context);
+        self::assertArrayNotHasKey('content_type', $context);
     }
 }

--- a/tests/Handler/HeaderProcessorTest.php
+++ b/tests/Handler/HeaderProcessorTest.php
@@ -25,6 +25,15 @@ class HeaderProcessorTest extends TestCase
         self::assertSame(['X-Foo' => ['bar']], $headers);
     }
 
+    public function testParsesBoundaryStatusCodes(): void
+    {
+        [, $informationalStatus] = HeaderProcessor::parseHeaders(['HTTP/1.1 100 Continue']);
+        [, $customServerErrorStatus] = HeaderProcessor::parseHeaders(['HTTP/1.1 599 Custom']);
+
+        self::assertSame(100, $informationalStatus);
+        self::assertSame(599, $customServerErrorStatus);
+    }
+
     public function testRejectsMalformedStatusCode(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -33,5 +42,26 @@ class HeaderProcessorTest extends TestCase
         HeaderProcessor::parseHeaders([
             'HTTP/1.1 200abc Weird',
         ]);
+    }
+
+    /**
+     * @dataProvider invalidStatusCodeProvider
+     */
+    public function testRejectsOutOfRangeStatusCode(string $statusLine): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HTTP status code is invalid');
+
+        HeaderProcessor::parseHeaders([$statusLine]);
+    }
+
+    public static function invalidStatusCodeProvider(): iterable
+    {
+        return [
+            ['HTTP/1.1 099 Bad'],
+            ['HTTP/1.1 600 Bad'],
+            ['HTTP/1.1 700 Bad'],
+            ['HTTP/1.1 999 Bad'],
+        ];
     }
 }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -850,7 +850,7 @@ class StreamHandlerTest extends TestCase
             self::assertFalse($called);
             self::assertFalse($e->hasResponse());
             self::assertNull($e->getResponse());
-            self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+            self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
             self::assertInstanceOf(TransferStats::class, $stats);
             self::assertFalse($stats->hasResponse());
             self::assertNull($stats->getResponse());

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -217,6 +217,9 @@ class PoolTest extends TestCase
             self::assertInstanceOf(RequestException::class, $reason);
             self::assertFalse($reason->hasResponse());
             self::assertNull($reason->getResponse());
+            self::assertArrayNotHasKey('http_code', $reason->getHandlerContext());
+            self::assertArrayNotHasKey('header_size', $reason->getHandlerContext());
+            self::assertArrayNotHasKey('content_type', $reason->getHandlerContext());
         }
     }
 


### PR DESCRIPTION
Rejects invalid HTTP response status classes during header parsing and avoids exposing response-derived cURL stats for response creation failures.