### PR TITLE
Normalize retry delay callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added `string` return types to `__toString()` methods
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
+- Support retry delay callbacks with retry count only or full retry context
 - Validate malformed `auth` request option arrays
 - Reject invalid `HandlerStack::remove()` arguments
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -85,6 +85,27 @@ continues to use the same exponential backoff calculation by default. If you
 called the static method directly, inline that calculation or pass a custom
 delay callable to `Middleware::retry()`.
 
+#### Retry delay callback arguments
+
+Retry delay callbacks may now explicitly use either the documented one-argument
+form or the existing three-argument form.
+
+```php
+// Retry count only:
+$delay = static function (int $retries): int {
+    return $retries * 1000;
+};
+
+// Full retry context:
+$delay = static function (int $retries, ?ResponseInterface $response, RequestInterface $request): int {
+    return $retries * 1000;
+};
+```
+
+Callbacks that accept three arguments continue to receive the response and
+request. One-argument callbacks are now called with only the retry count, which
+also allows internal PHP functions with a single-argument signature.
+
 #### RedirectMiddleware default settings
 
 `RedirectMiddleware::$defaultSettings` has been removed. Use

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -217,18 +217,6 @@ parameters:
 			path: src/Middleware.php
 
 		-
-			message: '#^PHPDoc tag @var has invalid value \(callable\(int\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 24 on line 2$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/RetryMiddleware.php
-
-		-
-			message: '#^Property GuzzleHttp\\RetryMiddleware\:\:\$delay has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/RetryMiddleware.php
-
-		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
 			count: 1

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -127,8 +127,8 @@ final class Middleware
      * before listener accepts a request and options array, and the after
      * listener accepts a request, options array, and response promise.
      *
-     * @param callable $before Function to invoke before forwarding the request.
-     * @param callable $after  Function invoked after forwarding.
+     * @param (callable(RequestInterface, array): mixed)|null                   $before Function to invoke before forwarding the request.
+     * @param (callable(RequestInterface, array, PromiseInterface): mixed)|null $after  Function invoked after forwarding.
      *
      * @return callable Returns a function that accepts the next handler.
      */
@@ -239,8 +239,8 @@ final class Middleware
      * Middleware that applies a map function to the request before passing to
      * the next handler.
      *
