### PR TITLE
Update documentation for 8.0

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-1.  PHP 7.2.5
+1.  PHP 7.4
 2.  To use the PHP stream handler, `allow_url_fopen` must be enabled in your system's php.ini.
 3.  To use the cURL handler, you must have a recent version of cURL >= 7.19.4 compiled with OpenSSL and zlib.
 
@@ -21,7 +21,7 @@ curl -sS https://getcomposer.org/installer | php
 You can add Guzzle as a dependency using Composer:
 
 ```bash
-composer require guzzlehttp/guzzle:^7.0
+composer require guzzlehttp/guzzle:^8.0
 ```
 
 Alternatively, you can specify Guzzle as a dependency in your project's existing composer.json file:
@@ -29,7 +29,7 @@ Alternatively, you can specify Guzzle as a dependency in your project's existing
 ```js
 {
   "require": {
-     "guzzlehttp/guzzle": "^7.0"
+     "guzzlehttp/guzzle": "^8.0"
   }
 }
 ```
@@ -52,7 +52,7 @@ The git repository contains an [upgrade guide](../UPGRADING.md) that details wha
 
 1.  Guzzle utilizes PSR-1, PSR-2, PSR-4, and PSR-7.
 2.  Guzzle is meant to be lean and fast with very few dependencies. This means that not every feature request will be accepted.
-3.  Guzzle has a minimum PHP version requirement of PHP 7.2. Pull requests must not require a PHP version greater than PHP 7.2 unless the feature is only utilized conditionally and the file can be parsed by PHP 7.2.
+3.  Guzzle has a minimum PHP version requirement of PHP 7.4. Pull requests must not require a PHP version greater than PHP 7.4 unless the feature is only utilized conditionally and the file can be parsed by PHP 7.4.
 4.  All pull requests must include unit tests to ensure the change works as expected and to prevent regressions.
 
 ### Running the tests

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -5,7 +5,7 @@ namespace GuzzleHttp;
 /**
  * This class contains a list of built-in Guzzle request options.
  *
- * @see https://github.com/guzzle/guzzle/blob/7.11/docs/request-options.md
+ * @see https://github.com/guzzle/guzzle/blob/8.0/docs/request-options.md
  */
 final class RequestOptions
 {


### PR DESCRIPTION
## Summary
- update overview installation examples and minimum PHP version for 8.0
- point request option API docs at the 8.0 Markdown docs

## Testing
- checked for stale 7.0/PHP 7.2/request-options doc references
- checked diff whitespace