### PR TITLE
Normalize no-proxy matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added parameter and return types to `SetCookie` methods
 - Added `string` return types to `__toString()` methods
 - Normalize and validate proxy no-proxy options consistently across handlers
+- Normalize no-proxy domain and IP literal matching consistently
 - Pass the request as the second argument to `on_headers` callbacks
 - Reject invalid `SetCookie` constructor field types instead of coercing them
 - Support retry delay callbacks with retry count only or full retry context

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -167,15 +167,23 @@ strings, and the `proxy['no']` value may be either an array of strings or a
 comma-delimited string such as the value from the `NO_PROXY` environment
 variable. Other values now throw `InvalidArgumentException`.
 
+No-proxy matching is normalized more consistently. Domain entries are matched
+case-insensitively, exact IP literal entries compare normalized IP addresses,
+and `NO_PROXY` environment entries are trimmed with the same parser used for
+request options. Internal spaces in `NO_PROXY` entries are preserved instead of
+removed.
+
 Explicit proxy options also override environment no-proxy settings. If you pass
 a `proxy` request option and want to exclude hosts, provide the `no` value
 explicitly:
 
 ```php
+$noProxy = getenv('NO_PROXY');
+
 $client->request('GET', '/', [
     'proxy' => [
         'http' => 'http://localhost:8125',
-        'no' => getenv('NO_PROXY') ?: '',
+        'no' => $noProxy === false ? '' : $noProxy,
     ],
 ]);
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -495,7 +495,7 @@ Note: because the HTTP_PROXY variable may contain arbitrary user input on some (
 Defines the proxy to use when sending requests using the "https" protocol.
 
 `NO_PROXY`
-Defines URLs for which a proxy should not be used. See the [`proxy` option](request-options.md#proxy).
+Defines hosts and IP rules for which a proxy should not be used. See the [`proxy` option](request-options.md#proxy).
 
 ### Relevant ini Settings
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -780,17 +780,17 @@ Pass a string to specify a proxy for all protocols.
 $client->request('GET', '/', ['proxy' => 'http://localhost:8125']);
 ```
 
-Pass an associative array to specify HTTP proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair to provide a list of host names that should not be proxied to. No-proxy entries may include ports, for example `example.com:8080` or `[::1]:8080`. IP no-proxy entries may use CIDR notation, for example `192.168.0.0/16` or `fd00::/8`. CIDR entries match IP literals only and are not port-specific.
+Pass an associative array to specify HTTP proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair to provide a list of entries that should not be proxied to. No-proxy entries may include host names, host-and-port pairs, IP literals, or IP CIDR rules. The wildcard entry `*` matches all hosts, and a port-specific wildcard such as `*:80` matches any host using effective port `80`. Domain entries are matched case-insensitively. A bare domain such as `example.com` matches both `example.com` and `foo.example.com`; a leading-dot domain such as `.example.com` matches subdomains but not `example.com` itself. No-proxy entries may include ports, for example `example.com:8080` or `[::1]:8080`. IP literals are normalized before matching, so equivalent IPv6 spellings such as `::1` and `0:0:0:0:0:0:0:1` match. CIDR entries match IP literals only and are not port-specific.
 
 > [!NOTE]
-> Guzzle will automatically populate this value with your environment's `NO_PROXY` environment variable. However, when providing a `proxy` request option, it is up to you to provide the `no` value parsed from the `NO_PROXY` environment variable (e.g., `explode(',', getenv('NO_PROXY'))`).
+> Guzzle will automatically populate this value with your environment's `NO_PROXY` environment variable. However, when providing a `proxy` request option, it is up to you to provide the `no` value from the `NO_PROXY` environment variable.
 
 ```php
 $client->request('GET', '/', [
     'proxy' => [
         'http'  => 'http://localhost:8125', // Use this proxy with "http"
         'https' => 'http://localhost:9124', // Use this proxy with "https",
-        'no' => ['.mit.edu', 'foo.com', 'example.com:8080', '10.0.0.0/8'] // Don't use a proxy with these
+        'no' => ['.mit.edu', 'foo.com', 'example.com:8080', '::1', '[fd00::1]:8080', '10.0.0.0/8', 'fd00::/8'] // Don't use a proxy with these
     ]
 ]);
 ```

