### PR TITLE
Add PSR-17 request and URI factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add generic PHPDoc annotations to async HTTP and handler APIs
 - Add CIDR notation support for IP no-proxy rules
 - Add network and timeout exception types
+- Add PSR-17 `request_factory` and `uri_factory` request options for client-created requests and URIs
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "ext-json": "*",
         "guzzlehttp/promises": "^3.0@dev",
         "guzzlehttp/psr7": "^3.0@dev",
-        "psr/http-client": "^1.0"
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -869,6 +869,61 @@ $data = $body->read(1024);
 $line = fgets($body->detach());
 ```
 
+## request_factory
+
+Summary
+PSR-17 request factory used when Guzzle creates requests.
+
+Types
+`Psr\Http\Message\RequestFactoryInterface`
+
+Default
+`GuzzleHttp\Psr7\HttpFactory`
+
+Constant
+`GuzzleHttp\RequestOptions::REQUEST_FACTORY`
+
+```php
+$factory = new \GuzzleHttp\Psr7\HttpFactory();
+
+$client->request('GET', '/get', [
+    'request_factory' => $factory,
+]);
+```
+
+This option can be set on a client or per request. It affects request-side object creation only and does not affect response implementations returned by handlers.
+
+> [!NOTE]
+> This option only affects requests created by `request()`, `requestAsync()`, and shortcut methods such as `get()` and `post()`. Requests passed to `send()`, `sendAsync()`, or `sendRequest()` are used as provided.
+
+## uri_factory
+
+Summary
+PSR-17 URI factory used when Guzzle creates URI objects from strings.
+
+Types
+`Psr\Http\Message\UriFactoryInterface`
+
+Default
+`GuzzleHttp\Psr7\HttpFactory`
+
+Constant
+`GuzzleHttp\RequestOptions::URI_FACTORY`
+
+```php
+$factory = new \GuzzleHttp\Psr7\HttpFactory();
+
+$client = new GuzzleHttp\Client([
+    'base_uri' => 'https://api.example.com',
+    'uri_factory' => $factory,
+]);
+```
+
+This option can be set on a client or per request. It is used for string request URI values and string `base_uri` values. URI objects implementing `Psr\Http\Message\UriInterface` are used as provided.
+
+> [!NOTE]
+> This option affects request-side URI creation only. It does not affect response implementations returned by handlers or redirect `Location` parsing.
+
 ## sink
 
 Summary

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\HttpFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -62,9 +63,22 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             throw new InvalidArgumentException('handler must be a callable');
         }
 
-        // Convert the base_uri to a UriInterface
+        $factory = new HttpFactory();
+
+        if (!isset($config[RequestOptions::REQUEST_FACTORY])) {
+            $config[RequestOptions::REQUEST_FACTORY] = $factory;
+        }
+
+        if (!isset($config[RequestOptions::URI_FACTORY])) {
+            $config[RequestOptions::URI_FACTORY] = $factory;
+        }
+
+        Utils::requireRequestFactory($config[RequestOptions::REQUEST_FACTORY]);
+        $uriFactory = Utils::requireUriFactory($config[RequestOptions::URI_FACTORY]);
+
+        // Convert the base_uri to a UriInterface using the configured URI factory.
         if (isset($config['base_uri'])) {
-            $config['base_uri'] = Psr7\Utils::uriFor($config['base_uri']);
+            $config['base_uri'] = Utils::createUri($config['base_uri'], $uriFactory);
         }
 
         $this->configureDefaults($config);
@@ -135,18 +149,21 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     public function requestAsync(string $method, $uri = '', array $options = []): PromiseInterface
     {
         $options = $this->prepareDefaults($options);
-        // Remove request modifying parameter because it can be done up-front.
-        $headers = $options['headers'] ?? [];
-        $body = $options['body'] ?? null;
-        $version = self::normalizeProtocolVersion($options['version'] ?? '1.1');
+
+        $factory = new HttpFactory();
+        $uriFactory = Utils::requireUriFactory($options[RequestOptions::URI_FACTORY] ?? $factory);
+        $requestFactory = Utils::requireRequestFactory($options[RequestOptions::REQUEST_FACTORY] ?? $factory);
+
         // Merge the URI into the base URI.
-        $uri = $this->buildUri(Psr7\Utils::uriFor($uri), $options);
-        if (\is_array($body)) {
-            throw $this->invalidBody();
+        $uriIsString = \is_string($uri);
+        $uri = Utils::createUri($uri, $uriFactory);
+        $builtUri = $this->buildUri($uri, $options);
+        if ($uriIsString && $builtUri !== $uri) {
+            $builtUri = Utils::createUri((string) $builtUri, $uriFactory);
         }
-        $request = new Psr7\Request($method, $uri, $headers, $body, $version);
-        // Remove the option so that they are not doubly-applied.
-        unset($options['headers'], $options['body'], $options['version']);
+
+        $uri = $builtUri;
+        $request = $requestFactory->createRequest($method, $uri);
 
         return $this->transfer($request, $options);
     }
@@ -192,7 +209,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     private function buildUri(UriInterface $uri, array $config): UriInterface
     {
         if (isset($config['base_uri'])) {
-            $uri = Psr7\UriResolver::resolve(Psr7\Utils::uriFor($config['base_uri']), $uri);
+            $uriFactory = Utils::requireUriFactory($config[RequestOptions::URI_FACTORY] ?? new HttpFactory());
+            $uri = Psr7\UriResolver::resolve(Utils::createUri($config['base_uri'], $uriFactory), $uri);
         }
 
         if (isset($config['idn_conversion']) && ($config['idn_conversion'] !== false)) {

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -219,6 +219,13 @@ final class RequestOptions
     public const QUERY = 'query';
 
     /**
+     * request_factory: (Psr\Http\Message\RequestFactoryInterface) PSR-17
+     * request factory used when creating requests through request() and
+     * requestAsync().
+     */
+    public const REQUEST_FACTORY = 'request_factory';
+
+    /**
      * sink: (resource|string|StreamInterface) Where the data of the
      * response is written to. Defaults to a PHP temp stream. Providing a
      * string will write data to a file by the given name.
@@ -270,6 +277,12 @@ final class RequestOptions
      * seconds are rejected by the built-in stream handler.
      */
     public const READ_TIMEOUT = 'read_timeout';
+
+    /**
+     * uri_factory: (Psr\Http\Message\UriFactoryInterface) PSR-17 URI factory
+     * used when creating URI objects from string request URI and base_uri values.
+     */
+    public const URI_FACTORY = 'uri_factory';
 
     /**
      * version: (string|float) Specifies the HTTP protocol version to attempt

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -8,6 +8,8 @@ use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Handler\StreamHandler;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 final class Utils
@@ -620,6 +622,60 @@ final class Utils
         }
 
         return $milliseconds;
+    }
+
+    /**
+     * @param mixed $factory
+     *
+     * @internal
+     */
+    public static function requireRequestFactory($factory): RequestFactoryInterface
+    {
+        if (!$factory instanceof RequestFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::REQUEST_FACTORY,
+                RequestFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    /**
+     * @param mixed $factory
+     *
+     * @internal
+     */
+    public static function requireUriFactory($factory): UriFactoryInterface
+    {
+        if (!$factory instanceof UriFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::URI_FACTORY,
+                UriFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    /**
+     * @param mixed $uri
+     *
+     * @internal
+     */
+    public static function createUri($uri, UriFactoryInterface $uriFactory): UriInterface
+    {
+        if ($uri instanceof UriInterface) {
+            return $uri;
+        }
+
+        if (\is_string($uri)) {
+            return $uriFactory->createUri($uri);
+        }
+
+        throw new InvalidArgumentException(\sprintf('URI must be a string or %s', UriInterface::class));
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -18,8 +18,11 @@ use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriFactoryInterface;
+use Psr\Http\Message\UriInterface;
 
 class ClientTest extends TestCase
 {
@@ -183,6 +186,306 @@ class ClientTest extends TestCase
             'http://bar.com/baz',
             (string) $mock->getLastRequest()->getUri()
         );
+    }
+
+    public function testClientHasDefaultPsr17Factories(): void
+    {
+        $client = new Client(['handler' => new MockHandler()]);
+        $config = self::readClientConfig($client);
+
+        self::assertArrayHasKey(RequestOptions::REQUEST_FACTORY, $config);
+        self::assertInstanceOf(RequestFactoryInterface::class, $config[RequestOptions::REQUEST_FACTORY]);
+        self::assertArrayHasKey(RequestOptions::URI_FACTORY, $config);
+        self::assertInstanceOf(UriFactoryInterface::class, $config[RequestOptions::URI_FACTORY]);
+    }
+
+    public function testRequestUsesConfiguredRequestAndUriFactories(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path');
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame('http://example.com/path', (string) $request->getUri());
+        self::assertSame(['http://example.com/path'], $factory->uriCalls());
+        self::assertSame('GET', $factory->requestCalls()[0][0]);
+        self::assertInstanceOf(ClientTestUri::class, $factory->requestCalls()[0][1]);
+    }
+
+    public function testRequestAppliesHeadersBodyQueryAndVersionAfterFactoryCreation(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::HEADERS => ['X-Test' => '1'],
+            RequestOptions::BODY => 'payload',
+            RequestOptions::QUERY => ['a' => 'b'],
+            RequestOptions::VERSION => '2',
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertSame('1', $request->getHeaderLine('X-Test'));
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame('a=b', $request->getUri()->getQuery());
+        self::assertSame('2', $request->getProtocolVersion());
+    }
+
+    public function testRequestPreservesMethodCasingWithConfiguredRequestFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+        ]);
+
+        $client->request('gEt', 'http://example.com/path');
+
+        self::assertSame('gEt', $factory->requestCalls()[0][0]);
+        self::assertSame('gEt', $mock->getLastRequest()->getMethod());
+    }
+
+    public function testStringBaseUriUsesConfiguredUriFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            'base_uri' => 'http://example.com/base/',
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $config = self::readClientConfig($client);
+        self::assertInstanceOf(ClientTestUri::class, $config['base_uri']);
+
+        $client->request('GET', 'relative');
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame('http://example.com/base/relative', (string) $request->getUri());
+        self::assertSame(
+            ['http://example.com/base/', 'relative', 'http://example.com/base/relative'],
+            $factory->uriCalls()
+        );
+    }
+
+    public function testPerRequestFactoriesOverrideClientFactories(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $clientFactory = new ClientTestFactory();
+        $requestFactory = new ClientTestFactory(ClientTestAlternateRequest::class, ClientTestAlternateUri::class);
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $clientFactory,
+            RequestOptions::URI_FACTORY => $clientFactory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path', [
+            RequestOptions::REQUEST_FACTORY => $requestFactory,
+            RequestOptions::URI_FACTORY => $requestFactory,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestAlternateRequest::class, $request);
+        self::assertInstanceOf(ClientTestAlternateUri::class, $request->getUri());
+        self::assertSame([], $clientFactory->requestCalls());
+        self::assertSame([], $clientFactory->uriCalls());
+    }
+
+    public function testPerRequestBaseUriUsesPerRequestUriFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $clientFactory = new ClientTestFactory();
+        $requestFactory = new ClientTestFactory(ClientTestAlternateRequest::class, ClientTestAlternateUri::class);
+        $client = new Client([
+            'handler' => $mock,
+            'base_uri' => 'http://client.example/base/',
+            RequestOptions::REQUEST_FACTORY => $clientFactory,
+            RequestOptions::URI_FACTORY => $clientFactory,
+        ]);
+
+        $client->request('GET', 'relative', [
+            'base_uri' => 'http://request.example/base/',
+            RequestOptions::REQUEST_FACTORY => $requestFactory,
+            RequestOptions::URI_FACTORY => $requestFactory,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestAlternateUri::class, $request->getUri());
+        self::assertSame('http://request.example/base/relative', (string) $request->getUri());
+        self::assertSame(['http://client.example/base/'], $clientFactory->uriCalls());
+        self::assertSame(
+            ['relative', 'http://request.example/base/', 'http://request.example/base/relative'],
+            $requestFactory->uriCalls()
+        );
+    }
+
+    public function testPerRequestUriFactoryControlsResolvedUriWithClientBaseUriString(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            'base_uri' => 'http://example.com/base/',
+        ]);
+
+        $client->request('GET', 'relative', [
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame('http://example.com/base/relative', (string) $request->getUri());
+        self::assertSame(['relative', 'http://example.com/base/relative'], $factory->uriCalls());
+    }
+
+    public function testNullPerRequestRequestFactoryFallsBackToDefaultFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path', [
+            RequestOptions::REQUEST_FACTORY => null,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(Request::class, $request);
+        self::assertNotInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame([], $factory->requestCalls());
+    }
+
+    public function testNullPerRequestUriFactoryFallsBackToDefaultFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path', [
+            RequestOptions::URI_FACTORY => null,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(Uri::class, $request->getUri());
+        self::assertNotInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame([], $factory->uriCalls());
+    }
+
+    public function testNullPerRequestUriFactoryFallsBackToDefaultFactoryWhenResolvingClientBaseUri(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            'base_uri' => 'http://example.com/base/',
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'relative', [
+            RequestOptions::URI_FACTORY => null,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(Uri::class, $request->getUri());
+        self::assertNotInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame('http://example.com/base/relative', (string) $request->getUri());
+        self::assertSame(['http://example.com/base/'], $factory->uriCalls());
+    }
+
+    public function testInvalidRequestFactoryIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('request_factory must be an instance of Psr\\Http\\Message\\RequestFactoryInterface');
+
+        new Client([
+            RequestOptions::REQUEST_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidUriFactoryIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('uri_factory must be an instance of Psr\\Http\\Message\\UriFactoryInterface');
+
+        new Client([
+            RequestOptions::URI_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidPerRequestRequestFactoryIsRejected(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('request_factory must be an instance of Psr\\Http\\Message\\RequestFactoryInterface');
+
+        $client->request('GET', 'http://example.com', [
+            RequestOptions::REQUEST_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidPerRequestUriFactoryIsRejected(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('uri_factory must be an instance of Psr\\Http\\Message\\UriFactoryInterface');
+
+        $client->request('GET', 'http://example.com', [
+            RequestOptions::URI_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testSendDoesNotUseRequestFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->send(new Request('GET', 'http://example.com/path'));
+
+        self::assertInstanceOf(Request::class, $mock->getLastRequest());
+        self::assertNotInstanceOf(ClientTestRequest::class, $mock->getLastRequest());
+        self::assertSame([], $factory->requestCalls());
+        self::assertSame([], $factory->uriCalls());
     }
 
     public function testMergesDefaultOptionsAndDoesNotOverwriteUa(): void
@@ -1191,4 +1494,71 @@ final class ClientTestRequest extends Request
 
 final class ClientTestUri extends Uri
 {
+}
+
+final class ClientTestAlternateRequest extends Request
+{
+}
+
+final class ClientTestAlternateUri extends Uri
+{
+}
+
+final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInterface
+{
+    /** @var class-string<Request> */
+    private $requestClass;
+
+    /** @var class-string<Uri> */
+    private $uriClass;
+
+    /** @var array<int, array{0: string, 1: mixed}> */
+    private $requestCalls = [];
+
+    /** @var string[] */
+    private $uriCalls = [];
+
+    /**
+     * @param class-string<Request> $requestClass
+     * @param class-string<Uri>     $uriClass
+     */
+    public function __construct(string $requestClass = ClientTestRequest::class, string $uriClass = ClientTestUri::class)
+    {
+        $this->requestClass = $requestClass;
+        $this->uriClass = $uriClass;
+    }
+
+    public function createRequest(string $method, $uri): RequestInterface
+    {
+        $this->requestCalls[] = [$method, $uri];
+
+        $class = $this->requestClass;
+
+        return new $class($method, $uri);
+    }
+
+    public function createUri(string $uri = ''): UriInterface
+    {
+        $this->uriCalls[] = $uri;
+
+        $class = $this->uriClass;
+
+        return new $class($uri);
+    }
+
+    /**
+     * @return array<int, array{0: string, 1: mixed}>
+     */
+    public function requestCalls(): array
+    {
+        return $this->requestCalls;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function uriCalls(): array
+    {
+        return $this->uriCalls;
+    }
 }


### PR DESCRIPTION
This change adds PSR-17 request and URI factory support for requests and URIs that Guzzle creates internally. Guzzle 8 already targets PSR-7 3.x, where `GuzzleHttp\Psr7\HttpFactory` provides the standard PSR-17 factory interfaces, so exposing these factories as normal client and request options gives applications with custom PSR-7 implementations a supported way to keep client-created request and URI objects in their own implementations.

The new `request_factory` option is used when `request()`, `requestAsync()`, and the shortcut methods create a request. The new `uri_factory` option is used when string request URI values and string `base_uri` values are converted into URI objects. Both options can be configured on the client or overridden per request, and requests passed directly to `send()`, `sendAsync()`, or `sendRequest()` continue to be used as provided.

This is intentionally limited to the first request-creation path. Redirect `Location` parsing, request body stream creation, multipart internals, response creation, and handler-level streams are left unchanged so they can be reviewed separately in follow-up work.