### PR TITLE
Document cross-origin redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Changed no-proxy matching to account for request ports when evaluating host-and-port rules
 - Prevent `CurlMultiHandler` destructors from throwing during cleanup
 - Improve invalid response handling across handlers
+- Clarified cross-origin redirect credential behavior in the documentation
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Changed no-proxy matching to account for request ports when evaluating host-and-port rules
 - Prevent `CurlMultiHandler` destructors from throwing during cleanup
 - Improve invalid response handling across handlers
-- Clarified cross-origin redirect credential behavior in the documentation
 
 ### Deprecated
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -54,6 +54,8 @@ $client = new Client(['handler' => HandlerStack::create(new CurlMultiHandler([
 ]))]);
 ```
 
+Custom cURL request options remain active during redirects unless Guzzle documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
+
 ## How can I add custom stream context options?
 
 You can pass custom [stream context options](https://www.php.net/manual/en/context.php) using the **stream_context** key of the request option. The **stream_context** array is an associative array where each key is a PHP transport, and each value is an associative array of transport options.
@@ -73,6 +75,8 @@ $client->request('GET', '/', [
     ]
 ]);
 ```
+
+Custom stream context options remain active during redirects unless Guzzle documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
 
 ## Why am I getting an SSL verification error?
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -425,6 +425,8 @@ Guzzle will automatically follow redirects unless you tell it not to. You can cu
 - Set to `false` to disable redirects.
 - Pass an associative array containing the 'max' key to specify the maximum number of redirects and optionally provide a 'strict' key value to specify whether or not to use strict RFC compliant redirects (meaning redirect POST requests with POST requests vs. doing what most browsers do which is redirect POST requests with GET requests).
 
+See the [`allow_redirects` option](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
+
 ```php
 $response = $client->request('GET', 'http://github.com');
 echo $response->getStatusCode();

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -104,6 +104,16 @@ echo $res->getHeaderLine('X-Guzzle-Redirect-Status-History');
 > [!NOTE]
 > This option has **no** effect when making requests using `GuzzleHttp\Client::sendRequest()`. In order to stay compliant with PSR-18 any redirect response is returned as is.
 
+### Cross-Origin Redirects
+
+Guzzle considers a redirect cross-origin when the scheme, host, or effective port changes.
+
+On cross-origin redirects, Guzzle removes the `Authorization` and `Cookie` headers and clears cURL HTTP authentication options such as `CURLOPT_HTTPAUTH` and `CURLOPT_USERPWD`.
+
+Guzzle does not automatically remove other request options or headers solely because the redirect is cross-origin. This matches curl's redirect model. In particular, TLS client authentication options such as `cert`, `ssl_key`, custom cURL TLS options, and stream context TLS options are not removed automatically on cross-origin redirects.
+
+If TLS client credentials are only trusted for the original origin, disable automatic redirects and handle redirect responses manually, or use separate clients and request options for trusted origins.
+
 ## auth
 
 Summary
@@ -215,6 +225,9 @@ Constant
 ```php
 $client->request('GET', '/', ['cert' => ['/path/server.pem', 'password']]);
 ```
+
+> [!NOTE]
+> TLS client certificate options remain active during redirects. See [Cross-Origin Redirects](#cross-origin-redirects) for details.
 
 ## cookies
 
@@ -913,6 +926,9 @@ Constant
 
 > [!NOTE]
 > `ssl_key` is implemented by HTTP handlers. This is currently only supported by the cURL handler, but might be supported by other third-part handlers.
+
+> [!NOTE]
+> TLS client key options remain active during redirects. See [Cross-Origin Redirects](#cross-origin-redirects) for details.
 
 ## stream
 


### PR DESCRIPTION
Clarifies how cross-origin redirects handle credentials and transfer options, including TLS client certificate settings. This is docs-only.