### PR TITLE
Harden PSR-7 response integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0
 - Store response cookies without a `Domain` attribute as host-only cookies
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
+- Reject malformed response protocol versions and reason phrases
+- Wrap malformed redirect `Location` values in `BadResponseException`
 - Default HTTPS requests sent by the built-in cURL and stream handlers to TLS 1.2 or newer
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -32,10 +32,16 @@ final class HeaderProcessor
         }
 
         $parts = \explode(' ', $statusLine, 3);
-        $version = \explode('/', $parts[0])[1] ?? null;
+        $protocol = $parts[0];
 
-        if ($version === null) {
+        if (0 !== \strncasecmp($protocol, 'HTTP/', 5)) {
             throw new \RuntimeException('HTTP version missing from header data');
+        }
+
+        $version = \substr($protocol, 5);
+
+        if (!\preg_match('/^\d+(?:\.\d+)?$/D', $version)) {
+            throw new \RuntimeException('HTTP version is invalid');
         }
 
         $status = $parts[1] ?? null;
@@ -48,13 +54,19 @@ final class HeaderProcessor
             throw new \RuntimeException('HTTP status code is invalid');
         }
 
+        $reason = $parts[2] ?? null;
+
+        if ($reason !== null && !\preg_match('/^[\x09\x20-\x7E\x80-\xFF]*$/D', $reason)) {
+            throw new \RuntimeException('HTTP reason phrase is invalid');
+        }
+
         foreach ($headers as $header) {
             if (\strpos($header, ':') === false) {
                 throw new \RuntimeException('HTTP header line is invalid');
             }
         }
 
-        return [$version, (int) $status, $parts[2] ?? null, Utils::headersFromLines($headers)];
+        return [$version, (int) $status, $reason, Utils::headersFromLines($headers)];
     }
 
     /**

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -220,10 +220,16 @@ class RedirectMiddleware
         ResponseInterface $response,
         array $protocols
     ): UriInterface {
-        $location = Psr7\UriResolver::resolve(
-            $request->getUri(),
-            new Psr7\Uri($response->getHeaderLine('Location'))
-        );
+        $location = $response->getHeaderLine('Location');
+
+        try {
+            $location = Psr7\UriResolver::resolve(
+                $request->getUri(),
+                new Psr7\Uri($location)
+            );
+        } catch (\InvalidArgumentException $e) {
+            throw new BadResponseException(\sprintf('Redirect URI, %s, is invalid: %s', $location, $e->getMessage()), $request, $response, $e);
+        }
 
         // Ensure that the redirect URI is allowed based on the protocols.
         if (!\in_array($location->getScheme(), $protocols)) {

--- a/tests/Handler/HeaderProcessorTest.php
+++ b/tests/Handler/HeaderProcessorTest.php
@@ -47,6 +47,34 @@ class HeaderProcessorTest extends TestCase
         ]);
     }
 
+    public function testRejectsMissingProtocolVersion(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HTTP version missing from header data');
+
+        HeaderProcessor::parseHeaders([
+            'FTP/1.1 200 OK',
+        ]);
+    }
+
+    /**
+     * @dataProvider invalidProtocolVersionProvider
+     */
+    public function testRejectsMalformedProtocolVersion(string $statusLine): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HTTP version is invalid');
+
+        HeaderProcessor::parseHeaders([$statusLine]);
+    }
+
+    public static function invalidProtocolVersionProvider(): iterable
+    {
+        yield ['HTTP/foo 200 OK'];
+        yield ['HTTP/ 200 OK'];
+        yield ['HTTP/1.1.1 200 OK'];
+    }
+
     public function testParsesBoundaryStatusCodes(): void
     {
         [, $informationalStatus] = HeaderProcessor::parseHeaders(['HTTP/1.1 100 Continue']);
@@ -63,6 +91,16 @@ class HeaderProcessorTest extends TestCase
 
         HeaderProcessor::parseHeaders([
             'HTTP/1.1 200abc Weird',
+        ]);
+    }
+
+    public function testRejectsMalformedReasonPhrase(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('HTTP reason phrase is invalid');
+
+        HeaderProcessor::parseHeaders([
+            "HTTP/1.1 200 OK\x00",
         ]);
     }
 

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -159,6 +159,26 @@ class RedirectMiddlewareTest extends TestCase
         $handler($request, ['allow_redirects' => ['max' => 3]])->wait();
     }
 
+    public function testRejectsMalformedRedirectUri(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://[::1']),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('GET', 'http://example.com');
+
+        try {
+            $handler($request, ['allow_redirects' => ['max' => 3]])->wait();
+            self::fail('Expected BadResponseException.');
+        } catch (BadResponseException $e) {
+            self::assertSame(302, $e->getResponse()->getStatusCode());
+            self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+            self::assertStringStartsWith('Redirect URI,', $e->getMessage());
+        }
+    }
+
     public function testAddsRefererHeader(): void
     {
         $mock = new MockHandler([


### PR DESCRIPTION
This validates response start-lines before creating PSR-7 responses and wraps malformed redirect Location values in Guzzle exceptions.