### PR TITLE
Normalize proxy options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Hardened `FileCookieJar` persistence against unsafe unserialization
 - Adjusted `guzzlehttp/promises` version constraint to `^3.0`
 - Adjusted `guzzlehttp/psr7` version constraint to `^3.0`
+- Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,6 +36,26 @@ work, but callbacks that inspect all arguments, for example with
 `func_get_args()` or a variadic parameter, will observe the additional
 `Psr\Http\Message\RequestInterface` argument.
 
+#### Proxy option validation
+
+The `proxy` request option is validated more strictly. Proxy values must be
+strings, and the `proxy['no']` value may be either an array of strings or a
+comma-delimited string such as the value from the `NO_PROXY` environment
+variable. Other values now throw `InvalidArgumentException`.
+
+Explicit proxy options also override environment no-proxy settings. If you pass
+a `proxy` request option and want to exclude hosts, provide the `no` value
+explicitly:
+
+```php
+$client->request('GET', '/', [
+    'proxy' => [
+        'http' => 'http://localhost:8125',
+        'no' => getenv('NO_PROXY') ?: '',
+    ],
+]);
+```
+
 6.0 to 7.0
 ----------
 

--- a/docs/request-options.rst
+++ b/docs/request-options.rst
@@ -864,15 +864,15 @@ Pass a string to specify a proxy for all protocols.
 
 Pass an associative array to specify HTTP proxies for specific URI schemes
 (i.e., "http", "https"). Provide a ``no`` key value pair to provide a list of
-host names that should not be proxied to.
+host names that should not be proxied to. The ``no`` value may be an array of
+host names or a comma-delimited string.
 
 .. note::
 
     Guzzle will automatically populate this value with your environment's
     ``NO_PROXY`` environment variable. However, when providing a ``proxy``
-    request option, it is up to you to provide the ``no`` value parsed from
-    the ``NO_PROXY`` environment variable
-    (e.g., ``explode(',', getenv('NO_PROXY'))``).
+    request option, it is up to you to provide the ``no`` value from the
+    ``NO_PROXY`` environment variable.
 
 .. code-block:: php
 
@@ -881,6 +881,15 @@ host names that should not be proxied to.
             'http'  => 'http://localhost:8125', // Use this proxy with "http"
             'https' => 'http://localhost:9124', // Use this proxy with "https",
             'no' => ['.mit.edu', 'foo.com']    // Don't use a proxy with these
+        ]
+    ]);
+
+.. code-block:: php
+
+    $client->request('GET', '/', [
+        'proxy' => [
+            'http' => 'http://localhost:8125',
+            'no' => getenv('NO_PROXY') ?: ''
         ]
     ]);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -127,12 +127,6 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
-			message: '#^Parameter \#2 \$noProxyArray of static method GuzzleHttp\\Utils\:\:isHostInNoProxy\(\) expects array\<string\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
 			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlFactory\:\:applyCurlOptions\(\) has invalid type CurlHandle\.$#'
 			identifier: class.notFound
 			count: 1
