### PR TITLE
Reject empty request protocol versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Default HTTPS requests sent by the built-in cURL and stream handlers to TLS 1.2 or newer
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them
+- Reject empty request protocol versions
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -48,6 +48,15 @@ applying them. `timeout`, `connect_timeout`, and `read_timeout` must be `0` or a
 least `0.001` seconds when provided. Positive values below 1 millisecond now
 throw `InvalidArgumentException` instead of being converted to no timeout.
 
+#### Protocol version validation
+
+Empty request protocol versions are no longer treated as omitted. Passing
+`'version' => ''` in request options or sending a PSR-7 request whose protocol
+version is `''` now throws an exception before the request is sent.
+
+Omit the `version` request option to use Guzzle's default HTTP/1.1 behavior, or
+pass an explicit supported protocol version such as `'1.1'`.
+
 #### TLS minimum version
 
 The built-in cURL and stream handlers now default HTTPS requests to TLS 1.2 or

--- a/src/Client.php
+++ b/src/Client.php
@@ -304,9 +304,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         $request = $this->applyOptions($request, $options);
 
         if ('' === $request->getProtocolVersion()) {
-            trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Sending a request with an empty protocol version is deprecated; guzzlehttp/guzzle 8.0 will reject empty protocol versions.');
-
-            $request = Psr7\Utils::modifyRequest($request, ['version' => '1.1']);
+            throw new InvalidArgumentException('HTTP protocol version must not be empty.');
         }
 
         /** @var HandlerStack $handler */
@@ -479,9 +477,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     private static function normalizeProtocolVersion($version): string
     {
         if ('' === $version) {
-            trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing an empty "version" request option is deprecated; guzzlehttp/guzzle 8.0 will reject empty protocol versions.');
-
-            return '1.1';
+            throw new InvalidArgumentException('HTTP protocol version must not be empty.');
         }
 
         return \is_float($version) ? \number_format($version, 1, '.', '') : (string) $version;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -47,10 +47,7 @@ class CurlFactory implements CurlFactoryInterface
         $protocolVersion = $request->getProtocolVersion();
 
         if ('' === $protocolVersion) {
-            trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Sending a request with an empty protocol version is deprecated; guzzlehttp/guzzle 8.0 will reject empty protocol versions.');
-
-            $protocolVersion = '1.1';
-            $request = \GuzzleHttp\Psr7\Utils::modifyRequest($request, ['version' => $protocolVersion]);
+            throw new ConnectException('HTTP protocol version must not be empty.', $request);
         }
 
         if ('3' === $protocolVersion || '3.0' === $protocolVersion) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -43,10 +43,7 @@ class StreamHandler
         $protocolVersion = $request->getProtocolVersion();
 
         if ('' === $protocolVersion) {
-            trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Sending a request with an empty protocol version is deprecated; guzzlehttp/guzzle 8.0 will reject empty protocol versions.');
-
-            $protocolVersion = '1.1';
-            $request = Psr7\Utils::modifyRequest($request, ['version' => $protocolVersion]);
+            throw new ConnectException('HTTP protocol version must not be empty.', $request);
         }
 
         if ('1.0' !== $protocolVersion && '1.1' !== $protocolVersion) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -51,25 +51,27 @@ class ClientTest extends TestCase
         self::assertSame(200, $r->getStatusCode());
     }
 
-    public function testEmptyProtocolVersionRequestOptionDefaultsToHttp11()
+    public function testRejectsEmptyProtocolVersionRequestOption()
     {
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
 
-        $client->get('http://example.com', ['version' => '']);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP protocol version must not be empty.');
 
-        self::assertSame('1.1', $mock->getLastRequest()->getProtocolVersion());
+        $client->get('http://example.com', ['version' => '']);
     }
 
-    public function testEmptyRequestProtocolVersionDefaultsToHttp11()
+    public function testRejectsEmptyRequestProtocolVersion()
     {
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $request = new Request('GET', 'http://example.com', [], null, '');
 
-        $client->send($request);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP protocol version must not be empty.');
 
-        self::assertSame('1.1', $mock->getLastRequest()->getProtocolVersion());
+        $client->send($request);
     }
 
     public function testClientHasOptions()

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -633,14 +633,15 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
     }
 
-    public function testEmptyProtocolVersionDefaultsToHttp11()
+    public function testRejectsEmptyProtocolVersion()
     {
-        Server::flush();
-        Server::enqueue([new Psr7\Response()]);
-        $a = new Handler\CurlMultiHandler();
+        $factory = new CurlFactory(3);
         $request = new Psr7\Request('GET', Server::$url, [], null, '');
-        $a($request, []);
-        self::assertEquals(\CURL_HTTP_VERSION_1_1, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('HTTP protocol version must not be empty.');
+
+        $factory->create($request, []);
     }
 
     public function testThrowsWhenHttp3IsUnsupported()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -55,15 +55,14 @@ class StreamHandlerTest extends TestCase
         self::assertSame('Bar', $sent->getHeaderLine('foo'));
     }
 
-    public function testEmptyProtocolVersionDefaultsToHttp11()
+    public function testRejectsEmptyProtocolVersion()
     {
-        $this->queueRes();
         $handler = new StreamHandler();
 
-        $response = $handler(new Request('GET', Server::$url, [], null, ''), [])->wait();
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('HTTP protocol version must not be empty.');
 
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame('1.1', Server::received()[0]->getProtocolVersion());
+        $handler(new Request('GET', Server::$url, [], null, ''), []);
     }
 
     public function testAddsErrorToResponse()


### PR DESCRIPTION
This removes the 7.x compatibility behavior for empty request protocol versions. Empty protocol versions now fail clearly before a handler can produce an unclear HTTP/ error.