### PR TITLE
Raise cURL floor and default to TLS 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
 - Reject invalid `HandlerStack::remove()` arguments
+- Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0
 - Store response cookies without a `Domain` attribute as host-only cookies
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
+- Default HTTPS requests sent by the built-in cURL and stream handlers to TLS 1.2 or newer
+- Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -33,6 +33,28 @@ Guzzle 8 requires PHP `^7.4 || ^8.0`. Guzzle 7 supported PHP
 Guzzle 8 also requires `guzzlehttp/promises` 3.x and `guzzlehttp/psr7` 3.x. If
 your application uses those packages directly, review their upgrade guides.
 
+#### cURL minimum version
+
+Guzzle 8 requires libcurl 7.34.0 or higher when using the built-in cURL
+handlers. If the default handler stack detects an older libcurl version, it will
+not select the cURL handler automatically. Manually configured cURL handlers also
+reject requests when the linked libcurl version is lower than 7.34.0.
+
+#### TLS minimum version
+
+The built-in cURL and stream handlers now default HTTPS requests to TLS 1.2 or
+newer. Applications that must connect to legacy TLS 1.0 or TLS 1.1 endpoints can
+explicitly lower the minimum version with the `crypto_method` request option:
+
+```php
+$client->request('GET', 'https://legacy.example.com', [
+    'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT,
+]);
+```
+
+Handler-specific overrides through the `curl` and `stream_context` request
+options remain available for applications that need finer transport control.
+
 #### Native type declarations
 
 Guzzle 8 adds native parameter and return types where PHP 7.4 allows. Code

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,7 +38,8 @@ your application uses those packages directly, review their upgrade guides.
 Guzzle 8 requires libcurl 7.34.0 or higher when using the built-in cURL
 handlers. If the default handler stack detects an older libcurl version, it will
 not select the cURL handler automatically. Manually configured cURL handlers also
-reject requests when the linked libcurl version is lower than 7.34.0.
+reject requests when the linked libcurl version is lower than 7.34.0 or the PHP
+cURL extension does not expose TLS 1.2 support.
 
 #### TLS minimum version
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,7 +4,7 @@
 
 1.  PHP 7.4
 2.  To use the PHP stream handler, `allow_url_fopen` must be enabled in your system's php.ini.