-     * @param callable $fn Function that accepts a RequestInterface and returns
-     *                     a RequestInterface.
+     * @param callable(RequestInterface): RequestInterface $fn Function that accepts a RequestInterface and returns
+     *                                                         a RequestInterface.
      */
     public static function mapRequest(callable $fn): callable
     {
@@ -255,8 +255,8 @@ final class Middleware
      * Middleware that applies a map function to the resolved promise's
      * response.
      *
-     * @param callable $fn Function that accepts a ResponseInterface and
-     *                     returns a ResponseInterface.
+     * @param callable(ResponseInterface): ResponseInterface $fn Function that accepts a ResponseInterface and
+     *                                                           returns a ResponseInterface.
      */
     public static function mapResponse(callable $fn): callable
     {

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -168,9 +168,9 @@ final class Middleware
      * If no delay function is provided, a simple implementation of exponential
      * backoff will be utilized.
      *
-     * @param callable                                                                                 $decider Function that accepts the number of retries,
-     *                                                                                                          a request, [response], and [exception] and
-     *                                                                                                          returns true if the request is to be retried.
+     * @param callable(int, RequestInterface, ResponseInterface|null, mixed): bool                     $decider Function that accepts the number of retries,
+     *                                                                                                          a request, [response], and [rejection reason]
+     *                                                                                                          and returns true if the request is to be retried.
      * @param (callable(int): int)|(callable(int, ResponseInterface|null, RequestInterface): int)|null $delay   Function that accepts the number of retries
      *                                                                                                          or retry context and returns the number of
      *                                                                                                          milliseconds to delay.

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -168,11 +168,12 @@ final class Middleware
      * If no delay function is provided, a simple implementation of exponential
      * backoff will be utilized.
      *
-     * @param callable $decider Function that accepts the number of retries,
-     *                          a request, [response], and [exception] and
-     *                          returns true if the request is to be retried.
-     * @param callable $delay   Function that accepts the number of retries and
-     *                          returns the number of milliseconds to delay.
+     * @param callable                                                                                 $decider Function that accepts the number of retries,
+     *                                                                                                          a request, [response], and [exception] and
+     *                                                                                                          returns true if the request is to be retried.
+     * @param (callable(int): int)|(callable(int, ResponseInterface|null, RequestInterface): int)|null $delay   Function that accepts the number of retries
+     *                                                                                                          or retry context and returns the number of
+     *                                                                                                          milliseconds to delay.
      *
      * @return callable Returns a function that accepts the next handler.
      */

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -21,7 +21,7 @@ class RetryMiddleware
     private $nextHandler;
 
     /**
-     * @var callable
+     * @var callable(int, RequestInterface, ResponseInterface|null, mixed): bool
      */
     private $decider;
 
@@ -31,10 +31,9 @@ class RetryMiddleware
     private $delay;
 
     /**
-     * @param callable                                                                                 $decider     Function that accepts the number of retries,
-     *                                                                                                              a request, [response], and [exception] and
-     *                                                                                                              returns true if the request is to be
-     *                                                                                                              retried.
+     * @param callable(int, RequestInterface, ResponseInterface|null, mixed): bool                     $decider     Function that accepts the number of retries,
+     *                                                                                                              a request, [response], and [rejection reason]
+     *                                                                                                              and returns true if the request is to be retried.
      * @param callable(RequestInterface, array): PromiseInterface                                      $nextHandler Next handler to invoke.
      * @param (callable(int): int)|(callable(int, ResponseInterface|null, RequestInterface): int)|null $delay       Function that returns the number of milliseconds to delay.
      */

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -26,19 +26,17 @@ class RetryMiddleware
     private $decider;
 
     /**
-     * @var callable(int)
+     * @var callable
      */
     private $delay;
 
     /**
-     * @param callable                                            $decider     Function that accepts the number of retries,
-     *                                                                         a request, [response], and [exception] and
-     *                                                                         returns true if the request is to be
-     *                                                                         retried.
-     * @param callable(RequestInterface, array): PromiseInterface $nextHandler Next handler to invoke.
-     * @param (callable(int): int)|null                           $delay       Function that accepts the number of retries
-     *                                                                         and returns the number of
-     *                                                                         milliseconds to delay.
+     * @param callable                                                                                 $decider     Function that accepts the number of retries,
+     *                                                                                                              a request, [response], and [exception] and
+     *                                                                                                              returns true if the request is to be
+     *                                                                                                              retried.
+     * @param callable(RequestInterface, array): PromiseInterface                                      $nextHandler Next handler to invoke.
+     * @param (callable(int): int)|(callable(int, ResponseInterface|null, RequestInterface): int)|null $delay       Function that returns the number of milliseconds to delay.
      */
     public function __construct(callable $decider, callable $nextHandler, ?callable $delay = null)
     {
@@ -104,8 +102,27 @@ class RetryMiddleware
 
     private function doRetry(RequestInterface $request, array $options, ?ResponseInterface $response = null): PromiseInterface
     {
-        $options['delay'] = ($this->delay)(++$options['retries'], $response, $request);
+        ++$options['retries'];
+        $options['delay'] = $this->getDelay($options['retries'], $response, $request);
 
         return $this($request, $options);
+    }
+
+    private function getDelay(int $retries, ?ResponseInterface $response, RequestInterface $request): int
+    {
+        $delay = $this->delay;
+
+        if (self::acceptsRetryContext($delay)) {
+            return $delay($retries, $response, $request);
+        }
+
+        return $delay($retries);
+    }
+
+    private static function acceptsRetryContext(callable $callback): bool
+    {
+        $reflection = new \ReflectionFunction(\Closure::fromCallable($callback));
+
+        return $reflection->isVariadic() || $reflection->getNumberOfParameters() >= 3;
     }
 }

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -26,7 +26,7 @@ class RetryMiddleware
     private $decider;
 
     /**
-     * @var callable
+     * @var (callable(int): int)|(callable(int, ResponseInterface|null, RequestInterface): int)
      */
     private $delay;
 

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -42,6 +42,63 @@ class RetryMiddlewareTest extends TestCase
         self::assertSame(202, $p->wait()->getStatusCode());
     }
 
+    public function testRetriesWithOneArgumentDelayCallable()
+    {
+        $delayCalls = [];
+        $decider = static function (int $retries): bool {
+            return $retries < 1;
+        };
+        $delay = static function (int $retries) use (&$delayCalls): int {
+            $delayCalls[] = $retries;
+
+            return 1;
+        };
+
+        $m = Middleware::retry($decider, $delay);
+        $h = new MockHandler([new Response(200), new Response(201)]);
+        $c = new Client(['handler' => $m($h)]);
+
+        self::assertSame(201, $c->send(new Request('GET', 'http://test.com'))->getStatusCode());
+        self::assertSame([1], $delayCalls);
+    }
+
+    public function testRetriesWithInternalOneArgumentDelayCallable()
+    {
+        $decider = static function (int $retries): bool {
+            return $retries < 1;
+        };
+
+        $m = Middleware::retry($decider, 'abs');
+        $h = new MockHandler([new Response(200), new Response(201)]);
+        $c = new Client(['handler' => $m($h)]);
+
+        self::assertSame(201, $c->send(new Request('GET', 'http://test.com'))->getStatusCode());
+    }
+
+    public function testRetriesWithVariadicDelayCallableReceivesContext()
+    {
+        $delayArgs = [];
+        $decider = static function (int $retries): bool {
+            return $retries < 1;
+        };
+        $delay = static function (...$args) use (&$delayArgs): int {
+            $delayArgs = $args;
+
+            return 1;
+        };
+
+        $m = Middleware::retry($decider, $delay);
+        $h = new MockHandler([new Response(200), new Response(201)]);
+        $c = new Client(['handler' => $m($h)]);
+
+        $c->send(new Request('GET', 'http://test.com'));
+
+        self::assertCount(3, $delayArgs);
+        self::assertSame(1, $delayArgs[0]);
+        self::assertInstanceOf(Response::class, $delayArgs[1]);
+        self::assertInstanceOf(Request::class, $delayArgs[2]);
+    }
+
     public function testDoesNotRetryWhenDeciderReturnsFalse()
     {
         $decider = static function () {


### PR DESCRIPTION
This normalizes retry delay callback invocation so callbacks can use either the documented retry-count-only form or the existing full-context form. Internal one-argument callables such as `abs` now work without receiving extra arguments, while three-argument and variadic callbacks continue to receive the response and request context.