### PR TITLE
Deprecate `RetryMiddleware::exponentialDelay()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Adjusted `guzzlehttp/psr7` version constraint to `^2.10`
 - Improve invalid response handling across handlers
 
+### Deprecated
+
+- Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
+
 ### Fixed
 
 - Remove middleware by name when the name is also a callable string

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -44,16 +44,22 @@ class RetryMiddleware
     {
         $this->decider = $decider;
         $this->nextHandler = $nextHandler;
-        $this->delay = $delay ?: __CLASS__.'::exponentialDelay';
+        $this->delay = $delay ?: static function (int $retries): int {
+            return (int) 2 ** ($retries - 1) * 1000;
+        };
     }
 
     /**
      * Default exponential backoff delay function.
      *
      * @return int milliseconds.
+     *
+     * @deprecated since 7.11, will be removed in 8.0.
      */
     public static function exponentialDelay(int $retries): int
     {
+        trigger_deprecation('guzzlehttp/guzzle', '7.11', '%s::%s() is deprecated and will be removed in 8.0.', __CLASS__, __FUNCTION__);
+
         return (int) 2 ** ($retries - 1) * 1000;
     }
 

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -5,6 +5,7 @@ namespace GuzzleHttp\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RetryMiddleware;
@@ -74,12 +75,50 @@ class RetryMiddlewareTest extends TestCase
         self::assertNull($calls[1][3]);
     }
 
-    public function testBackoffCalculateDelay()
+    public function testUsesDefaultExponentialDelay()
     {
-        self::assertSame(0, RetryMiddleware::exponentialDelay(0));
-        self::assertSame(1000, RetryMiddleware::exponentialDelay(1));
-        self::assertSame(2000, RetryMiddleware::exponentialDelay(2));
-        self::assertSame(4000, RetryMiddleware::exponentialDelay(3));
-        self::assertSame(8000, RetryMiddleware::exponentialDelay(4));
+        $responses = [new Response(500), new Response(500), new Response(200)];
+        $delays = [];
+        $handler = static function ($request, array $options) use (&$responses, &$delays) {
+            if (isset($options['delay'])) {
+                $delays[] = $options['delay'];
+            }
+
+            return Create::promiseFor(\array_shift($responses));
+        };
+        $decider = static function ($retries) {
+            return $retries < 2;
+        };
+
+        $m = Middleware::retry($decider);
+        $p = $m($handler)(new Request('GET', 'http://test.com'), []);
+
+        self::assertSame(200, $p->wait()->getStatusCode());
+        self::assertSame([1000, 2000], $delays);
+    }
+
+    public function testExponentialDelayIsDeprecated()
+    {
+        $deprecations = [];
+
+        set_error_handler(static function (int $severity, string $message) use (&$deprecations): bool {
+            if ($severity !== \E_USER_DEPRECATED) {
+                return false;
+            }
+
+            $deprecations[] = $message;
+
+            return true;
+        });
+
+        try {
+            self::assertSame(1000, RetryMiddleware::exponentialDelay(1));
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertSame([
+            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\RetryMiddleware::exponentialDelay() is deprecated and will be removed in 8.0.',
+        ], $deprecations);
     }
 }


### PR DESCRIPTION
Deprecates `RetryMiddleware::exponentialDelay()` as the 7.11 compatibility step before removing it in 8.0.

Refs #2500.