### PR TITLE
Reject malformed protocol versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Default HTTPS requests sent by the built-in cURL and stream handlers to TLS 1.2 or newer
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them
-- Reject empty request protocol versions
+- Reject empty or malformed request protocol versions
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -71,12 +71,14 @@ throw `InvalidArgumentException` instead of being converted to no timeout.
 
 #### Protocol version validation
 
-Empty request protocol versions are no longer treated as omitted. Passing
-`'version' => ''` in request options or sending a PSR-7 request whose protocol
-version is `''` now throws an exception before the request is sent.
+Empty or malformed request protocol versions are no longer treated as omitted.
+Passing `'version' => ''`, `'version' => 'HTTP/1.1'`, or sending a PSR-7
+request whose protocol version is empty or malformed now throws an exception
+before the request is sent.
 
 Omit the `version` request option to use Guzzle's default HTTP/1.1 behavior, or
-pass an explicit supported protocol version such as `'1.1'`.
+pass an explicit supported protocol version such as `'1.1'`. Do not include the
+`HTTP/` prefix.
 
 #### TLS minimum version
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -309,9 +309,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     {
         $request = $this->applyOptions($request, $options);
 
-        if ('' === $request->getProtocolVersion()) {
-            throw new InvalidArgumentException('HTTP protocol version must not be empty.');
-        }
+        self::assertProtocolVersion($request->getProtocolVersion());
 
         /** @var HandlerStack $handler */
         $handler = $options['handler'];
@@ -484,11 +482,22 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      */
     private static function normalizeProtocolVersion($version): string
     {
+        $version = \is_float($version) ? \number_format($version, 1, '.', '') : (string) $version;
+
+        self::assertProtocolVersion($version);
+
+        return $version;
+    }
+
+    private static function assertProtocolVersion(string $version): void
+    {
         if ('' === $version) {
             throw new InvalidArgumentException('HTTP protocol version must not be empty.');
         }
 
-        return \is_float($version) ? \number_format($version, 1, '.', '') : (string) $version;
+        if (1 !== \preg_match('/^\d+(?:\.\d+)?$/D', $version)) {
+            throw new InvalidArgumentException('HTTP protocol version must be a valid HTTP version number.');
+        }
     }
 
     /**

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -50,6 +50,10 @@ class CurlFactory implements CurlFactoryInterface
             throw new ConnectException('HTTP protocol version must not be empty.', $request);
         }
 
+        if (1 !== \preg_match('/^\d+(?:\.\d+)?$/D', $protocolVersion)) {
+            throw new ConnectException('HTTP protocol version must be a valid HTTP version number.', $request);
+        }
+
         if ('3' === $protocolVersion || '3.0' === $protocolVersion) {
             if (!CurlVersion::supportsHttp3()) {
                 throw new ConnectException('HTTP/3 is supported by the cURL handler, however the installed PHP cURL extension or libcurl does not support HTTP/3.', $request);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -47,6 +47,10 @@ class StreamHandler
             throw new ConnectException('HTTP protocol version must not be empty.', $request);
         }
 
+        if (1 !== \preg_match('/^\d+(?:\.\d+)?$/D', $protocolVersion)) {
+            throw new ConnectException('HTTP protocol version must be a valid HTTP version number.', $request);
+        }
+
         if ('1.0' !== $protocolVersion && '1.1' !== $protocolVersion) {
             throw new ConnectException(sprintf('HTTP/%s is not supported by the stream handler.', $protocolVersion), $request);
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -17,6 +17,8 @@ use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class ClientTest extends TestCase
@@ -66,12 +68,51 @@ class ClientTest extends TestCase
     {
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
-        $request = new Request('GET', 'http://example.com', [], null, '');
+        $request = self::requestWithProtocolVersion('');
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('HTTP protocol version must not be empty.');
 
         $client->send($request);
+    }
+
+    /**
+     * @dataProvider malformedProtocolVersionProvider
+     */
+    public function testRejectsMalformedProtocolVersionRequestOption(string $version): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP protocol version must be a valid HTTP version number.');
+
+        $client->get('http://example.com', ['version' => $version]);
+    }
+
+    /**
+     * @dataProvider malformedProtocolVersionProvider
+     */
+    public function testRejectsMalformedRequestProtocolVersion(string $version): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('HTTP protocol version must be a valid HTTP version number.');
+
+        $client->send(self::requestWithProtocolVersion($version));
+    }
+
+    public static function malformedProtocolVersionProvider(): iterable
+    {
+        yield ['HTTP/1.1'];
+        yield ['1.1 '];
+        yield [' 1.1'];
+        yield ['1.'];
+        yield ['.1'];
+        yield ['1.1.1'];
+        yield ['foo'];
     }
 
     public function testClientHasOptions(): void
@@ -999,6 +1040,41 @@ class ClientTest extends TestCase
         }, null, Client::class);
 
         return $readConfig($client);
