### PR TITLE
Convert default settings to constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Removed
 
 - Dropped support for PHP 7.2 and 7.3
+- Removed `RedirectMiddleware::$defaultSettings`; use `RedirectMiddleware::DEFAULT_SETTINGS`
 - Removed the deprecated `RetryMiddleware::exponentialDelay()` method
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -46,6 +46,11 @@ continues to use the same exponential backoff calculation by default. If you
 called the static method directly, inline that calculation or pass a custom
 delay callable to `Middleware::retry()`.
 
+#### RedirectMiddleware default settings
+
+`RedirectMiddleware::$defaultSettings` has been removed. Use
+`RedirectMiddleware::DEFAULT_SETTINGS` instead.
+
 #### on_headers callback arguments
 
 The `on_headers` request option callback now receives the request as its second

--- a/src/Client.php
+++ b/src/Client.php
@@ -207,7 +207,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     private function configureDefaults(array $config): void
     {
         $defaults = [
-            'allow_redirects' => RedirectMiddleware::$defaultSettings,
+            'allow_redirects' => RedirectMiddleware::DEFAULT_SETTINGS,
             'http_errors' => true,
             'decode_content' => true,
             'verify' => true,

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -10,7 +10,7 @@ class SetCookie
     /**
      * @var array
      */
-    private static $defaults = [
+    private const DEFAULTS = [
         'Name' => null,
         'Value' => null,
         'Domain' => null,
@@ -40,7 +40,7 @@ class SetCookie
     public static function fromString(string $cookie): self
     {
         // Create the default return array
-        $data = self::$defaults;
+        $data = self::DEFAULTS;
         // Explode the cookie string using a series of semicolons
         $pieces = \array_filter(\array_map('trim', \explode(';', $cookie)));
         // The name of the cookie (first kvp) must exist and include an equal sign.
@@ -61,7 +61,7 @@ class SetCookie
                 $data['Name'] = $key;
                 $data['Value'] = $value;
             } else {
-                foreach (\array_keys(self::$defaults) as $search) {
+                foreach (\array_keys(self::DEFAULTS) as $search) {
                     if (!\strcasecmp($search, $key)) {
                         if ($search === 'Max-Age') {
                             if (is_numeric($value)) {
@@ -92,7 +92,7 @@ class SetCookie
      */
     public function __construct(array $data = [])
     {
-        $this->data = self::$defaults;
+        $this->data = self::DEFAULTS;
 
         if (\array_key_exists('HostOnly', $data)) {
             $this->setHostOnly((bool) $data['HostOnly']);
@@ -136,7 +136,7 @@ class SetCookie
         }
 
         // Set the remaining values that don't have extra validation logic
-        foreach (array_diff(array_keys($data), array_keys(self::$defaults)) as $key) {
+        foreach (array_diff(array_keys($data), array_keys(self::DEFAULTS)) as $key) {
             $this->data[$key] = $data[$key];
         }
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -26,7 +26,7 @@ class RedirectMiddleware
     /**
      * @var array
      */
-    public static $defaultSettings = [
+    public const DEFAULT_SETTINGS = [
         'max' => 5,
         'protocols' => ['http', 'https'],
         'strict' => false,
@@ -56,12 +56,12 @@ class RedirectMiddleware
         }
 
         if ($options['allow_redirects'] === true) {
-            $options['allow_redirects'] = self::$defaultSettings;
+            $options['allow_redirects'] = self::DEFAULT_SETTINGS;
         } elseif (!\is_array($options['allow_redirects'])) {
             throw new \InvalidArgumentException('allow_redirects must be true, false, or array');
         } else {
             // Merge the default settings with the provided settings
-            $options['allow_redirects'] += self::$defaultSettings;
+            $options['allow_redirects'] += self::DEFAULT_SETTINGS;
         }
 
         if (empty($options['allow_redirects']['max'])) {


### PR DESCRIPTION
Replaces `RedirectMiddleware::$defaultSettings` with `RedirectMiddleware::DEFAULT_SETTINGS`.

---

Supersedes #2463.
