### PR TITLE
Use string Content-Length in testing docs

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -33,7 +33,7 @@ a response or exception by shifting return values off of a queue.
     // Create a mock and queue two responses.
     $mock = new MockHandler([
         new Response(200, ['X-Foo' => 'Bar'], 'Hello, World'),
-        new Response(202, ['Content-Length' => 0]),
+        new Response(202, ['Content-Length' => '0']),
         new RequestException('Error Communicating with Server', new Request('GET', 'test'))
     ]);
 
@@ -177,7 +177,7 @@ can queue an HTTP response or an array of responses by calling
 
     // Start the server and queue a response
     Server::enqueue([
-        new Response(200, ['Content-Length' => 0])
+        new Response(200, ['Content-Length' => '0'])
     ]);
 
     $client = new Client(['base_uri' => Server::$url]);


### PR DESCRIPTION
This updates the testing docs to show Content-Length as a string header value. That keeps the examples aligned with the stricter PSR-7 header value expectations without changing runtime behavior.