### PR TITLE
Fix removing callable string middleware names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fail clearly when an HTTP response header line is invalid
+- Remove middleware by name when the name is also a callable string
 - Treat empty request protocol versions as HTTP/1.1
 
 

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -185,11 +185,25 @@ class HandlerStack
         }
 
         $this->cached = null;
-        $idx = \is_callable($remove) ? 0 : 1;
+
+        if (\is_string($remove)) {
+            $count = \count($this->stack);
+            $this->stack = \array_values(\array_filter(
+                $this->stack,
+                static function ($tuple) use ($remove) {
+                    return $tuple[1] !== $remove;
+                }
+            ));
+
+            if ($count !== \count($this->stack) || !\is_callable($remove)) {
+                return;
+            }
+        }
+
         $this->stack = \array_values(\array_filter(
             $this->stack,
-            static function ($tuple) use ($idx, $remove) {
-                return $tuple[$idx] !== $remove;
+            static function ($tuple) use ($remove) {
+                return $tuple[0] !== $remove;
             }
         ));
     }

--- a/tests/HandlerStackTest.php
+++ b/tests/HandlerStackTest.php
@@ -88,6 +88,51 @@ class HandlerStackTest extends TestCase
         self::assertSame('Hello - test1131', $composed('test'));
     }
 
+    public function testCanRemoveMiddlewareByCallableStringName()
+    {
+        $meths = $this->getFunctions();
+        $builder = new HandlerStack();
+        $builder->setHandler($meths[1]);
+        $builder->push($meths[2], 'strlen');
+
+        $builder->remove('strlen');
+
+        $composed = $builder->resolve();
+        self::assertSame('Hello - test', $composed('test'));
+        self::assertSame([], $meths[0]);
+    }
+
+    public function testCanRemoveMiddlewareByCallableStringInstance()
+    {
+        $builder = new HandlerStack();
+        $builder->setHandler(static function ($value) {
+            return 'Hello - '.$value;
+        });
+        $builder->push(__CLASS__.'::addSuffixMiddleware');
+
+        $builder->remove(__CLASS__.'::addSuffixMiddleware');
+
+        $composed = $builder->resolve();
+        self::assertSame('Hello - test', $composed('test'));
+    }
+
+    public function testRemovePrefersNameWhenStringIsAlsoCallable()
+    {
+        $meths = $this->getFunctions();
+        $name = __CLASS__.'::addSuffixMiddleware';
+
+        $builder = new HandlerStack();
+        $builder->setHandler($meths[1]);
+        $builder->push($meths[2], $name);
+        $builder->push($name);
+
+        $builder->remove($name);
+
+        $composed = $builder->resolve();
+        self::assertSame('Hello - testx', $composed('test'));
+        self::assertSame([], $meths[0]);
+    }
+
     public function testCanPrintMiddleware()
     {
         $meths = $this->getFunctions();
@@ -209,6 +254,13 @@ class HandlerStackTest extends TestCase
 
     public static function foo()
     {
+    }
+
+    public static function addSuffixMiddleware(callable $handler)
+    {
+        return static function ($value) use ($handler) {
+            return $handler($value.'x');
+        };
     }
 
     public function bar()


### PR DESCRIPTION
Backports the 7.11 HandlerStack fix to 7.10.

- Prefer middleware name removal for string remove values before callable instance fallback.
- Preserve callable string middleware instance removal when no name matches.
- Add regression coverage and a 7.10.3 changelog entry.

Tests not run locally; relying on CI.