### PR TITLE
Validate timeout options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
 - Default HTTPS requests sent by the built-in cURL and stream handlers to TLS 1.2 or newer
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
+- Validate built-in handler timeout options before applying them
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,6 +41,13 @@ not select the cURL handler automatically. Manually configured cURL handlers als
 reject requests when the linked libcurl version is lower than 7.34.0 or the PHP
 cURL extension does not expose TLS 1.2 support.
 
+#### Timeout option validation
+
+The built-in cURL and stream handlers now validate timeout option values before
+applying them. `timeout`, `connect_timeout`, and `read_timeout` must be `0` or at
+least `0.001` seconds when provided. Positive values below 1 millisecond now
+throw `InvalidArgumentException` instead of being converted to no timeout.
+
 #### TLS minimum version
 
 The built-in cURL and stream handlers now default HTTPS requests to TLS 1.2 or

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -246,7 +246,7 @@ $client->request('GET', '/get', ['cookies' => $jar]);
 ## connect_timeout
 
 Summary
-Float describing the number of seconds to wait while trying to connect to a server. Use `0` to wait 300 seconds (the default behavior).
+Float describing the number of seconds to wait while trying to connect to a server. Use `0` to wait 300 seconds (the default behavior). Positive values below `0.001` seconds are rejected by the built-in cURL handler.
 
 Types
 float
@@ -828,7 +828,7 @@ $client->request('GET', '/get?abc=123', ['query' => ['foo' => 'bar']]);
 ## read_timeout
 
 Summary
-Float describing the timeout to use when reading a streamed body
+Float describing the timeout to use when reading a streamed body. Positive values below `0.001` seconds are rejected by the built-in stream handler.
 
 Types
 float
@@ -989,7 +989,7 @@ If you do not need a specific certificate bundle, then Mozilla provides a common
 ## timeout
 
 Summary
-Float describing the total timeout of the request in seconds. Use `0` to wait indefinitely (the default behavior).
+Float describing the total timeout of the request in seconds. Use `0` to wait indefinitely (the default behavior). Positive values below `0.001` seconds are rejected by the built-in handlers.
 
 Types
 float

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -563,8 +563,9 @@ class CurlFactory implements CurlFactoryInterface
 
         $timeoutRequiresNoSignal = false;
         if (isset($options['timeout'])) {
-            $timeoutRequiresNoSignal |= $options['timeout'] < 1;
-            $conf[\CURLOPT_TIMEOUT_MS] = $options['timeout'] * 1000;
+            $timeout = Utils::timeoutToMilliseconds($options['timeout'], 'timeout');
+            $timeoutRequiresNoSignal |= $timeout < 1000;
+            $conf[\CURLOPT_TIMEOUT_MS] = $timeout;
         }
 
         // CURL default value is CURL_IPRESOLVE_WHATEVER
@@ -577,8 +578,9 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (isset($options['connect_timeout'])) {
-            $timeoutRequiresNoSignal |= $options['connect_timeout'] < 1;
-            $conf[\CURLOPT_CONNECTTIMEOUT_MS] = $options['connect_timeout'] * 1000;
+            $connectTimeout = Utils::timeoutToMilliseconds($options['connect_timeout'], 'connect_timeout');
+            $timeoutRequiresNoSignal |= $connectTimeout < 1000;
+            $conf[\CURLOPT_CONNECTTIMEOUT_MS] = $connectTimeout;
         }
 
         if ($timeoutRequiresNoSignal && \strtoupper(\substr(\PHP_OS, 0, 3)) !== 'WIN') {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -318,6 +318,10 @@ class StreamHandler
             throw new \InvalidArgumentException('on_headers must be callable');
         }
 