--- a/src/Client.php
+++ b/src/Client.php
@@ -230,9 +230,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $defaults['proxy']['https'] = $proxy;
         }
 
-        if ($noProxy = Utils::getenv('NO_PROXY')) {
-            $cleanedNoProxy = \str_replace(' ', '', $noProxy);
-            $defaults['proxy']['no'] = \explode(',', $cleanedNoProxy);
+        $noProxy = Utils::getenv('NO_PROXY');
+        if ($noProxy !== null) {
+            $noProxy = Utils::normalizeNoProxy($noProxy);
+            if ($noProxy !== []) {
+                $defaults['proxy']['no'] = $noProxy;
+            }
         }
 
         $this->config = $config + $defaults;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -626,11 +626,10 @@ class CurlFactory implements CurlFactoryInterface
                     }
 
                     $uri = $easy->request->getUri();
-                    $host = $uri->getHost();
                     $noProxy = isset($proxy['no']) ? Utils::normalizeNoProxy($proxy['no']) : [];
                     if ($noProxy !== [] && Utils::isUriInNoProxy($uri, $noProxy)) {
                         $conf[\CURLOPT_PROXY] = '';
-                        $conf[\CURLOPT_NOPROXY] = $host;
+                        $conf[\CURLOPT_NOPROXY] = '*';
                     } else {
                         $conf[\CURLOPT_PROXY] = $proxy[$scheme];
                         $conf[\CURLOPT_NOPROXY] = '';

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -203,8 +203,10 @@ final class RequestOptions
      * array to specify different proxies for different protocols (where the
      * key is the protocol and the value is a proxy string). Provide a "no"
      * key as a string or array of strings to specify hosts, host-and-port
-     * pairs, or IP CIDR rules that should not be proxied. CIDR rules match
-     * IP literals only and are not port-specific.
+     * pairs, IP literals, IP CIDR rules, or wildcard rules that should not be
+     * proxied. Domain rules are matched case-insensitively. Exact IP literals
+     * are normalized before matching. CIDR rules match IP literals only and
+     * are not port-specific.
      */
     public const PROXY = 'proxy';
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -134,17 +134,18 @@ final class Utils
     /**
      * Returns true if the provided host matches any of the no proxy areas.
      *
-     * This method will strip a port from the host if it is present. Each pattern
-     * can be matched with an exact match (e.g., "foo.com" == "foo.com") or a
-     * partial match: (e.g., "foo.com" == "baz.foo.com" and ".foo.com" ==
-     * "baz.foo.com", but ".foo.com" != "foo.com").
+     * This method will strip a port from the host if it is present. Domain
+     * patterns are matched case-insensitively. Exact IP literal patterns are
+     * matched by their normalized binary address.
      *
      * Areas are matched in the following cases:
      * 1. "*" (without quotes) always matches any hosts.
-     * 2. An exact match.
-     * 3. The area starts with "." and the area is the last part of the host. e.g.
+     * 2. An exact domain or IP literal match.
+     * 3. A bare domain matches itself and its subdomains. e.g. 'mit.edu' will
+     *    match 'mit.edu' and 'foo.mit.edu'.
+     * 4. The area starts with "." and the area is the last part of the host. e.g.
      *    '.mit.edu' will match any host that ends with '.mit.edu'.
-     * 4. IP CIDR entries match IP literal hosts. e.g. '192.168.0.0/16' will
+     * 5. IP CIDR entries match IP literal hosts. e.g. '192.168.0.0/16' will
      *    match '192.168.1.10' and 'fd00::/8' will match '[fd00::1]'.
      *
      * @param string   $host         Host to check against the patterns.
@@ -158,35 +159,20 @@ final class Utils
             throw new InvalidArgumentException('Empty host provided');
         }
 
-        $host = self::normalizeNoProxyHost($host, true);
+        $target = self::parseNoProxyHostString($host);
+        if ($target === null) {
+            return false;
+        }
 
         foreach ($noProxyArray as $area) {
+            $area = \trim($area);
+
             if ($area === '*') {
                 return true;
             }
 
-            if ($area === '') {
-                continue;
-            }
-
-            if (self::matchesNoProxyCidr($host, $area)) {
-                return true;
-            }
-
-            $area = self::normalizeNoProxyHost($area, false);
-
-            if ($area === $host) {
-                // Exact matches.
-                return true;
-            }
-            // Special match if the area when prefixed with ".". Remove any
-            // existing leading "." and add a new leading ".".
-            $area = '.'.\ltrim($area, '.');
-            if (
-                \strpos($host, ':') === false
-                && \strpos($area, ':') === false
-                && \substr($host, -\strlen($area)) === $area
-            ) {
+            $rule = self::parseNoProxyRule($area);
+            if ($rule !== null && self::noProxyRuleMatches($target, $rule)) {
                 return true;
             }
         }
@@ -203,39 +189,20 @@ final class Utils
      */
     public static function isUriInNoProxy(UriInterface $uri, array $noProxyArray): bool
     {
-        $host = $uri->getHost();
-        if ($host === '') {
+        $target = self::parseNoProxyTarget($uri);
+        if ($target === null) {
             return false;
         }
 
-        $port = $uri->getPort();
-        if ($port === null) {
-            $port = self::getDefaultPort($uri->getScheme());
-        }
-
         foreach ($noProxyArray as $area) {
+            $area = \trim($area);
+
             if ($area === '*') {
                 return true;
             }
 
-            if ($area === '') {
-                continue;
-            }
-
-            if (self::matchesNoProxyCidr($host, $area)) {
-                return true;
-            }
-
-            if (\strpos($area, '/') !== false) {
-                continue;
-            }
-
-            [$area, $areaPort] = self::splitNoProxyHostAndPort($area);
-            if ($areaPort !== null && $areaPort !== $port) {
-                continue;
-            }
-
-            if (self::isHostInNoProxy($host, [$area])) {
+            $rule = self::parseNoProxyRule($area);
+            if ($rule !== null && self::noProxyRuleMatches($target, $rule)) {
                 return true;
             }
         }
@@ -243,58 +210,149 @@ final class Utils
         return false;
     }
 
-    private static function normalizeNoProxyHost(string $host, bool $stripPort): string
+    /**
+     * @return array{type: string, value: string, port: int|null, matchesRoot: bool}|null
+     */
+    private static function parseNoProxyTarget(UriInterface $uri): ?array
     {
-        if ($host !== '' && $host[0] === '[') {
-            $closingBracket = \strpos($host, ']');
-
-            if ($closingBracket !== false) {
-                $address = \substr($host, 1, $closingBracket - 1);
-                $tail = \substr($host, $closingBracket + 1);
-
-                if (
-                    ($tail === '' || ($stripPort && \preg_match('/^:\d+$/', $tail)))
-                    && \filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)
-                ) {
-                    return \strtolower($address);
-                }
-            }
+        $host = $uri->getHost();
+        if ($host === '') {
+            return null;
         }
 
-        if (\filter_var($host, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
-            return \strtolower($host);
-        }
-
-        if ($stripPort) {
-            [$host] = \explode(':', $host, 2);
-        }
-
-        return $host;
+        return self::parseNoProxyHost($host, $uri->getPort() ?? self::getDefaultPort($uri->getScheme()), true);
     }
 
     /**
-     * @return array{0: string, 1: int|null}
+     * @return array{type: string, value: string, port: int|null, matchesRoot: bool}|null
      */
-    private static function splitNoProxyHostAndPort(string $area): array
+    private static function parseNoProxyHostString(string $host): ?array
+    {
+        $hostAndPort = self::splitNoProxyHostAndPort($host);
+        if ($hostAndPort === null) {
+            return null;
+        }
+
+        [$host] = $hostAndPort;
+
+        return self::parseNoProxyHost($host, null, true);
+    }
+
+    /**
+     * @return array{type: string, value: string, port: int|null, matchesRoot: bool}|array{type: string, value: string, prefix: int}|null
+     */
+    private static function parseNoProxyRule(string $area): ?array
+    {
+        $area = \trim($area);
+        if ($area === '' || $area === '*') {
+            return null;
+        }
+
+        if (\strpos($area, '/') !== false) {
+            return self::parseNoProxyCidrRule($area);
+        }
+
+        $matchesRoot = true;
+        if ($area[0] === '.') {
+            $matchesRoot = false;
+            $area = \substr($area, 1);
+        }
+
+        $hostAndPort = self::splitNoProxyHostAndPort($area);
+        if ($hostAndPort === null) {
+            return null;
+        }
+
+        [$host, $port] = $hostAndPort;
+
+        if ($host === '*') {
+            if (!$matchesRoot) {
+                return null;
+            }
+
+            return [
+                'type' => 'wildcard',
+                'value' => '*',
+                'port' => $port,
+                'matchesRoot' => true,
+            ];
+        }
+
+        $rule = self::parseNoProxyHost($host, $port, $matchesRoot);
+        if ($rule !== null && !$matchesRoot && $rule['type'] === 'ip') {
+            return null;
+        }
+
+        return $rule;
+    }
+
+    /**
+     * @return array{type: string, value: string, port: int|null, matchesRoot: bool}|null
+     */
+    private static function parseNoProxyHost(string $host, ?int $port, bool $matchesRoot): ?array
+    {
+        if ($host !== '' && $host[0] === '[') {
+            if (\substr($host, -1) !== ']') {
+                return null;
+            }
+
+            $address = \substr($host, 1, -1);
+            if (!\filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
+                return null;
+            }
+
+            $host = $address;
+        }
+
+        $packedIp = self::packIpAddress($host);
+        if ($packedIp !== false) {
+            return [
+                'type' => 'ip',
+                'value' => $packedIp,
+                'port' => $port,
+                'matchesRoot' => $matchesRoot,
+            ];
+        }
+
+        if ($host === '' || \strpos($host, ':') !== false) {
+            return null;
+        }
+
+        return [
+            'type' => 'domain',
+            'value' => \strtolower($host),
+            'port' => $port,
+            'matchesRoot' => $matchesRoot,
+        ];
+    }
+
+    /**
+     * @return array{0: string, 1: int|null}|null
+     */
+    private static function splitNoProxyHostAndPort(string $area): ?array
     {
         if ($area !== '' && $area[0] === '[') {
             $closingBracket = \strpos($area, ']');
-
-            if ($closingBracket !== false) {
-                $tail = \substr($area, $closingBracket + 1);
-                if ($tail !== '' && $tail[0] === ':') {
-                    $port = self::parseNoProxyPort(\substr($tail, 1));
-
-                    if ($port !== null) {
-                        return [\substr($area, 0, $closingBracket + 1), $port];
-                    }
-                }
+            if ($closingBracket === false) {
+                return null;
             }
 
-            return [$area, null];
+            $host = \substr($area, 0, $closingBracket + 1);
+            $tail = \substr($area, $closingBracket + 1);
+            if ($tail === '') {
+                return [$host, null];
+            }
+
+            if ($tail[0] !== ':') {
+                return null;
+            }
+
+            $port = self::parseNoProxyPort(\substr($tail, 1));
+
+            return $port === null ? null : [$host, $port];
         }
 
-        if (\filter_var($area, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
+        if (self::packIpAddress($area) !== false) {
             return [$area, null];
         }
 
@@ -305,7 +363,7 @@ final class Utils
 
         $port = self::parseNoProxyPort(\substr($area, $colon + 1));
         if ($port === null) {
-            return [$area, null];
+            return null;
         }
 
         return [\substr($area, 0, $colon), $port];
@@ -335,16 +393,19 @@ final class Utils
         return null;
     }
 
-    private static function matchesNoProxyCidr(string $host, string $area): bool
+    /**
+     * @return array{type: string, value: string, prefix: int}|null
+     */
+    private static function parseNoProxyCidrRule(string $area): ?array
     {
         $slash = \strpos($area, '/');
         if ($slash === false) {
-            return false;
+            return null;
         }
 
         $prefix = \substr($area, $slash + 1);
         if ($prefix === '' || !\ctype_digit($prefix)) {
-            return false;
+            return null;
         }
 
         $network = \substr($area, 0, $slash);
@@ -352,25 +413,79 @@ final class Utils
             $network = \substr($network, 1, -1);
         }
 
-        $network = @\inet_pton($network);
+        $network = self::packIpAddress($network);
         if ($network === false) {
-            return false;
-        }
-
-        $host = @\inet_pton(self::normalizeNoProxyHost($host, true));
-        if ($host === false || \strlen($host) !== \strlen($network)) {
-            return false;
+            return null;
         }
 
         $prefix = (int) $prefix;
         if ($prefix > \strlen($network) * 8) {
+            return null;
+        }
+
+        return [
+            'type' => 'cidr',
+            'value' => $network,
+            'prefix' => $prefix,
+        ];
+    }
+
+    /**
+     * @param array{type: string, value: string, port: int|null, matchesRoot: bool}                      $target
+     * @param array{type: string, value: string, port?: int|null, matchesRoot?: bool, prefix?: int|null} $rule
+     */
+    private static function noProxyRuleMatches(array $target, array $rule): bool
+    {
+        if ($rule['type'] === 'wildcard') {
+            return ($rule['port'] ?? null) === null || $rule['port'] === $target['port'];
+        }
+
+        if ($rule['type'] === 'cidr') {
+            if ($target['type'] !== 'ip' || !isset($rule['prefix'])) {
+                return false;
+            }
+
+            if (\strlen($target['value']) !== \strlen($rule['value'])) {
+                return false;
+            }
+
+            return self::ipMatchesPrefix($target['value'], $rule['value'], $rule['prefix']);
+        }
+
+        if (($rule['port'] ?? null) !== null && $rule['port'] !== $target['port']) {
             return false;
         }
 
-        return self::matchesIpPrefix($host, $network, $prefix);
+        if ($rule['type'] !== $target['type']) {
+            return false;
+        }
+
+        if ($rule['type'] === 'ip') {
+            return $rule['value'] === $target['value'];
+        }
+
+        if (($rule['matchesRoot'] ?? false) && $target['value'] === $rule['value']) {
+            return true;
+        }
+
+        $suffix = '.'.$rule['value'];
+
+        return \substr($target['value'], -\strlen($suffix)) === $suffix;
     }
 
-    private static function matchesIpPrefix(string $address, string $network, int $prefix): bool
+    /**
+     * @return string|false
+     */
+    private static function packIpAddress(string $ip)
+    {
+        if (!\filter_var($ip, \FILTER_VALIDATE_IP)) {
+            return false;
+        }
+
+        return \inet_pton($ip);
+    }
+
+    private static function ipMatchesPrefix(string $address, string $network, int $prefix): bool
     {
         $fullBytes = \intdiv($prefix, 8);
         $remainingBits = $prefix % 8;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -698,14 +698,41 @@ class ClientTest extends TestCase
             self::assertSame(['http' => '127.0.0.1'], $config['proxy']);
 
             \putenv('HTTPS_PROXY=127.0.0.2');
-            \putenv('NO_PROXY=127.0.0.3, 127.0.0.4');
+            \putenv('NO_PROXY= 127.0.0.3 , 127.0.0.4 , [::1]:8080 ');
             $client = new Client();
             $config = self::readClientConfig($client);
             self::assertArrayHasKey('proxy', $config);
             self::assertSame(
-                ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3', '127.0.0.4']],
+                ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3', '127.0.0.4', '[::1]:8080']],
                 $config['proxy']
             );
+
+            \putenv('HTTP_PROXY=');
+            \putenv('HTTPS_PROXY=');
+            \putenv('NO_PROXY=0');
+            $client = new Client();
+            $config = self::readClientConfig($client);
+            self::assertArrayHasKey('proxy', $config);
+            self::assertSame(['no' => ['0']], $config['proxy']);
+
+            \putenv('NO_PROXY= , , ');
+            $client = new Client();
+            $config = self::readClientConfig($client);
+            self::assertArrayNotHasKey('proxy', $config);
+
+            \putenv('HTTP_PROXY=127.0.0.1');
+            $client = new Client();
+            $config = self::readClientConfig($client);
+            self::assertArrayHasKey('proxy', $config);
+            self::assertSame(['http' => '127.0.0.1'], $config['proxy']);
+
+            \putenv('HTTP_PROXY=');
+
+            \putenv('NO_PROXY=exa mple.com, foo.com');
+            $client = new Client();
+            $config = self::readClientConfig($client);
+            self::assertArrayHasKey('proxy', $config);
+            self::assertSame(['no' => ['exa mple.com', 'foo.com']], $config['proxy']);
         } finally {
             \putenv('HTTP_PROXY=');
             \putenv('HTTPS_PROXY=');

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -220,8 +220,11 @@ class CurlFactoryTest extends TestCase
         self::assertEquals('http://bar.com', $_SERVER['_curl'][\CURLOPT_PROXY]);
         self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         $this->checkNoProxyForHost('http://test.test.com', ['test.test.com'], false);
+        $this->checkNoProxyForHost('http://example.com', ['EXAMPLE.com'], false);
+        $this->checkNoProxyForHost('http://foo.example.com', ['EXAMPLE.com'], false);
         $this->checkNoProxyForHost('http://test.test.com', ['.test.com'], false);
         $this->checkNoProxyForHost('http://test.test.com', 'test.test.com,example.com', false);
+        $this->checkNoProxyForHost('http://example.com', ' EXAMPLE.com , other.com ', false);
         $this->checkNoProxyForHost('http://test.test.com', '.example.com,example.org', true);
         $this->checkNoProxyForHost('http://test.test.com', [], true);
         $this->checkNoProxyForHost('http://test.test.com', '', true);
@@ -233,8 +236,13 @@ class CurlFactoryTest extends TestCase
         $this->checkNoProxyForHost('http://test.com:8080', ['.test.com:8080'], true);
         $this->checkNoProxyForHost('http://[::1]:8080', ['[::1]:8080'], false);
         $this->checkNoProxyForHost('http://[::1]:8081', ['[::1]:8080'], true);
+        $this->checkNoProxyForHost('http://[0:0:0:0:0:0:0:1]', ['::1'], false);
+        $this->checkNoProxyForHost('http://[::1]:8081', ['[0:0:0:0:0:0:0:1]:8080'], true);
         $this->checkNoProxyForHost('http://test.test.com', ['*.test.com'], true);
+        $this->checkNoProxyForHost('http://test.example.com', ['*.example.com'], true);
         $this->checkNoProxyForHost('http://test.test.com', ['*'], false);
+        $this->checkNoProxyForHost('http://example.com', ['*:80'], false);
+        $this->checkNoProxyForHost('https://example.com', ['*:80'], true);
         $this->checkNoProxyForHost('http://127.0.0.1', ['127.0.0.*'], true);
         $this->checkNoProxyForHost('http://192.168.1.10', ['192.168.0.0/16'], false);
         $this->checkNoProxyForHost('http://192.169.1.10', ['192.168.0.0/16'], true);
@@ -279,11 +287,14 @@ class CurlFactoryTest extends TestCase
             ],
         ]);
         if ($assertUseProxy) {
-            self::assertSame('http://bar.com', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame(
+                \parse_url($url, \PHP_URL_SCHEME) === 'https' ? 'https://t' : 'http://bar.com',
+                $_SERVER['_curl'][\CURLOPT_PROXY]
+            );
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         } else {
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
-            self::assertSame(parse_url($url, \PHP_URL_HOST), $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         }
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -449,12 +449,30 @@ class StreamHandlerTest extends TestCase
         self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'https://example.com')['http']['proxy']);
         self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://example.com:8080')['http']['proxy']);
 
+        $proxy['no'] = ['EXAMPLE.com'];
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://example.com')['http']);
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://foo.example.com')['http']);
+
+        $proxy['no'] = ' EXAMPLE.com , other.com ';
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://example.com')['http']);
+
         $proxy['no'] = ['.example.com:8080'];
         self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://foo.example.com:8080')['http']);
         self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://example.com:8080')['http']['proxy']);
         self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://foo.example.com:8081')['http']['proxy']);
 
+        $proxy['no'] = ['.EXAMPLE.com:8080'];
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://foo.example.com:8080')['http']);
+        self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://example.com:8080')['http']['proxy']);
+
         $proxy['no'] = ['[::1]:8080'];
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://[::1]:8080')['http']);
+        self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://[::1]:8081')['http']['proxy']);
+
+        $proxy['no'] = ['::1'];
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://[0:0:0:0:0:0:0:1]')['http']);
+
+        $proxy['no'] = ['[0:0:0:0:0:0:0:1]:8080'];
         self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://[::1]:8080')['http']);
         self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://[::1]:8081')['http']['proxy']);
 
@@ -465,6 +483,13 @@ class StreamHandlerTest extends TestCase
         $proxy['no'] = ['fd00::/8'];
         self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://[fd00::1]')['http']);
         self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://[fe80::1]')['http']['proxy']);
+
+        $proxy['no'] = ['*.example.com'];
+        self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://test.example.com')['http']['proxy']);
+
+        $proxy['no'] = ['*:80'];
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://example.com')['http']);
+        self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'https://example.com')['http']['proxy']);
     }
 
     public function testUsesProxy(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -115,6 +115,11 @@ class UtilsTest extends TestCase
             ['mit.edu', ['baz', '*'], true],
             ['0', ['0'], true],
             ['foo.example.com', ['example.com'], true],
+            ['EXAMPLE.com', ['example.com'], true],
+            ['example.com', ['EXAMPLE.com'], true],
+            ['foo.example.com', ['EXAMPLE.com'], true],
+            ['foo.example.com:123', ['.EXAMPLE.com'], true],
+            ['example.com', ['.EXAMPLE.com'], false],
             ['example.com', ['example.com:443'], false],
             ['[::1]', ['[::1]'], true],
             ['[::1]', ['::1'], true],
@@ -122,11 +127,18 @@ class UtilsTest extends TestCase
             ['[::1]', ['[::1]:8080'], false],
             ['[::1]:8080', ['::1'], true],
             ['[::1]:8080', ['[::1]'], true],
+            ['[::1]:8080', ['[::1]:8080'], false],
             ['[fd00::1]', ['fd00::1'], true],
             ['[fd00::1]', ['[fd00::2]'], false],
             ['[2a00:f48:1008::212:183:10]', ['2a00:f48:1008::212:183:10'], true],
             ['[2a00:f48:1008::212:183:10]', ['[2a00:f48:1008::212:183:10]'], true],
             ['[2A00:F48:1008::212:183:10]', ['2a00:f48:1008::212:183:10'], true],
+            ['[0:0:0:0:0:0:0:1]', ['::1'], true],
+            ['[::1]', ['[0:0:0:0:0:0:0:1]'], true],
+            ['example.com:443', ['example.com'], true],
+            ['example.com:443', ['example.com:443'], false],
+            ['127.0.0.1', ['.127.0.0.1'], false],
+            ['foo.127.0.0.1', ['127.0.0.1'], false],
             ['192.168.1.10', ['192.168.0.0/16'], true],
             ['192.169.1.10', ['192.168.0.0/16'], false],
             ['[fd00::1]', ['fd00::/8'], true],
@@ -145,11 +157,16 @@ class UtilsTest extends TestCase
     public function testNormalizesNoProxyString(): void
     {
         self::assertSame(['foo.com', '.bar.com'], Utils::normalizeNoProxy(' foo.com, .bar.com, '));
+        self::assertSame(['foo.com', 'bar.com'], Utils::normalizeNoProxy(' foo.com , bar.com , '));
+        self::assertSame(['foo.com', 'bar.com'], Utils::normalizeNoProxy('foo.com,,bar.com,'));
+        self::assertSame(['foo.com', 'bar.com'], Utils::normalizeNoProxy(" \tfoo.com\t , \nbar.com\n "));
+        self::assertSame(['exa mple.com', 'foo.com'], Utils::normalizeNoProxy('exa mple.com, foo.com'));
     }
 
     public function testNormalizesNoProxyArray(): void
     {
         self::assertSame(['foo.com', '.bar.com'], Utils::normalizeNoProxy([' foo.com ', '', '.bar.com']));
+        self::assertSame(['foo.com', 'bar.com'], Utils::normalizeNoProxy([' foo.com ', '', ' bar.com ']));
     }
 
     public function testValidatesNoProxyValue(): void
@@ -173,28 +190,57 @@ class UtilsTest extends TestCase
         return [
             ['http://example.com', ['example.com:80'], true],
             ['https://example.com', ['example.com:443'], true],
+            ['http://example.com', ['EXAMPLE.com'], true],
+            ['http://foo.example.com', ['EXAMPLE.com'], true],
+            ['http://foo.example.com', ['.EXAMPLE.com'], true],
+            ['http://example.com', ['.EXAMPLE.com'], false],
+            ['http://notexample.com', ['example.com'], false],
             ['http://example.com:8080', ['example.com:8080'], true],
             ['http://example.com:8081', ['example.com:8080'], false],
             ['http://foo.example.com:8080', ['example.com:8080'], true],
             ['http://foo.example.com:8080', ['.example.com:8080'], true],
+            ['http://foo.example.com:8080', ['.EXAMPLE.com:8080'], true],
+            ['http://foo.example.com:8081', ['.EXAMPLE.com:8080'], false],
             ['http://example.com:8080', ['.example.com:8080'], false],
+            ['http://127.0.0.1', ['127.0.0.1'], true],
+            ['http://127.0.0.1:8080', ['127.0.0.1:8080'], true],
+            ['http://127.0.0.1:8081', ['127.0.0.1:8080'], false],
+            ['http://127.0.0.1', ['.127.0.0.1'], false],
             ['http://[::1]:8080', ['[::1]:8080'], true],
             ['http://[::1]:8081', ['[::1]:8080'], false],
             ['http://[::1]', ['[::1]:80'], true],
             ['https://[::1]', ['[::1]:443'], true],
             ['http://[::1]', ['::1:80'], false],
+            ['http://[0:0:0:0:0:0:0:1]', ['::1'], true],
+            ['http://[::1]', ['[0:0:0:0:0:0:0:1]'], true],
+            ['http://[::1]:8080', ['[0:0:0:0:0:0:0:1]:8080'], true],
+            ['http://[::1]:8081', ['[0:0:0:0:0:0:0:1]:8080'], false],
+            ['http://[::1:80]', ['::1:80'], true],
+            ['http://[::1]', ['.[::1]'], false],
             ['http://test.test.com', ['*.test.com'], false],
             ['http://127.0.0.1', ['127.0.0.*'], false],
             ['http://0', ['0'], true],
             ['http://anything.test', ['*'], true],
+            ['http://example.com', ['*:80'], true],
+            ['https://example.com', ['*:80'], false],
+            ['http://example.com:8080', ['*:80'], false],
+            ['http://example.com', ['.*'], false],
+            ['http://example.com', ['.*:80'], false],
             ['http://example.com', ['example.com:abc'], false],
             ['http://example.com', ['example.com:99999'], false],
+            ['http://example.com', ["foo\0bar"], false],
+            ['http://127.0.0.1', ["127.0.0.1\0evil"], false],
+            ['http://[::1]', ["::1\0evil"], false],
             ['http://192.168.1.10', ['192.168.0.0/16'], true],
+            ['http://192.168.255.255', ['192.168.0.0/16'], true],
             ['http://192.169.1.10', ['192.168.0.0/16'], false],
+            ['http://192.169.0.0', ['192.168.0.0/16'], false],
             ['http://127.0.0.1', ['127.0.0.0/8'], true],
             ['http://10.1.2.3:8080', ['10.0.0.0/8'], true],
             ['http://[fd00::1]', ['fd00::/8'], true],
             ['http://[fd00::1]', ['[fd00::]/8'], true],
+            ['http://[fdff:ffff::1]', ['fd00::/8'], true],
+            ['http://[fe00::1]', ['fd00::/8'], false],
             ['http://[fe80::1]', ['fe80::/10'], true],
             ['http://[febf::1]', ['fe80::/10'], true],
             ['http://[fec0::1]', ['fe80::/10'], false],
@@ -207,12 +253,14 @@ class UtilsTest extends TestCase
             ['http://[fd00::1]:8080', ['[fd00::]/8:8080'], false],
             ['http://192.168.1.10', ['fd00::/8'], false],
             ['http://[fd00::1]', ['192.168.0.0/16'], false],
+            ['http://192.168.1.10', ["192.168.0.0\0evil/16"], false],
             ['http://203.0.113.10', ['0.0.0.0/0'], true],
             ['http://203.0.113.10', ['203.0.113.10/32'], true],
             ['http://203.0.113.11', ['203.0.113.10/32'], false],
             ['http://[2001:db8::1]', ['::/0'], true],
             ['http://[2001:db8::1]', ['2001:db8::1/128'], true],
             ['http://[2001:db8::2]', ['2001:db8::1/128'], false],
+            ['/relative-path', ['*'], false],
         ];
     }
 


### PR DESCRIPTION
This normalizes no-proxy domain and IP literal matching and uses the shared no-proxy normalization for environment defaults.