### PR TITLE
Stabilize SetCookie expiry test

### DIFF
--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -476,11 +476,11 @@ class SetCookieTest extends TestCase
                 true,
             ],
             [
-                'FOO=bar; expires='.\date(\DateTime::RFC1123, \time() + 10).';',
+                'FOO=bar; expires='.\gmdate('D, d M Y H:i:s \G\M\T', \time() + 30).';',
                 false,
             ],
             [
-                'FOO=bar; expires='.\date(\DateTime::RFC1123, \time() - 10).';',
+                'FOO=bar; expires='.\gmdate('D, d M Y H:i:s \G\M\T', \time() - 30).';',
                 true,
             ],
             [


### PR DESCRIPTION
This avoids a narrow timing window in the SetCookie expiry data provider that can expire before assertion on slower CI workers.