+    }
+
+    private static function requestWithProtocolVersion(string $protocolVersion): RequestInterface
+    {
+        return new ClientTestRequestWithProtocolVersion($protocolVersion);
+    }
+}
+
+final class ClientTestRequestWithProtocolVersion extends Request
+{
+    /** @var string */
+    private $protocolVersion;
+
+    public function __construct(string $protocolVersion)
+    {
+        parent::__construct('GET', 'http://example.com');
+
+        $this->protocolVersion = $protocolVersion;
+    }
+
+    public function getProtocolVersion(): string
+    {
+        return $this->protocolVersion;
+    }
+
+    public function withProtocolVersion(string $version): MessageInterface
+    {
+        if ($this->protocolVersion === $version) {
+            return $this;
+        }
+
+        $new = clone $this;
+        $new->protocolVersion = $version;
+
+        return $new;
     }
 }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -15,6 +15,7 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Server\Server;
 use GuzzleHttp\TransferStats;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -650,10 +651,21 @@ class CurlFactoryTest extends TestCase
     public function testRejectsEmptyProtocolVersion(): void
     {
         $factory = new CurlFactory(3);
-        $request = new Psr7\Request('GET', Server::$url, [], null, '');
+        $request = self::requestWithProtocolVersion('');
 
         $this->expectException(ConnectException::class);
         $this->expectExceptionMessage('HTTP protocol version must not be empty.');
+
+        $factory->create($request, []);
+    }
+
+    public function testRejectsMalformedProtocolVersion(): void
+    {
+        $factory = new CurlFactory(3);
+        $request = self::requestWithProtocolVersion('HTTP/1.1');
+
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('HTTP protocol version must be a valid HTTP version number.');
 
         $factory->create($request, []);
     }
@@ -1372,5 +1384,37 @@ class CurlFactoryTest extends TestCase
         }, null, CurlFactory::class);
 
         return $readHandles($factory);
+    }
+
+    private static function requestWithProtocolVersion(string $protocolVersion): RequestInterface
+    {
+        return new class($protocolVersion) extends Psr7\Request {
+            /** @var string */
+            private $protocolVersion;
+
+            public function __construct(string $protocolVersion)
+            {
+                parent::__construct('GET', Server::$url);
+
+                $this->protocolVersion = $protocolVersion;
+            }
+
+            public function getProtocolVersion(): string
+            {
+                return $this->protocolVersion;
+            }
+
+            public function withProtocolVersion(string $version): MessageInterface
+            {
+                if ($this->protocolVersion === $version) {
+                    return $this;
+                }
+
+                $new = clone $this;
+                $new->protocolVersion = $version;
+
+                return $new;
+            }
+        };
     }
 }

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -127,25 +127,6 @@ class CurlMultiHandlerTest extends TestCase
         self::assertGreaterThanOrEqual($expected, Utils::currentTime());
     }
 
-    public function testUsesTimeoutEnvironmentVariables()
-    {
-        unset($_SERVER['GUZZLE_CURL_SELECT_TIMEOUT']);
-        \putenv('GUZZLE_CURL_SELECT_TIMEOUT=');
-
-        try {
-            $a = new CurlMultiHandler();
-            // Default if no options are given and no environment variable is set
-            self::assertEquals(1, self::readSelectTimeout($a));
-
-            \putenv('GUZZLE_CURL_SELECT_TIMEOUT=3');
-            $a = new CurlMultiHandler();
-            // Handler reads from the environment if no options are given
-            self::assertEquals(3, self::readSelectTimeout($a));
-        } finally {
-            \putenv('GUZZLE_CURL_SELECT_TIMEOUT=');
-        }
-    }
-
     public function throwsWhenAccessingInvalidProperty(): void
     {
         $h = new CurlMultiHandler();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -16,6 +16,7 @@ use GuzzleHttp\Server\Server;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -62,7 +63,17 @@ class StreamHandlerTest extends TestCase
         $this->expectException(ConnectException::class);
         $this->expectExceptionMessage('HTTP protocol version must not be empty.');
 
-        $handler(new Request('GET', Server::$url, [], null, ''), []);
+        $handler(self::requestWithProtocolVersion(''), []);
+    }
+
+    public function testRejectsMalformedProtocolVersion(): void
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('HTTP protocol version must be a valid HTTP version number.');
+
+        $handler(self::requestWithProtocolVersion('HTTP/1.1'), []);
     }
 
     public function testAddsErrorToResponse(): void
@@ -1134,5 +1145,37 @@ class StreamHandlerTest extends TestCase
                 RequestOptions::STREAM => true,
             ]
         )->wait();
+    }
+
+    private static function requestWithProtocolVersion(string $protocolVersion): RequestInterface
+    {
+        return new class($protocolVersion) extends Request {
+            /** @var string */
+            private $protocolVersion;
+
+            public function __construct(string $protocolVersion)
+            {
+                parent::__construct('GET', Server::$url);
+
+                $this->protocolVersion = $protocolVersion;
+            }
+
+            public function getProtocolVersion(): string
+            {
+                return $this->protocolVersion;
+            }
+
+            public function withProtocolVersion(string $version): MessageInterface
+            {
+                if ($this->protocolVersion === $version) {
+                    return $this;
+                }
+
+                $new = clone $this;
+                $new->protocolVersion = $version;
+
+                return $new;
+            }
+        };
     }
 }


### PR DESCRIPTION
This rejects malformed request protocol versions before sending requests and updates the related 8.0 tests.