### PR TITLE
Update Guzzle 8 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  COMPOSER_ROOT_VERSION: 7.11.x-dev
+  COMPOSER_ROOT_VERSION: 8.0.x-dev
 
 jobs:
   build-lowest-version:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  COMPOSER_ROOT_VERSION: 7.11.x-dev
+  COMPOSER_ROOT_VERSION: 8.0.x-dev
 
 jobs:
   phpstan:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Changed
 
 - Hardened `FileCookieJar` persistence against unsafe unserialization
+- Adjusted `guzzlehttp/promises` version constraint to `^3.0`
+- Adjusted `guzzlehttp/psr7` version constraint to `^3.0`
 - Pass the request as the second argument to `on_headers` callbacks
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
+
+### Removed
+
+- Dropped support for PHP 7.2 and 7.3
 
 
 ## 7.11.0 - Upcoming

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,14 @@ automatically on destruction. If your application intentionally unserializes a
 Saved cookie files now JSON-escape tag characters. Existing cookie files remain
 readable, and cookie values are unchanged when loaded.
 
+#### PHP Version and Dependencies
+
+Guzzle 8 requires PHP `^7.4 || ^8.0`. Guzzle 7 supported PHP
+`^7.2.5 || ^8.0`.
+
+Guzzle 8 also requires `guzzlehttp/promises` 3.x and `guzzlehttp/psr7` 3.x. If
+your application uses those packages directly, review their upgrade guides.
+
 #### on_headers callback arguments
 
 The `on_headers` request option callback now receives the request as its second

--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "guzzlehttp/promises": "^2.3",
-        "guzzlehttp/psr7": "^2.10",
+        "guzzlehttp/promises": "^3.0@dev",
+        "guzzlehttp/psr7": "^3.0@dev",
         "psr/http-client": "^1.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },
@@ -62,7 +62,7 @@
         "ext-curl": "*",
         "bamarni/composer-bin-plugin": "^1.8.2",
         "guzzle/client-integration-tests": "3.0.2",
-        "guzzlehttp/test-server": "^0.3.2",
+        "guzzlehttp/test-server": "^1.0@dev",
         "php-http/message-factory": "^1.1",
         "phpunit/phpunit": "^8.5.52 || ^9.6.34",
         "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -82,7 +82,7 @@
                 "name": "guzzle/client-integration-tests",
                 "version": "v3.0.2",
                 "require": {
-                    "guzzlehttp/psr7": "^1.7 || ^2.0",
+                    "guzzlehttp/psr7": "^1.7 || ^2.0 || ^3.0@dev",
                     "php": "^7.4 || ^8.0",
                     "php-http/message": "^1.0 || ^2.0",
                     "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.11",

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -298,6 +298,18 @@ class ClientTest extends TestCase
         self::assertSame('foo', (string) $last->getBody());
     }
 
+    public function testAddsIteratorBody()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $request = new Request('PUT', 'http://foo.com');
+        $client->send($request, [
+            'body' => new \ArrayIterator(['foo', 'bar']),
+        ]);
+        $last = $mock->getLastRequest();
+        self::assertSame('foobar', (string) $last->getBody());
+    }
+
     public function testValidatesQuery()
     {
         $mock = new MockHandler();

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -228,6 +228,25 @@ class MockHandlerTest extends TestCase
         self::assertSame($e, $c);
     }
 
+    public function testLateRejectedHandlerReceivesRejectedReason()
+    {
+        $e = new \Exception('a');
+        $mock = new MockHandler([$e]);
+        $request = new Request('GET', 'http://example.com');
+
+        $promise = $mock($request, []);
+        $promise->wait(false);
+
+        $reason = null;
+        $promise->then(null, static function ($value) use (&$reason): void {
+            $reason = $value;
+        });
+
+        \GuzzleHttp\Promise\Utils::queue()->run();
+
+        self::assertSame($e, $reason);
+    }
+
     public function testThrowsWhenNoMoreResponses()
     {
         $mock = new MockHandler();


### PR DESCRIPTION
Updates Guzzle 8 to target the next major supporting packages:

- `guzzlehttp/promises` 3.x
- `guzzlehttp/psr7` 3.x
- `guzzlehttp/test-server` 1.x for dev tests

Also adds smoke coverage for iterator request bodies with psr7 3.x and late rejection callbacks with promises 3.x.
