### PR TITLE
Prevent CurlMultiHandler destructor failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Changed
 
 - Adjusted `guzzlehttp/psr7` version constraint to `^2.10`
+- Prevent `CurlMultiHandler` destructors from throwing during cleanup
 - Improve invalid response handling across handlers
 
 

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -119,8 +119,13 @@ class CurlMultiHandler
     public function __destruct()
     {
         if (isset($this->_mh)) {
-            \curl_multi_close($this->_mh);
-            unset($this->_mh);
+            try {
+                \curl_multi_close($this->_mh);
+            } catch (\Throwable $e) {
+                // Destructors must not throw.
+            } finally {
+                unset($this->_mh);
+            }
         }
     }
 

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -61,6 +61,31 @@ class CurlMultiHandlerTest extends TestCase
         self::assertEquals(2, Helpers::readObjectAttribute($a, 'selectTimeout'));
     }
 
+    public function testDestructorDoesNotThrowWhenCurlMultiCloseFails()
+    {
+        $handler = new CurlMultiHandler();
+
+        $setMultiHandle = \Closure::bind(static function (CurlMultiHandler $handler): void {
+            $handler->_mh = new \stdClass();
+        }, null, CurlMultiHandler::class);
+        $hasMultiHandle = \Closure::bind(static function (CurlMultiHandler $handler): bool {
+            return isset($handler->_mh);
+        }, null, CurlMultiHandler::class);
+
+        $setMultiHandle($handler);
+        \set_error_handler(static function (int $severity, string $message, string $file, int $line): void {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $handler->__destruct();
+        } finally {
+            \restore_error_handler();
+        }
+
+        self::assertFalse($hasMultiHandle($handler));
+    }
+
     public function testCanCancel()
     {
         Server::flush();


### PR DESCRIPTION
Makes CurlMultiHandler cleanup best-effort so destructor failures do not escape.

Fixes #3341.