### PR TITLE
Clarify JSON Accept header behavior

### DIFF
--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -579,7 +579,7 @@ Enables/disables IDN support, can also be used for precise control by combining 
 ## json
 
 Summary
-The `json` option is used to easily upload JSON encoded data as the body of a request. A Content-Type header of `application/json` will be added if no Content-Type header is already present on the message.
+The `json` option is used to easily upload JSON encoded data as the body of a request. A Content-Type header of `application/json` will be added if no Content-Type header is already present on the message. An Accept header is not added automatically; pass one explicitly if the server requires JSON response content negotiation.
 
 Types
 Any PHP type that can be operated on by PHP's `json_encode()` function.

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -154,7 +154,8 @@ final class RequestOptions
     /**
      * json: (mixed) Adds JSON data to a request. The provided value is JSON
      * encoded and a Content-Type header of application/json will be added to
-     * the request if no Content-Type header is already present.
+     * the request if no Content-Type header is already present. An Accept
+     * header is not added automatically.
      */
     public const JSON = 'json';
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -413,6 +413,22 @@ class ClientTest extends TestCase
         $last = $mock->getLastRequest();
         self::assertSame('{"foo":"bar"}', (string) $mock->getLastRequest()->getBody());
         self::assertSame('application/json', $last->getHeaderLine('Content-Type'));
+        self::assertFalse($last->hasHeader('Accept'));
+    }
+
+    public function testCanAddJsonDataWithAcceptHeader(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $request = new Request('PUT', 'http://foo.com');
+        $client->send($request, [
+            'headers' => ['Accept' => 'application/vnd.api+json'],
+            'json' => ['foo' => 'bar'],
+        ]);
+        $last = $mock->getLastRequest();
+        self::assertSame('{"foo":"bar"}', (string) $last->getBody());
+        self::assertSame('application/json', $last->getHeaderLine('Content-Type'));
+        self::assertSame('application/vnd.api+json', $last->getHeaderLine('Accept'));
     }
 
     public function testCanAddJsonDataWithoutOverwritingContentType(): void


### PR DESCRIPTION
This documents and tests that the json request option adds Content-Type when needed but does not add an Accept header.