### PR TITLE
Add timeout exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add HTTP/3 request support to the built-in cURL handlers when PHP 8.4+ and libcurl provide HTTP/3 support
 - Add generic PHPDoc annotations to async HTTP and handler APIs
 - Add CIDR notation support for IP no-proxy rules
+- Add network and timeout exception types
 
 ### Changed
 
@@ -37,6 +38,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them
 - Reject empty or malformed request protocol versions
+- Throw `TimeoutException` for reliably detected transfer timeouts
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -50,6 +50,17 @@ $client->request('GET', 'https://example.com');
 The convenience methods such as `$client->get()`, `$client->post()`, and their
 async variants continue to use uppercase standard methods.
 
+#### Network and timeout exceptions
+
+`ConnectException` now extends `GuzzleHttp\Exception\NetworkException`, which
+extends `GuzzleHttp\Exception\TransferException` and implements PSR-18's
+`NetworkExceptionInterface`.
+
+When a built-in handler can reliably identify a transfer timeout, it now throws
+`GuzzleHttp\Exception\TimeoutException`. `TimeoutException` extends
+`ConnectException`, so existing `catch (ConnectException $e)` and
+`catch (TransferException $e)` blocks continue to catch timeout failures.
+
 #### Multipart request serialization
 
 Guzzle 8 uses Guzzle PSR-7 3.x for multipart request bodies. Multipart parts

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -450,7 +450,9 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 ```
 . \RuntimeException
 └── TransferException (implements GuzzleException)
-    ├── ConnectException (implements NetworkExceptionInterface)
+    ├── NetworkException (implements NetworkExceptionInterface)
+    │   └── ConnectException
+    │       └── TimeoutException
     └── RequestException
         ├── BadResponseException
         │   ├── ServerException
@@ -460,7 +462,11 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 
 Guzzle throws exceptions for errors that occur during a transfer.
 
-- A `GuzzleHttp\Exception\ConnectException` exception is thrown in the event of a networking error. This exception extends from `GuzzleHttp\Exception\TransferException`.
+- `GuzzleHttp\Exception\NetworkException` is the base class for networking errors. This exception extends from `GuzzleHttp\Exception\TransferException`.
+
+- A `GuzzleHttp\Exception\ConnectException` exception is thrown when a connection cannot be established. This exception extends from `GuzzleHttp\Exception\NetworkException`.
+
+- A `GuzzleHttp\Exception\TimeoutException` exception is thrown when a transfer timeout can be reliably identified. This exception extends from `GuzzleHttp\Exception\ConnectException`.
 
 - A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\RequestException`.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1003,7 +1003,7 @@ Constant
 ```php
 // Timeout if a server does not return a response in 3.14 seconds.
 $client->request('GET', '/delay/5', ['timeout' => 3.14]);
-// PHP Fatal error:  Uncaught exception 'GuzzleHttp\Exception\TransferException'
+// PHP Fatal error:  Uncaught exception 'GuzzleHttp\Exception\TimeoutException'
 ```
 
 ## version

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -2,7 +2,6 @@
 
 namespace GuzzleHttp\Exception;
 
-use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -10,7 +9,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * Note that no response is present for a ConnectException
  */
