### PR TITLE
[8.0] Remove RetryMiddleware::exponentialDelay()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Removed
 
 - Dropped support for PHP 7.2 and 7.3
+- Removed the deprecated `RetryMiddleware::exponentialDelay()` method
 
 
 ## 7.11.0 - Upcoming

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,6 +21,13 @@ Guzzle 8 requires PHP `^7.4 || ^8.0`. Guzzle 7 supported PHP
 Guzzle 8 also requires `guzzlehttp/promises` 3.x and `guzzlehttp/psr7` 3.x. If
 your application uses those packages directly, review their upgrade guides.
 
+#### RetryMiddleware::exponentialDelay
+
+`RetryMiddleware::exponentialDelay()` has been removed. The retry middleware
+continues to use the same exponential backoff calculation by default. If you
+called the static method directly, inline that calculation or pass a custom
+delay callable to `Middleware::retry()`.
+
 #### on_headers callback arguments
 
 The `on_headers` request option callback now receives the request as its second

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -49,20 +49,6 @@ class RetryMiddleware
         };
     }
 
-    /**
-     * Default exponential backoff delay function.
-     *
-     * @return int milliseconds.
-     *
-     * @deprecated since 7.11, will be removed in 8.0.
-     */
-    public static function exponentialDelay(int $retries): int
-    {
-        trigger_deprecation('guzzlehttp/guzzle', '7.11', '%s::%s() is deprecated and will be removed in 8.0.', __CLASS__, __FUNCTION__);
-
-        return (int) 2 ** ($retries - 1) * 1000;
-    }
-
     public function __invoke(RequestInterface $request, array $options): PromiseInterface
     {
         if (!isset($options['retries'])) {

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -8,7 +8,6 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\RetryMiddleware;
 use PHPUnit\Framework\TestCase;
 
 class RetryMiddlewareTest extends TestCase
@@ -95,30 +94,5 @@ class RetryMiddlewareTest extends TestCase
 
         self::assertSame(200, $p->wait()->getStatusCode());
         self::assertSame([1000, 2000], $delays);
-    }
-
-    public function testExponentialDelayIsDeprecated()
-    {
-        $deprecations = [];
-
-        set_error_handler(static function (int $severity, string $message) use (&$deprecations): bool {
-            if ($severity !== \E_USER_DEPRECATED) {
-                return false;
-            }
-
-            $deprecations[] = $message;
-
-            return true;
-        });
-
-        try {
-            self::assertSame(1000, RetryMiddleware::exponentialDelay(1));
-        } finally {
-            restore_error_handler();
-        }
-
-        self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\RetryMiddleware::exponentialDelay() is deprecated and will be removed in 8.0.',
-        ], $deprecations);
     }
 }


### PR DESCRIPTION
Removes the deprecated `RetryMiddleware::exponentialDelay()` method in 8.0, following the 7.11 deprecation in #3362.

Supersedes #2500.
