### PR TITLE
Handle empty request protocol versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fail clearly when an HTTP response header line is invalid
+- Treat empty request protocol versions as HTTP/1.1
 
 
 ## 7.10.2 - 2026-05-20

--- a/src/Client.php
+++ b/src/Client.php
@@ -326,6 +326,11 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     private function transfer(RequestInterface $request, array $options): PromiseInterface
     {
         $request = $this->applyOptions($request, $options);
+
+        if ('' === $request->getProtocolVersion()) {
+            $request = Psr7\Utils::modifyRequest($request, ['version' => '1.1']);
+        }
+
         /** @var HandlerStack $handler */
         $handler = $options['handler'];
 
@@ -474,6 +479,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      */
     private static function normalizeProtocolVersion($version): string
     {
+        if ('' === $version) {
+            return '1.1';
+        }
+
         return \is_float($version) ? \number_format($version, 1, '.', '') : (string) $version;
     }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -49,6 +49,11 @@ class CurlFactory implements CurlFactoryInterface
     {
         $protocolVersion = $request->getProtocolVersion();
 
+        if ('' === $protocolVersion) {
+            $protocolVersion = '1.1';
+            $request = \GuzzleHttp\Psr7\Utils::modifyRequest($request, ['version' => $protocolVersion]);
+        }
+
         if ('2' === $protocolVersion || '2.0' === $protocolVersion) {
             if (!self::supportsHttp2()) {
                 throw new ConnectException('HTTP/2 is supported by the cURL handler, however libcurl is built without HTTP/2 support.', $request);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -42,6 +42,11 @@ class StreamHandler
 
         $protocolVersion = $request->getProtocolVersion();
 
+        if ('' === $protocolVersion) {
+            $protocolVersion = '1.1';
+            $request = Psr7\Utils::modifyRequest($request, ['version' => $protocolVersion]);
+        }
+
         if ('1.0' !== $protocolVersion && '1.1' !== $protocolVersion) {
             throw new ConnectException(sprintf('HTTP/%s is not supported by the stream handler.', $protocolVersion), $request);
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -58,6 +58,27 @@ class ClientTest extends TestCase
         self::assertSame(200, $r->getStatusCode());
     }
 
+    public function testEmptyProtocolVersionRequestOptionDefaultsToHttp11()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $client->get('http://example.com', ['version' => '']);
+
+        self::assertSame('1.1', $mock->getLastRequest()->getProtocolVersion());
+    }
+
+    public function testEmptyRequestProtocolVersionDefaultsToHttp11()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $request = new Request('GET', 'http://example.com', [], null, '');
+
+        $client->send($request);
+
+        self::assertSame('1.1', $mock->getLastRequest()->getProtocolVersion());
+    }
+
     public function testClientHasOptions()
     {
         $client = new Client([

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -573,6 +573,16 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
     }
 
+    public function testEmptyProtocolVersionDefaultsToHttp11()
+    {
+        Server::flush();
+        Server::enqueue([new Psr7\Response()]);
+        $a = new Handler\CurlMultiHandler();
+        $request = new Psr7\Request('GET', Server::$url, [], null, '');
+        $a($request, []);
+        self::assertEquals(\CURL_HTTP_VERSION_1_1, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+    }
+
     public function testSavesToStream()
     {
         $stream = \fopen('php://memory', 'r+');

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -52,6 +52,17 @@ class StreamHandlerTest extends TestCase
         self::assertSame('Bar', $sent->getHeaderLine('foo'));
     }
 
+    public function testEmptyProtocolVersionDefaultsToHttp11()
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+
+        $response = $handler(new Request('GET', Server::$url, [], null, ''), [])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('1.1', Server::received()[0]->getProtocolVersion());
+    }
+
     public function testAddsErrorToResponse()
     {
         $handler = new StreamHandler();


### PR DESCRIPTION
This treats an empty request protocol version as omitted and sends the request with Guzzle's default HTTP/1.1 behavior. It keeps cURL and stream handlers consistent while preserving the existing errors for unsupported non-empty versions.