### PR TITLE
Treat request methods case-sensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Validate built-in handler timeout options before applying them
 - Reject empty or malformed request protocol versions
 - Throw `TimeoutException` for reliably detected transfer timeouts
+- Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,13 +35,14 @@ your application uses those packages directly, review their upgrade guides.
 
 #### Request method casing
 
-Guzzle 8 uses Guzzle PSR-7 3.x, whose `Request` implementation no longer
-uppercases request methods. Request method names are case-sensitive and are now
-preserved as provided.
+Guzzle 8 uses Guzzle PSR-7 3.x, whose request implementations preserve method
+casing. HTTP method names are case-sensitive, so Guzzle now sends the method
+exactly as provided and applies built-in method-specific behavior only to exact
+standard method names such as `GET`, `HEAD`, `POST`, and `PUT`.
 
 If you previously relied on `new Request('get', ...)` or
-`$client->request('get', ...)` being sent as `GET`, normalize the method before
-constructing or sending the request:
+`$client->request('get', ...)` being sent or treated as `GET`, normalize the
+method before constructing or sending the request:
 
 ```php
 $client->request('GET', 'https://example.com');

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -150,6 +150,11 @@ echo $request->getMethod();
 // MOVE
 ```
 
+HTTP method names are case-sensitive. Guzzle sends the method string exactly as
+provided by the request. Use uppercase standard methods such as `GET`, `POST`,
+and `HEAD` when you want standard method-specific behavior from Guzzle's
+middleware and handlers.
+
 You can create and send a request using methods on a client that map to the HTTP method you wish to use.
 
 GET

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -65,13 +65,7 @@ class StreamHandler
 
             // Append a content-length header if body size is zero to match
             // the behavior of `CurlHandler`
-            if (
-                (
-                    0 === \strcasecmp('PUT', $request->getMethod())
-                    || 0 === \strcasecmp('POST', $request->getMethod())
-                )
-                && 0 === $request->getBody()->getSize()
-            ) {
+            if (($request->getMethod() === 'PUT' || $request->getMethod() === 'POST') && 0 === $request->getBody()->getSize()) {
                 $request = $request->withHeader('Content-Length', '0');
             }
 
@@ -138,7 +132,7 @@ class StreamHandler
         $stream = Psr7\Utils::streamFor($stream);
         $sink = $stream;
 
-        if (\strcasecmp('HEAD', $request->getMethod())) {
+        if ($request->getMethod() !== 'HEAD') {
             $sink = $this->createSink($stream, $options);
         }
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -179,7 +179,7 @@ class RedirectMiddleware
             $safeMethods = ['GET', 'HEAD', 'OPTIONS'];
             $requestMethod = $request->getMethod();
 
-            $modify['method'] = in_array($requestMethod, $safeMethods) ? $requestMethod : 'GET';
+            $modify['method'] = \in_array($requestMethod, $safeMethods, true) ? $requestMethod : 'GET';
             $modify['body'] = '';
         }
 

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -562,13 +562,37 @@ class RedirectMiddlewareTest extends TestCase
                 'request' => new Request('GET', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'GET',
             ],
+            'get' => [
+                'request' => new RedirectTestMethodRequest('get', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
+            ],
+            'gEt' => [
+                'request' => new RedirectTestMethodRequest('gEt', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
+            ],
             'HEAD' => [
                 'request' => new Request('HEAD', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'HEAD',
             ],
+            'head' => [
+                'request' => new RedirectTestMethodRequest('head', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
+            ],
+            'Head' => [
+                'request' => new RedirectTestMethodRequest('Head', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
+            ],
             'OPTIONS' => [
                 'request' => new Request('OPTIONS', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'OPTIONS',
+            ],
+            'options' => [
+                'request' => new RedirectTestMethodRequest('options', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
+            ],
+            'OpTiOnS' => [
+                'request' => new RedirectTestMethodRequest('OpTiOnS', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
             ],
             'PATCH' => [
                 'request' => new Request('PATCH', 'http://example.com/'),
@@ -592,4 +616,33 @@ final class RedirectTestRequest extends Request
 
 final class RedirectTestUri extends Uri
 {
+}
+
+final class RedirectTestMethodRequest extends Request
+{
+    /** @var string */
+    private $method;
+
+    /**
+     * @param string|UriInterface $uri
+     */
+    public function __construct(string $method, $uri)
+    {
+        parent::__construct('GET', $uri);
+
+        $this->method = $method;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function withMethod($method): RequestInterface
+    {
+        $new = clone $this;
+        $new->method = $method;
+
+        return $new;
+    }
 }


### PR DESCRIPTION
Guzzle 8 uses Guzzle PSR-7 3.x, where request method casing is preserved instead of being normalized automatically. This change makes Guzzle's outbound method-specific behavior match that model by treating request method names as case-sensitive when deciding whether to apply built-in `HEAD`, `POST`, or `PUT` handling.

The stream handler now only adds the empty-body `Content-Length: 0` compatibility header for exact `POST` and `PUT` methods, and it only skips response body draining for exact `HEAD` requests. Redirect method handling now uses a strict exact safe-method comparison as well, with coverage for lower and mixed-case method variants so they are not treated as uppercase standard methods while being sent differently on the wire.

The upgrade guide and request documentation now make the contract explicit: Guzzle sends the method exactly as provided, and applications should use uppercase standard methods when they want standard method-specific middleware and handler behavior.