### PR TITLE
Remove HandlerStack deprecation shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added `string` return types to `__toString()` methods
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
+- Reject invalid `HandlerStack::remove()` arguments
 - Store response cookies without a `Domain` attribute as host-only cookies
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,9 @@ overriding affected methods must update method signatures accordingly.
 
 `HandlerStack::__toString()` and `SetCookie::__toString()` now return `string`.
 
+`HandlerStack::remove()` now throws `TypeError` when passed a value that is
+neither a callable nor a middleware name string.
+
 `SetCookie::setSecure()`, `SetCookie::setDiscard()`, and
 `SetCookie::setHttpOnly()` now require boolean parameters. Calls from files that
 declare strict types will throw `TypeError` for non-boolean values.

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,7 @@
         "ext-json": "*",
         "guzzlehttp/promises": "^3.0@dev",
         "guzzlehttp/psr7": "^3.0@dev",
-        "psr/http-client": "^1.0",
-        "symfony/deprecation-contracts": "^2.2 || ^3.0"
+        "psr/http-client": "^1.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -178,8 +178,9 @@ class HandlerStack
      */
     public function remove($remove): void
     {
-        if (!is_string($remove) && !is_callable($remove)) {
-            trigger_deprecation('guzzlehttp/guzzle', '7.4', 'Not passing a callable or string to %s::%s() is deprecated and will cause an error in 8.0.', __CLASS__, __FUNCTION__);
+        if (!\is_string($remove) && !\is_callable($remove)) {
+            // TODO: Move this to the parameter definition in 9.0.
+            throw new \TypeError(__METHOD__.'(): Argument #1 ($remove) must be of type callable|string');
         }
 
         $this->cached = null;


### PR DESCRIPTION
This replaces the HandlerStack::remove() deprecation shim with the 8.0 TypeError behavior for invalid arguments. It also removes the now-unused symfony/deprecation-contracts dependency and keeps the related upgrade and changelog notes together with the other 8.0 type changes.