-3.  To use the cURL handler, you must have a recent version of cURL >= 7.19.4 compiled with OpenSSL and zlib.
+3.  To use the cURL handler, you must have cURL >= 7.34.0 compiled with OpenSSL and zlib.
 
 > [!NOTE]
 > Guzzle no longer requires cURL in order to send HTTP requests. Guzzle will use the PHP stream wrapper to send HTTP requests if cURL is not installed. Alternatively, you can provide your own HTTP handler used to send requests. Keep in mind that cURL is still required for sending concurrent requests.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -284,7 +284,7 @@ $client->request('GET', '/foo', ['crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2
 ```
 
 > [!NOTE]
-> This setting must be set to one of the `STREAM_CRYPTO_METHOD_TLS*_CLIENT` constants. It controls the minimum TLS protocol version. PHP 7.4 or higher is required in order to use TLS 1.3, and cURL 7.52.0 or higher is required to use TLS 1.3 with the cURL handler.
+> This setting must be set to one of the `STREAM_CRYPTO_METHOD_TLS*_CLIENT` constants. It controls the minimum TLS protocol version. cURL 7.52.0 or higher is required to use TLS 1.3 with the cURL handler.
 
 ## debug
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -274,7 +274,7 @@ Types
 int
 
 Default
-None
+TLS 1.2 or newer for HTTPS requests sent by the built-in cURL and stream handlers.
 
 Constant
 `GuzzleHttp\RequestOptions::CRYPTO_METHOD`
@@ -284,7 +284,7 @@ $client->request('GET', '/foo', ['crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2
 ```
 
 > [!NOTE]
-> This setting must be set to one of the `STREAM_CRYPTO_METHOD_TLS*_CLIENT` constants. PHP 7.4 or higher is required in order to use TLS 1.3, and cURL 7.34.0 or higher is required in order to specify a crypto method, with cURL 7.52.0 or higher being required to use TLS 1.3.
+> This setting must be set to one of the `STREAM_CRYPTO_METHOD_TLS*_CLIENT` constants. It controls the minimum TLS protocol version. PHP 7.4 or higher is required in order to use TLS 1.3, and cURL 7.52.0 or higher is required to use TLS 1.3 with the cURL handler.
 
 ## debug
 
@@ -311,7 +311,7 @@ Running the above example would output something like the following:
     *   Trying 107.21.213.98... * Connected to httpbin.org (107.21.213.98) port 80 (#0)
     > GET /get HTTP/1.1
     Host: httpbin.org
-    User-Agent: Guzzle/4.0 curl/7.21.4 PHP/5.5.7
+    User-Agent: GuzzleHttp/8
 
     < HTTP/1.1 200 OK
     < Access-Control-Allow-Origin: *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,18 +55,6 @@ parameters:
 			path: src/Cookie/SetCookie.php
 
 		-
-			message: '#^Cannot access offset ''features'' on array\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: src/Handler/CurlFactory.php
-
-		-
-			message: '#^Cannot access offset ''version'' on array\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
 			message: '#^Cannot call method getBody\(\) on Psr\\Http\\Message\\ResponseInterface\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -257,12 +245,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: src/RetryMiddleware.php
-
-		-
-			message: '#^Cannot access offset ''version'' on array\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Utils.php
 
 		-
 			message: '#^Cannot cast mixed to string\.$#'

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -702,7 +702,7 @@ class CurlFactory implements CurlFactoryInterface
                     || \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $cryptoMethod
                 ) {
                     $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
-                } elseif (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
+                } elseif (\STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
                     if (!self::supportsTls13()) {
                         throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
                     }
@@ -719,7 +719,7 @@ class CurlFactory implements CurlFactoryInterface
                     throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.2 not supported by your version of cURL');
                 }
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
-            } elseif (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
+            } elseif (\STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
                 if (!self::supportsTls13()) {
                     throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
                 }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -22,6 +22,9 @@ class CurlFactory implements CurlFactoryInterface
 {
     public const CURL_VERSION_STR = 'curl_version';
 
+    private const MIN_CURL_VERSION = '7.34.0';
+    private const CURL_VERSION_TLS_13 = '7.52.0';
+
     /**
      * @var resource[]|\CurlHandle[]
      */
@@ -42,6 +45,8 @@ class CurlFactory implements CurlFactoryInterface
 
     public function create(RequestInterface $request, array $options): EasyHandle
     {
+        self::ensureSupportedCurlVersion($request);
+
         $protocolVersion = $request->getProtocolVersion();
 
         if ('2' === $protocolVersion || '2.0' === $protocolVersion) {
@@ -162,11 +167,28 @@ class CurlFactory implements CurlFactoryInterface
 
         if (null === $supportsHttp2) {
             $supportsHttp2 = self::supportsTls12()
-                && defined('CURL_VERSION_HTTP2')
-                && (\CURL_VERSION_HTTP2 & \curl_version()['features']);
+                && (\CURL_VERSION_HTTP2 & self::getCurlVersionInfo()['features']);
         }
 
         return $supportsHttp2;
+    }
+
+    private static function ensureSupportedCurlVersion(RequestInterface $request): void
+    {
+        if (version_compare(self::getCurlVersion(), self::MIN_CURL_VERSION, '<')) {
+            throw new ConnectException(\sprintf(
+                'cURL %s or higher is required by the cURL handler; %s is installed.',
+                self::MIN_CURL_VERSION,
+                self::getCurlVersion()
+            ), $request);
+        }
+
+        if (!\defined('CURL_SSLVERSION_TLSv1_2')) {
+            throw new ConnectException(\sprintf(
+                'The PHP cURL extension must be built against cURL %s or higher to use the cURL handler.',
+                self::MIN_CURL_VERSION
+            ), $request);
+        }
     }
 
     private static function supportsTls12(): bool
@@ -174,7 +196,7 @@ class CurlFactory implements CurlFactoryInterface
         static $supportsTls12 = null;
 
         if (null === $supportsTls12) {
-            $supportsTls12 = \CURL_SSLVERSION_TLSv1_2 & \curl_version()['features'];
+            $supportsTls12 = version_compare(self::getCurlVersion(), self::MIN_CURL_VERSION, '>=');
         }
 
         return $supportsTls12;
@@ -186,7 +208,7 @@ class CurlFactory implements CurlFactoryInterface
 
         if (null === $supportsTls13) {
             $supportsTls13 = defined('CURL_SSLVERSION_TLSv1_3')
-                && (\CURL_SSLVERSION_TLSv1_3 & \curl_version()['features']);
+                && version_compare(self::getCurlVersion(), self::CURL_VERSION_TLS_13, '>=');
         }
 
         return $supportsTls13;
@@ -302,13 +324,30 @@ class CurlFactory implements CurlFactoryInterface
 
     private static function getCurlVersion(): string
     {
-        static $curlVersion = null;
+        return self::getCurlVersionInfo()['version'];
+    }
 
-        if (null === $curlVersion) {
-            $curlVersion = \curl_version()['version'];
+    /**
+     * @return array{version: string, features: int}
+     */
+    private static function getCurlVersionInfo(): array
+    {
+        static $curlVersionInfo = null;
+
+        if (null === $curlVersionInfo) {
+            $curlVersionInfo = \curl_version();
+
+            if (
+                !\is_array($curlVersionInfo)
+                || !isset($curlVersionInfo['version'], $curlVersionInfo['features'])
+                || !\is_string($curlVersionInfo['version'])
+                || !\is_int($curlVersionInfo['features'])
+            ) {
+                throw new \RuntimeException('Unable to determine cURL version.');
+            }
         }
 
-        return $curlVersion;
+        return $curlVersionInfo;
     }
 
     private static function createRejection(EasyHandle $easy, array $ctx): PromiseInterface
@@ -405,9 +444,7 @@ class CurlFactory implements CurlFactoryInterface
             \CURLOPT_CONNECTTIMEOUT => 300,
         ];
 
-        if (\defined('CURLOPT_PROTOCOLS')) {
-            $conf[\CURLOPT_PROTOCOLS] = \CURLPROTO_HTTP | \CURLPROTO_HTTPS;
-        }
+        $conf[\CURLOPT_PROTOCOLS] = \CURLPROTO_HTTP | \CURLPROTO_HTTPS;
 
         $version = $easy->request->getProtocolVersion();
 
@@ -648,18 +685,24 @@ class CurlFactory implements CurlFactoryInterface
             }
         }
 
-        if (isset($options['crypto_method'])) {
+        $cryptoMethod = $options['crypto_method'] ?? null;
+
+        if (null === $cryptoMethod && 'https' === $easy->request->getUri()->getScheme() && !isset($options['curl'][\CURLOPT_SSLVERSION])) {
+            $cryptoMethod = \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+        }
+
+        if (null !== $cryptoMethod) {
             $protocolVersion = $easy->request->getProtocolVersion();
 
             // If HTTP/2, upgrade TLS 1.0 and 1.1 to 1.2
             if ('2' === $protocolVersion || '2.0' === $protocolVersion) {
                 if (
-                    \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $options['crypto_method']
-                    || \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $options['crypto_method']
-                    || \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $options['crypto_method']
+                    \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $cryptoMethod
+                    || \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $cryptoMethod
+                    || \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $cryptoMethod
                 ) {
                     $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
-                } elseif (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $options['crypto_method']) {
+                } elseif (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
                     if (!self::supportsTls13()) {
                         throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
                     }
@@ -667,16 +710,16 @@ class CurlFactory implements CurlFactoryInterface
                 } else {
                     throw new \InvalidArgumentException('Invalid crypto_method request option: unknown version provided');
                 }
-            } elseif (\STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $options['crypto_method']) {
+            } elseif (\STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $cryptoMethod) {
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_0;
-            } elseif (\STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $options['crypto_method']) {
+            } elseif (\STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $cryptoMethod) {
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_1;
-            } elseif (\STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $options['crypto_method']) {
+            } elseif (\STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $cryptoMethod) {
                 if (!self::supportsTls12()) {
                     throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.2 not supported by your version of cURL');
                 }
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
-            } elseif (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $options['crypto_method']) {
+            } elseif (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
                 if (!self::supportsTls13()) {
                     throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
                 }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -22,9 +22,6 @@ class CurlFactory implements CurlFactoryInterface
 {
     public const CURL_VERSION_STR = 'curl_version';
 
-    private const MIN_CURL_VERSION = '7.34.0';
-    private const CURL_VERSION_TLS_13 = '7.52.0';
-
     /**
      * @var resource[]|\CurlHandle[]
      */
@@ -45,12 +42,12 @@ class CurlFactory implements CurlFactoryInterface
 
     public function create(RequestInterface $request, array $options): EasyHandle
     {
-        self::ensureSupportedCurlVersion($request);
+        CurlVersion::ensureSupported($request);
 
         $protocolVersion = $request->getProtocolVersion();
 
         if ('2' === $protocolVersion || '2.0' === $protocolVersion) {
-            if (!self::supportsHttp2()) {
+            if (!CurlVersion::supportsHttp2()) {
                 throw new ConnectException('HTTP/2 is supported by the cURL handler, however libcurl is built without HTTP/2 support.', $request);
             }
         } elseif ('1.0' !== $protocolVersion && '1.1' !== $protocolVersion) {
@@ -161,59 +158,6 @@ class CurlFactory implements CurlFactoryInterface
         return (string) $option;
     }
 
-    private static function supportsHttp2(): bool
-    {
-        static $supportsHttp2 = null;
-
-        if (null === $supportsHttp2) {
-            $supportsHttp2 = self::supportsTls12()
-                && (\CURL_VERSION_HTTP2 & self::getCurlVersionInfo()['features']);
-        }
-
-        return $supportsHttp2;
-    }
-
-    private static function ensureSupportedCurlVersion(RequestInterface $request): void
-    {
-        if (version_compare(self::getCurlVersion(), self::MIN_CURL_VERSION, '<')) {
-            throw new ConnectException(\sprintf(
-                'cURL %s or higher is required by the cURL handler; %s is installed.',
-                self::MIN_CURL_VERSION,
-                self::getCurlVersion()
-            ), $request);
-        }
-
-        if (!\defined('CURL_SSLVERSION_TLSv1_2')) {
-            throw new ConnectException(\sprintf(
-                'The PHP cURL extension must be built against cURL %s or higher to use the cURL handler.',
-                self::MIN_CURL_VERSION
-            ), $request);
-        }
-    }
-
-    private static function supportsTls12(): bool
-    {
-        static $supportsTls12 = null;
-
-        if (null === $supportsTls12) {
-            $supportsTls12 = version_compare(self::getCurlVersion(), self::MIN_CURL_VERSION, '>=');
-        }
-
-        return $supportsTls12;
-    }
-
-    private static function supportsTls13(): bool
-    {
-        static $supportsTls13 = null;
-
-        if (null === $supportsTls13) {
-            $supportsTls13 = defined('CURL_SSLVERSION_TLSv1_3')
-                && version_compare(self::getCurlVersion(), self::CURL_VERSION_TLS_13, '>=');
-        }
-
-        return $supportsTls13;
-    }
-
     public function release(EasyHandle $easy): void
     {
         $resource = $easy->handle;
@@ -317,37 +261,9 @@ class CurlFactory implements CurlFactoryInterface
             $ctx += \curl_getinfo($easy->handle);
         }
 
-        $ctx[self::CURL_VERSION_STR] = self::getCurlVersion();
+        CurlVersion::addToHandlerContext($ctx);
 
         return $ctx;
-    }
-
-    private static function getCurlVersion(): string
-    {
-        return self::getCurlVersionInfo()['version'];
-    }
-
-    /**
-     * @return array{version: string, features: int}
-     */
-    private static function getCurlVersionInfo(): array
-    {
-        static $curlVersionInfo = null;
-
-        if (null === $curlVersionInfo) {
-            $curlVersionInfo = \curl_version();
-
-            if (
-                !\is_array($curlVersionInfo)
-                || !isset($curlVersionInfo['version'], $curlVersionInfo['features'])
-                || !\is_string($curlVersionInfo['version'])
-                || !\is_int($curlVersionInfo['features'])
-            ) {
-                throw new \RuntimeException('Unable to determine cURL version.');
-            }
-        }
-
-        return $curlVersionInfo;
     }
 
     private static function createRejection(EasyHandle $easy, array $ctx): PromiseInterface
@@ -703,7 +619,7 @@ class CurlFactory implements CurlFactoryInterface
                 ) {
                     $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
                 } elseif (\STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
-                    if (!self::supportsTls13()) {
+                    if (!CurlVersion::supportsTls13()) {
                         throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
                     }
                     $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;
@@ -715,12 +631,9 @@ class CurlFactory implements CurlFactoryInterface
             } elseif (\STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $cryptoMethod) {
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_1;
             } elseif (\STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $cryptoMethod) {
-                if (!self::supportsTls12()) {
-                    throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.2 not supported by your version of cURL');
-                }
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
             } elseif (\STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
-                if (!self::supportsTls13()) {
+                if (!CurlVersion::supportsTls13()) {
                     throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
                 }
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -19,6 +19,10 @@ final class CurlVersion
      */
     private static $versionInfo = null;
 
+    private function __construct()
+    {
+    }
+
     public static function supportsTls12(): bool
     {
         $version = self::get();

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -17,7 +17,7 @@ final class CurlVersion
     /**
      * @var array{version: string, features: int}|false|null
      */
-    private static $versionInfo = null;
+    private static $versionInfo;
 
     private function __construct()
     {

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace GuzzleHttp\Handler;
+
+use GuzzleHttp\Exception\ConnectException;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @internal
+ */
+final class CurlVersion
+{
+    private const MIN_VERSION = '7.34.0';
+
+    private const TLS_13_VERSION = '7.52.0';
+
+    /**
+     * @var array{version: string, features: int}|false|null
+     */
+    private static $versionInfo = null;
+
+    public static function supportsTls12(): bool
+    {
+        $version = self::get();
+
+        return \defined('CURL_SSLVERSION_TLSv1_2')
+            && null !== $version
+            && version_compare($version, self::MIN_VERSION, '>=');
+    }
+
+    public static function supportsTls13(): bool
+    {
+        $version = self::get();
+
+        return \defined('CURL_SSLVERSION_TLSv1_3')
+            && null !== $version
+            && version_compare($version, self::TLS_13_VERSION, '>=');
+    }
+
+    public static function supportsHttp2(): bool
+    {
+        return self::supportsTls12()
+            && (\CURL_VERSION_HTTP2 & self::getInfo()['features']);
+    }
+
+    public static function ensureSupported(RequestInterface $request): void
+    {
+        if (self::supportsTls12()) {
+            return;
+        }
+
+        $version = self::get();
+
+        if (null === $version || version_compare($version, self::MIN_VERSION, '<')) {
+            throw new ConnectException(\sprintf(
+                'cURL %s or higher is required by the cURL handler; %s is installed.',
+                self::MIN_VERSION,
+                $version ?? 'an unknown version'
+            ), $request);
+        }
+
+        if (!\defined('CURL_SSLVERSION_TLSv1_2')) {
+            throw new ConnectException(\sprintf(
+                'The PHP cURL extension must be built against cURL %s or higher to use the cURL handler.',
+                self::MIN_VERSION
+            ), $request);
+        }
+    }
+
+    public static function addToHandlerContext(array &$context): void
+    {
+        $version = self::get();
+
+        if (null === $version) {
+            throw new \RuntimeException('Unable to determine cURL version.');
+        }
+
+        $context[CurlFactory::CURL_VERSION_STR] = $version;
+    }
+
+    private static function get(): ?string
+    {
+        $versionInfo = self::getVersionInfo();
+
+        return null === $versionInfo ? null : $versionInfo['version'];
+    }
+
+    /**
+     * @return array{version: string, features: int}
+     */
+    private static function getInfo(): array
+    {
+        $versionInfo = self::getVersionInfo();
+
+        if (null === $versionInfo) {
+            throw new \RuntimeException('Unable to determine cURL version.');
+        }
+
+        return $versionInfo;
+    }
+
+    /**
+     * @return array{version: string, features: int}|null
+     */
+    private static function getVersionInfo(): ?array
+    {
+        if (null === self::$versionInfo) {
+            if (!\function_exists('curl_version')) {
+                self::$versionInfo = false;
+            } else {
+                $versionInfo = \curl_version();
+                self::$versionInfo = \is_array($versionInfo)
+                    && isset($versionInfo['version'], $versionInfo['features'])
+                    && \is_string($versionInfo['version'])
+                    && \is_int($versionInfo['features'])
+                        ? [
+                            'version' => $versionInfo['version'],
+                            'features' => $versionInfo['features'],
+                        ]
+                        : false;
+            }
+        }
+
+        return false === self::$versionInfo ? null : self::$versionInfo;
+    }
+}

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -581,7 +581,7 @@ class StreamHandler
             return;
         }
 
-        if (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && $value === \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT) {
+        if ($value === \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT) {
             $options['ssl']['min_proto_version'] = \STREAM_CRYPTO_PROTO_TLSv1_3;
 
             return;

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -312,6 +312,7 @@ class StreamHandler
 
         $params = [];
         $context = $this->getDefaultContext($request);
+        $streamContextHasTlsSettings = self::hasStreamContextTlsSettings($options);
 
         if (isset($options['on_headers']) && !\is_callable($options['on_headers'])) {
             throw new \InvalidArgumentException('on_headers must be callable');
@@ -327,11 +328,19 @@ class StreamHandler
         }
 
         if (isset($options['stream_context'])) {
-            if (!\is_array($options['stream_context'])) {
+            $streamContext = $options['stream_context'];
+            if (!\is_array($streamContext)) {
                 throw new \InvalidArgumentException('stream_context must be an array');
             }
-            $context = \array_replace_recursive($context, $options['stream_context']);
+            $context = \array_replace_recursive($context, $streamContext);
+
+            $sslContext = $streamContext['ssl'] ?? null;
+            if ($streamContextHasTlsSettings && \is_array($sslContext) && !\array_key_exists('min_proto_version', $sslContext)) {
+                unset($context['ssl']['min_proto_version']);
+            }
         }
+
+        $this->addDefaultTlsMinimum($request, $context);
 
         // Microsoft NTLM authentication only supported with curl handler
         if (isset($options['auth'][2]) && 'ntlm' === $options['auth'][2]) {
@@ -397,6 +406,39 @@ class StreamHandler
         }
 
         return $uri;
+    }
+
+    private static function hasStreamContextTlsSettings(array $options): bool
+    {
+        if (!isset($options['stream_context']) || !\is_array($options['stream_context'])) {
+            return false;
+        }
+
+        $sslContext = $options['stream_context']['ssl'] ?? null;
+        if (!\is_array($sslContext)) {
+            return false;
+        }
+
+        return \array_key_exists('crypto_method', $sslContext)
+            || \array_key_exists('min_proto_version', $sslContext)
+            || \array_key_exists('max_proto_version', $sslContext);
+    }
+
+    private function addDefaultTlsMinimum(RequestInterface $request, array &$context): void
+    {
+        if ('https' !== $request->getUri()->getScheme() || !isset($context['ssl']) || !\is_array($context['ssl'])) {
+            return;
+        }
+
+        if (
+            \array_key_exists('crypto_method', $context['ssl'])
+            || \array_key_exists('min_proto_version', $context['ssl'])
+            || \array_key_exists('max_proto_version', $context['ssl'])
+        ) {
+            return;
+        }
+
+        $context['ssl']['min_proto_version'] = \STREAM_CRYPTO_PROTO_TLSv1_2;
     }
 
     private function getDefaultContext(RequestInterface $request): array
@@ -521,13 +563,26 @@ class StreamHandler
      */
     private function add_crypto_method(RequestInterface $request, array &$options, $value, array &$params): void
     {
-        if (
-            $value === \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT
-            || $value === \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
-            || $value === \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
-            || (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && $value === \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT)
-        ) {
-            $options['http']['crypto_method'] = $value;
+        if ($value === \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT) {
+            $options['ssl']['min_proto_version'] = \STREAM_CRYPTO_PROTO_TLSv1_0;
+
+            return;
+        }
+
+        if ($value === \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT) {
+            $options['ssl']['min_proto_version'] = \STREAM_CRYPTO_PROTO_TLSv1_1;
+
+            return;
+        }
+
+        if ($value === \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT) {
+            $options['ssl']['min_proto_version'] = \STREAM_CRYPTO_PROTO_TLSv1_2;
+
+            return;
+        }
+
+        if (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && $value === \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT) {
+            $options['ssl']['min_proto_version'] = \STREAM_CRYPTO_PROTO_TLSv1_3;
 
             return;
         }

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -78,9 +78,8 @@ final class RequestOptions
      * requests to TLS 1.2 or newer.
      *
      * This setting must be set to one of the
-     * ``STREAM_CRYPTO_METHOD_TLS*_CLIENT`` constants. PHP 7.4 or higher is
-     * required in order to use TLS 1.3, and cURL 7.52.0 or higher is required
-     * to use TLS 1.3 with the cURL handler.
+     * ``STREAM_CRYPTO_METHOD_TLS*_CLIENT`` constants. cURL 7.52.0 or higher
+     * is required to use TLS 1.3 with the cURL handler.
      */
     public const CRYPTO_METHOD = 'crypto_method';
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -74,13 +74,13 @@ final class RequestOptions
 
     /**
      * crypto_method: (int) A value describing the minimum TLS protocol
-     * version to use.
+     * version to use. The built-in cURL and stream handlers default HTTPS
+     * requests to TLS 1.2 or newer.
      *
      * This setting must be set to one of the
      * ``STREAM_CRYPTO_METHOD_TLS*_CLIENT`` constants. PHP 7.4 or higher is
-     * required in order to use TLS 1.3, and cURL 7.34.0 or higher is required
-     * in order to specify a crypto method, with cURL 7.52.0 or higher being
-     * required to use TLS 1.3.
+     * required in order to use TLS 1.3, and cURL 7.52.0 or higher is required
+     * to use TLS 1.3 with the cURL handler.
      */
     public const CRYPTO_METHOD = 'crypto_method';
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -98,7 +98,7 @@ final class Utils
             }
         }
 
-        if (null !== $curlVersion && version_compare($curlVersion, self::MIN_CURL_VERSION, '>=')) {
+        if (null !== $curlVersion && \defined('CURL_SSLVERSION_TLSv1_2') && version_compare($curlVersion, self::MIN_CURL_VERSION, '>=')) {
             if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
                 $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
             } elseif (\function_exists('curl_exec')) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -5,14 +5,13 @@ namespace GuzzleHttp;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Handler\StreamHandler;
 use Psr\Http\Message\UriInterface;
 
 final class Utils
 {
-    private const MIN_CURL_VERSION = '7.34.0';
-
     /**
      * Debug function used to describe the provided value type and class.
      *
@@ -88,17 +87,8 @@ final class Utils
     public static function chooseHandler(): callable
     {
         $handler = null;
-        $curlVersion = null;
 
-        if (\function_exists('curl_version')) {
-            $curlVersionInfo = \curl_version();
-
-            if (\is_array($curlVersionInfo) && isset($curlVersionInfo['version']) && \is_string($curlVersionInfo['version'])) {
-                $curlVersion = $curlVersionInfo['version'];
-            }
-        }
-
-        if (null !== $curlVersion && \defined('CURL_SSLVERSION_TLSv1_2') && version_compare($curlVersion, self::MIN_CURL_VERSION, '>=')) {
+        if (CurlVersion::supportsTls12()) {
             if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
                 $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
             } elseif (\function_exists('curl_exec')) {
@@ -113,7 +103,7 @@ final class Utils
                 ? Proxy::wrapStreaming($handler, new StreamHandler())
                 : new StreamHandler();
         } elseif (!$handler) {
-            throw new \RuntimeException(\sprintf('GuzzleHttp requires cURL %s or higher, the allow_url_fopen ini setting, or a custom HTTP handler.', self::MIN_CURL_VERSION));
+            throw new \RuntimeException('GuzzleHttp requires a supported cURL version, the allow_url_fopen ini setting, or a custom HTTP handler.');
         }
 
         return $handler;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -11,6 +11,8 @@ use Psr\Http\Message\UriInterface;
 
 final class Utils
 {
+    private const MIN_CURL_VERSION = '7.34.0';
+
     /**
      * Debug function used to describe the provided value type and class.
      *
@@ -86,8 +88,17 @@ final class Utils
     public static function chooseHandler(): callable
     {
         $handler = null;
+        $curlVersion = null;
 
-        if (\defined('CURLOPT_CUSTOMREQUEST') && \function_exists('curl_version') && version_compare(curl_version()['version'], '7.21.2') >= 0) {
+        if (\function_exists('curl_version')) {
+            $curlVersionInfo = \curl_version();
+
+            if (\is_array($curlVersionInfo) && isset($curlVersionInfo['version']) && \is_string($curlVersionInfo['version'])) {
+                $curlVersion = $curlVersionInfo['version'];
+            }
+        }
+
+        if (null !== $curlVersion && version_compare($curlVersion, self::MIN_CURL_VERSION, '>=')) {
             if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
                 $handler = Proxy::wrapSync(new CurlMultiHandler(), new CurlHandler());
             } elseif (\function_exists('curl_exec')) {
@@ -102,7 +113,7 @@ final class Utils
                 ? Proxy::wrapStreaming($handler, new StreamHandler())
                 : new StreamHandler();
         } elseif (!$handler) {
-            throw new \RuntimeException('GuzzleHttp requires cURL, the allow_url_fopen ini setting, or a custom HTTP handler.');
+            throw new \RuntimeException(\sprintf('GuzzleHttp requires cURL %s or higher, the allow_url_fopen ini setting, or a custom HTTP handler.', self::MIN_CURL_VERSION));
         }
 
         return $handler;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -350,9 +350,6 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
     }
 
-    /**
-     * @requires PHP >= 7.4
-     */
     public function testAddsCryptoMethodTls13()
     {
         $f = new CurlFactory(3);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -81,12 +81,10 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(0, $_SERVER['_curl'][\CURLOPT_HEADER]);
         self::assertSame(300, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT]);
         self::assertInstanceOf('Closure', $_SERVER['_curl'][\CURLOPT_HEADERFUNCTION]);
-        if (\defined('CURLOPT_PROTOCOLS')) {
-            self::assertSame(
-                \CURLPROTO_HTTP | \CURLPROTO_HTTPS,
-                $_SERVER['_curl'][\CURLOPT_PROTOCOLS]
-            );
-        }
+        self::assertSame(
+            \CURLPROTO_HTTP | \CURLPROTO_HTTPS,
+            $_SERVER['_curl'][\CURLOPT_PROTOCOLS]
+        );
         self::assertContains('Expect:', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
         self::assertContains('Accept:', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
         self::assertContains('Content-Type:', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
@@ -294,6 +292,32 @@ class CurlFactoryTest extends TestCase
         self::assertSame('Bar', $response->getHeaderLine('Foo'));
         self::assertSame('2', $response->getHeaderLine('Content-Length'));
         self::assertSame('hi', (string) $response->getBody());
+    }
+
+    public function testDefaultsHttpsToTls12Minimum()
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+
+        self::assertEquals(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+    }
+
+    public function testDoesNotSetDefaultTlsMinimumForHttp()
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'http://example.com'), []);
+
+        self::assertArrayNotHasKey(\CURLOPT_SSLVERSION, $_SERVER['_curl']);
+    }
+
+    public function testCurlSslVersionOptionOverridesDefaultTlsMinimum()
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'curl' => [\CURLOPT_SSLVERSION => \CURL_SSLVERSION_TLSv1_1],
+        ]);
+
+        self::assertEquals(\CURL_SSLVERSION_TLSv1_1, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
     }
 
     public function testValidatesCryptoMethodInvalidMethod()

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler;
 use GuzzleHttp\Handler\CurlFactory;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7;
@@ -352,6 +353,10 @@ class CurlFactoryTest extends TestCase
 
     public function testAddsCryptoMethodTls13()
     {
+        if (!CurlVersion::supportsTls13()) {
+            self::markTestSkipped('TLS 1.3 is not supported by this cURL installation.');
+        }
+
         $f = new CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), ['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]);
         self::assertEquals(\CURL_SSLVERSION_TLSv1_3, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -320,6 +320,20 @@ class StreamHandlerTest extends TestCase
         return $options;
     }
 
+    private function applyDefaultTlsMinimum(string $uri, array $context): array
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', $uri);
+        $method = new \ReflectionMethod(StreamHandler::class, 'addDefaultTlsMinimum');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $method->invokeArgs($handler, [$request, &$context]);
+
+        return $context;
+    }
+
     public function testAddsProxy()
     {
         $this->expectException(ConnectException::class);
@@ -459,25 +473,48 @@ class StreamHandlerTest extends TestCase
         $this->getSendResult(['crypto_method' => 123]);
     }
 
+    public function testDefaultsHttpsToTls12Minimum()
+    {
+        $context = $this->applyDefaultTlsMinimum('https://example.com', ['ssl' => []]);
+
+        self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_2, $context['ssl']['min_proto_version']);
+    }
+
+    public function testDoesNotDefaultTlsMinimumForHttp()
+    {
+        $context = $this->applyDefaultTlsMinimum('http://example.com', ['ssl' => []]);
+
+        self::assertArrayNotHasKey('min_proto_version', $context['ssl']);
+    }
+
+    public function testDoesNotDefaultTlsMinimumWhenTlsContextExists()
+    {
+        $context = $this->applyDefaultTlsMinimum('https://example.com', [
+            'ssl' => ['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT],
+        ]);
+
+        self::assertArrayNotHasKey('min_proto_version', $context['ssl']);
+    }
+
     public function testSetsCryptoMethodTls10()
     {
         $res = $this->getSendResult(['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT]);
         $opts = \stream_context_get_options($res->getBody()->detach());
-        self::assertSame(\STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT, $opts['http']['crypto_method']);
+        self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_0, $opts['ssl']['min_proto_version']);
     }
 
     public function testSetsCryptoMethodTls11()
     {
         $res = $this->getSendResult(['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT]);
         $opts = \stream_context_get_options($res->getBody()->detach());
-        self::assertSame(\STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT, $opts['http']['crypto_method']);
+        self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_1, $opts['ssl']['min_proto_version']);
     }
 
     public function testSetsCryptoMethodTls12()
     {
         $res = $this->getSendResult(['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT]);
         $opts = \stream_context_get_options($res->getBody()->detach());
-        self::assertSame(\STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT, $opts['http']['crypto_method']);
+        self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_2, $opts['ssl']['min_proto_version']);
     }
 
     /**
@@ -487,7 +524,34 @@ class StreamHandlerTest extends TestCase
     {
         $res = $this->getSendResult(['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]);
         $opts = \stream_context_get_options($res->getBody()->detach());
-        self::assertSame(\STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT, $opts['http']['crypto_method']);
+        self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_3, $opts['ssl']['min_proto_version']);
+    }
+
+    public function testStreamContextTlsMinimumOverridesCryptoMethod()
+    {
+        $res = $this->getSendResult([
+            'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+            'stream_context' => [
+                'ssl' => ['min_proto_version' => \STREAM_CRYPTO_PROTO_TLSv1_0],
+            ],
+        ]);
+        $opts = \stream_context_get_options($res->getBody()->detach());
+
+        self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_0, $opts['ssl']['min_proto_version']);
+    }
+
+    public function testStreamContextCryptoMethodOverridesCryptoMethod()
+    {
+        $res = $this->getSendResult([
+            'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+            'stream_context' => [
+                'ssl' => ['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT],
+            ],
+        ]);
+        $opts = \stream_context_get_options($res->getBody()->detach());
+
+        self::assertSame(\STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT, $opts['ssl']['crypto_method']);
+        self::assertArrayNotHasKey('min_proto_version', $opts['ssl']);
     }
 
     public function testCanSetPasswordWhenSettingCert()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -517,9 +517,6 @@ class StreamHandlerTest extends TestCase
         self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_2, $opts['ssl']['min_proto_version']);
     }
 
-    /**
-     * @requires PHP >=7.4
-     */
     public function testSetsCryptoMethodTls13()
     {
         $res = $this->getSendResult(['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]);


### PR DESCRIPTION
This raises the minimum supported libcurl version for Guzzle 8's built-in cURL handlers to 7.34.0. The default handler selection now skips cURL when the linked libcurl version is too old, and manually configured cURL handlers fail clearly with the same requirement.

HTTPS requests sent through the built-in cURL and stream handlers now default to TLS 1.2 or newer. Applications that still need to connect to legacy TLS 1.0 or TLS 1.1 endpoints can opt in with the existing crypto_method request option or lower-level handler-specific options.

The stream handler now applies crypto_method through the SSL context as a minimum protocol version, which makes its behavior match the option documentation and the cURL handler more closely. The upgrade guide and request option docs have been updated to describe the cURL and TLS changes separately.