### PR TITLE
Deprecate empty request protocol versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Deprecated
 
+- Deprecated empty request protocol versions, which will be rejected in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -326,6 +326,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         $request = $this->applyOptions($request, $options);
 
         if ('' === $request->getProtocolVersion()) {
+            trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Sending a request with an empty protocol version is deprecated; guzzlehttp/guzzle 8.0 will reject empty protocol versions.');
+
             $request = Psr7\Utils::modifyRequest($request, ['version' => '1.1']);
         }
 
@@ -478,6 +480,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     private static function normalizeProtocolVersion($version): string
     {
         if ('' === $version) {
+            trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing an empty "version" request option is deprecated; guzzlehttp/guzzle 8.0 will reject empty protocol versions.');
+
             return '1.1';
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -50,6 +50,8 @@ class CurlFactory implements CurlFactoryInterface
         $protocolVersion = $request->getProtocolVersion();
 
         if ('' === $protocolVersion) {
+            trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Sending a request with an empty protocol version is deprecated; guzzlehttp/guzzle 8.0 will reject empty protocol versions.');
+
             $protocolVersion = '1.1';
             $request = \GuzzleHttp\Psr7\Utils::modifyRequest($request, ['version' => $protocolVersion]);
         }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -43,6 +43,8 @@ class StreamHandler
         $protocolVersion = $request->getProtocolVersion();
 
         if ('' === $protocolVersion) {
+            trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Sending a request with an empty protocol version is deprecated; guzzlehttp/guzzle 8.0 will reject empty protocol versions.');
+
             $protocolVersion = '1.1';
             $request = Psr7\Utils::modifyRequest($request, ['version' => $protocolVersion]);
         }


### PR DESCRIPTION
This keeps the 7.x compatibility behavior for empty request protocol versions, but deprecates relying on it before 8.0 rejects empty protocol versions.