### PR TITLE
Pass request to on_headers callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Changed
 
 - Hardened `FileCookieJar` persistence against unsafe unserialization
+- Pass the request as the second argument to `on_headers` callbacks
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,14 @@ automatically on destruction. If your application intentionally unserializes a
 Saved cookie files now JSON-escape tag characters. Existing cookie files remain
 readable, and cookie values are unchanged when loaded.
 
+#### on_headers callback arguments
+
+The `on_headers` request option callback now receives the request as its second
+argument. Existing userland callbacks that accept only the response continue to
+work, but callbacks that inspect all arguments, for example with
+`func_get_args()` or a variadic parameter, will observe the additional
+`Psr\Http\Message\RequestInterface` argument.
+
 6.0 to 7.0
 ----------
 

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -733,19 +733,26 @@ on_headers
 :Types: - callable
 :Constant: ``GuzzleHttp\RequestOptions::ON_HEADERS``
 
-The callable accepts a ``Psr\Http\Message\ResponseInterface`` object. If an exception
-is thrown by the callable, then the promise associated with the response will
-be rejected with a ``GuzzleHttp\Exception\RequestException`` that wraps the
-exception that was thrown.
+The callable accepts a ``Psr\Http\Message\ResponseInterface`` object as the
+first argument and a ``Psr\Http\Message\RequestInterface`` object as the second
+argument. If an exception is thrown by the callable, then the promise associated
+with the response will be rejected with a ``GuzzleHttp\Exception\RequestException``
+that wraps the exception that was thrown.
 
 You may need to know what headers and status codes were received before data
 can be written to the sink.
 
 .. code-block:: php
 
