### PR TITLE
Cover header processor errors

### DIFF
--- a/tests/Handler/HeaderProcessorTest.php
+++ b/tests/Handler/HeaderProcessorTest.php
@@ -17,12 +17,32 @@ class HeaderProcessorTest extends TestCase
             'Ignored: header',
             'HTTP/1.1 200 OK',
             'X-Foo: bar',
+            'X-Foo: baz',
+            'X-Bar: qux',
         ]);
 
         self::assertSame('1.1', $version);
         self::assertSame(200, $status);
         self::assertSame('OK', $reason);
-        self::assertSame(['X-Foo' => ['bar']], $headers);
+        self::assertSame(['X-Foo' => ['bar', 'baz'], 'X-Bar' => ['qux']], $headers);
+    }
+
+    public function testRejectsEmptyHeaderData(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected a non-empty array of header data');
+
+        HeaderProcessor::parseHeaders([]);
+    }
+
+    public function testRejectsMissingStatusCode(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HTTP status code missing from header data');
+
+        HeaderProcessor::parseHeaders([
+            'HTTP/1.1',
+        ]);
     }
 
     public function testRejectsMalformedStatusCode(): void


### PR DESCRIPTION
This adds a little more coverage around HeaderProcessor's normal parsing and failure paths. It keeps the recent invalid-header-line handling covered without expanding into handler integration tests.