### PR TITLE
Require psr7 implementation preservation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,6 @@ jobs:
       max-parallel: 10
       matrix:
         php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
-        psr7: ['^2.8']
-        include:
-          - php: '8.5'
-            psr7: '^2.8@dev'
 
     steps:
       - name: Set up PHP
@@ -80,9 +76,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download dependencies
-        run: |
-          composer require --no-update "guzzlehttp/psr7:${{ matrix.psr7 }}"
-          composer update --no-interaction --no-progress
+        run: composer update --no-interaction --no-progress
 
       - name: Start test servers
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ## 7.11.0 - Upcoming
 
+### Changed
+
+- Adjusted `guzzlehttp/psr7` version constraint to `^2.10`
+
 ### Fixed
 
 - Improve invalid response handling across handlers

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/promises": "^2.3",
-        "guzzlehttp/psr7": "2.10.x-dev",
+        "guzzlehttp/psr7": "^2.10",
         "psr/http-client": "^1.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/promises": "^2.3",
-        "guzzlehttp/psr7": "^2.8",
+        "guzzlehttp/psr7": "2.10.x-dev",
         "psr/http-client": "^1.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -729,6 +729,45 @@ class ClientTest extends TestCase
         );
     }
 
+    public function testSendPreservesCustomRequestWhenApplyingRequestOptions()
+    {
+        $mockHandler = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mockHandler]);
+        $request = new ClientTestRequest('POST', new ClientTestUri('http://foo.com/path'));
+
+        $client->send($request, [
+            RequestOptions::HEADERS => ['X-Test' => '1'],
+            RequestOptions::BODY => 'payload',
+            RequestOptions::QUERY => ['a' => 'b'],
+            RequestOptions::VERSION => '1.0',
+        ]);
+
+        $lastRequest = $mockHandler->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $lastRequest);
+        self::assertInstanceOf(ClientTestUri::class, $lastRequest->getUri());
+        self::assertSame('http://foo.com/path?a=b', (string) $lastRequest->getUri());
+        self::assertSame('1', $lastRequest->getHeaderLine('X-Test'));
+        self::assertSame('payload', (string) $lastRequest->getBody());
+        self::assertSame('1.0', $lastRequest->getProtocolVersion());
+    }
+
+    public function testSendPreservesCustomUriWhenMergingBaseUri()
+    {
+        $mockHandler = new MockHandler([new Response()]);
+        $client = new Client([
+            'handler' => $mockHandler,
+            'base_uri' => new ClientTestUri('http://foo.com/base/'),
+        ]);
+        $request = new ClientTestRequest('GET', new ClientTestUri('relative'));
+
+        $client->send($request);
+
+        $lastRequest = $mockHandler->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $lastRequest);
+        self::assertInstanceOf(ClientTestUri::class, $lastRequest->getUri());
+        self::assertSame('http://foo.com/base/relative', (string) $lastRequest->getUri());
+    }
+
     public function testHandlerIsCallable()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -862,4 +901,12 @@ class ClientTest extends TestCase
         self::assertSame('https://xn--d1acpjx3f.xn--p1ai/images', (string) $request->getUri());
         self::assertSame('xn--d1acpjx3f.xn--p1ai', (string) $request->getHeaderLine('Host'));
     }
+}
+
+final class ClientTestRequest extends Request
+{
+}
+
+final class ClientTestUri extends Uri
+{
 }

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -53,6 +53,26 @@ class PrepareBodyMiddlewareTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
     }
 
+    public function testPreservesCustomRequestWhenAddingContentLength()
+    {
+        $h = new MockHandler([
+            static function (RequestInterface $request) {
+                self::assertInstanceOf(PrepareBodyTestRequest::class, $request);
+                self::assertSame('7', $request->getHeaderLine('Content-Length'));
+
+                return new Response(200);
+            },
+        ]);
+        $m = Middleware::prepareBody();
+        $stack = new HandlerStack($h);
+        $stack->push($m);
+        $comp = $stack->resolve();
+        $p = $comp(new PrepareBodyTestRequest('POST', 'http://www.google.com', [], 'payload'), []);
+        self::assertInstanceOf(PromiseInterface::class, $p);
+        $response = $p->wait();
+        self::assertSame(200, $response->getStatusCode());
+    }
+
     public function testAddsTransferEncodingWhenNoContentLength()
     {
         $body = FnStream::decorate(Psr7\Utils::streamFor('foo'), [
@@ -136,6 +156,30 @@ class PrepareBodyMiddlewareTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
     }
 
+    public function testPreservesCustomRequestWhenAddingExpect()
+    {
+        $h = new MockHandler([
+            static function (RequestInterface $request) {
+                self::assertInstanceOf(PrepareBodyTestRequest::class, $request);
+                self::assertSame('100-Continue', $request->getHeaderLine('Expect'));
+
+                return new Response(200);
+            },
+        ]);
+
+        $m = Middleware::prepareBody();
+        $stack = new HandlerStack($h);
+        $stack->push($m);
+        $comp = $stack->resolve();
+        $p = $comp(
+            new PrepareBodyTestRequest('POST', 'http://www.google.com', [], 'payload'),
+            ['expect' => true]
+        );
+        self::assertInstanceOf(PromiseInterface::class, $p);
+        $response = $p->wait();
+        self::assertSame(200, $response->getStatusCode());
+    }
+
     public function testIgnoresIfExpectIsPresent()
     {
         $bd = Psr7\Utils::streamFor(\fopen(__DIR__.'/../composer.json', 'r'));
@@ -159,4 +203,8 @@ class PrepareBodyMiddlewareTest extends TestCase
         $response = $p->wait();
         self::assertSame(200, $response->getStatusCode());
     }
+}
+
+final class PrepareBodyTestRequest extends Request
+{
 }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\RedirectMiddleware;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -77,6 +78,27 @@ class RedirectMiddlewareTest extends TestCase
         $response = $promise->wait();
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('http://example.com/foo', (string) $mock->getLastRequest()->getUri());
+    }
+
+    public function testRelativeRedirectPreservesCustomRequestAndUriImplementations()
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => '/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new RedirectTestRequest('GET', new RedirectTestUri('http://example.com?a=b'));
+        $response = $handler($request, [
+            'allow_redirects' => ['max' => 2],
+        ])->wait();
+
+        $lastRequest = $mock->getLastRequest();
+        self::assertSame(200, $response->getStatusCode());
+        self::assertInstanceOf(RedirectTestRequest::class, $lastRequest);
+        self::assertInstanceOf(RedirectTestUri::class, $lastRequest->getUri());
+        self::assertSame('http://example.com/foo', (string) $lastRequest->getUri());
     }
 
     public function testLimitsToMaxRedirects()
@@ -543,4 +565,12 @@ class RedirectMiddlewareTest extends TestCase
             ],
         ];
     }
+}
+
+final class RedirectTestRequest extends Request
+{
+}
+
+final class RedirectTestUri extends Uri
+{
 }


### PR DESCRIPTION
Bumps the psr7 requirement to the pending 2.10 development branch so CI can exercise the implementation-preservation fixes before the stable tag is available.

This also removes the psr7-version branching from CI and adds focused tests covering custom request/URI preservation through client option application, redirects, and prepare-body middleware.