### PR TITLE
Use null semantics when clearing cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
 - Support retry delay callbacks with retry count only or full retry context
+- Treat only `null` as an omitted path or name when clearing cookies
 - Validate malformed `auth` request option arrays
 - Reject invalid `HandlerStack::remove()` arguments
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -161,6 +161,20 @@ $client->request('GET', '/', [
 ]);
 ```
 
+#### CookieJar::clear null semantics
+
+`CookieJar::clear()` now treats only `null` as an omitted path or name.
+Previously, falsy path or name values such as `'0'` or `''` could be interpreted
+as omitted and clear a broader set of cookies than intended.
+
+If you call `clear()` to clear all cookies, continue passing no arguments:
+
+```php
+$jar->clear();
+```
+
+If you pass a path or name, that value is now treated as provided.
+
 6.0 to 7.0
 ----------
 

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -109,14 +109,14 @@ class CookieJar implements CookieJarInterface
             $this->cookies = [];
 
             return;
-        } elseif (!$path) {
+        } elseif ($path === null) {
             $this->cookies = \array_filter(
                 $this->cookies,
                 static function (SetCookie $cookie) use ($domain): bool {
                     return $cookie->getDomain() === null || !$cookie->matchesDomain($domain);
                 }
             );
-        } elseif (!$name) {
+        } elseif ($name === null) {
             $this->cookies = \array_filter(
                 $this->cookies,
                 static function (SetCookie $cookie) use ($path, $domain): bool {
@@ -128,9 +128,9 @@ class CookieJar implements CookieJarInterface
         } else {
             $this->cookies = \array_filter(
                 $this->cookies,
-                static function (SetCookie $cookie) use ($path, $domain, $name) {
+                static function (SetCookie $cookie) use ($path, $domain, $name): bool {
                     return !($cookie->getDomain() !== null
-                        && $cookie->getName() == $name
+                        && $cookie->getName() === $name
                         && $cookie->matchesPath($path)
                         && $cookie->matchesDomain($domain));
                 }

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -126,8 +126,72 @@ class CookieJarTest extends TestCase
         self::assertCount(1, $this->jar);
 
         // Remove cookie by name
-        $this->jar->clear(null, null, 'test');
+        $this->jar->clear('baz.com', '/foo', 'test');
         self::assertCount(0, $this->jar);
+    }
+
+    public function testDeletesCookieNamedZero(): void
+    {
+        $jar = new CookieJar();
+        $jar->setCookie(new SetCookie([
+            'Name' => '0',
+            'Value' => 'zero',
+            'Domain' => 'bar.com',
+            'Path' => '/boo',
+        ]));
+        $jar->setCookie(new SetCookie([
+            'Name' => 'other',
+            'Value' => '123',
+            'Domain' => 'bar.com',
+            'Path' => '/boo',
+        ]));
+
+        $jar->clear('bar.com', '/boo', '0');
+
+        $names = \array_map(static function (SetCookie $cookie) {
+            return $cookie->getName();
+        }, $jar->getIterator()->getArrayCopy());
+
+        self::assertSame(['other'], $names);
+    }
+
+    public static function falsyCookiePathProvider(): array
+    {
+        return [['0'], ['']];
+    }
+
+    /**
+     * @dataProvider falsyCookiePathProvider
+     */
+    public function testClearsFalsyPathAsProvided(string $path): void
+    {
+        $jar = new CookieJar();
+        $jar->setCookie(new SetCookie([
+            'Name' => 'target',
+            'Value' => '123',
+            'Domain' => 'bar.com',
+            'Path' => $path,
+        ]));
+        $jar->setCookie(new SetCookie([
+            'Name' => 'other-path',
+            'Value' => '123',
+            'Domain' => 'bar.com',
+            'Path' => '/boo',
+        ]));
+        $jar->setCookie(new SetCookie([
+            'Name' => 'other-domain',
+            'Value' => '123',
+            'Domain' => 'baz.com',
+            'Path' => $path,
+        ]));
+
+        $jar->clear('bar.com', $path);
+
+        $names = \array_map(static function (SetCookie $cookie) {
+            return $cookie->getName();
+        }, $jar->getIterator()->getArrayCopy());
+
+        self::assertSame(['other-path', 'other-domain'], $names);
     }
 
     public static function domainClearProvider(): array


### PR DESCRIPTION
This makes `CookieJar::clear()` treat only `null` as an omitted path or name. Falsy values like `'0'` and `''` now narrow the clear operation instead of clearing a broader set of cookies, and exact name removal now uses strict comparison.