### PR TITLE
Validate certificate option shape

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,12 +241,6 @@ parameters:
 			path: src/Handler/EasyHandle.php
 
 		-
-			message: '#^Parameter \#1 \$filename of function file_exists expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Handler/StreamHandler.php
-
-		-
 			message: '#^Parameter \#1 \$url of method GuzzleHttp\\Handler\\StreamHandler\:\:parse_proxy\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -255,12 +249,6 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$noProxyArray of static method GuzzleHttp\\Utils\:\:isHostInNoProxy\(\) expects array\<string\>, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Handler/StreamHandler.php
-
-		-
-			message: '#^Part \$value \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
 			count: 1
 			path: src/Handler/StreamHandler.php
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -661,8 +661,19 @@ class CurlFactory implements CurlFactoryInterface
         if (isset($options['cert'])) {
             $cert = $options['cert'];
             if (\is_array($cert)) {
-                $conf[\CURLOPT_SSLCERTPASSWD] = $cert[1];
+                if (!isset($cert[0]) || !\is_string($cert[0])) {
+                    throw new \InvalidArgumentException('Invalid cert request option');
+                }
+                if (isset($cert[1])) {
+                    if (!\is_string($cert[1])) {
+                        throw new \InvalidArgumentException('Invalid cert request option');
+                    }
+                    $conf[\CURLOPT_SSLCERTPASSWD] = $cert[1];
+                }
                 $cert = $cert[0];
+            }
+            if (!\is_string($cert)) {
+                throw new \InvalidArgumentException('Invalid cert request option');
             }
             if (!\file_exists($cert)) {
                 throw new \InvalidArgumentException("SSL certificate not found: {$cert}");

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -545,8 +545,20 @@ class StreamHandler
     private function add_cert(RequestInterface $request, array &$options, $value, array &$params): void
     {
         if (\is_array($value)) {
-            $options['ssl']['passphrase'] = $value[1];
+            if (!isset($value[0]) || !\is_string($value[0])) {
+                throw new \InvalidArgumentException('Invalid cert request option');
+            }
+            if (isset($value[1])) {
+                if (!\is_string($value[1])) {
+                    throw new \InvalidArgumentException('Invalid cert request option');
+                }
+                $options['ssl']['passphrase'] = $value[1];
+            }
             $value = $value[0];
+        }
+
+        if (!\is_string($value)) {
+            throw new \InvalidArgumentException('Invalid cert request option');
         }
 
         if (!\file_exists($value)) {

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -358,6 +358,45 @@ class CurlFactoryTest extends TestCase
         self::assertEquals('test', $_SERVER['_curl'][\CURLOPT_SSLCERTPASSWD]);
     }
 
+    public function testAddsCertWithArrayPathOnly()
+    {
+        $f = new CurlFactory(3);
+        $easy = $f->create(new Psr7\Request('GET', 'http://example.com'), ['cert' => [__FILE__]]);
+
+        try {
+            self::assertInstanceOf(EasyHandle::class, $easy);
+        } finally {
+            if (\PHP_VERSION_ID < 80000) {
+                \curl_close($easy->handle);
+            }
+        }
+    }
+
+    /**
+     * @dataProvider invalidCertOptionProvider
+     *
+     * @param mixed $cert
+     */
+    public function testValidatesCertOptionShape($cert)
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid cert request option');
+        $f->create(new Psr7\Request('GET', 'http://example.com'), ['cert' => $cert]);
+    }
+
+    public static function invalidCertOptionProvider(): array
+    {
+        return [
+            [[]],
+            [['passphrase' => 'test']],
+            [[new \stdClass(), 'test']],
+            [[__FILE__, new \stdClass()]],
+            [new \stdClass()],
+        ];
+    }
+
     public function testAddsDerCert()
     {
         $certFile = tempnam(sys_get_temp_dir(), 'mock_test_cert');

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -446,6 +446,48 @@ class StreamHandlerTest extends TestCase
         self::assertSame('foo', $opts['ssl']['passphrase']);
     }
 
+    public function testCanSetCertWithArrayPathOnly()
+    {
+        $path = __FILE__;
+        $handler = new StreamHandler();
+        $options = [];
+        $params = [];
+        $method = new \ReflectionMethod(StreamHandler::class, 'add_cert');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $method->invokeArgs($handler, [new Request('GET', 'http://example.com'), &$options, [$path], &$params]);
+
+        self::assertSame($path, $options['ssl']['local_cert']);
+        self::assertArrayNotHasKey('passphrase', $options['ssl']);
+    }
+
+    /**
+     * @dataProvider invalidCertOptionProvider
+     *
+     * @param mixed $cert
+     */
+    public function testEnsuresCertOptionShapeIsValid($cert)
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid cert request option');
+        $handler(new Request('GET', 'http://example.com'), ['cert' => $cert]);
+    }
+
+    public static function invalidCertOptionProvider(): array
+    {
+        return [
+            [[]],
+            [['passphrase' => 'test']],
+            [[new \stdClass(), 'test']],
+            [[__FILE__, new \stdClass()]],
+            [new \stdClass()],
+        ];
+    }
+
     public function testDebugAttributeWritesToStream()
     {
         $this->queueRes();


### PR DESCRIPTION
This validates the `cert` request option before either handler reads array offsets or passes the value to filesystem APIs. Valid string paths and array paths still work, including the existing path-only array form, while malformed values now fail with a clear invalid argument exception instead of warnings or raw engine errors.
