### PR TITLE
Add host-only cookie support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added boolean parameter types to `SetCookie` flag setters
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
+- Store response cookies without a `Domain` attribute as host-only cookies
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
 
 ### Removed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,18 @@ automatically on destruction. If your application intentionally unserializes a
 Saved cookie files now JSON-escape tag characters. Existing cookie files remain
 readable, and cookie values are unchanged when loaded.
 
+#### Host-only cookies
+
+Cookies extracted from responses without a `Domain` attribute are now stored as
+host-only cookies. They are sent only to the exact host that set them.
+
+Previously, Guzzle stored these cookies with the request host as a normal domain
+cookie, so they could also be sent to subdomains. Applications relying on that
+behavior should use an explicit `Domain` attribute.
+
+`SetCookie::toArray()` may include `HostOnly => true` for host-only cookies.
+Existing persisted cookie files without this key load as non-host-only cookies.
+
 #### PHP Version and Dependencies
 
 Guzzle 8 requires PHP `^7.4 || ^8.0`. Guzzle 7 supported PHP

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -479,10 +479,11 @@ You can manually set cookies into a cookie jar with the named constructor
         'example.org'
     );
 
-Domainless ``SetCookie`` instances can be stored in a cookie jar for
-representing or forwarding ``Set-Cookie`` headers. Because manually-created
-domainless cookies do not include an origin host, Guzzle will not send them on
-outgoing requests.
+Cookies received from responses without a ``Domain`` attribute are stored as
+host-only cookies and are sent only to the exact host that set them. Domainless
+``SetCookie`` instances can still be stored in a cookie jar for representing or
+forwarding ``Set-Cookie`` headers. Because manually-created domainless cookies
+do not include an origin host, Guzzle will not send them on outgoing requests.
 
 You can get a cookie by its name with the ``getCookieByName($name)`` method
 which returns a ``GuzzleHttp\Cookie\SetCookie`` instance.

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -174,6 +174,7 @@ class CookieJar implements CookieJarInterface
             // identical.
             if ($c->getPath() != $cookie->getPath()
                 || $c->getDomain() != $cookie->getDomain()
+                || $c->getHostOnly() != $cookie->getHostOnly()
                 || $c->getName() != $cookie->getName()
             ) {
                 continue;
@@ -224,15 +225,21 @@ class CookieJar implements CookieJarInterface
     public function extractCookies(RequestInterface $request, ResponseInterface $response): void
     {
         if ($cookieHeader = $response->getHeader('Set-Cookie')) {
+            $requestHost = \strtolower($request->getUri()->getHost());
+
             foreach ($cookieHeader as $cookie) {
                 $sc = SetCookie::fromString($cookie);
-                if (!$sc->getDomain()) {
-                    $sc->setDomain($request->getUri()->getHost());
+                $domain = $sc->getDomain();
+                if ($domain === null || $domain === '') {
+                    $sc->setDomain($requestHost);
+                    $sc->setHostOnly(true);
+                } else {
+                    $sc->setHostOnly(false);
                 }
                 if (0 !== \strpos($sc->getPath(), '/')) {
                     $sc->setPath($this->getCookiePathFromRequest($request));
                 }
-                if (!$sc->matchesDomain($request->getUri()->getHost())) {
+                if (!$sc->matchesDomain($requestHost)) {
                     continue;
                 }
                 // Note: At this point `$sc->getDomain()` being a public suffix should
@@ -300,11 +307,20 @@ class CookieJar implements CookieJarInterface
     {
         $cookieValue = $cookie->getValue();
         if (($cookieValue === null || $cookieValue === '') && $cookie->getDomain() !== null) {
-            $this->clear(
-                $cookie->getDomain(),
-                $cookie->getPath(),
-                $cookie->getName()
-            );
+            $this->removeCookie($cookie);
         }
+    }
+
+    private function removeCookie(SetCookie $cookie): void
+    {
+        $this->cookies = \array_filter(
+            $this->cookies,
+            static function (SetCookie $stored) use ($cookie): bool {
+                return !($stored->getName() == $cookie->getName()
+                    && $stored->getPath() == $cookie->getPath()
+                    && $stored->getDomain() == $cookie->getDomain()
+                    && $stored->getHostOnly() == $cookie->getHostOnly());
+            }
+        );
     }
 }

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -524,7 +524,7 @@ class SetCookie
         $domain = \strtolower($domain);
 
         if ($domain !== '' && $domain[0] === '.') {
-            return \substr($domain, 1) ?: '';
+            return \substr($domain, 1);
         }
 
         return $domain;

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -28,6 +28,11 @@ class SetCookie
     private $data;
 
     /**
+     * @var bool Whether this cookie was set without a Domain attribute.
+     */
+    private $hostOnly = false;
+
+    /**
      * Create a new SetCookie object from a string.
      *
      * @param string $cookie Set-Cookie header string
@@ -72,6 +77,9 @@ class SetCookie
                         continue 2;
                     }
                 }
+                if (!\strcasecmp('HostOnly', $key)) {
+                    continue;
+                }
                 $data[$key] = $value;
             }
         }
@@ -85,6 +93,11 @@ class SetCookie
     public function __construct(array $data = [])
     {
         $this->data = self::$defaults;
+
+        if (\array_key_exists('HostOnly', $data)) {
+            $this->setHostOnly($data['HostOnly']);
+            unset($data['HostOnly']);
+        }
 
         if (isset($data['Name'])) {
             $this->setName($data['Name']);
@@ -140,6 +153,9 @@ class SetCookie
     {
         $str = $this->data['Name'].'='.($this->data['Value'] ?? '').'; ';
         foreach ($this->data as $k => $v) {
+            if ($k === 'Domain' && $this->getHostOnly()) {
+                continue;
+            }
             if ($k !== 'Name' && $k !== 'Value' && $v !== null && $v !== false) {
                 if ($k === 'Expires') {
                     $str .= 'Expires='.\gmdate('D, d M Y H:i:s \G\M\T', $v).'; ';
@@ -154,7 +170,12 @@ class SetCookie
 
     public function toArray(): array
     {
-        return $this->data;
+        $data = $this->data;
+        if ($this->getHostOnly()) {
+            $data['HostOnly'] = true;
+        }
+
+        return $data;
     }
 
     /**
@@ -226,7 +247,31 @@ class SetCookie
             trigger_deprecation('guzzlehttp/guzzle', '7.4', 'Not passing a string or null to %s::%s() is deprecated and will cause an error in 8.0.', __CLASS__, __FUNCTION__);
         }
 
-        $this->data['Domain'] = null === $domain ? null : (string) $domain;
+        $this->data['Domain'] = null === $domain ? null : self::normalizeDomain((string) $domain);
+    }
+
+    /**
+     * Get whether this cookie is scoped to the origin host only.
+     *
+     * @return bool
+     */
+    public function getHostOnly()
+    {
+        return $this->hostOnly;
+    }
+
+    /**
+     * Set whether this cookie is scoped to the origin host only.
+     *
+     * @param bool $hostOnly Set to true for host-only cookies
+     */
+    public function setHostOnly($hostOnly): void
+    {
+        if (!is_bool($hostOnly)) {
+            trigger_deprecation('guzzlehttp/guzzle', '8.0', 'Not passing a bool to %s::%s() is deprecated and will cause an error in 9.0.', __CLASS__, __FUNCTION__);
+        }
+
+        $this->hostOnly = (bool) $hostOnly;
     }
 
     /**
@@ -401,15 +446,19 @@ class SetCookie
     public function matchesDomain(string $domain): bool
     {
         $cookieDomain = $this->getDomain();
-        if (null === $cookieDomain) {
-            return true;
+        if (null === $cookieDomain || $cookieDomain === '') {
+            return false;
         }
 
         // Remove the leading '.' as per spec in RFC 6265.
         // https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.3
-        $cookieDomain = \ltrim(\strtolower($cookieDomain), '.');
+        $cookieDomain = self::normalizeDomain($cookieDomain);
 
         $domain = \strtolower($domain);
+
+        if ($this->getHostOnly()) {
+            return $domain === $cookieDomain;
+        }
 
         // Domain not set or exact match.
         if ('' === $cookieDomain || $domain === $cookieDomain) {
@@ -469,6 +518,21 @@ class SetCookie
             return 'The cookie domain must not be empty';
         }
 
+        if ($this->getHostOnly() && $domain === null) {
+            return 'Host-only cookies must have a domain';
+        }
+
         return true;
+    }
+
+    private static function normalizeDomain(string $domain): string
+    {
+        $domain = \strtolower($domain);
+
+        if ($domain !== '' && $domain[0] === '.') {
+            return \substr($domain, 1);
+        }
+
+        return $domain;
     }
 }

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -524,7 +524,7 @@ class SetCookie
         $domain = \strtolower($domain);
 
         if ($domain !== '' && $domain[0] === '.') {
-            return \substr($domain, 1);
+            return \substr_replace($domain, '', 0, 1);
         }
 
         return $domain;

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -95,7 +95,7 @@ class SetCookie
         $this->data = self::$defaults;
 
         if (\array_key_exists('HostOnly', $data)) {
-            $this->setHostOnly($data['HostOnly']);
+            $this->setHostOnly((bool) $data['HostOnly']);
             unset($data['HostOnly']);
         }
 
@@ -262,16 +262,10 @@ class SetCookie
 
     /**
      * Set whether this cookie is scoped to the origin host only.
-     *
-     * @param bool $hostOnly Set to true for host-only cookies
      */
-    public function setHostOnly($hostOnly): void
+    public function setHostOnly(bool $hostOnly): void
     {
-        if (!is_bool($hostOnly)) {
-            trigger_deprecation('guzzlehttp/guzzle', '8.0', 'Not passing a bool to %s::%s() is deprecated and will cause an error in 9.0.', __CLASS__, __FUNCTION__);
-        }
-
-        $this->hostOnly = (bool) $hostOnly;
+        $this->hostOnly = $hostOnly;
     }
 
     /**
@@ -530,7 +524,7 @@ class SetCookie
         $domain = \strtolower($domain);
 
         if ($domain !== '' && $domain[0] === '.') {
-            return \substr($domain, 1);
+            return \substr($domain, 1) ?: '';
         }
 
         return $domain;

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -399,6 +399,104 @@ class CookieJarTest extends TestCase
         $request = new Request('GET', 'http://www.example.com');
         $this->jar->extractCookies($request, $response);
         self::assertCount(1, $this->jar);
+
+        $cookie = $this->jar->getCookieByName('fpc');
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertSame('www.example.com', $cookie->getDomain());
+        self::assertTrue($cookie->getHostOnly());
+    }
+
+    public function testExtractsCookieWithoutDomainAsHostOnly(): void
+    {
+        $this->jar->extractCookies(
+            new Request('GET', 'https://example.com/'),
+            new Response(200, ['Set-Cookie' => 'sid=abc; Path=/'])
+        );
+
+        $cookie = $this->jar->getCookieByName('sid');
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertSame('example.com', $cookie->getDomain());
+        self::assertTrue($cookie->getHostOnly());
+    }
+
+    public function testDoesNotSendHostOnlyCookieToSubdomain(): void
+    {
+        $this->jar->extractCookies(
+            new Request('GET', 'https://example.com/'),
+            new Response(200, ['Set-Cookie' => 'sid=abc; Path=/'])
+        );
+
+        $sameHost = $this->jar->withCookieHeader(new Request('GET', 'https://example.com/'));
+        $subdomain = $this->jar->withCookieHeader(new Request('GET', 'https://foo.example.com/'));
+
+        self::assertSame('sid=abc', $sameHost->getHeaderLine('Cookie'));
+        self::assertFalse($subdomain->hasHeader('Cookie'));
+    }
+
+    public function testSendsDomainCookieToSubdomain(): void
+    {
+        $this->jar->extractCookies(
+            new Request('GET', 'https://example.com/'),
+            new Response(200, ['Set-Cookie' => 'sid=abc; Domain=example.com; Path=/'])
+        );
+
+        $request = $this->jar->withCookieHeader(new Request('GET', 'https://foo.example.com/'));
+
+        self::assertSame('sid=abc', $request->getHeaderLine('Cookie'));
+    }
+
+    public function testEmptyDomainAttributeCreatesHostOnlyCookie(): void
+    {
+        $this->jar->extractCookies(
+            new Request('GET', 'https://example.com/'),
+            new Response(200, ['Set-Cookie' => 'sid=abc; Domain=; Path=/'])
+        );
+
+        $cookie = $this->jar->getCookieByName('sid');
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertSame('example.com', $cookie->getDomain());
+        self::assertTrue($cookie->getHostOnly());
+    }
+
+    public function testHostOnlyAndDomainCookiesWithSameNameCanCoexist(): void
+    {
+        $this->jar->extractCookies(
+            new Request('GET', 'https://example.com/'),
+            new Response(200, ['Set-Cookie' => 'sid=host; Path=/'])
+        );
+        $this->jar->extractCookies(
+            new Request('GET', 'https://example.com/'),
+            new Response(200, ['Set-Cookie' => 'sid=domain; Domain=example.com; Path=/'])
+        );
+
+        self::assertCount(2, $this->jar);
+
+        $sameHost = $this->jar->withCookieHeader(new Request('GET', 'https://example.com/'));
+        $subdomain = $this->jar->withCookieHeader(new Request('GET', 'https://foo.example.com/'));
+
+        self::assertSame('sid=host; sid=domain', $sameHost->getHeaderLine('Cookie'));
+        self::assertSame('sid=domain', $subdomain->getHeaderLine('Cookie'));
+    }
+
+    public function testClearingSubdomainDoesNotRemoveParentHostOnlyCookie(): void
+    {
+        $this->jar->setCookie(new SetCookie([
+            'Name' => 'sid',
+            'Value' => 'host',
+            'Domain' => 'example.com',
+            'HostOnly' => true,
+        ]));
+        $this->jar->setCookie(new SetCookie([
+            'Name' => 'sid',
+            'Value' => 'domain',
+            'Domain' => 'example.com',
+        ]));
+
+        $this->jar->clear('foo.example.com');
+
+        self::assertCount(1, $this->jar);
+        $request = $this->jar->withCookieHeader(new Request('GET', 'https://example.com/'));
+        self::assertSame('sid=host', $request->getHeaderLine('Cookie'));
     }
 
     public static function getMatchingCookiesDataProvider()
@@ -520,6 +618,9 @@ class CookieJarTest extends TestCase
         $this->jar->extractCookies($request, $response);
         $newRequest = $this->jar->withCookieHeader(new Request('GET', 'http://www.example.com/foo'));
         self::assertTrue($newRequest->hasHeader('Cookie'));
+
+        $subdomainRequest = $this->jar->withCookieHeader(new Request('GET', 'http://foo.www.example.com/foo'));
+        self::assertFalse($subdomainRequest->hasHeader('Cookie'));
     }
 
     public static function getCookiePathsDataProvider()

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -107,6 +107,28 @@ class FileCookieJarTest extends TestCase
         unset($jar, $reloaded);
     }
 
+    public function testPersistsHostOnlyCookie(): void
+    {
+        $jar = new FileCookieJar($this->file);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => 'bar',
+            'Domain' => 'example.com',
+            'HostOnly' => true,
+            'Expires' => \time() + 1000,
+        ]));
+        $jar->save($this->file);
+
+        $reloaded = new FileCookieJar($this->file);
+        $cookie = $reloaded->getCookieByName('foo');
+
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertSame('example.com', $cookie->getDomain());
+        self::assertTrue($cookie->getHostOnly());
+
+        unset($jar, $reloaded);
+    }
+
     public function testRemovesCookie()
     {
         $jar = new FileCookieJar($this->file);

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -139,6 +139,28 @@ class SessionCookieJarTest extends TestCase
         unset($jar, $reloaded, $_SESSION[$this->sessionVar]);
     }
 
+    public function testPersistsHostOnlyCookie(): void
+    {
+        $jar = new SessionCookieJar($this->sessionVar);
+        $jar->setCookie(new SetCookie([
+            'Name' => 'foo',
+            'Value' => 'bar',
+            'Domain' => 'example.com',
+            'HostOnly' => true,
+            'Expires' => \time() + 1000,
+        ]));
+        $jar->save();
+
+        $reloaded = new SessionCookieJar($this->sessionVar);
+        $cookie = $reloaded->getCookieByName('foo');
+
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertSame('example.com', $cookie->getDomain());
+        self::assertTrue($cookie->getHostOnly());
+
+        unset($jar, $reloaded, $_SESSION[$this->sessionVar]);
+    }
+
     public static function providerPersistsToSessionParameters()
     {
         return [

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -96,7 +96,7 @@ class SetCookieTest extends TestCase
     public function testMatchesDomain()
     {
         $cookie = new SetCookie();
-        self::assertTrue($cookie->matchesDomain('baz.com'));
+        self::assertFalse($cookie->matchesDomain('baz.com'));
 
         $cookie->setDomain('baz.com');
         self::assertTrue($cookie->matchesDomain('baz.com'));
@@ -122,6 +122,33 @@ class SetCookieTest extends TestCase
 
         $cookie->setDomain('example.com/'); // malformed domain
         self::assertFalse($cookie->matchesDomain('example.com'));
+    }
+
+    public function testHostOnlyCookieOnlyMatchesExactDomain(): void
+    {
+        $cookie = new SetCookie([
+            'Name' => 'sid',
+            'Value' => 'abc',
+            'Domain' => 'example.com',
+            'HostOnly' => true,
+        ]);
+
+        self::assertTrue($cookie->matchesDomain('example.com'));
+        self::assertFalse($cookie->matchesDomain('foo.example.com'));
+        self::assertFalse($cookie->matchesDomain('not-example.com'));
+    }
+
+    public function testHostOnlyCookieMatchesIpExactly(): void
+    {
+        $cookie = new SetCookie([
+            'Name' => 'sid',
+            'Value' => 'abc',
+            'Domain' => '127.0.0.1',
+            'HostOnly' => true,
+        ]);
+
+        self::assertTrue($cookie->matchesDomain('127.0.0.1'));
+        self::assertFalse($cookie->matchesDomain('foo.127.0.0.1'));
     }
 
     public static function pathMatchProvider()
@@ -217,6 +244,38 @@ class SetCookieTest extends TestCase
         self::assertSame('test=123; Path=/', (string) $cookie);
     }
 
+    public function testConvertsHostOnlyCookieToStringWithoutDomainAttribute()
+    {
+        $cookie = new SetCookie([
+            'Name' => 'test',
+            'Value' => '123',
+            'Domain' => 'example.com',
+            'HostOnly' => true,
+        ]);
+
+        self::assertSame('test=123; Path=/', (string) $cookie);
+        self::assertTrue($cookie->toArray()['HostOnly']);
+    }
+
+    public function testIgnoresHostOnlySetCookieExtension()
+    {
+        $cookie = SetCookie::fromString('test=123; HostOnly; Domain=example.com');
+
+        self::assertFalse($cookie->getHostOnly());
+        self::assertArrayNotHasKey('HostOnly', $cookie->toArray());
+    }
+
+    public function testRejectsHostOnlyCookieWithoutDomain()
+    {
+        $cookie = new SetCookie([
+            'Name' => 'test',
+            'Value' => '123',
+            'HostOnly' => true,
+        ]);
+
+        self::assertSame('Host-only cookies must have a domain', $cookie->validate());
+    }
+
     /**
      * Provides the parsed information from a cookie
      *
@@ -307,7 +366,7 @@ class SetCookieTest extends TestCase
                 [
                     'Name' => 'expires',
                     'Value' => 'tomorrow',
-                    'Domain' => '.example.com',
+                    'Domain' => 'example.com',
                     'Path' => '/Space Out/',
                     'Expires' => 'Tue, 21-Nov-2006 08:33:44 GMT',
                     'Discard' => null,
@@ -335,7 +394,7 @@ class SetCookieTest extends TestCase
                 [
                     'Name' => 'path',
                     'Value' => 'indexAction',
-                    'Domain' => '.foo.com',
+                    'Domain' => 'foo.com',
                     'Path' => '/',
                     'Expires' => 'Tue, 21-Nov-2006 08:33:44 GMT',
                     'Secure' => false,
@@ -364,7 +423,7 @@ class SetCookieTest extends TestCase
                 [
                     'Name' => 'PHPSESSID',
                     'Value' => '123456789+abcd%2Cef',
-                    'Domain' => '.localdomain',
+                    'Domain' => 'localdomain',
                     'Path' => '/foo/baz',
                     'Expires' => 'Tue, 21-Nov-2006 08:33:44 GMT',
                     'Secure' => true,
@@ -378,7 +437,7 @@ class SetCookieTest extends TestCase
                 [
                     'Name' => 'fr',
                     'Value' => 'synced',
-                    'Domain' => '.example.com',
+                    'Domain' => 'example.com',
                     'Path' => '/',
                     'Expires' => null,
                     'Secure' => true,
@@ -393,7 +452,7 @@ class SetCookieTest extends TestCase
                 [
                     'Name' => 'SESS3a6f27284c4d8b34b6f4ff98cb87703e',
                     'Value' => 'Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH',
-                    'Domain' => '.example.com',
+                    'Domain' => 'example.com',
                     'Path' => '/',
                     'Expires' => 'Wed, 07-Jun-2023 15:56:35 GMT',
                     'Secure' => false,
@@ -408,7 +467,7 @@ class SetCookieTest extends TestCase
                 [
                     'Name' => 'SESS3a6f27284c4d8b34b6f4ff98cb87703e',
                     'Value' => 'Ts-5YeSyvOCMS%2CzkEb9eDfW4C4ZNFOcRYdu-3JpEAXIm58aH',
-                    'Domain' => '.example.com',
+                    'Domain' => 'example.com',
                     'Path' => '/',
                     'Expires' => 'Wed, 07-Jun-2023 15:56:35 GMT',
                     'Secure' => false,


### PR DESCRIPTION
## Summary
- store response cookies without `Domain` as host-only cookies
- send host-only cookies only to the exact origin host
- persist host-only cookie metadata

## Notes
This follows RFC 6265bis uniqueness behavior, so host-only and domain cookies with the same name/domain/path may coexist.
