### PR TITLE
Add PSR-17 stream factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add generic PHPDoc annotations to async HTTP and handler APIs
 - Add CIDR notation support for IP no-proxy rules
 - Add network and timeout exception types
-- Add PSR-17 `request_factory` and `uri_factory` request options for client-created requests and URIs
+- Add PSR-17 `request_factory`, `stream_factory`, and `uri_factory` request options for client-created requests, request body streams, and URIs
 
 ### Changed
 

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -6,6 +6,8 @@ Guzzle is an HTTP client that sends HTTP requests to a server and receives HTTP 
 
 Guzzle relies on the `guzzlehttp/psr7` Composer package for its message implementation of PSR-7.
 
+By default, Guzzle uses `GuzzleHttp\Psr7\HttpFactory` as its PSR-17 request, URI, and stream factory when it creates requests through a client. Applications that need another PSR-7 implementation can provide PSR-17 factories with the `request_factory`, `uri_factory`, and `stream_factory` request options.
+
 You can create a request using the `GuzzleHttp\Psr7\Request` class:
 
 ```php
@@ -294,6 +296,8 @@ Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More inform
 ### Creating Streams
 
 The best way to create a stream is using the `GuzzleHttp\Psr7\Utils::streamFor` method. This method accepts strings, resources returned from `fopen()`, an object that implements `__toString()`, iterators, callables, and instances of `Psr\Http\Message\StreamInterface`.
+
+When Guzzle creates request body streams from options such as `body`, `form_params`, or `json`, the `stream_factory` request option can replace the default PSR-17 stream factory. Streams supplied directly as `Psr\Http\Message\StreamInterface` instances are used as provided.
 
 ```php
 use GuzzleHttp\Psr7;

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -204,6 +204,8 @@ This setting can be set to any of the following types:
   $client->request('POST', '/post', ['body' => $stream]);
   ```
 
+Supported non-stream body values are converted to PSR-7 streams using the configured `stream_factory`. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+
 > [!NOTE]
 > This option cannot be used with `form_params`, `multipart`, or `json`
 
@@ -895,6 +897,34 @@ This option can be set on a client or per request. It affects request-side objec
 
 > [!NOTE]
 > This option only affects requests created by `request()`, `requestAsync()`, and shortcut methods such as `get()` and `post()`. Requests passed to `send()`, `sendAsync()`, or `sendRequest()` are used as provided.
+
+## stream_factory
+
+Summary
+PSR-17 stream factory used when Guzzle creates request body streams.
+
+Types
+`Psr\Http\Message\StreamFactoryInterface`
+
+Default
+`GuzzleHttp\Psr7\HttpFactory`
+
+Constant
+`GuzzleHttp\RequestOptions::STREAM_FACTORY`
+
+```php
+$factory = new \GuzzleHttp\Psr7\HttpFactory();
+
+$client->request('POST', '/post', [
+    'body' => 'payload',
+    'stream_factory' => $factory,
+]);
+```
+
+This option can be set on a client or per request. It is used when Guzzle converts the `body`, `form_params`, or `json` request options into `Psr\Http\Message\StreamInterface` instances, and when redirect handling resets a request body. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+
+> [!NOTE]
+> This option affects request-side body stream creation only. It does not affect response body implementations returned by handlers, response sinks, callable or iterator bodies, or multipart internals.
 
 ## uri_factory
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -73,7 +73,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $config[RequestOptions::URI_FACTORY] = $factory;
         }
 
+        if (!isset($config[RequestOptions::STREAM_FACTORY])) {
+            $config[RequestOptions::STREAM_FACTORY] = $factory;
+        }
+
         Utils::requireRequestFactory($config[RequestOptions::REQUEST_FACTORY]);
+        Utils::requireStreamFactory($config[RequestOptions::STREAM_FACTORY]);
         $uriFactory = Utils::requireUriFactory($config[RequestOptions::URI_FACTORY]);
 
         // Convert the base_uri to a UriInterface using the configured URI factory.
@@ -401,7 +406,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($options['body'])) {
                 throw $this->invalidBody();
             }
-            $modify['body'] = Psr7\Utils::streamFor($options['body']);
+            $streamFactory = Utils::requireStreamFactory($options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory());
+            $modify['body'] = Utils::createBodyStream($options['body'], $streamFactory);
             unset($options['body']);
         }
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -180,9 +180,11 @@ class RedirectMiddleware
         ) {
             $safeMethods = ['GET', 'HEAD', 'OPTIONS'];
             $requestMethod = $request->getMethod();
+            $factory = new HttpFactory();
+            $streamFactory = Utils::requireStreamFactory($options[RequestOptions::STREAM_FACTORY] ?? $factory);
 
             $modify['method'] = \in_array($requestMethod, $safeMethods, true) ? $requestMethod : 'GET';
-            $modify['body'] = '';
+            $modify['body'] = Utils::createBodyStream('', $streamFactory);
         }
 
         $uriFactory = Utils::requireUriFactory($options[RequestOptions::URI_FACTORY] ?? new HttpFactory());

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -43,7 +43,8 @@ final class RequestOptions
 
     /**
      * body: (resource|string|null|int|float|StreamInterface|callable|\Iterator)
-     * Body to send in the request.
+     * Body to send in the request. Supported non-stream values are converted
+     * using the configured stream_factory.
      */
     public const BODY = 'body';
 
@@ -224,6 +225,13 @@ final class RequestOptions
      * requestAsync().
      */
     public const REQUEST_FACTORY = 'request_factory';
+
+    /**
+     * stream_factory: (Psr\Http\Message\StreamFactoryInterface) PSR-17
+     * stream factory used when creating request body streams from body,
+     * form_params, and json request options.
+     */
+    public const STREAM_FACTORY = 'stream_factory';
 
     /**
      * sink: (resource|string|StreamInterface) Where the data of the

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -9,6 +9,8 @@ use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Handler\StreamHandler;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -661,6 +663,24 @@ final class Utils
     }
 
     /**
+     * @param mixed $factory
+     *
+     * @internal
+     */
+    public static function requireStreamFactory($factory): StreamFactoryInterface
+    {
+        if (!$factory instanceof StreamFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::STREAM_FACTORY,
+                StreamFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    /**
      * @param mixed $uri
      *
      * @internal
@@ -676,6 +696,40 @@ final class Utils
         }
 
         throw new InvalidArgumentException(\sprintf('URI must be a string or %s', UriInterface::class));
+    }
+
+    /**
+     * @param mixed $body
+     *
+     * @internal
+     */
+    public static function createBodyStream($body, StreamFactoryInterface $streamFactory): StreamInterface
+    {
+        if ($body instanceof StreamInterface) {
+            return $body;
+        }
+
+        if (\is_resource($body)) {
+            return $streamFactory->createStreamFromResource($body);
+        }
+
+        if ($body === null) {
+            return $streamFactory->createStream();
+        }
+
+        if (\is_scalar($body)) {
+            return $streamFactory->createStream((string) $body);
+        }
+
+        if ($body instanceof \Iterator || \is_callable($body)) {
+            return Psr7\Utils::streamFor($body);
+        }
+
+        if (\is_object($body) && \method_exists($body, '__toString')) {
+            return $streamFactory->createStream((string) $body);
+        }
+
+        throw new InvalidArgumentException('Invalid resource type: '.\gettype($body));
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -21,6 +21,8 @@ use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -197,6 +199,8 @@ class ClientTest extends TestCase
         self::assertInstanceOf(RequestFactoryInterface::class, $config[RequestOptions::REQUEST_FACTORY]);
         self::assertArrayHasKey(RequestOptions::URI_FACTORY, $config);
         self::assertInstanceOf(UriFactoryInterface::class, $config[RequestOptions::URI_FACTORY]);
+        self::assertArrayHasKey(RequestOptions::STREAM_FACTORY, $config);
+        self::assertInstanceOf(StreamFactoryInterface::class, $config[RequestOptions::STREAM_FACTORY]);
     }
 
     public function testRequestUsesConfiguredRequestAndUriFactories(): void
@@ -243,6 +247,155 @@ class ClientTest extends TestCase
         self::assertSame('payload', (string) $request->getBody());
         self::assertSame('a=b', $request->getUri()->getQuery());
         self::assertSame('2', $request->getProtocolVersion());
+    }
+
+    public function testBodyUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => 'payload',
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame(['payload'], $factory->streamCalls());
+    }
+
+    public function testResourceBodyUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        \fwrite($resource, 'payload');
+        \rewind($resource);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => $resource,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame(1, $factory->streamResourceCalls());
+    }
+
+    public function testStringableBodyUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+        $body = new class {
+            public function __toString(): string
+            {
+                return 'payload';
+            }
+        };
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => $body,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame(['payload'], $factory->streamCalls());
+    }
+
+    public function testStreamBodyIsPreservedWithConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $stream = Psr7\Utils::streamFor('payload');
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => $stream,
+        ]);
+
+        self::assertSame($stream, $mock->getLastRequest()->getBody());
+        self::assertSame([], $factory->streamCalls());
+        self::assertSame(0, $factory->streamResourceCalls());
+    }
+
+    public function testJsonUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::JSON => ['foo' => 'bar'],
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('{"foo":"bar"}', (string) $request->getBody());
+        self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+        self::assertSame(['{"foo":"bar"}'], $factory->streamCalls());
+    }
+
+    public function testFormParamsUseConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::FORM_PARAMS => ['foo' => 'bar baz'],
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('foo=bar+baz', (string) $request->getBody());
+        self::assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        self::assertSame(['foo=bar+baz'], $factory->streamCalls());
+    }
+
+    public function testSendUsesConfiguredStreamFactoryForBodyOption(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->send(new Request('POST', 'http://example.com/path'), [
+            RequestOptions::BODY => 'payload',
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(Request::class, $request);
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame([], $factory->requestCalls());
+        self::assertSame([], $factory->uriCalls());
+        self::assertSame(['payload'], $factory->streamCalls());
     }
 
     public function testRequestPreservesMethodCasingWithConfiguredRequestFactory(): void
@@ -422,6 +575,115 @@ class ClientTest extends TestCase
         self::assertSame(['http://example.com/base/'], $factory->uriCalls());
     }
 
+    public function testPerRequestStreamFactoryOverridesClientStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $clientFactory = new ClientTestFactory();
+        $requestFactory = new ClientTestFactory(ClientTestRequest::class, ClientTestUri::class, ClientTestAlternateStream::class);
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $clientFactory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => 'payload',
+            RequestOptions::STREAM_FACTORY => $requestFactory,
+        ]);
+
+        self::assertSame([], $clientFactory->streamCalls());
+        self::assertSame(['payload'], $requestFactory->streamCalls());
+        self::assertInstanceOf(ClientTestAlternateStream::class, $mock->getLastRequest()->getBody());
+    }
+
+    public function testNullPerRequestStreamFactoryFallsBackToDefaultFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => 'payload',
+            RequestOptions::STREAM_FACTORY => null,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertNotInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame([], $factory->streamCalls());
+    }
+
+    public function testCallableBodyFallsBackToGuzzleStreamHandling(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $called = false;
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => static function (int $length) use (&$called) {
+                if ($called) {
+                    return false;
+                }
+
+                $called = true;
+
+                return 'payload';
+            },
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertNotInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame([], $factory->streamCalls());
+    }
+
+    public function testIteratorBodyFallsBackToGuzzleStreamHandling(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => new \ArrayIterator(['pay', 'load']),
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertNotInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame([], $factory->streamCalls());
+    }
+
+    public function testMultipartBodyDoesNotUseConfiguredStreamFactoryForAggregateBody(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::MULTIPART => [
+                [
+                    'name' => 'foo',
+                    'contents' => 'bar',
+                ],
+            ],
+        ]);
+
+        self::assertInstanceOf(Psr7\MultipartStream::class, $mock->getLastRequest()->getBody());
+        self::assertSame([], $factory->streamCalls());
+    }
+
     public function testInvalidRequestFactoryIsRejected(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -439,6 +701,16 @@ class ClientTest extends TestCase
 
         new Client([
             RequestOptions::URI_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidStreamFactoryIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
+
+        new Client([
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
         ]);
     }
 
@@ -467,6 +739,21 @@ class ClientTest extends TestCase
 
         $client->request('GET', 'http://example.com', [
             RequestOptions::URI_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidPerRequestStreamFactoryIsRejected(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
+
+        $client->request('POST', 'http://example.com', [
+            RequestOptions::BODY => 'payload',
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
         ]);
     }
 
@@ -1504,7 +1791,15 @@ final class ClientTestAlternateUri extends Uri
 {
 }
 
-final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInterface
+final class ClientTestStream extends Psr7\Stream
+{
+}
+
+final class ClientTestAlternateStream extends Psr7\Stream
+{
+}
+
+final class ClientTestFactory implements RequestFactoryInterface, StreamFactoryInterface, UriFactoryInterface
 {
     /** @var class-string<Request> */
     private $requestClass;
@@ -1512,20 +1807,34 @@ final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInte
     /** @var class-string<Uri> */
     private $uriClass;
 
+    /** @var class-string<Psr7\Stream> */
+    private $streamClass;
+
     /** @var array<int, array{0: string, 1: mixed}> */
     private $requestCalls = [];
 
     /** @var string[] */
     private $uriCalls = [];
 
+    /** @var string[] */
+    private $streamCalls = [];
+
+    /** @var int */
+    private $streamResourceCalls = 0;
+
     /**
-     * @param class-string<Request> $requestClass
-     * @param class-string<Uri>     $uriClass
+     * @param class-string<Request>     $requestClass
+     * @param class-string<Uri>         $uriClass
+     * @param class-string<Psr7\Stream> $streamClass
      */
-    public function __construct(string $requestClass = ClientTestRequest::class, string $uriClass = ClientTestUri::class)
-    {
+    public function __construct(
+        string $requestClass = ClientTestRequest::class,
+        string $uriClass = ClientTestUri::class,
+        string $streamClass = ClientTestStream::class
+    ) {
         $this->requestClass = $requestClass;
         $this->uriClass = $uriClass;
+        $this->streamClass = $streamClass;
     }
 
     public function createRequest(string $method, $uri): RequestInterface
@@ -1546,6 +1855,33 @@ final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInte
         return new $class($uri);
     }
 
+    public function createStream(string $content = ''): StreamInterface
+    {
+        $this->streamCalls[] = $content;
+
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        \fwrite($resource, $content);
+        \rewind($resource);
+        $class = $this->streamClass;
+
+        return new $class($resource);
+    }
+
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+    {
+        $class = $this->streamClass;
+
+        return new $class(Psr7\Utils::tryFopen($filename, $mode));
+    }
+
+    public function createStreamFromResource($resource): StreamInterface
+    {
+        ++$this->streamResourceCalls;
+        $class = $this->streamClass;
+
+        return new $class($resource);
+    }
+
     /**
      * @return array<int, array{0: string, 1: mixed}>
      */
@@ -1560,5 +1896,18 @@ final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInte
     public function uriCalls(): array
     {
         return $this->uriCalls;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function streamCalls(): array
+    {
+        return $this->streamCalls;
+    }
+
+    public function streamResourceCalls(): int
+    {
+        return $this->streamResourceCalls;
     }
 }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
@@ -18,6 +19,8 @@ use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -218,6 +221,47 @@ class RedirectMiddlewareTest extends TestCase
         ]);
 
         self::assertTrue($called);
+    }
+
+    public function testRedirectBodyResetUsesConfiguredStreamFactory(): void
+    {
+        $redirectMiddleware = new RedirectMiddleware(static function (): void {
+        });
+        $factory = new RedirectTestStreamFactory();
+        $request = new Request('POST', 'http://example.com/', [], 'payload');
+
+        $modifiedRequest = $redirectMiddleware->modifyRequest($request, [
+            'allow_redirects' => [
+                'protocols' => ['http', 'https'],
+                'strict' => false,
+                'referer' => false,
+            ],
+            RequestOptions::STREAM_FACTORY => $factory,
+        ], new Response(302, ['Location' => 'http://example.com/redirected']));
+
+        self::assertSame('GET', $modifiedRequest->getMethod());
+        self::assertInstanceOf(RedirectTestStream::class, $modifiedRequest->getBody());
+        self::assertSame('', (string) $modifiedRequest->getBody());
+        self::assertSame([''], $factory->streamCalls());
+    }
+
+    public function testInvalidStreamFactoryOptionForRedirectBodyResetIsRejected(): void
+    {
+        $redirectMiddleware = new RedirectMiddleware(static function (): void {
+        });
+        $request = new Request('POST', 'http://example.com/', [], 'payload');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
+
+        $redirectMiddleware->modifyRequest($request, [
+            'allow_redirects' => [
+                'protocols' => ['http', 'https'],
+                'strict' => false,
+                'referer' => false,
+            ],
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
+        ], new Response(302, ['Location' => 'http://example.com/redirected']));
     }
 
     public function testRelativeRedirectPreservesCustomRequestAndUriImplementations(): void
@@ -864,5 +908,43 @@ final class RedirectTestFailingUriFactory implements UriFactoryInterface
     public function createUri(string $uri = ''): UriInterface
     {
         throw new \InvalidArgumentException('Factory could not create URI.');
+    }
+}
+
+final class RedirectTestStream extends Psr7\Stream
+{
+}
+
+final class RedirectTestStreamFactory implements StreamFactoryInterface
+{
+    /** @var string[] */
+    private $streamCalls = [];
+
+    public function createStream(string $content = ''): StreamInterface
+    {
+        $this->streamCalls[] = $content;
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        \fwrite($resource, $content);
+        \rewind($resource);
+
+        return new RedirectTestStream($resource);
+    }
+
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+    {
+        return new RedirectTestStream(Psr7\Utils::tryFopen($filename, $mode));
+    }
+
+    public function createStreamFromResource($resource): StreamInterface
+    {
+        return new RedirectTestStream($resource);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function streamCalls(): array
+    {
+        return $this->streamCalls;
     }
 }


### PR DESCRIPTION
This change completes the request-side PSR-17 factory work by adding a `stream_factory` request option for request body stream creation. Guzzle already supports configurable request and URI factories, and request bodies are the remaining request-side objects that Guzzle creates from user options before handing a request to middleware and handlers.

The new option can be configured on the client or per request and defaults to `GuzzleHttp\Psr7\HttpFactory`. Guzzle uses it when converting supported `body`, `form_params`, and `json` values into PSR-7 streams, and when redirect handling resets a request body during a non-strict redirect rewrite. Existing `StreamInterface` bodies are used as provided, while callable, iterator, and multipart bodies keep Guzzle's existing stream handling because PSR-17 does not provide abstractions for those cases.

This remains intentionally request-side only. Response bodies, response sinks, multipart internals, and handler-created streams are unchanged.