### PR TITLE
Validate auth option shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added `string` return types to `__toString()` methods
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
+- Validate malformed `auth` request option arrays
 - Reject invalid `HandlerStack::remove()` arguments
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0
 - Store response cookies without a `Domain` attribute as host-only cookies

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -118,6 +118,28 @@ $client->request('GET', '/', [
 ]);
 ```
 
+#### Auth option validation
+
+The `auth` request option now validates array values before applying them. Auth
+arrays must contain username and password strings at indexes `0` and `1`. If an
+auth type is provided at index `2`, it must be one of `basic`, `digest`, or
+`ntlm`.
+
+Invalid auth arrays that previously emitted warnings, coerced values, or did
+nothing now throw `GuzzleHttp\Exception\InvalidArgumentException`.
+
+```php
+// Valid:
+$client->request('GET', '/', [
+    'auth' => ['username', 'password', 'basic'],
+]);
+
+// Invalid in 8.0:
+$client->request('GET', '/', [
+    'auth' => ['username'],
+]);
+```
+
 6.0 to 7.0
 ----------
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,24 +25,6 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: '#^Parameter \#1 \$str of function strtolower expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Client.php
-
-		-
-			message: '#^Part \$value\[0\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 3
-			path: src/Client.php
-
-		-
-			message: '#^Part \$value\[1\] \(mixed\) of encapsed string cannot be cast to string\.$#'
-			identifier: encapsedStringPart.nonString
-			count: 3
-			path: src/Client.php
-
-		-
 			message: '#^Result of && is always false\.$#'
 			identifier: booleanAnd.alwaysFalse
 			count: 1

--- a/src/Client.php
+++ b/src/Client.php
@@ -375,25 +375,46 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             unset($options['body']);
         }
 
-        if (!empty($options['auth']) && \is_array($options['auth'])) {
+        if (isset($options['auth']) && \is_array($options['auth'])) {
             $value = $options['auth'];
-            $type = isset($value[2]) ? \strtolower($value[2]) : 'basic';
-            switch ($type) {
+
+            if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value)) {
+                throw new InvalidArgumentException('auth must contain username and password strings');
+            }
+
+            $username = $value[0];
+            $password = $value[1];
+
+            if (!\is_string($username) || !\is_string($password)) {
+                throw new InvalidArgumentException('auth must contain username and password strings');
+            }
+
+            $type = 'basic';
+            if (\array_key_exists(2, $value)) {
+                $type = $value[2];
+                if (!\is_string($type)) {
+                    throw new InvalidArgumentException('auth type must be a string');
+                }
+            }
+
+            switch (\strtolower($type)) {
                 case 'basic':
                     // Ensure that we don't have the header in different case and set the new value.
                     $modify['set_headers'] = Psr7\Utils::caselessRemove(['Authorization'], $modify['set_headers']);
                     $modify['set_headers']['Authorization'] = 'Basic '
-                        .\base64_encode("$value[0]:$value[1]");
+                        .\base64_encode($username.':'.$password);
                     break;
                 case 'digest':
                     // @todo: Do not rely on curl
                     $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_DIGEST;
-                    $options['curl'][\CURLOPT_USERPWD] = "$value[0]:$value[1]";
+                    $options['curl'][\CURLOPT_USERPWD] = $username.':'.$password;
                     break;
                 case 'ntlm':
                     $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_NTLM;
-                    $options['curl'][\CURLOPT_USERPWD] = "$value[0]:$value[1]";
+                    $options['curl'][\CURLOPT_USERPWD] = $username.':'.$password;
                     break;
+                default:
+                    throw new InvalidArgumentException(\sprintf('Unsupported auth type "%s"', $type));
             }
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -388,11 +388,29 @@ class ClientTest extends TestCase
         self::assertFalse($last->hasHeader('Authorization'));
     }
 
+    public function testAuthCanBeNull()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock, 'auth' => ['a', 'b']]);
+        $client->get('http://foo.com', ['auth' => null]);
+        $last = $mock->getLastRequest();
+        self::assertFalse($last->hasHeader('Authorization'));
+    }
+
     public function testAuthCanBeArrayForBasicAuth()
     {
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b']]);
+        $last = $mock->getLastRequest();
+        self::assertSame('Basic YTpi', $last->getHeaderLine('Authorization'));
+    }
+
+    public function testAuthCanBeArrayForExplicitBasicAuth()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->get('http://foo.com', ['auth' => ['a', 'b', 'basic']]);
         $last = $mock->getLastRequest();
         self::assertSame('Basic YTpi', $last->getHeaderLine('Authorization'));
     }
@@ -428,6 +446,34 @@ class ClientTest extends TestCase
         $client->get('http://foo.com', ['auth' => 'foo']);
         $last = $mock->getLastOptions();
         self::assertSame('foo', $last['auth']);
+    }
+
+    /**
+     * @dataProvider invalidAuthOptionProvider
+     *
+     * @param mixed[] $auth
+     */
+    public function testValidatesAuthOptionArray(array $auth)
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $client->get('http://foo.com', ['auth' => $auth]);
+    }
+
+    public static function invalidAuthOptionProvider(): array
+    {
+        return [
+            [[]],
+            [['user']],
+            [[['user'], 'pass']],
+            [['user', ['pass']]],
+            [['user', 'pass', null]],
+            [['user', 'pass', 1]],
+            [['user', 'pass', []]],
+            [['user', 'pass', 'unknown']],
+        ];
     }
 
     public function testCanAddFormParams()


### PR DESCRIPTION
This validates malformed `auth` arrays before Guzzle applies them. Valid basic, digest, and NTLM auth arrays keep working, while missing credentials or invalid auth types now fail with a clear exception instead of producing warnings, coercions, or no-op behavior.