### PR TITLE
Update changelog for certificate option validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fail clearly when cURL options cannot be applied
+- Fail clearly when the certificate option is malformed
 - Fail clearly when JSON decode depth is invalid
 - Fail clearly when session cookie data is malformed
 - Fail clearly when the stream progress option is not callable


### PR DESCRIPTION
This adds the missing 7.10.1 changelog entry for the certificate option validation fix merged in #3355.
