### PR TITLE
Quote multipart boundary parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Hardened `FileCookieJar` persistence against unsafe unserialization
 - Adjusted `guzzlehttp/promises` version constraint to `^3.0`
 - Adjusted `guzzlehttp/psr7` version constraint to `^3.0`
+- Quote multipart `Content-Type` boundary parameters when required
 - Added parameter and return types to `SetCookie` methods
 - Added `string` return types to `__toString()` methods
 - Normalize and validate proxy no-proxy options consistently across handlers

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -33,12 +33,22 @@ Guzzle 8 requires PHP `^7.4 || ^8.0`. Guzzle 7 supported PHP
 Guzzle 8 also requires `guzzlehttp/promises` 3.x and `guzzlehttp/psr7` 3.x. If
 your application uses those packages directly, review their upgrade guides.
 
-#### Multipart request part headers
+#### Multipart request serialization
 
 Guzzle 8 uses Guzzle PSR-7 3.x for multipart request bodies. Multipart parts
 created through the `multipart` request option no longer include generated
 per-part `Content-Length` headers by default. If your tests compare raw
 multipart payloads, remove those generated part headers from expected strings.
+
+Generated multipart `Content-Disposition` header `name` and `filename`
+parameters now escape double quotes, carriage returns, and line feeds as `%22`,
+`%0D`, and `%0A`. Custom multipart part header names and values, and explicit
+PSR-7 multipart boundaries, are also validated by PSR-7.
+
+Guzzle now quotes the `boundary` parameter in generated
+`Content-Type: multipart/form-data` headers when an explicit PSR-7
+`MultipartStream` boundary contains characters that require quoting.
+Automatically generated boundaries are unchanged.
 
 You can still pass an explicit `Content-Length` header in a multipart element's
 `headers` array if a non-standard peer requires it.

--- a/src/Client.php
+++ b/src/Client.php
@@ -459,8 +459,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             // Use a multipart/form-data POST if a Content-Type is not set.
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\Utils::caselessRemove(['Content-Type'], $options['_conditional']);
-            $options['_conditional']['Content-Type'] = 'multipart/form-data; boundary='
-                .$request->getBody()->getBoundary();
+            $options['_conditional']['Content-Type'] = self::getMultipartContentType($request->getBody());
         }
 
         // Merge in conditional headers if they are not present.
@@ -501,6 +500,17 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         if (1 !== \preg_match('/^\d+(?:\.\d+)?$/D', $version)) {
             throw new InvalidArgumentException('HTTP protocol version must be a valid HTTP version number.');
         }
+    }
+
+    private static function getMultipartContentType(Psr7\MultipartStream $body): string
+    {
+        $boundary = $body->getBoundary();
+
+        if (false !== \strpbrk($boundary, '()<>@,;:\"/[]?= ')) {
+            $boundary = '"'.$boundary.'"';
+        }
+
+        return 'multipart/form-data; boundary='.$boundary;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -679,6 +679,86 @@ class ClientTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider multipartBoundaryRequiringQuotesProvider
+     */
+    public function testQuotesMultipartBoundaryParameterWhenRequired(string $boundary): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->send(new Request(
+            'POST',
+            'http://foo.com',
+            [],
+            new Psr7\MultipartStream([], $boundary)
+        ));
+
+        $last = $mock->getLastRequest();
+        self::assertSame(
+            'multipart/form-data; boundary="'.$boundary.'"',
+            $last->getHeaderLine('Content-Type')
+        );
+    }
+
+    public static function multipartBoundaryRequiringQuotesProvider(): iterable
+    {
+        yield 'colon' => ['abc:def'];
+        yield 'slash' => ['abc/def'];
+        yield 'parentheses' => ['abc(def)'];
+        yield 'space' => ['abc def'];
+        yield 'question mark' => ['abc?def'];
+        yield 'equals' => ['abc=def'];
+        yield 'comma' => ['abc,def'];
+    }
+
+    /**
+     * @dataProvider unquotedMultipartBoundaryProvider
+     */
+    public function testLeavesMultipartBoundaryParameterUnquotedWhenPossible(string $boundary): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->send(new Request(
+            'POST',
+            'http://foo.com',
+            [],
+            new Psr7\MultipartStream([], $boundary)
+        ));
+
+        $last = $mock->getLastRequest();
+        self::assertSame(
+            'multipart/form-data; boundary='.$boundary,
+            $last->getHeaderLine('Content-Type')
+        );
+    }
+
+    public static function unquotedMultipartBoundaryProvider(): iterable
+    {
+        yield 'letters and digits' => ['abc123'];
+        yield 'hyphen and underscore' => ['abc-def_123'];
+        yield 'apostrophe' => ["abc'def"];
+        yield 'plus' => ['abc+def'];
+        yield 'period' => ['abc.def'];
+    }
+
+    public function testPreservesExistingMultipartContentTypeHeader(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->send(new Request(
+            'POST',
+            'http://foo.com',
+            ['Content-Type' => 'multipart/form-data; boundary=provided'],
+            new Psr7\MultipartStream([], 'abc:def')
+        ));
+
+        $last = $mock->getLastRequest();
+        self::assertSame(
+            'multipart/form-data; boundary=provided',
+            $last->getHeaderLine('Content-Type')
+        );
+    }
+
     public function testUsesProxyEnvironmentVariables(): void
     {
         unset($_SERVER['HTTP_PROXY'], $_SERVER['HTTPS_PROXY'], $_SERVER['NO_PROXY']);


### PR DESCRIPTION
This quotes multipart/form-data boundary parameters when an explicit PSR-7 MultipartStream boundary contains characters that require quoting.