### PR TITLE
Remove CurlMultiHandler deprecation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Removed
 
 - Dropped support for PHP 7.2 and 7.3
+- Removed support for the `GUZZLE_CURL_SELECT_TIMEOUT` environment variable; use `CurlMultiHandler`'s `select_timeout` option
 - Removed `RedirectMiddleware::$defaultSettings`; use `RedirectMiddleware::DEFAULT_SETTINGS`
 - Removed the deprecated `RetryMiddleware::exponentialDelay()` method
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -47,6 +47,11 @@ declare strict types will throw `TypeError` for non-boolean values.
 `SetCookie::getExpires()` now returns `int|null`. Invalid textual expiration
 dates are treated as `null`.
 
+#### CurlMultiHandler select timeout
+
+The `GUZZLE_CURL_SELECT_TIMEOUT` environment variable is no longer read. Pass
+the `select_timeout` option to `CurlMultiHandler` instead.
+
 #### RetryMiddleware::exponentialDelay
 
 `RetryMiddleware::exponentialDelay()` has been removed. The retry middleware

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -486,9 +486,6 @@ All of the above exceptions extend from `GuzzleHttp\Exception\TransferException`
 
 Guzzle exposes a few environment variables that can be used to customize the behavior of the library.
 
-`GUZZLE_CURL_SELECT_TIMEOUT`
-Controls the duration in seconds that a `curl_multi_*` handler will use when selecting on curl handles using `curl_multi_select()`. Some systems have issues with PHP's implementation of `curl_multi_select()` where calling this function always results in waiting for the maximum duration of the timeout.
-
 `HTTP_PROXY`
 Defines the proxy to use when sending requests using the "http" protocol.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -133,12 +133,6 @@ parameters:
 			path: src/Handler/CurlHandler.php
 
 		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
 			message: '#^Method GuzzleHttp\\Handler\\CurlMultiHandler\:\:__get\(\) has invalid return type CurlMultiHandle\.$#'
 			identifier: class.notFound
 			count: 1

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -70,14 +70,7 @@ class CurlMultiHandler
     {
         $this->factory = $options['handle_factory'] ?? new CurlFactory(50);
 
-        if (isset($options['select_timeout'])) {
-            $this->selectTimeout = $options['select_timeout'];
-        } elseif ($selectTimeout = Utils::getenv('GUZZLE_CURL_SELECT_TIMEOUT')) {
-            trigger_deprecation('guzzlehttp/guzzle', '7.2.0', 'Using environment variable GUZZLE_CURL_SELECT_TIMEOUT is deprecated. Use option "select_timeout" instead.');
-            $this->selectTimeout = (int) $selectTimeout;
-        } else {
-            $this->selectTimeout = 1;
-        }
+        $this->selectTimeout = $options['select_timeout'] ?? 1;
 
         $this->options = $options['options'] ?? [];
 
@@ -231,12 +224,8 @@ class CurlMultiHandler
      *
      * @return bool True on success, false on failure.
      */
-    private function cancel($id): bool
+    private function cancel(int $id): bool
     {
-        if (!is_int($id)) {
-            trigger_deprecation('guzzlehttp/guzzle', '7.4', 'Not passing an integer to %s::%s() is deprecated and will cause an error in 8.0.', __CLASS__, __FUNCTION__);
-        }
-
         // Cannot cancel if it has been processed.
         if (!isset($this->handles[$id])) {
             return false;

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -128,25 +128,6 @@ class CurlMultiHandlerTest extends TestCase
         self::assertGreaterThanOrEqual($expected, Utils::currentTime());
     }
 
-    public function testUsesTimeoutEnvironmentVariables()
-    {
-        unset($_SERVER['GUZZLE_CURL_SELECT_TIMEOUT']);
-        \putenv('GUZZLE_CURL_SELECT_TIMEOUT=');
-
-        try {
-            $a = new CurlMultiHandler();
-            // Default if no options are given and no environment variable is set
-            self::assertEquals(1, Helpers::readObjectAttribute($a, 'selectTimeout'));
-
-            \putenv('GUZZLE_CURL_SELECT_TIMEOUT=3');
-            $a = new CurlMultiHandler();
-            // Handler reads from the environment if no options are given
-            self::assertEquals(3, Helpers::readObjectAttribute($a, 'selectTimeout'));
-        } finally {
-            \putenv('GUZZLE_CURL_SELECT_TIMEOUT=');
-        }
-    }
-
     public function throwsWhenAccessingInvalidProperty()
     {
         $h = new CurlMultiHandler();


### PR DESCRIPTION
This removes the deprecated GUZZLE_CURL_SELECT_TIMEOUT environment variable from CurlMultiHandler and requires callers to use the select_timeout option instead. It also removes the obsolete deprecation guard around the private cancel method, updates the quickstart and upgrade notes, and refreshes the PHPStan baseline after the removed guard.