### PR TITLE
Avoid non-iterable Pool collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Fixed
 
+- Avoid passing non-iterable request collections to `Pool`
 - Fail clearly when an HTTP response header line is invalid
 - Treat empty request protocol versions as HTTP/1.1
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -289,6 +289,12 @@ parameters:
 			path: src/Middleware.php
 
 		-
+			message: '#^Call to function is_iterable\(\) with array\|Iterator will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Pool.php
+
+		-
 			message: '#^PHPDoc tag @var has invalid value \(callable\(int\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 24 on line 2$#'
 			identifier: phpDoc.parseError
 			count: 1

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -30,7 +30,7 @@ class Pool implements PromisorInterface
 
     /**
      * @param ClientInterface $client   Client used to send the requests.
-     * @param mixed           $requests Requests or functions that return
+     * @param array|\Iterator $requests Requests or functions that return
      *                                  requests to send concurrently.
      * @param array           $config   Associative array of options
      *                                  - concurrency: (int) Maximum number of requests to send concurrently

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -30,7 +30,7 @@ class Pool implements PromisorInterface
 
     /**
      * @param ClientInterface $client   Client used to send the requests.
-     * @param array|\Iterator $requests Requests or functions that return
+     * @param mixed           $requests Requests or functions that return
      *                                  requests to send concurrently.
      * @param array           $config   Associative array of options
      *                                  - concurrency: (int) Maximum number of requests to send concurrently
@@ -51,7 +51,7 @@ class Pool implements PromisorInterface
             $opts = [];
         }
 
-        $iterable = P\Create::iterFor($requests);
+        $iterable = P\Create::iterFor(\is_iterable($requests) ? $requests : [$requests]);
         $requests = static function () use ($iterable, $client, $opts) {
             foreach ($iterable as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {


### PR DESCRIPTION
This avoids passing non-iterable request collections to promise helpers.