@@ -239,18 +233,6 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: src/Handler/EasyHandle.php
-
-		-
-			message: '#^Parameter \#1 \$url of method GuzzleHttp\\Handler\\StreamHandler\:\:parse_proxy\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Handler/StreamHandler.php
-
-		-
-			message: '#^Parameter \#2 \$noProxyArray of static method GuzzleHttp\\Utils\:\:isHostInNoProxy\(\) expects array\<string\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Handler/StreamHandler.php
 
 		-
 			message: '#^Variable \$options in empty\(\) always exists and is not falsy\.$#'

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -620,16 +620,29 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (isset($options['proxy'])) {
-            if (!\is_array($options['proxy'])) {
-                $conf[\CURLOPT_PROXY] = $options['proxy'];
+            $proxy = $options['proxy'];
+            if (!\is_array($proxy)) {
+                if (!\is_string($proxy)) {
+                    throw new \InvalidArgumentException('proxy must be a string or array');
+                }
+
+                $conf[\CURLOPT_PROXY] = $proxy;
+                $conf[\CURLOPT_NOPROXY] = '';
             } else {
                 $scheme = $easy->request->getUri()->getScheme();
-                if (isset($options['proxy'][$scheme])) {
+                if (isset($proxy[$scheme])) {
+                    if (!\is_string($proxy[$scheme])) {
+                        throw new \InvalidArgumentException('proxy values must be strings');
+                    }
+
                     $host = $easy->request->getUri()->getHost();
-                    if (isset($options['proxy']['no']) && Utils::isHostInNoProxy($host, $options['proxy']['no'])) {
-                        unset($conf[\CURLOPT_PROXY]);
+                    $noProxy = isset($proxy['no']) ? Utils::normalizeNoProxy($proxy['no']) : [];
+                    if ($noProxy !== [] && Utils::isHostInNoProxy($host, $noProxy)) {
+                        $conf[\CURLOPT_PROXY] = '';
+                        $conf[\CURLOPT_NOPROXY] = $host;
                     } else {
-                        $conf[\CURLOPT_PROXY] = $options['proxy'][$scheme];
+                        $conf[\CURLOPT_PROXY] = $proxy[$scheme];
+                        $conf[\CURLOPT_NOPROXY] = '';
                     }
                 }
             }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -444,17 +444,26 @@ class StreamHandler
         $uri = null;
 
         if (!\is_array($value)) {
+            if (!\is_string($value)) {
+                throw new \InvalidArgumentException('proxy must be a string or array');
+            }
+
             $uri = $value;
         } else {
             $scheme = $request->getUri()->getScheme();
             if (isset($value[$scheme])) {
-                if (!isset($value['no']) || !Utils::isHostInNoProxy($request->getUri()->getHost(), $value['no'])) {
+                if (!\is_string($value[$scheme])) {
+                    throw new \InvalidArgumentException('proxy values must be strings');
+                }
+
+                $noProxy = isset($value['no']) ? Utils::normalizeNoProxy($value['no']) : [];
+                if ($noProxy === [] || !Utils::isHostInNoProxy($request->getUri()->getHost(), $noProxy)) {
                     $uri = $value[$scheme];
                 }
             }
         }
 
-        if (!$uri) {
+        if ($uri === null || $uri === '') {
             return;
         }
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -201,7 +201,9 @@ final class RequestOptions
     /**
      * proxy: (string|array) Pass a string to specify an HTTP proxy, or an
      * array to specify different proxies for different protocols (where the
-     * key is the protocol and the value is a proxy string).
+     * key is the protocol and the value is a proxy string). Provide a "no"
+     * key as a string or array of strings to specify hosts that should not be
+     * proxied.
      */
     public const PROXY = 'proxy';
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -185,6 +185,38 @@ final class Utils
     }
 
     /**
+     * Normalize a no-proxy list from request options.
+     *
+     * @param mixed $noProxy No-proxy value as passed via request transfer options.
+     *
+     * @return string[]
+     *
+     * @internal
+     */
+    public static function normalizeNoProxy($noProxy): array
+    {
+        if (\is_string($noProxy)) {
+            $noProxy = \explode(',', $noProxy);
+        } elseif (!\is_array($noProxy)) {
+            throw new InvalidArgumentException('proxy no list must be a string or array of strings');
+        }
+
+        $result = [];
+        foreach ($noProxy as $area) {
+            if (!\is_string($area)) {
+                throw new InvalidArgumentException('proxy no list must be a string or array of strings');
+            }
+
+            $area = \trim($area);
+            if ($area !== '') {
+                $result[] = $area;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Wrapper for json_decode that throws when an error occurs.
      *
      * @param string $json    JSON data to parse

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -207,6 +207,7 @@ class CurlFactoryTest extends TestCase
         $f = new CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['proxy' => 'http://bar.com']);
         self::assertEquals('http://bar.com', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
     }
 
     public function testAddsViaScheme()
@@ -216,11 +217,39 @@ class CurlFactoryTest extends TestCase
             'proxy' => ['http' => 'http://bar.com', 'https' => 'https://t'],
         ]);
         self::assertEquals('http://bar.com', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         $this->checkNoProxyForHost('http://test.test.com', ['test.test.com'], false);
         $this->checkNoProxyForHost('http://test.test.com', ['.test.com'], false);
+        $this->checkNoProxyForHost('http://test.test.com', 'test.test.com,example.com', false);
+        $this->checkNoProxyForHost('http://test.test.com', '.example.com,example.org', true);
+        $this->checkNoProxyForHost('http://test.test.com', [], true);
+        $this->checkNoProxyForHost('http://test.test.com', '', true);
         $this->checkNoProxyForHost('http://test.test.com', ['*.test.com'], true);
         $this->checkNoProxyForHost('http://test.test.com', ['*'], false);
         $this->checkNoProxyForHost('http://127.0.0.1', ['127.0.0.*'], true);
+    }
+
+    /**
+     * @dataProvider invalidProxyOptionProvider
+     *
+     * @param mixed $proxy
+     */
+    public function testValidatesProxyOption($proxy)
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $f->create(new Psr7\Request('GET', Server::$url), ['proxy' => $proxy]);
+    }
+
+    public static function invalidProxyOptionProvider(): array
+    {
+        return [
+            [new \stdClass()],
+            [['http' => new \stdClass()]],
+            [['http' => 'http://bar.com', 'no' => new \stdClass()]],
+            [['http' => 'http://bar.com', 'no' => [new \stdClass()]]],
+        ];
     }
 
     private function checkNoProxyForHost($url, $noProxy, $assertUseProxy)
@@ -234,9 +263,11 @@ class CurlFactoryTest extends TestCase
             ],
         ]);
         if ($assertUseProxy) {
-            self::assertArrayHasKey(\CURLOPT_PROXY, $_SERVER['_curl']);
+            self::assertSame('http://bar.com', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         } else {
-            self::assertArrayNotHasKey(\CURLOPT_PROXY, $_SERVER['_curl']);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame(parse_url($url, \PHP_URL_HOST), $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         }
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -299,6 +299,25 @@ class StreamHandlerTest extends TestCase
         return $handler($request, $opts)->wait();
     }
 
+    /**
+     * @param mixed $proxy
+     */
+    private function getProxyContext($proxy, string $uri = 'http://example.com'): array
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', $uri);
+        $options = ['http' => []];
+        $params = [];
+        $method = new \ReflectionMethod(StreamHandler::class, 'add_proxy');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $method->invokeArgs($handler, [$request, &$options, $proxy, &$params]);
+
+        return $options;
+    }
+
     public function testAddsProxy()
     {
         $this->expectException(ConnectException::class);
@@ -327,6 +346,48 @@ class StreamHandlerTest extends TestCase
         ]]);
         $opts = \stream_context_get_options($res->getBody()->detach());
         self::assertArrayNotHasKey('proxy', $opts['http']);
