### PR TITLE
Validate JSON decode depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fail clearly when cURL options cannot be applied
+- Fail clearly when JSON decode depth is invalid
 - Fail clearly when session cookie data is malformed
 - Prevent response creation failures from exposing stale cURL responses
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -343,12 +343,6 @@ parameters:
 			path: src/Utils.php
 
 		-
-			message: '#^Parameter \#3 \$depth of function json_decode expects int\<1, max\>, int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Utils.php
-
-		-
 			message: '#^Parameter \#3 \$depth of function json_encode expects int\<1, max\>, int given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -272,6 +272,10 @@ EOT
      */
     public static function jsonDecode(string $json, bool $assoc = false, int $depth = 512, int $options = 0)
     {
+        if ($depth < 1) {
+            throw new InvalidArgumentException('json_decode error: Maximum stack depth exceeded');
+        }
+
         $data = \json_decode($json, $assoc, $depth, $options);
         if (\JSON_ERROR_NONE !== \json_last_error()) {
             throw new InvalidArgumentException('json_decode error: '.\json_last_error_msg());

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -187,6 +187,31 @@ class UtilsTest extends TestCase
 
         \GuzzleHttp\json_decode('{{]]');
     }
+
+    /**
+     * @dataProvider invalidJsonDepthProvider
+     */
+    public function testDecodesJsonAndThrowsOnInvalidDepth(int $depth)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Utils::jsonDecode('{}', true, $depth);
+    }
+
+    /**
+     * @dataProvider invalidJsonDepthProvider
+     */
+    public function testDecodesJsonAndThrowsOnInvalidDepthLegacy(int $depth)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        \GuzzleHttp\json_decode('{}', true, $depth);
+    }
+
+    public static function invalidJsonDepthProvider(): array
+    {
+        return [[0], [-1]];
+    }
 }
 
 final class StrClass


### PR DESCRIPTION
This makes `Utils::jsonDecode()` check the depth argument before calling PHP's `json_decode()`. Invalid depths now go through Guzzle's normal JSON decode exception path instead of surfacing as a native engine error. I added coverage for the static helper and deprecated function wrapper, and removed the PHPStan baseline entry that covered this call.
