### PR TITLE
Fix removing callable string middleware names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Adjusted `guzzlehttp/psr7` version constraint to `^2.10`
 - Improve invalid response handling across handlers
 
+### Fixed
+
+- Remove middleware by name when the name is also a callable string
+
 
 ## 7.10.1 - 2026-05-19
 

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -185,11 +185,25 @@ class HandlerStack
         }
 
         $this->cached = null;
-        $idx = \is_callable($remove) ? 0 : 1;
+
+        if (\is_string($remove)) {
+            $count = \count($this->stack);
+            $this->stack = \array_values(\array_filter(
+                $this->stack,
+                static function ($tuple) use ($remove) {
+                    return $tuple[1] !== $remove;
+                }
+            ));
+
+            if ($count !== \count($this->stack) || !\is_callable($remove)) {
+                return;
+            }
+        }
+
         $this->stack = \array_values(\array_filter(
             $this->stack,
-            static function ($tuple) use ($idx, $remove) {
-                return $tuple[$idx] !== $remove;
+            static function ($tuple) use ($remove) {
+                return $tuple[0] !== $remove;
             }
         ));
     }

--- a/tests/HandlerStackTest.php
+++ b/tests/HandlerStackTest.php
@@ -88,6 +88,51 @@ class HandlerStackTest extends TestCase
         self::assertSame('Hello - test1131', $composed('test'));
     }
 
+    public function testCanRemoveMiddlewareByCallableStringName()
+    {
+        $meths = $this->getFunctions();
+        $builder = new HandlerStack();
+        $builder->setHandler($meths[1]);
+        $builder->push($meths[2], 'strlen');
+
+        $builder->remove('strlen');
+
+        $composed = $builder->resolve();
+        self::assertSame('Hello - test', $composed('test'));
+        self::assertSame([], $meths[0]);
+    }
+
+    public function testCanRemoveMiddlewareByCallableStringInstance()
+    {
+        $builder = new HandlerStack();
+        $builder->setHandler(static function ($value) {
+            return 'Hello - '.$value;
+        });
+        $builder->push(__CLASS__.'::addSuffixMiddleware');
+
+        $builder->remove(__CLASS__.'::addSuffixMiddleware');
+
+        $composed = $builder->resolve();
+        self::assertSame('Hello - test', $composed('test'));
+    }
+
+    public function testRemovePrefersNameWhenStringIsAlsoCallable()
+    {
+        $meths = $this->getFunctions();
+        $name = __CLASS__.'::addSuffixMiddleware';
+
+        $builder = new HandlerStack();
+        $builder->setHandler($meths[1]);
+        $builder->push($meths[2], $name);
+        $builder->push($name);
+
+        $builder->remove($name);
+
+        $composed = $builder->resolve();
+        self::assertSame('Hello - testx', $composed('test'));
+        self::assertSame([], $meths[0]);
+    }
+
     public function testCanPrintMiddleware()
     {
         $meths = $this->getFunctions();
@@ -209,6 +254,13 @@ class HandlerStackTest extends TestCase
 
     public static function foo()
     {
+    }
+
+    public static function addSuffixMiddleware(callable $handler)
+    {
+        return static function ($value) use ($handler) {
+            return $handler($value.'x');
+        };
     }
 
     public function bar()


### PR DESCRIPTION
This makes `HandlerStack::remove()` prefer middleware names when a string is passed. Names like `strlen` are currently treated as callable strings, so removing a middleware by that name silently fails. Callable-string removal still works when there is no middleware with the same name.