+    use Psr\Http\Message\RequestInterface;
+    use Psr\Http\Message\ResponseInterface;
+
     // Reject responses that are greater than 1024 bytes.
     $client->request('GET', 'http://httpbin.org/stream/1024', [
-        'on_headers' => function (ResponseInterface $response) {
+        'on_headers' => function (
+            ResponseInterface $response,
+            RequestInterface $request
+        ) {
             if ($response->getHeaderLine('Content-Length') > 1024) {
                 throw new \Exception('The file is too big!');
             }
@@ -755,7 +762,8 @@ can be written to the sink.
 .. note::
 
     When writing HTTP handlers, the ``on_headers`` function must be invoked
-    before writing data to the body of the response.
+    with the response and request before writing data to the body of the
+    response.
 
 
 .. _on_stats:

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -813,7 +813,7 @@ class CurlFactory implements CurlFactoryInterface
                 }
                 if ($onHeaders !== null) {
                     try {
-                        $onHeaders($easy->response);
+                        $onHeaders($easy->response, $easy->request);
                     } catch (\Throwable $e) {
                         // Associate the exception with the handle and trigger
                         // a curl header write error by returning 0.

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -96,8 +96,8 @@ class MockHandler implements \Countable
                 throw new \InvalidArgumentException('on_headers must be callable');
             }
             try {
-                $options['on_headers']($response);
-            } catch (\Exception $e) {
+                $options['on_headers']($response, $request);
+            } catch (\Throwable $e) {
                 $msg = 'An error was encountered during the on_headers event';
                 $response = new RequestException($msg, $request, $response, $e);
             }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -134,7 +134,7 @@ class StreamHandler
 
         if (isset($options['on_headers'])) {
             try {
-                $options['on_headers']($response);
+                $options['on_headers']($response, $request);
             } catch (\Throwable $e) {
                 return P\Create::rejectionFor(
                     new RequestException('An error was encountered during the on_headers event', $request, $response, $e)

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -172,7 +172,9 @@ final class RequestOptions
     /**
      * on_headers: (callable) A callable that is invoked when the HTTP headers
      * of the response have been received but the body has not yet begun to
-     * download.
+     * download. The callable is passed the response and request as
+     * {@see \Psr\Http\Message\ResponseInterface} and
+     * {@see \Psr\Http\Message\RequestInterface} objects, respectively.
      */
     public const ON_HEADERS = 'on_headers';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Server\Server;
 use GuzzleHttp\Tests\Helpers;
 use GuzzleHttp\TransferStats;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -947,6 +948,7 @@ class CurlFactoryTest extends TestCase
         ]);
         $req = new Psr7\Request('GET', Server::$url);
         $got = null;
+        $gotRequest = null;
 
         $stream = Psr7\Utils::streamFor();
         $stream = Psr7\FnStream::decorate($stream, [
@@ -960,13 +962,19 @@ class CurlFactoryTest extends TestCase
         $handler = new Handler\CurlHandler();
         $promise = $handler($req, [
             'sink' => $stream,
-            'on_headers' => static function (ResponseInterface $res) use (&$got) {
+            'on_headers' => static function (
+                ResponseInterface $res,
+                RequestInterface $request
+            ) use (&$got, &$gotRequest, $req) {
                 $got = $res;
+                $gotRequest = $request;
+                self::assertSame($req, $request);
                 self::assertEquals('bar', $res->getHeaderLine('X-Foo'));
             },
         ]);
 
         $response = $promise->wait();
+        self::assertSame($req, $gotRequest);
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('bar', $response->getHeaderLine('X-Foo'));
         self::assertSame('abc 123', (string) $response->getBody());

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -10,6 +10,8 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\TransferStats;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @covers \GuzzleHttp\Handler\MockHandler
@@ -157,6 +159,50 @@ class MockHandlerTest extends TestCase
         $this->expectException(RequestException::class);
         $this->expectExceptionMessage('An error was encountered during the on_headers event');
         $promise->wait();
+    }
+
+    public function testRejectsPromiseWhenOnHeadersThrowsThrowable()
+    {
+        $res = new Response();
+        $mock = new MockHandler([$res]);
+        $request = new Request('GET', 'http://example.com');
+        $promise = $mock($request, [
+            'on_headers' => static function (): void {
+                throw new \Error('test');
+            },
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('An error was encountered during the on_headers event', $e->getMessage());
+            self::assertInstanceOf(\Error::class, $e->getPrevious());
+        }
+    }
+
+    public function testInvokesOnHeadersWithResponseAndRequest()
+    {
+        $res = new Response(201, ['X-Foo' => 'bar']);
+        $mock = new MockHandler([$res]);
+        $request = new Request('GET', 'http://example.com');
+        $gotResponse = null;
+        $gotRequest = null;
+
+        $promise = $mock($request, [
+            'on_headers' => static function (
+                ResponseInterface $response,
+                RequestInterface $receivedRequest
+            ) use (&$gotResponse, &$gotRequest): void {
+                $gotResponse = $response;
+                $gotRequest = $receivedRequest;
+                self::assertSame('bar', $response->getHeaderLine('X-Foo'));
+            },
+        ]);
+
+        self::assertSame($res, $promise->wait());
+        self::assertSame($res, $gotResponse);
+        self::assertSame($request, $gotRequest);
     }
 
     public function testInvokesOnFulfilled()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Server\Server;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -720,6 +721,7 @@ class StreamHandlerTest extends TestCase
         ]);
         $req = new Request('GET', Server::$url);
         $got = null;
+        $gotRequest = null;
 
         $stream = Psr7\Utils::streamFor();
         $stream = FnStream::decorate($stream, [
@@ -733,13 +735,19 @@ class StreamHandlerTest extends TestCase
         $handler = new StreamHandler();
         $promise = $handler($req, [
             'sink' => $stream,
-            'on_headers' => static function (ResponseInterface $res) use (&$got) {
+            'on_headers' => static function (
+                ResponseInterface $res,
+                RequestInterface $request
+            ) use (&$got, &$gotRequest, $req) {
                 $got = $res;
+                $gotRequest = $request;
+                self::assertSame($req, $request);
                 self::assertSame('bar', $res->getHeaderLine('X-Foo'));
             },
         ]);
 
         $response = $promise->wait();
+        self::assertSame($req, $gotRequest);
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('bar', $response->getHeaderLine('X-Foo'));
         self::assertSame('abc 123', (string) $response->getBody());

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -15,6 +15,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class PoolTest extends TestCase
 {
@@ -86,6 +87,42 @@ class PoolTest extends TestCase
         $p->promise()->wait();
         self::assertCount(1, $h);
         self::assertTrue($h[0]->hasHeader('x-foo'));
+    }
+
+    public function testOnHeadersOptionReceivesCurrentPoolRequest()
+    {
+        $requests = [
+            new Request('GET', 'http://example.com/one'),
+            new Request('GET', 'http://example.com/two'),
+        ];
+        $handler = new MockHandler([
+            new Response(200, ['X-Request' => 'one']),
+            new Response(200, ['X-Request' => 'two']),
+        ]);
+        $client = new Client(['handler' => $handler]);
+        $seen = [];
+
+        $pool = new Pool($client, $requests, [
+            'concurrency' => 1,
+            'options' => [
+                'on_headers' => static function (
+                    ResponseInterface $response,
+                    RequestInterface $request
+                ) use (&$seen): void {
+                    $seen[] = [
+                        (string) $request->getUri(),
+                        $response->getHeaderLine('X-Request'),
+                    ];
+                },
+            ],
+        ]);
+
+        $pool->promise()->wait();
+
+        self::assertSame([
+            ['http://example.com/one', 'one'],
+            ['http://example.com/two', 'two'],
+        ], $seen);
     }
 
     public function testCanProvideCallablesThatReturnResponses()


### PR DESCRIPTION
Adds the originating request as the second argument to `on_headers` callbacks.

Supersedes #3269.