### PR TITLE
Harden session cookie persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fail clearly when cURL options cannot be applied
+- Fail clearly when session cookie data is malformed
 - Prevent response creation failures from exposing stale cURL responses
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,24 +49,6 @@ parameters:
 			path: src/Cookie/CookieJar.php
 
 		-
-			message: '#^Parameter \#1 \$data of class GuzzleHttp\\Cookie\\SetCookie constructor expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Cookie/SessionCookieJar.php
-
-		-
-			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Cookie/SessionCookieJar.php
-
-		-
-			message: '#^Parameter \#1 \$string of function strlen expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Cookie/SessionCookieJar.php
-
-		-
 			message: '#^Call to function is_bool\(\) with bool will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 3

--- a/src/Cookie/SessionCookieJar.php
+++ b/src/Cookie/SessionCookieJar.php
@@ -54,7 +54,12 @@ class SessionCookieJar extends CookieJar
             }
         }
 
-        $_SESSION[$this->sessionKey] = \json_encode($json);
+        $json = \json_encode($json);
+        if (false === $json) {
+            throw new \RuntimeException('Unable to encode cookie data');
+        }
+
+        $_SESSION[$this->sessionKey] = $json;
     }
 
     /**
@@ -65,12 +70,22 @@ class SessionCookieJar extends CookieJar
         if (!isset($_SESSION[$this->sessionKey])) {
             return;
         }
-        $data = \json_decode($_SESSION[$this->sessionKey], true);
+
+        $json = $_SESSION[$this->sessionKey];
+        if (!\is_string($json)) {
+            throw new \RuntimeException('Invalid cookie data');
+        }
+
+        $data = \json_decode($json, true);
         if (\is_array($data)) {
             foreach ($data as $cookie) {
+                if (!\is_array($cookie)) {
+                    throw new \RuntimeException('Invalid cookie data');
+                }
+
                 $this->setCookie(new SetCookie($cookie));
             }
-        } elseif (\strlen($data)) {
+        } elseif (\is_scalar($data) && \strlen((string) $data)) {
             throw new \RuntimeException('Invalid cookie data');
         }
     }

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -20,6 +20,8 @@ class SessionCookieJarTest extends TestCase
         if (!isset($_SESSION)) {
             $_SESSION = [];
         }
+
+        unset($_SESSION[$this->sessionVar]);
     }
 
     public function testValidatesCookieSession()
@@ -28,6 +30,40 @@ class SessionCookieJarTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         new SessionCookieJar($this->sessionVar);
+    }
+
+    /**
+     * @dataProvider invalidCookieSessionProvider
+     *
+     * @param mixed $sessionData
+     */
+    public function testValidatesMalformedCookieSession($sessionData)
+    {
+        $_SESSION[$this->sessionVar] = $sessionData;
+
+        $this->expectException(\RuntimeException::class);
+        new SessionCookieJar($this->sessionVar);
+    }
+
+    public function testValidatesCookieSessionJsonEncoding(): void
+    {
+        $jar = new SessionCookieJar($this->sessionVar, true);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => "\x99",
+            'Domain' => 'foo.com',
+            'Expires' => \time() + 1000,
+        ]));
+
+        try {
+            $jar->save();
+            self::fail('Expected RuntimeException was not thrown');
+        } catch (\RuntimeException $e) {
+            self::assertSame('Unable to encode cookie data', $e->getMessage());
+        } finally {
+            $jar->clear();
+            unset($jar, $_SESSION[$this->sessionVar]);
+        }
     }
 
     public function testLoadsFromSession()
@@ -87,6 +123,15 @@ class SessionCookieJarTest extends TestCase
         return [
             [false],
             [true],
+        ];
+    }
+
+    public static function invalidCookieSessionProvider(): array
+    {
+        return [
+            [[]],
+            [new \stdClass()],
+            ['[1]'],
         ];
     }
 }


### PR DESCRIPTION
This makes `SessionCookieJar` treat malformed persisted session data as invalid cookie data instead of letting raw PHP type errors leak out. It also checks JSON encoding before writing back to `$_SESSION`, so an encoding failure cannot store `false` and poison a later load. Valid persisted session cookies continue to load and save as before.
