### PR TITLE
Use valid PSR-7 test fixtures

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -22,7 +22,7 @@ class ClientTest extends TestCase
     public function testUsesDefaultHandler()
     {
         $client = new Client();
-        Server::enqueue([new Response(200, ['Content-Length' => 0])]);
+        Server::enqueue([new Response(200, ['Content-Length' => '0'])]);
         $response = $client->get(Server::$url);
         self::assertSame(200, $response->getStatusCode());
     }
@@ -40,7 +40,7 @@ class ClientTest extends TestCase
     {
         $client = new Client();
         Server::flush();
-        Server::enqueue([new Response(200, ['Content-Length' => 2], 'hi')]);
+        Server::enqueue([new Response(200, ['Content-Length' => '2'], 'hi')]);
         $p = $client->getAsync(Server::$url, ['query' => ['test' => 'foo']]);
         self::assertInstanceOf(PromiseInterface::class, $p);
         self::assertSame(200, $p->wait()->getStatusCode());

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -38,7 +38,7 @@ class CurlFactoryTest extends TestCase
             new Psr7\Response(200, [
                 'Foo' => 'Bar',
                 'Baz' => 'bam',
-                'Content-Length' => 2,
+                'Content-Length' => '2',
             ], 'hi'),
         ]);
         $stream = Psr7\Utils::streamFor();
@@ -246,7 +246,7 @@ class CurlFactoryTest extends TestCase
             new Psr7\Response(200, [
                 'Foo' => 'Bar',
                 'Baz' => 'bam',
-                'Content-Length' => 2,
+                'Content-Length' => '2',
             ], 'hi'),
         ]);
 
@@ -471,7 +471,7 @@ class CurlFactoryTest extends TestCase
     private function addDecodeResponse($withEncoding = true)
     {
         $content = \gzencode('test');
-        $headers = ['Content-Length' => \strlen($content)];
+        $headers = ['Content-Length' => (string) \strlen($content)];
         if ($withEncoding) {
             $headers['Content-Encoding'] = 'gzip';
         }
@@ -625,7 +625,7 @@ class CurlFactoryTest extends TestCase
     {
         $this->addDecodeResponse();
         $handler = new Handler\CurlMultiHandler();
-        $request = new Psr7\Request('PUT', Server::$url, ['Content-Length' => 3], 'foo');
+        $request = new Psr7\Request('PUT', Server::$url, ['Content-Length' => '3'], 'foo');
         $response = $handler($request, []);
         $response->wait();
         $sent = Server::received()[0];
@@ -719,7 +719,7 @@ class CurlFactoryTest extends TestCase
     {
         Server::flush();
         Server::enqueue([
-            new Psr7\Response(200, ['Test' => 'Hello', 'Content-Length' => 4], 'test'),
+            new Psr7\Response(200, ['Test' => 'Hello', 'Content-Length' => '4'], 'test'),
         ]);
         $request = new Psr7\Request('PUT', Server::$url, [
             'Expect' => '100-Continue',
@@ -997,7 +997,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame(1024 * 1024, $body->tell());
 
         $req = new Psr7\Request('POST', 'https://www.example.com', [
-            'Content-Length' => 1024 * 1024 * 2,
+            'Content-Length' => (string) (1024 * 1024 * 2),
         ], $body);
         $factory = new CurlFactory(1);
         $factory->create($req, []);
@@ -1013,7 +1013,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame(1024 * 1024, $body->tell());
 
         $req = new Psr7\Request('POST', 'https://www.example.com', [
-            'Content-Length' => 1024 * 1024,
+            'Content-Length' => (string) (1024 * 1024),
         ], $body);
         $factory = new CurlFactory(1);
         $factory->create($req, []);
@@ -1040,7 +1040,7 @@ class CurlFactoryTest extends TestCase
         Server::flush();
         Server::enqueue([
             new Psr7\Response(200, [
-                'Content-Length' => $expectedLength,
+                'Content-Length' => (string) $expectedLength,
             ], \str_repeat('x', $expectedLength)),
         ]);
 

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -90,7 +90,7 @@ class CurlHandlerTest extends TestCase
         $request = new Request(
             'PUT',
             Server::$url,
-            ['Content-Length' => 1000000],
+            ['Content-Length' => '1000000'],
             $stream
         );
         $handler($request, [])->wait();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -27,7 +27,7 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([
             new Response(200, [
                 'Foo' => 'Bar',
-                'Content-Length' => 8,
+                'Content-Length' => '8',
             ], 'hi there'),
         ]);
     }
@@ -170,7 +170,7 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([
             new Response(200, [
                 'Foo' => 'Bar',
-                'Content-Length' => 8,
+                'Content-Length' => '8',
             ], 'hi there... This has way too much data!'),
         ]);
         $handler = new StreamHandler();
@@ -189,7 +189,7 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([
             new Response(200, [
                 'Foo' => 'Bar',
-                'Content-Length' => 8,
+                'Content-Length' => '8',
             ], ''),
         ]);
         $handler = new StreamHandler();
@@ -208,7 +208,7 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([
             new Response(200, [
                 'Content-Encoding' => 'gzip',
-                'Content-Length' => \strlen($content),
+                'Content-Length' => (string) \strlen($content),
             ], $content),
         ]);
         $handler = new StreamHandler();
@@ -226,7 +226,7 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([
             new Response(200, [
                 'Content-Encoding' => 'gzip',
-                'Content-Length' => \strlen($content),
+                'Content-Length' => (string) \strlen($content),
             ], $content),
         ]);
         $handler = new StreamHandler();
@@ -244,7 +244,7 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([
             new Response(200, [
                 'Content-Encoding' => 'gzip',
-                'Content-Length' => \strlen($content),
+                'Content-Length' => (string) \strlen($content),
             ], $content),
         ]);
         $handler = new StreamHandler();
@@ -268,7 +268,7 @@ class StreamHandlerTest extends TestCase
         Server::enqueue([
             new Response(200, [
                 'Content-Encoding' => 'gzip',
-                'Content-Length' => \strlen($content),
+                'Content-Length' => (string) \strlen($content),
             ], $content),
         ]);
         $handler = new StreamHandler();
@@ -587,7 +587,7 @@ class StreamHandlerTest extends TestCase
     {
         $this->queueRes();
         $handler = new StreamHandler();
-        $request = new Request('PUT', Server::$url, ['Content-Length' => 3], 'foo');
+        $request = new Request('PUT', Server::$url, ['Content-Length' => '3'], 'foo');
         $handler($request, []);
         $req = Server::received()[0];
         self::assertEquals('', $req->getHeaderLine('Content-Type'));

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -118,7 +118,7 @@ class PoolTest extends TestCase
             new Request('GET', 'http://foo.com/404'),
         ];
         $fn = static function (RequestInterface $request) {
-            return new Response(\substr($request->getUri()->getPath(), 1));
+            return new Response((int) \substr($request->getUri()->getPath(), 1));
         };
         $mock = new MockHandler([$fn, $fn, $fn, $fn]);
         $handler = HandlerStack::create($mock);
@@ -140,7 +140,7 @@ class PoolTest extends TestCase
         ];
         $mock = new MockHandler([
             static function (RequestInterface $request) {
-                return new Response(\substr($request->getUri()->getPath(), 1));
+                return new Response((int) \substr($request->getUri()->getPath(), 1));
             },
         ]);
         $client = new Client(['handler' => $mock]);


### PR DESCRIPTION
This updates test fixtures to pass valid PSR-7 constructor arguments. The assertions and tested behavior stay the same, but the tests no longer rely on psr7 coercing header values or response status codes.