### PR TITLE
Undeprecate Client::getConfig

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -199,8 +199,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * @param string|null $option The config option to retrieve.
      *
      * @return mixed
-     *
-     * @deprecated Client::getConfig will be removed in guzzlehttp/guzzle:8.0.
      */
     public function getConfig(?string $option = null)
     {


### PR DESCRIPTION
This removes the deprecated annotation from the concrete Client::getConfig method while leaving ClientInterface::getConfig deprecated for removal in 8.0.