### PR TITLE
Add HTTP/3 support to cURL handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ## 8.0.0 - Upcoming
 
+### Added
+
+- Add HTTP/3 request support to the built-in cURL handlers when PHP 8.4+ and libcurl provide HTTP/3 support
+
 ### Changed
 
 - Hardened `FileCookieJar` persistence against unsafe unserialization
@@ -15,7 +19,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
 - Reject invalid `HandlerStack::remove()` arguments
-- Add HTTP/3 request support to the built-in cURL handlers when libcurl provides HTTP/3 support
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0
 - Store response cookies without a `Domain` attribute as host-only cookies
 - Tighten invalid response handling and avoid exposing response-derived cURL stats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
 - Reject invalid `HandlerStack::remove()` arguments
+- Add HTTP/3 request support to the built-in cURL handlers when libcurl provides HTTP/3 support
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0
 - Store response cookies without a `Domain` attribute as host-only cookies
 - Tighten invalid response handling and avoid exposing response-derived cURL stats

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,9 +6,6 @@
 2.  To use the PHP stream handler, `allow_url_fopen` must be enabled in your system's php.ini.
 3.  To use the cURL handler, you must have cURL >= 7.34.0 compiled with OpenSSL and zlib.
 
-> [!NOTE]
-> Guzzle no longer requires cURL in order to send HTTP requests. Guzzle will use the PHP stream wrapper to send HTTP requests if cURL is not installed. Alternatively, you can provide your own HTTP handler used to send requests. Keep in mind that cURL is still required for sending concurrent requests.
-
 ## Installation
 
 The recommended way to install Guzzle is with [Composer](https://getcomposer.org). Composer is a dependency management tool for PHP that allows you to declare the dependencies your project needs and installs them into your project.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1028,7 +1028,7 @@ $request = $client->request('GET', '/get', ['version' => 1.0]);
 $request = $client->request('GET', 'https://example.com', ['version' => 3.0]);
 ```
 
-The built-in cURL handler supports HTTP versions `1.0`, `1.1`, `2.0`, and `3.0`, depending on the linked libcurl capabilities. HTTP/3 requires a PHP cURL extension built against libcurl 7.66.0 or higher, a runtime libcurl built with HTTP/3 and QUIC support, and TLS 1.3 support exposed by the PHP cURL extension.
+The built-in cURL handler supports HTTP versions `1.0`, `1.1`, `2.0`, and `3.0`, depending on the linked libcurl capabilities. HTTP/3 requires PHP 8.4 or higher, a PHP cURL extension built against libcurl 7.66.0 or higher, a runtime libcurl built with HTTP/3 and QUIC support, and TLS 1.3 support exposed by the PHP cURL extension.
 
 The built-in stream handler supports only HTTP versions `1.0` and `1.1`.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -406,7 +406,7 @@ Set to `true` to enable the "Expect: 100-Continue" header for all requests that 
 By default, Guzzle will add the "Expect: 100-Continue" header when the size of the body of a request is greater than 1 MB and a request is using HTTP/1.1.
 
 > [!NOTE]
-> This option only takes effect when using HTTP/1.1. The HTTP/1.0 and HTTP/2.0 protocols do not support the "Expect: 100-Continue" header. Support for handling the "Expect: 100-Continue" workflow must be implemented by Guzzle HTTP handlers used by a client.
+> This option only takes effect when using HTTP/1.1. The HTTP/1.0, HTTP/2, and HTTP/3 protocols do not support the "Expect: 100-Continue" header. Support for handling the "Expect: 100-Continue" workflow must be implemented by Guzzle HTTP handlers used by a client.
 
 ## force_ip_resolve
 
@@ -1009,7 +1009,7 @@ $client->request('GET', '/delay/5', ['timeout' => 3.14]);
 ## version
 
 Summary
-Protocol version to use with the request.
+Protocol version to attempt to use with the request.
 
 Types
 string, float
@@ -1023,4 +1023,16 @@ Constant
 ```php
 // Force HTTP/1.0
 $request = $client->request('GET', '/get', ['version' => 1.0]);
+
+// Attempt HTTP/3 with the cURL handler
+$request = $client->request('GET', 'https://example.com', ['version' => 3.0]);
 ```
+
+The built-in cURL handler supports HTTP versions `1.0`, `1.1`, `2.0`, and `3.0`, depending on the linked libcurl capabilities. HTTP/3 requires a PHP cURL extension built against libcurl 7.66.0 or higher, a runtime libcurl built with HTTP/3 and QUIC support, and TLS 1.3 support exposed by the PHP cURL extension.
+
+The built-in stream handler supports only HTTP versions `1.0` and `1.1`.
+
+HTTP/3 requests sent by the built-in cURL handler use TLS 1.3 or newer. Lower TLS versions requested through `crypto_method` or `curl` options are upgraded to TLS 1.3 for HTTP/3 requests.
+
+> [!NOTE]
+> For HTTP/3, Guzzle uses libcurl's `CURL_HTTP_VERSION_3`, which attempts HTTP/3 and allows libcurl to fall back to an earlier HTTP version if needed.

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -46,7 +46,11 @@ class CurlFactory implements CurlFactoryInterface
 
         $protocolVersion = $request->getProtocolVersion();
 
-        if ('2' === $protocolVersion || '2.0' === $protocolVersion) {
+        if ('3' === $protocolVersion || '3.0' === $protocolVersion) {
+            if (!CurlVersion::supportsHttp3()) {
+                throw new ConnectException('HTTP/3 is supported by the cURL handler, however the installed PHP cURL extension or libcurl does not support HTTP/3.', $request);
+            }
+        } elseif ('2' === $protocolVersion || '2.0' === $protocolVersion) {
             if (!CurlVersion::supportsHttp2()) {
                 throw new ConnectException('HTTP/2 is supported by the cURL handler, however libcurl is built without HTTP/2 support.', $request);
             }
@@ -71,6 +75,10 @@ class CurlFactory implements CurlFactoryInterface
         // Add handler options from the request configuration options
         if (isset($options['curl'])) {
             $conf = \array_replace($conf, $options['curl']);
+        }
+
+        if ('3' === $protocolVersion || '3.0' === $protocolVersion) {
+            $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;
         }
 
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
@@ -364,7 +372,12 @@ class CurlFactory implements CurlFactoryInterface
 
         $version = $easy->request->getProtocolVersion();
 
-        if ('2' === $version || '2.0' === $version) {
+        if ('3' === $version || '3.0' === $version) {
+            if (!\defined('CURL_HTTP_VERSION_3')) {
+                throw new \RuntimeException('HTTP/3 is not supported by this cURL installation.');
+            }
+            $conf[\CURLOPT_HTTP_VERSION] = (int) \constant('CURL_HTTP_VERSION_3');
+        } elseif ('2' === $version || '2.0' === $version) {
             $conf[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2_0;
         } elseif ('1.1' === $version) {
             $conf[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_1_1;
@@ -609,9 +622,23 @@ class CurlFactory implements CurlFactoryInterface
 
         if (null !== $cryptoMethod) {
             $protocolVersion = $easy->request->getProtocolVersion();
+            $isHttp3 = '3' === $protocolVersion || '3.0' === $protocolVersion;
+            $isHttp2 = '2' === $protocolVersion || '2.0' === $protocolVersion;
 
-            // If HTTP/2, upgrade TLS 1.0 and 1.1 to 1.2
-            if ('2' === $protocolVersion || '2.0' === $protocolVersion) {
+            if ($isHttp3) {
+                // HTTP/3 runs over QUIC and requires TLS 1.3.
+                if (
+                    \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $cryptoMethod
+                    || \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $cryptoMethod
+                    || \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $cryptoMethod
+                    || \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod
+                ) {
+                    $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;
+                } else {
+                    throw new \InvalidArgumentException('Invalid crypto_method request option: unknown version provided');
+                }
+            } elseif ($isHttp2) {
+                // If HTTP/2, upgrade TLS 1.0 and 1.1 to 1.2.
                 if (
                     \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $cryptoMethod
                     || \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $cryptoMethod

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -14,6 +14,8 @@ final class CurlVersion
 
     private const TLS_13_VERSION = '7.52.0';
 
+    private const HTTP_3_VERSION = '7.66.0';
+
     /**
      * @var array{version: string, features: int}|false|null
      */
@@ -45,6 +47,22 @@ final class CurlVersion
     {
         return self::supportsTls12()
             && (\CURL_VERSION_HTTP2 & self::getInfo()['features']);
+    }
+
+    public static function supportsHttp3(): bool
+    {
+        if (
+            !self::supportsTls13()
+            || !\defined('CURL_VERSION_HTTP3')
+            || !\defined('CURL_HTTP_VERSION_3')
+        ) {
+            return false;
+        }
+
+        $versionInfo = self::getInfo();
+
+        return version_compare($versionInfo['version'], self::HTTP_3_VERSION, '>=')
+            && 0 !== ((int) \constant('CURL_VERSION_HTTP3') & $versionInfo['features']);
     }
 
     public static function ensureSupported(RequestInterface $request): void

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -76,8 +76,8 @@ class PrepareBodyMiddleware
 
         $expect = $options['expect'] ?? null;
 
-        // Return if disabled or using HTTP/1.0
-        if ($expect === false || $request->getProtocolVersion() === '1.0') {
+        // Return if disabled or not using HTTP/1.1.
+        if ($expect === false || '1.1' !== $request->getProtocolVersion()) {
             return;
         }
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -266,7 +266,11 @@ final class RequestOptions
     public const READ_TIMEOUT = 'read_timeout';
 
     /**
-     * version: (float) Specifies the HTTP protocol version to attempt to use.
+     * version: (string|float) Specifies the HTTP protocol version to attempt
+     * to use.
+     *
+     * HTTP/3 is supported by the built-in cURL handler when the PHP cURL
+     * extension and linked libcurl support HTTP/3 and TLS 1.3.
      */
     public const VERSION = 'version';
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -269,8 +269,9 @@ final class RequestOptions
      * version: (string|float) Specifies the HTTP protocol version to attempt
      * to use.
      *
-     * HTTP/3 is supported by the built-in cURL handler when the PHP cURL
-     * extension and linked libcurl support HTTP/3 and TLS 1.3.
+     * HTTP/3 is supported by the built-in cURL handler on PHP 8.4 or higher
+     * when the PHP cURL extension and linked libcurl support HTTP/3 and
+     * TLS 1.3.
      */
     public const VERSION = 'version';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -633,6 +633,84 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
     }
 
+    public function testThrowsWhenHttp3IsUnsupported()
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => 0,
+        ]);
+
+        try {
+            $factory = new CurlFactory(3);
+
+            $this->expectException(ConnectException::class);
+            $this->expectExceptionMessage('HTTP/3 is supported by the cURL handler');
+
+            $factory->create(new Psr7\Request('GET', Server::$url, [], null, '3.0'), []);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    /**
+     * @dataProvider http3ProtocolVersionProvider
+     */
+    public function testMapsHttp3ProtocolVersionToCurlOption(string $protocolVersion)
+    {
+        if (!\defined('CURL_HTTP_VERSION_3')) {
+            self::markTestSkipped('HTTP/3 cURL constants are not available.');
+        }
+
+        $factory = new CurlFactory(3);
+        $easy = new EasyHandle();
+        $easy->request = new Psr7\Request('GET', 'https://example.com', [], null, $protocolVersion);
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'getDefaultConf');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $conf = $method->invoke($factory, $easy);
+
+        self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $conf[\CURLOPT_HTTP_VERSION]);
+    }
+
+    public function testHttp3UpgradesWeakCryptoMethodToTls13Minimum()
+    {
+        if (!CurlVersion::supportsHttp3()) {
+            self::markTestSkipped('HTTP/3 is not supported by this cURL installation.');
+        }
+
+        $factory = new CurlFactory(3);
+        $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+            'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT,
+        ]);
+
+        self::assertSame(\CURL_SSLVERSION_TLSv1_3, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+    }
+
+    public function testHttp3UpgradesCurlSslVersionOptionToTls13Minimum()
+    {
+        if (!CurlVersion::supportsHttp3()) {
+            self::markTestSkipped('HTTP/3 is not supported by this cURL installation.');
+        }
+
+        $factory = new CurlFactory(3);
+        $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+            'curl' => [\CURLOPT_SSLVERSION => \CURL_SSLVERSION_TLSv1_2],
+        ]);
+
+        self::assertSame(\CURL_SSLVERSION_TLSv1_3, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+    }
+
+    public static function http3ProtocolVersionProvider(): array
+    {
+        return [
+            ['3'],
+            ['3.0'],
+        ];
+    }
+
     public function testSavesToStream()
     {
         $stream = \fopen('php://memory', 'r+');
@@ -1195,5 +1273,24 @@ class CurlFactoryTest extends TestCase
         self::assertArrayNotHasKey('http_code', $context);
         self::assertArrayNotHasKey('header_size', $context);
         self::assertArrayNotHasKey('content_type', $context);
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
+
+        $previousVersionInfo = $property->getValue();
+
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
     }
 }

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Test\Handler;
+
+use GuzzleHttp\Handler\CurlVersion;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Handler\CurlVersion
+ */
+class CurlVersionTest extends TestCase
+{
+    /**
+     * @var array{version: string, features: int}|false|null
+     */
+    private $versionInfo;
+
+    protected function setUp(): void
+    {
+        $this->versionInfo = self::getVersionInfo();
+    }
+
+    protected function tearDown(): void
+    {
+        self::setVersionInfo($this->versionInfo);
+    }
+
+    public function testSupportsHttp3ReturnsFalseWhenVersionInfoIsUnavailable(): void
+    {
+        self::setVersionInfo(false);
+
+        self::assertFalse(CurlVersion::supportsHttp3());
+    }
+
+    public function testSupportsHttp3RequiresHttp3Feature(): void
+    {
+        self::requiresHttp3Constants();
+
+        self::setVersionInfo([
+            'version' => '7.66.0',
+            'features' => 0,
+        ]);
+
+        self::assertFalse(CurlVersion::supportsHttp3());
+    }
+
+    public function testSupportsHttp3RequiresHttp3RuntimeVersion(): void
+    {
+        self::requiresHttp3Constants();
+
+        self::setVersionInfo([
+            'version' => '7.65.0',
+            'features' => self::http3Feature(),
+        ]);
+
+        self::assertFalse(CurlVersion::supportsHttp3());
+    }
+
+    public function testSupportsHttp3WhenVersionAndFeatureAreAvailable(): void
+    {
+        self::requiresHttp3Constants();
+
+        self::setVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3Feature(),
+        ]);
+
+        self::assertTrue(CurlVersion::supportsHttp3());
+    }
+
+    private static function requiresHttp3Constants(): void
+    {
+        if (!\defined('CURL_VERSION_HTTP3') || !\defined('CURL_HTTP_VERSION_3')) {
+            self::markTestSkipped('HTTP/3 cURL constants are not available.');
+        }
+    }
+
+    private static function http3Feature(): int
+    {
+        return (int) \constant('CURL_VERSION_HTTP3');
+    }
+
+    /**
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function getVersionInfo()
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
+
+        return $property->getValue();
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     */
+    private static function setVersionInfo($versionInfo): void
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
+
+        $property->setValue(null, $versionInfo);
+    }
+}

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -66,6 +66,16 @@ class StreamHandlerTest extends TestCase
         )->wait();
     }
 
+    public function testRejectsHttp3()
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('HTTP/3.0 is not supported by the stream handler.');
+
+        $handler(new Request('GET', 'https://example.com', [], null, '3.0'), []);
+    }
+
     public function testStreamAttributeKeepsStreamOpen()
     {
         $this->queueRes();

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -158,6 +158,44 @@ class PrepareBodyMiddlewareTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
     }
 
+    public static function noExpectProtocolProvider()
+    {
+        return [
+            ['1.0'],
+            ['2'],
+            ['2.0'],
+            ['3'],
+            ['3.0'],
+        ];
+    }
+
+    /**
+     * @dataProvider noExpectProtocolProvider
+     */
+    public function testDoesNotAddExpectForProtocolsThatDoNotSupportIt(string $protocolVersion)
+    {
+        $bd = Psr7\Utils::streamFor(\fopen(__DIR__.'/../composer.json', 'r'));
+
+        $h = new MockHandler([
+            static function (RequestInterface $request) {
+                self::assertFalse($request->hasHeader('Expect'));
+
+                return new Response(200);
+            },
+        ]);
+
+        $m = Middleware::prepareBody();
+        $stack = new HandlerStack($h);
+        $stack->push($m);
+        $comp = $stack->resolve();
+        $p = $comp(new Request('PUT', 'http://www.google.com', [], $bd, $protocolVersion), [
+            'expect' => true,
+        ]);
+        self::assertInstanceOf(PromiseInterface::class, $p);
+        $response = $p->wait();
+        self::assertSame(200, $response->getStatusCode());
+    }
+
     public function testPreservesCustomRequestWhenAddingExpect()
     {
         $h = new MockHandler([


### PR DESCRIPTION
This adds HTTP/3 request support for the built-in cURL handlers when the runtime can actually support it. The capability check requires PHP 8.4 or higher, cURL HTTP/3 constants, runtime libcurl HTTP/3 support, and cURL TLS 1.3 support. HTTP/3 requests are mapped to libcurl's fallback-capable CURL_HTTP_VERSION_3 mode, while the stream handler continues to reject HTTP/3 explicitly.

HTTP/3 requests now force the cURL TLS version floor to TLS 1.3, including when weaker crypto_method or raw CURLOPT_SSLVERSION options are supplied. The prepare-body middleware also now only adds Expect: 100-Continue for HTTP/1.1, matching the existing request option documentation.

The docs and changelog describe HTTP/3 as cURL-handler-only and document the PHP 8.4, libcurl, QUIC, and TLS 1.3 requirements.