+        $readTimeout = isset($options['read_timeout'])
+            ? Utils::timeoutToMilliseconds($options['read_timeout'], 'read_timeout')
+            : null;
+
         if (!empty($options)) {
             foreach ($options as $key => $value) {
                 $method = "add_{$key}";
@@ -356,7 +360,7 @@ class StreamHandler
         );
 
         return $this->createResource(
-            function () use ($uri, $contextResource, $context, $options, $request) {
+            function () use ($uri, $contextResource, $context, $request, $readTimeout) {
                 $resource = @\fopen((string) $uri, 'r', false, $contextResource);
 
                 // See https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable
@@ -370,10 +374,9 @@ class StreamHandler
                     throw new ConnectException(sprintf('Connection refused for URI %s', $uri), $request, null, $context);
                 }
 
-                if (isset($options['read_timeout'])) {
-                    $readTimeout = $options['read_timeout'];
-                    $sec = (int) $readTimeout;
-                    $usec = ($readTimeout - $sec) * 100000;
+                if ($readTimeout !== null) {
+                    $sec = \intdiv($readTimeout, 1000);
+                    $usec = ($readTimeout % 1000) * 1000;
                     \stream_set_timeout($resource, $sec, $usec);
                 }
 
@@ -553,8 +556,10 @@ class StreamHandler
      */
     private function add_timeout(RequestInterface $request, array &$options, $value, array &$params): void
     {
-        if ($value > 0) {
-            $options['http']['timeout'] = $value;
+        $timeout = Utils::timeoutToMilliseconds($value, 'timeout');
+
+        if ($timeout > 0) {
+            $options['http']['timeout'] = $timeout / 1000;
         }
     }
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -68,7 +68,8 @@ final class RequestOptions
     /**
      * connect_timeout: (float, default=0) Float describing the number of
      * seconds to wait while trying to connect to a server. Use 0 to wait
-     * 300 seconds (the default behavior).
+     * 300 seconds (the default behavior). Positive values below 0.001 seconds
+     * are rejected by the built-in cURL handler.
      */
     public const CONNECT_TIMEOUT = 'connect_timeout';
 
@@ -256,12 +257,14 @@ final class RequestOptions
     /**
      * timeout: (float, default=0) Float describing the timeout of the
      * request in seconds. Use 0 to wait indefinitely (the default behavior).
+     * Positive values below 0.001 seconds are rejected by the built-in handlers.
      */
     public const TIMEOUT = 'timeout';
 
     /**
      * read_timeout: (float, default=default_socket_timeout ini setting) Float describing
-     * the body read timeout, for stream requests.
+     * the body read timeout, for stream requests. Positive values below 0.001
+     * seconds are rejected by the built-in stream handler.
      */
     public const READ_TIMEOUT = 'read_timeout';
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -279,6 +279,32 @@ final class Utils
     }
 
     /**
+     * Converts a request timeout option to integer milliseconds.
+     *
+     * @param mixed $value
+     *
+     * @internal
+     */
+    public static function timeoutToMilliseconds($value, string $option): int
+    {
+        if (!\is_int($value) && !\is_float($value) && (!\is_string($value) || !\is_numeric($value))) {
+            throw new InvalidArgumentException($option.' must be a number of seconds');
+        }
+
+        $seconds = (float) $value;
+        if (!\is_finite($seconds) || $seconds < 0) {
+            throw new InvalidArgumentException($option.' must be 0 or greater than or equal to 0.001 seconds');
+        }
+
+        $milliseconds = (int) ($seconds * 1000);
+        if ($seconds > 0 && $milliseconds === 0) {
+            throw new InvalidArgumentException($option.' must be 0 or greater than or equal to 0.001 seconds');
+        }
+
+        return $milliseconds;
+    }
+
+    /**
      * @throws InvalidArgumentException
      *
      * @internal

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -905,6 +905,52 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(200, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT_MS]);
     }
 
+    public function testAddsZeroTimeouts()
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', Server::$url), [
+            'timeout' => 0,
+            'connect_timeout' => 0,
+        ]);
+        self::assertSame(0, $_SERVER['_curl'][\CURLOPT_TIMEOUT_MS]);
+        self::assertSame(0, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT_MS]);
+    }
+
+    public function testTruncatesTimeoutsToMilliseconds()
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', Server::$url), [
+            'timeout' => 0.0015,
+            'connect_timeout' => 0.0025,
+        ]);
+        self::assertSame(1, $_SERVER['_curl'][\CURLOPT_TIMEOUT_MS]);
+        self::assertSame(2, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT_MS]);
+    }
+
+    /**
+     * @dataProvider invalidCurlTimeoutProvider
+     *
+     * @param mixed $value
+     */
+    public function testRejectsInvalidCurlTimeouts(string $option, $value)
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($option.' must be 0 or greater than or equal to 0.001 seconds');
+        $f->create(new Psr7\Request('GET', Server::$url), [$option => $value]);
+    }
+
+    public static function invalidCurlTimeoutProvider(): array
+    {
+        return [
+            ['timeout', 0.0001],
+            ['timeout', -1],
+            ['connect_timeout', 0.0001],
+            ['connect_timeout', -1],
+        ];
+    }
+
     public function testAddsStreamingBody()
     {
         $f = new CurlFactory(3);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -438,6 +438,35 @@ class StreamHandlerTest extends TestCase
         self::assertEquals(200, $opts['http']['timeout']);
     }
 
+    public function testTruncatesStreamTimeoutToMilliseconds()
+    {
+        $res = $this->getSendResult(['stream' => true, 'timeout' => 0.0015]);
+        $opts = \stream_context_get_options($res->getBody()->detach());
+        self::assertEquals(0.001, $opts['http']['timeout']);
+    }
+
+    /**
+     * @dataProvider invalidStreamTimeoutProvider
+     *
+     * @param mixed $value
+     */
+    public function testRejectsInvalidStreamTimeouts(string $option, $value)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($option.' must be 0 or greater than or equal to 0.001 seconds');
+        $this->getSendResult([$option => $value]);
+    }
+
+    public static function invalidStreamTimeoutProvider(): array
+    {
+        return [
+            ['timeout', 0.0001],
+            ['timeout', -1],
+            ['read_timeout', 0.0001],
+            ['read_timeout', -1],
+        ];
+    }
+
     public function testVerifiesVerifyIsValidIfPath()
     {
         $this->expectException(RequestException::class);


### PR DESCRIPTION
This validates built-in handler timeout options before applying them. It keeps 0 as the documented no-timeout value, rejects positive values that collapse to 0 milliseconds, and passes integer millisecond values to cURL and stream timeout APIs. It also documents the 8.0 behavior change for timeout, connect_timeout, and read_timeout.\n\nFixes #3338.