### PR TITLE
Validate stream progress option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Fail clearly when cURL options cannot be applied
 - Fail clearly when JSON decode depth is invalid
 - Fail clearly when session cookie data is malformed
+- Fail clearly when the stream progress option is not callable
 - Prevent response creation failures from exposing stale cURL responses
 
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -265,12 +265,6 @@ parameters:
 			path: src/Handler/StreamHandler.php
 
 		-
-			message: '#^Trying to invoke mixed but it''s not a callable\.$#'
-			identifier: callable.nonCallable
-			count: 1
-			path: src/Handler/StreamHandler.php
-
-		-
 			message: '#^Variable \$options in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -561,6 +561,10 @@ class StreamHandler
      */
     private function add_progress(RequestInterface $request, array &$options, $value, array &$params): void
     {
+        if (!\is_callable($value)) {
+            throw new \InvalidArgumentException('progress client option must be callable');
+        }
+
         self::addNotification(
             $params,
             static function ($code, $a, $b, $c, $transferred, $total) use ($value) {

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -626,6 +626,16 @@ class StreamHandlerTest extends TestCase
         $handler($req, ['on_headers' => 'error!']);
     }
 
+    public function testEnsuresProgressIsCallable()
+    {
+        $req = new Request('GET', 'http://example.com');
+        $handler = new StreamHandler();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('progress client option must be callable');
+        $handler($req, ['progress' => 'error!']);
+    }
+
     public function testRejectsPromiseWhenOnHeadersFails()
     {
         Server::flush();


### PR DESCRIPTION
This makes the stream handler validate the `progress` option before installing the notification callback. It now matches the cURL handler by failing clearly when `progress` is not callable, instead of failing later when PHP tries to invoke the value.