+    }
+
+    public function testAddsProxyButHonorsNoProxyString()
+    {
+        $opts = $this->getProxyContext([
+            'http' => 'http://proxy.example.com:8125',
+            'no' => 'example.com,localhost',
+        ]);
+
+        self::assertArrayNotHasKey('proxy', $opts['http']);
+    }
+
+    public function testAddsProxyWithEmptyNoProxyString()
+    {
+        $opts = $this->getProxyContext([
+            'http' => 'http://proxy.example.com:8125',
+            'no' => '',
+        ]);
+
+        self::assertSame('tcp://proxy.example.com:8125', $opts['http']['proxy']);
+    }
+
+    /**
+     * @dataProvider invalidProxyOptionProvider
+     *
+     * @param mixed $proxy
+     */
+    public function testEnsuresProxyOptionShapeIsValid($proxy)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->getProxyContext($proxy);
+    }
+
+    public static function invalidProxyOptionProvider(): array
+    {
+        return [
+            [new \stdClass()],
+            [['http' => new \stdClass()]],
+            [['http' => 'http://proxy.example.com:8125', 'no' => new \stdClass()]],
+            [['http' => 'http://proxy.example.com:8125', 'no' => [new \stdClass()]]],
+        ];
     }
 
     public function testUsesProxy()

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -119,6 +119,32 @@ class UtilsTest extends TestCase
         self::assertSame($result, Utils::isHostInNoProxy($host, $list));
     }
 
+    public function testNormalizesNoProxyString()
+    {
+        self::assertSame(['foo.com', '.bar.com'], Utils::normalizeNoProxy(' foo.com, .bar.com, '));
+    }
+
+    public function testNormalizesNoProxyArray()
+    {
+        self::assertSame(['foo.com', '.bar.com'], Utils::normalizeNoProxy([' foo.com ', '', '.bar.com']));
+    }
+
+    public function testValidatesNoProxyValue()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('proxy no list must be a string or array of strings');
+
+        Utils::normalizeNoProxy(new \stdClass());
+    }
+
+    public function testValidatesNoProxyArrayValues()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('proxy no list must be a string or array of strings');
+
+        Utils::normalizeNoProxy(['foo.com', new \stdClass()]);
+    }
+
     public function testEnsuresNoProxyCheckHostIsSet()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
This normalizes and validates proxy request options before either handler applies them. The `proxy['no']` value now accepts either an array of host patterns or a comma-delimited string, so `NO_PROXY` values can be passed directly. Explicit proxy options also clear cURL's environment no-proxy fallback unless the request option itself matches the host.