-class ConnectException extends TransferException implements NetworkExceptionInterface
+class ConnectException extends NetworkException
 {
     /**
      * @var RequestInterface

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace GuzzleHttp\Exception;
+
+use Psr\Http\Client\NetworkExceptionInterface;
+
+/**
+ * Base exception for network-related transfer failures.
+ */
+abstract class NetworkException extends TransferException implements NetworkExceptionInterface
+{
+}

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GuzzleHttp\Exception;
+
+/**
+ * Exception thrown when a transfer times out.
+ */
+class TimeoutException extends ConnectException
+{
+}

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TimeoutException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\LazyOpenStream;
@@ -296,7 +297,6 @@ class CurlFactory implements CurlFactoryInterface
     private static function createRejection(EasyHandle $easy, array $ctx): PromiseInterface
     {
         static $connectionErrors = [
-            \CURLE_OPERATION_TIMEOUTED => true,
             \CURLE_COULDNT_RESOLVE_HOST => true,
             \CURLE_COULDNT_CONNECT => true,
             \CURLE_SSL_CONNECT_ERROR => true,
@@ -349,10 +349,13 @@ class CurlFactory implements CurlFactoryInterface
             }
         }
 
-        // Create a connection exception if it was a specific error code.
-        $error = isset($connectionErrors[$easy->errno])
-            ? new ConnectException($message, $easy->request, null, $ctx)
-            : new RequestException($message, $easy->request, $easy->response, null, $ctx);
+        if ($easy->errno === \CURLE_OPERATION_TIMEOUTED) {
+            $error = new TimeoutException($message, $easy->request, null, $ctx);
+        } elseif (isset($connectionErrors[$easy->errno])) {
+            $error = new ConnectException($message, $easy->request, null, $ctx);
+        } else {
+            $error = new RequestException($message, $easy->request, $easy->response, null, $ctx);
+        }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */
         return P\Create::rejectionFor($error);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TimeoutException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
@@ -85,14 +86,16 @@ class StreamHandler
             // Determine if the error was a networking error.
             $message = $e->getMessage();
             // This list can probably get more comprehensive.
-            if (false !== \strpos($message, 'getaddrinfo') // DNS lookup failed
-                || false !== \strpos($message, 'Connection refused')
-                || false !== \strpos($message, "couldn't connect to host") // error on HHVM
-                || false !== \strpos($message, 'connection attempt failed')
-            ) {
-                $e = new ConnectException($e->getMessage(), $request, $e);
-            } else {
-                $e = RequestException::wrapException($request, $e);
+            if (!$e instanceof ConnectException) {
+                if (false !== \strpos($message, 'getaddrinfo') // DNS lookup failed
+                    || false !== \strpos($message, 'Connection refused')
+                    || false !== \strpos($message, "couldn't connect to host") // error on HHVM
+                    || false !== \strpos($message, 'connection attempt failed')
+                ) {
+                    $e = new ConnectException($e->getMessage(), $request, $e);
+                } else {
+                    $e = RequestException::wrapException($request, $e);
+                }
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
 
@@ -158,7 +161,7 @@ class StreamHandler
         // Do not drain when the request is a HEAD request because they have
         // no body.
         if ($sink !== $stream) {
-            $this->drain($stream, $sink, $response->getHeaderLine('Content-Length'));
+            $this->drain($request, $stream, $sink, $response->getHeaderLine('Content-Length'));
         }
 
         $this->invokeStats($options, $request, $startTime, $response, null);
@@ -242,17 +245,43 @@ class StreamHandler
      *
      * @throws \RuntimeException when the sink option is invalid.
      */
-    private function drain(StreamInterface $source, StreamInterface $sink, string $contentLength): StreamInterface
-    {
+    private function drain(
+        RequestInterface $request,
+        StreamInterface $source,
+        StreamInterface $sink,
+        string $contentLength
+    ): StreamInterface {
         // If a content-length header is provided, then stop reading once
         // that number of bytes has been read. This can prevent infinitely
         // reading from a stream when dealing with servers that do not honor
         // Connection: Close headers.
-        Psr7\Utils::copyToStream(
-            $source,
-            $sink,
-            (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1
-        );
+        try {
+            Psr7\Utils::copyToStream(
+                $source,
+                $sink,
+                (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1
+            );
+        } catch (\RuntimeException $e) {
+            if ($source->getMetadata('timed_out') === true) {
+                throw new TimeoutException(
+                    'The stream handler timed out while reading the response body',
+                    $request,
+                    $e,
+                    ['timed_out' => true]
+                );
+            }
+
+            throw $e;
+        }
+
+        if ($source->getMetadata('timed_out') === true) {
+            throw new TimeoutException(
+                'The stream handler timed out while reading the response body',
+                $request,
+                null,
+                ['timed_out' => true]
+            );
+        }
 
         $sink->seek(0);
         $source->close();

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\TimeoutException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Exception\TimeoutException as Psr7TimeoutException;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
@@ -261,24 +262,11 @@ class StreamHandler
                 $sink,
                 (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1
             );
-        } catch (\RuntimeException $e) {
-            if ($source->getMetadata('timed_out') === true) {
-                throw new TimeoutException(
-                    'The stream handler timed out while reading the response body',
-                    $request,
-                    $e,
-                    ['timed_out' => true]
-                );
-            }
-
-            throw $e;
-        }
-
-        if ($source->getMetadata('timed_out') === true) {
+        } catch (Psr7TimeoutException $e) {
             throw new TimeoutException(
-                'The stream handler timed out while reading the response body',
+                'The stream handler timed out while transferring the response body',
                 $request,
-                null,
+                $e,
                 ['timed_out' => true]
             );
         }

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TimeoutException;
 use GuzzleHttp\Handler;
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlVersion;
@@ -938,8 +939,43 @@ class CurlFactoryTest extends TestCase
             $factory
         );
 
-        $this->expectException(ConnectException::class);
-        $response->wait();
+        try {
+            $response->wait();
+            self::fail('Expected ConnectException');
+        } catch (TimeoutException $e) {
+            self::fail('Expected non-timeout ConnectException');
+        } catch (ConnectException $e) {
+            self::assertSame(\CURLE_COULDNT_CONNECT, $e->getHandlerContext()['errno']);
+        }
+    }
+
+    public function testCreatesTimeoutException(): void
+    {
+        $m = new \ReflectionMethod(CurlFactory::class, 'finishError');
+
+        if (PHP_VERSION_ID < 80100) {
+            $m->setAccessible(true);
+        }
+
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $easy = $factory->create($request, []);
+        $easy->errno = \CURLE_OPERATION_TIMEOUTED;
+        $response = $m->invoke(
+            null,
+            static function (): void {
+            },
+            $easy,
+            $factory
+        );
+
+        try {
+            $response->wait();
+            self::fail('Expected TimeoutException');
+        } catch (TimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(\CURLE_OPERATION_TIMEOUTED, $e->getHandlerContext()['errno']);
+        }
     }
 
     public function testAddsTimeouts(): void

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1125,7 +1125,8 @@ class StreamHandlerTest extends TestCase
         } catch (TimeoutException $e) {
             $exception = $e;
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The stream handler timed out while reading the response body', $e->getMessage());
+            self::assertSame('The stream handler timed out while transferring the response body', $e->getMessage());
+            self::assertInstanceOf(Psr7\Exception\TimeoutException::class, $e->getPrevious());
             self::assertSame(['timed_out' => true], $e->getHandlerContext());
         }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TimeoutException;
 use GuzzleHttp\Handler\StreamHandler;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
@@ -1100,6 +1101,37 @@ class StreamHandlerTest extends TestCase
         self::assertFalse($line);
         self::assertTrue(\stream_get_meta_data($body)['timed_out']);
         self::assertFalse(\feof($body));
+    }
+
+    public function testThrowsTimeoutExceptionWhenDrainingResponseBodyTimesOut(): void
+    {
+        Server::flush();
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url.'guzzle-server/read-timeout');
+        $stats = null;
+        $exception = null;
+
+        try {
+            $handler(
+                $request,
+                [
+                    RequestOptions::READ_TIMEOUT => 0.05,
+                    'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                        $stats = $transferStats;
+                    },
+                ]
+            )->wait();
+            self::fail('Expected TimeoutException');
+        } catch (TimeoutException $e) {
+            $exception = $e;
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('The stream handler timed out while reading the response body', $e->getMessage());
+            self::assertSame(['timed_out' => true], $e->getHandlerContext());
+        }
+
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertFalse($stats->hasResponse());
+        self::assertSame($exception, $stats->getHandlerErrorData());
     }
 
     public function testHandlesGarbageHttpServerGracefully(): void


### PR DESCRIPTION
Adds NetworkException and TimeoutException while preserving existing ConnectException catch behavior. Built-in handlers now throw TimeoutException only when a timeout can be reliably identified.