### PR TITLE
Validate SetCookie constructor fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added `string` return types to `__toString()` methods
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Pass the request as the second argument to `on_headers` callbacks
+- Reject invalid `SetCookie` constructor field types instead of coercing them
 - Support retry delay callbacks with retry count only or full retry context
 - Treat only `null` as an omitted path or name when clearing cookies
 - Validate malformed `auth` request option arrays

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -179,7 +179,8 @@ If you pass a path or name, that value is now treated as provided.
 
 `SetCookie` constructor arrays no longer coerce invalid field values. Cookie
 names, values, domains, paths, max-age values, expiry values, and boolean flags
-must use the documented types. Invalid constructor values now throw `TypeError`.
+must use the documented types. Invalid constructor values now throw
+`InvalidArgumentException`.
 
 ```php
 // Valid:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -175,6 +175,31 @@ $jar->clear();
 
 If you pass a path or name, that value is now treated as provided.
 
+#### SetCookie constructor field validation
+
+`SetCookie` constructor arrays no longer coerce invalid field values. Cookie
+names, values, domains, paths, max-age values, expiry values, and boolean flags
+must use the documented types. Invalid constructor values now throw `TypeError`.
+
+```php
+// Valid:
+new SetCookie([
+    'Name' => 'foo',
+    'Value' => 'bar',
+    'Domain' => 'example.com',
+    'Secure' => true,
+]);
+
+// Invalid in 8.0:
+new SetCookie([
+    'Name' => false,
+    'Value' => 'bar',
+]);
+```
+
+Cookies parsed from normal `Set-Cookie` headers continue to be normalized by
+`SetCookie::fromString()`.
+
 6.0 to 7.0
 ----------
 

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -52,7 +52,7 @@ class CookieJar implements CookieJarInterface
         $cookieJar = new self();
         foreach ($cookies as $name => $value) {
             if (!\is_scalar($value) && !(\is_object($value) && \method_exists($value, '__toString'))) {
-                throw new \TypeError('Cookie value must be scalar or stringable');
+                throw new \InvalidArgumentException('Cookie value must be scalar or stringable');
             }
 
             $cookieJar->setCookie(new SetCookie([

--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Cookie;
 
 use Psr\Http\Message\RequestInterface;
@@ -49,10 +51,14 @@ class CookieJar implements CookieJarInterface
     {
         $cookieJar = new self();
         foreach ($cookies as $name => $value) {
+            if (!\is_scalar($value) && !(\is_object($value) && \method_exists($value, '__toString'))) {
+                throw new \TypeError('Cookie value must be scalar or stringable');
+            }
+
             $cookieJar->setCookie(new SetCookie([
                 'Domain' => $domain,
-                'Name' => $name,
-                'Value' => $value,
+                'Name' => (string) $name,
+                'Value' => (string) $value,
                 'Discard' => true,
             ]));
         }

--- a/src/Cookie/CookieJarInterface.php
+++ b/src/Cookie/CookieJarInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Cookie;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -119,7 +119,7 @@ class FileCookieJar extends CookieJar
 
                 try {
                     $this->setCookie(new SetCookie($cookie));
-                } catch (\TypeError $e) {
+                } catch (\InvalidArgumentException $e) {
                     throw new \RuntimeException("Invalid cookie file: {$filename}", 0, $e);
                 }
             }

--- a/src/Cookie/FileCookieJar.php
+++ b/src/Cookie/FileCookieJar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Cookie;
 
 use GuzzleHttp\Utils;
@@ -111,7 +113,15 @@ class FileCookieJar extends CookieJar
         $data = Utils::jsonDecode($json, true);
         if (\is_array($data)) {
             foreach ($data as $cookie) {
-                $this->setCookie(new SetCookie($cookie));
+                if (!\is_array($cookie)) {
+                    throw new \RuntimeException("Invalid cookie file: {$filename}");
+                }
+
+                try {
+                    $this->setCookie(new SetCookie($cookie));
+                } catch (\TypeError $e) {
+                    throw new \RuntimeException("Invalid cookie file: {$filename}", 0, $e);
+                }
             }
         } elseif (\is_scalar($data) && !empty($data)) {
             throw new \RuntimeException("Invalid cookie file: {$filename}");

--- a/src/Cookie/SessionCookieJar.php
+++ b/src/Cookie/SessionCookieJar.php
@@ -87,7 +87,7 @@ class SessionCookieJar extends CookieJar
 
                 try {
                     $this->setCookie(new SetCookie($cookie));
-                } catch (\TypeError $e) {
+                } catch (\InvalidArgumentException $e) {
                     throw new \RuntimeException('Invalid cookie data', 0, $e);
                 }
             }

--- a/src/Cookie/SessionCookieJar.php
+++ b/src/Cookie/SessionCookieJar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Cookie;
 
 /**
@@ -83,7 +85,11 @@ class SessionCookieJar extends CookieJar
                     throw new \RuntimeException('Invalid cookie data');
                 }
 
-                $this->setCookie(new SetCookie($cookie));
+                try {
+                    $this->setCookie(new SetCookie($cookie));
+                } catch (\TypeError $e) {
+                    throw new \RuntimeException('Invalid cookie data', 0, $e);
+                }
             }
         } elseif (\is_scalar($data) && \strlen((string) $data)) {
             throw new \RuntimeException('Invalid cookie data');

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -95,6 +95,7 @@ class SetCookie
     public function __construct(array $data = [])
     {
         $this->data = self::DEFAULTS;
+        self::validateFieldTypes($data);
 
         if (\array_key_exists('HostOnly', $data)) {
             $this->setHostOnly($data['HostOnly']);
@@ -511,5 +512,35 @@ class SetCookie
         }
 
         return $domain;
+    }
+
+    /**
+     * @param mixed[] $data
+     */
+    private static function validateFieldTypes(array $data): void
+    {
+        foreach (['Name', 'Value', 'Domain', 'Path'] as $field) {
+            if (isset($data[$field]) && !\is_string($data[$field])) {
+                throw new \InvalidArgumentException(\sprintf('Cookie field "%s" must be a string', $field));
+            }
+        }
+
+        if (isset($data['Max-Age']) && !\is_int($data['Max-Age'])) {
+            throw new \InvalidArgumentException('Cookie field "Max-Age" must be an integer');
+        }
+
+        if (isset($data['Expires']) && !\is_int($data['Expires']) && !\is_string($data['Expires'])) {
+            throw new \InvalidArgumentException('Cookie field "Expires" must be an integer or string');
+        }
+
+        foreach (['Secure', 'Discard', 'HttpOnly'] as $field) {
+            if (isset($data[$field]) && !\is_bool($data[$field])) {
+                throw new \InvalidArgumentException(\sprintf('Cookie field "%s" must be a boolean', $field));
+            }
+        }
+
+        if (\array_key_exists('HostOnly', $data) && !\is_bool($data['HostOnly'])) {
+            throw new \InvalidArgumentException('Cookie field "HostOnly" must be a boolean');
+        }
     }
 }

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Cookie;
 
 /**
@@ -95,7 +97,7 @@ class SetCookie
         $this->data = self::DEFAULTS;
 
         if (\array_key_exists('HostOnly', $data)) {
-            $this->setHostOnly((bool) $data['HostOnly']);
+            $this->setHostOnly($data['HostOnly']);
             unset($data['HostOnly']);
         }
 

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -64,7 +64,7 @@ class CookieJarTest extends TestCase
 
     public function testRejectsNonScalarCookieValuesFromArray(): void
     {
-        $this->expectException(\TypeError::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         CookieJar::fromArray(['foo' => []], 'example.com');
     }

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -46,6 +46,29 @@ class CookieJarTest extends TestCase
         self::assertCount(2, $jar);
     }
 
+    public function testCreatesFromArrayWithScalarNamesAndValues(): void
+    {
+        $jar = CookieJar::fromArray([
+            1 => 0,
+            'enabled' => true,
+        ], 'example.com');
+
+        $numeric = $jar->getCookieByName('1');
+        $enabled = $jar->getCookieByName('enabled');
+
+        self::assertInstanceOf(SetCookie::class, $numeric);
+        self::assertSame('0', $numeric->getValue());
+        self::assertInstanceOf(SetCookie::class, $enabled);
+        self::assertSame('1', $enabled->getValue());
+    }
+
+    public function testRejectsNonScalarCookieValuesFromArray(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        CookieJar::fromArray(['foo' => []], 'example.com');
+    }
+
     public function testEmptyJarIsCountable()
     {
         self::assertCount(0, new CookieJar());
@@ -267,16 +290,6 @@ class CookieJarTest extends TestCase
             ],
             [
                 [
-                    'Name' => false,
-                ],
-            ],
-            [
-                [
-                    'Name' => true,
-                ],
-            ],
-            [
-                [
                     'Name' => 'foo',
                     'Domain' => 'foo.com',
                 ],
@@ -299,14 +312,14 @@ class CookieJarTest extends TestCase
                 [
                     'Name' => '',
                     'Domain' => 'foo.com',
-                    'Value' => 0,
+                    'Value' => '0',
                 ],
             ],
             [
                 [
                     'Name' => null,
                     'Domain' => 'foo.com',
-                    'Value' => 0,
+                    'Value' => '0',
                 ],
             ],
         ];
@@ -327,21 +340,21 @@ class CookieJarTest extends TestCase
                 [
                     'Name' => '0',
                     'Domain' => 'foo.com',
-                    'Value' => 0,
+                    'Value' => '0',
                 ],
             ],
             [
                 [
                     'Name' => 'foo',
                     'Domain' => 'foo.com',
-                    'Value' => 0,
+                    'Value' => '0',
                 ],
             ],
             [
                 [
                     'Name' => 'foo',
                     'Domain' => 'foo.com',
-                    'Value' => 0.0,
+                    'Value' => '0.0',
                 ],
             ],
             [
@@ -395,7 +408,7 @@ class CookieJarTest extends TestCase
             'Value' => 'bar',
             'Domain' => '.example.com',
             'Path' => '/',
-            'Max-Age' => '86400',
+            'Max-Age' => 86400,
             'Secure' => true,
             'Discard' => true,
             'Expires' => $t,
@@ -432,7 +445,7 @@ class CookieJarTest extends TestCase
             'Value' => 'bar',
             'Domain' => '.example.com',
             'Path' => '/',
-            'Max-Age' => '86400',
+            'Max-Age' => 86400,
             'Secure' => true,
             'Discard' => true,
             'Expires' => $t,
@@ -585,7 +598,7 @@ class CookieJarTest extends TestCase
                 'Value' => 'bar',
                 'Domain' => 'example.com',
                 'Path' => '/',
-                'Max-Age' => '86400',
+                'Max-Age' => 86400,
                 'Secure' => true,
             ]),
             new SetCookie([
@@ -593,7 +606,7 @@ class CookieJarTest extends TestCase
                 'Value' => 'foobar',
                 'Domain' => 'example.com',
                 'Path' => '/',
-                'Max-Age' => '86400',
+                'Max-Age' => 86400,
                 'Secure' => true,
             ]),
             new SetCookie([

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -237,6 +237,8 @@ class FileCookieJarTest extends TestCase
         return [
             [true],
             ['invalid-data'],
+            [[1]],
+            [[['Name' => false, 'Value' => 'bar']]],
         ];
     }
 }

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -175,6 +175,7 @@ class SessionCookieJarTest extends TestCase
             [[]],
             [new \stdClass()],
             ['[1]'],
+            ['[{"Name":false,"Value":"bar"}]'],
         ];
     }
 }

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -90,6 +90,55 @@ class SetCookieTest extends TestCase
         self::assertFalse($cookie->getHttpOnly());
     }
 
+    /**
+     * @dataProvider invalidCookieFieldProvider
+     *
+     * @param mixed[] $data
+     */
+    public function testRejectsInvalidCookieFieldTypes(array $data): void
+    {
+        $this->expectException(\TypeError::class);
+
+        new SetCookie($data);
+    }
+
+    public static function invalidCookieFieldProvider(): array
+    {
+        return [
+            [['Name' => false]],
+            [['Value' => false]],
+            [['Domain' => false]],
+            [['Path' => false]],
+            [['Max-Age' => '10']],
+            [['Expires' => false]],
+            [['Secure' => 'true']],
+            [['Discard' => 'true']],
+            [['HttpOnly' => 'true']],
+            [['HostOnly' => 'true']],
+        ];
+    }
+
+    public function testAllowsZeroNameAndValue(): void
+    {
+        $cookie = new SetCookie([
+            'Name' => '0',
+            'Value' => '0',
+            'Domain' => 'example.com',
+        ]);
+
+        self::assertSame('0', $cookie->getName());
+        self::assertSame('0', $cookie->getValue());
+    }
+
+    public function testFromStringStillNormalizesFlagsAndMaxAge(): void
+    {
+        $cookie = SetCookie::fromString('foo=bar; Max-Age=10; Secure; HttpOnly');
+
+        self::assertSame(10, $cookie->getMaxAge());
+        self::assertTrue($cookie->getSecure());
+        self::assertTrue($cookie->getHttpOnly());
+    }
+
     public function testDeterminesIfExpired()
     {
         $c = new SetCookie();

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -97,7 +97,7 @@ class SetCookieTest extends TestCase
      */
     public function testRejectsInvalidCookieFieldTypes(array $data): void
     {
-        $this->expectException(\TypeError::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         new SetCookie($data);
     }


### PR DESCRIPTION
This makes `SetCookie` constructor data use strict field types instead of relying on scalar coercion. Normal `Set-Cookie` header parsing still normalizes header strings, while malformed constructor and persisted cookie arrays now fail clearly. `CookieJar::fromArray()` continues to normalize simple scalar map values.