### PR TITLE
Document on_headers as a transfer option

### DIFF
--- a/docs/handlers-and-middleware.rst
+++ b/docs/handlers-and-middleware.rst
@@ -296,6 +296,7 @@ These request options are a subset of request options called
 - :ref:`delay-option`
 - :ref:`decode_content-option`
 - :ref:`expect-option`
+- :ref:`on-headers`
 - :ref:`proxy-option`
 - :ref:`sink-option`
 - :ref:`timeout-option`


### PR DESCRIPTION
Documents `on_headers` in the handler transfer options list.