### PR TITLE
Cast Content-Length to string in PrepareBodyMiddleware

### DIFF
--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -52,7 +52,7 @@ class PrepareBodyMiddleware
         ) {
             $size = $request->getBody()->getSize();
             if ($size !== null) {
-                $modify['set_headers']['Content-Length'] = $size;
+                $modify['set_headers']['Content-Length'] = (string) $size;
             } else {
                 $modify['set_headers']['Transfer-Encoding'] = 'chunked';
             }

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 
 class PrepareBodyMiddlewareTest extends TestCase
@@ -48,6 +49,45 @@ class PrepareBodyMiddlewareTest extends TestCase
         $stack->push($m);
         $comp = $stack->resolve();
         $p = $comp(new Request($method, 'http://www.google.com', [], $body), []);
+        self::assertInstanceOf(PromiseInterface::class, $p);
+        $response = $p->wait();
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testSetsContentLengthAsStringForStrictPsr7Implementations()
+    {
+        // PSR-7 MessageInterface::withHeader() requires string|string[] values.
+        // Strict implementations (e.g. TYPO3\CMS\Core\Http\Message) reject ints.
+        // See https://github.com/php-fig/http-message/blob/master/src/MessageInterface.php
+        $strictRequest = new class('PUT', 'http://www.example.com', [], 'Test') extends Request {
+            public function withHeader($header, $value): MessageInterface
+            {
+                if (\is_string($value)) {
+                    $value = [$value];
+                }
+                if (!\is_array($value) || $value !== \array_filter($value, 'is_string')) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'Invalid header value for header "%s". The value must be a string or an array of strings.',
+                        $header
+                    ));
+                }
+
+                return parent::withHeader($header, $value);
+            }
+        };
+
+        $h = new MockHandler([
+            static function (RequestInterface $request) {
+                self::assertSame('4', $request->getHeaderLine('Content-Length'));
+
+                return new Response(200);
+            },
+        ]);
+        $m = Middleware::prepareBody();
+        $stack = new HandlerStack($h);
+        $stack->push($m);
+        $comp = $stack->resolve();
+        $p = $comp($strictRequest, []);
         self::assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
         self::assertSame(200, $response->getStatusCode());


### PR DESCRIPTION
Fixes #3383.

`PrepareBodyMiddleware` was setting `Content-Length` as an `int` value taken
directly from `Stream::getSize()`. PSR-7 [`MessageInterface::withHeader()`](https://github.com/php-fig/http-message/blob/641e9f812d34d66373fa45ce7a1edf7e123d969a/src/MessageInterface.php#L131-L145)
requires `string|string[]`, so strict PSR-7 implementations throw
`InvalidArgumentException` as soon as the request gets there.

This was previously masked by `guzzlehttp/psr7` < 2.10.0, where
`Utils::modifyRequest()` rebuilt a fresh Guzzle `Request` whose lenient
`Psr7\Message` accepted the int. Since psr7 2.10.0 ([guzzle/psr7#655](https://github.com/guzzle/psr7/pull/655))
the original `RequestInterface` is mutated via `withHeader()` directly, so the
type violation reaches strict implementations untouched.

## Change
- `src/PrepareBodyMiddleware.php`: cast `$size` to string before assigning to
  `Content-Length`.
- `tests/PrepareBodyMiddlewareTest.php`: regression test using an anonymous
  class extending `Request` with a spec-compliant `withHeader()` (mirrors
  `TYPO3\CMS\Core\Http\Message`'s strictness).

## Verified
- Without the cast, the new test errors with the exact `InvalidArgumentException`
  reported downstream (see #3383).
- With the cast, all `PrepareBodyMiddleware` tests pass (14 / 14).

## Downstream affected
- TYPO3-Solr/ext-solr#4660 (TYPO3 14 + Solarium 6.4.1)