### PR TITLE
Allow safe domainless SetCookie storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Fixed
 
+- Allow domainless `SetCookie` instances to be stored without using them as wildcard request cookies
 - Remove middleware by name when the name is also a callable string
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Changed
 
 - Adjusted `guzzlehttp/psr7` version constraint to `^2.10`
+- Allow domainless `SetCookie` instances to be stored without using them as wildcard request cookies
 - Prevent `CurlMultiHandler` destructors from throwing during cleanup
 - Improve invalid response handling across handlers
 
@@ -17,7 +18,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Fixed
 
-- Allow domainless `SetCookie` instances to be stored without using them as wildcard request cookies
 - Remove middleware by name when the name is also a callable string
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -479,6 +479,11 @@ You can manually set cookies into a cookie jar with the named constructor
         'example.org'
     );
 
+Domainless ``SetCookie`` instances can be stored in a cookie jar for
+representing or forwarding ``Set-Cookie`` headers. Because manually-created
+domainless cookies do not include an origin host, Guzzle will not send them on
+outgoing requests.
+
 You can get a cookie by its name with the ``getCookieByName($name)`` method
 which returns a ``GuzzleHttp\Cookie\SetCookie`` instance.
 

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -105,7 +105,7 @@ class CookieJar implements CookieJarInterface
 
     public function clear(?string $domain = null, ?string $path = null, ?string $name = null): void
     {
-        if (!$domain) {
+        if ($domain === null) {
             $this->cookies = [];
 
             return;
@@ -113,14 +113,15 @@ class CookieJar implements CookieJarInterface
             $this->cookies = \array_filter(
                 $this->cookies,
                 static function (SetCookie $cookie) use ($domain): bool {
-                    return !$cookie->matchesDomain($domain);
+                    return $cookie->getDomain() === null || !$cookie->matchesDomain($domain);
                 }
             );
         } elseif (!$name) {
             $this->cookies = \array_filter(
                 $this->cookies,
                 static function (SetCookie $cookie) use ($path, $domain): bool {
-                    return !($cookie->matchesPath($path)
+                    return !($cookie->getDomain() !== null
+                        && $cookie->matchesPath($path)
                         && $cookie->matchesDomain($domain));
                 }
             );
@@ -128,7 +129,8 @@ class CookieJar implements CookieJarInterface
             $this->cookies = \array_filter(
                 $this->cookies,
                 static function (SetCookie $cookie) use ($path, $domain, $name) {
-                    return !($cookie->getName() == $name
+                    return !($cookie->getDomain() !== null
+                        && $cookie->getName() == $name
                         && $cookie->matchesPath($path)
                         && $cookie->matchesDomain($domain));
                 }
@@ -274,7 +276,8 @@ class CookieJar implements CookieJarInterface
         $path = $uri->getPath() ?: '/';
 
         foreach ($this->cookies as $cookie) {
-            if ($cookie->matchesPath($path)
+            if ($cookie->getDomain() !== null
+                && $cookie->matchesPath($path)
                 && $cookie->matchesDomain($host)
                 && !$cookie->isExpired()
                 && (!$cookie->getSecure() || $scheme === 'https')
@@ -296,7 +299,7 @@ class CookieJar implements CookieJarInterface
     private function removeCookieIfEmpty(SetCookie $cookie): void
     {
         $cookieValue = $cookie->getValue();
-        if ($cookieValue === null || $cookieValue === '') {
+        if (($cookieValue === null || $cookieValue === '') && $cookie->getDomain() !== null) {
             $this->clear(
                 $cookie->getDomain(),
                 $cookie->getPath(),

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -480,10 +480,10 @@ class SetCookie
             return 'The cookie value must not be empty';
         }
 
-        // Domains must not be empty, but can be 0. "0" is not a valid internet
-        // domain, but may be used as server name in a private network.
+        // Domains must not be empty, but may be omitted. "0" is not a valid
+        // internet domain, but may be used as server name in a private network.
         $domain = $this->getDomain();
-        if ($domain === null || $domain === '') {
+        if ($domain === '') {
             return 'The cookie domain must not be empty';
         }
 

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -128,6 +128,66 @@ class CookieJarTest extends TestCase
         self::assertCount(0, $this->jar);
     }
 
+    public static function domainClearProvider(): array
+    {
+        return [
+            ['example.com', null, null],
+            ['example.com', '/', null],
+            ['example.com', '/', 'domain-cookie'],
+        ];
+    }
+
+    /**
+     * @dataProvider domainClearProvider
+     */
+    public function testClearingDomainDoesNotRemoveCookieWithoutDomain(string $domain, ?string $path, ?string $name): void
+    {
+        $this->jar->setCookie(new SetCookie([
+            'Name' => 'domainless-cookie',
+            'Value' => 'value',
+        ]));
+        $this->jar->setCookie(new SetCookie([
+            'Name' => 'domain-cookie',
+            'Value' => 'value',
+            'Domain' => 'example.com',
+            'Path' => '/',
+        ]));
+
+        $this->jar->clear($domain, $path, $name);
+
+        self::assertCount(1, $this->jar);
+        $cookie = $this->jar->getCookieByName('domainless-cookie');
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertNull($cookie->getDomain());
+    }
+
+    public function testInvalidCookieWithoutDomainDoesNotClearJar(): void
+    {
+        $this->jar->setCookie(new SetCookie([
+            'Name' => 'session',
+            'Value' => 'value',
+            'Domain' => 'example.com',
+        ]));
+
+        self::assertFalse($this->jar->setCookie(new SetCookie(['Name' => 'session'])));
+        self::assertCount(1, $this->jar);
+    }
+
+    public function testInvalidCookieWithEmptyDomainDoesNotClearJar(): void
+    {
+        $this->jar->setCookie(new SetCookie([
+            'Name' => 'session',
+            'Value' => 'value',
+            'Domain' => 'example.com',
+        ]));
+
+        self::assertFalse($this->jar->setCookie(new SetCookie([
+            'Name' => 'session',
+            'Domain' => '',
+        ])));
+        self::assertCount(1, $this->jar);
+    }
+
     public static function providesIncompleteCookies(): array
     {
         return [
@@ -234,6 +294,31 @@ class CookieJarTest extends TestCase
     public function testDoesAddValidCookies(array $cookie)
     {
         self::assertTrue($this->jar->setCookie(new SetCookie($cookie)));
+    }
+
+    public function testAcceptsCookieWithoutDomain(): void
+    {
+        $jar = new CookieJar(true);
+        $cookie = new SetCookie([
+            'Name' => 'test',
+            'Value' => 'value',
+        ]);
+
+        self::assertTrue($jar->setCookie($cookie));
+        self::assertCount(1, $jar);
+        self::assertNull($jar->toArray()[0]['Domain']);
+    }
+
+    public function testDoesNotSendCookieWithoutDomainToRequests(): void
+    {
+        $this->jar->setCookie(new SetCookie([
+            'Name' => 'test',
+            'Value' => 'value',
+        ]));
+
+        $request = $this->jar->withCookieHeader(new Request('GET', 'https://example.com/'));
+
+        self::assertFalse($request->hasHeader('Cookie'));
     }
 
     public function testOverwritesCookiesThatAreOlderOrDiscardable()

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -86,6 +86,25 @@ class FileCookieJarTest extends TestCase
         unset($jar);
     }
 
+    public function testPersistsCookieWithoutDomain(): void
+    {
+        $jar = new FileCookieJar($this->file);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => 'bar',
+            'Expires' => \time() + 1000,
+        ]));
+        $jar->save($this->file);
+
+        $reloaded = new FileCookieJar($this->file);
+        $cookie = $reloaded->getCookieByName('foo');
+
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertNull($cookie->getDomain());
+
+        unset($jar, $reloaded);
+    }
+
     public function testRemovesCookie()
     {
         $jar = new FileCookieJar($this->file);

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -118,6 +118,25 @@ class SessionCookieJarTest extends TestCase
         unset($_SESSION[$this->sessionVar]);
     }
 
+    public function testPersistsCookieWithoutDomain(): void
+    {
+        $jar = new SessionCookieJar($this->sessionVar);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => 'bar',
+            'Expires' => \time() + 1000,
+        ]));
+        $jar->save();
+
+        $reloaded = new SessionCookieJar($this->sessionVar);
+        $cookie = $reloaded->getCookieByName('foo');
+
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertNull($cookie->getDomain());
+
+        unset($jar, $reloaded, $_SESSION[$this->sessionVar]);
+    }
+
     public static function providerPersistsToSessionParameters()
     {
         return [

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -163,6 +163,7 @@ class SetCookieTest extends TestCase
             ['', 'baz', 'bar', 'The cookie name must not be empty'],
             ['foo', null, 'bar', 'The cookie value must not be empty'],
             ['foo', 'baz', '', 'The cookie domain must not be empty'],
+            ['foo', 'baz', null, true],
             ["foo\r", 'baz', '0', 'Cookie name must not contain invalid characters: ASCII Control characters (0-31;127), space, tab and the following characters: ()<>@,;:\"/?={}'],
         ];
     }
@@ -202,6 +203,16 @@ class SetCookieTest extends TestCase
             'test=123; Domain=foo.com; Path=/abc; Expires=Sun, 27 Oct 2013 23:20:08 GMT; Secure; HttpOnly',
             (string) $cookie
         );
+    }
+
+    public function testConvertsToStringWithoutDomainAttribute()
+    {
+        $cookie = new SetCookie([
+            'Name' => 'test',
+            'Value' => '123',
+        ]);
+
+        self::assertSame('test=123; Path=/', (string) $cookie);
     }
 
     /**


### PR DESCRIPTION
- allow domainless `SetCookie` instances to validate and persist
- do not send manually-created domainless cookies as outbound wildcard cookies
- guard clearing paths from treating domainless cookies as domain matches

Fixes #3315.
Supersedes #3316.
