### PR TITLE
Add PSR-17 factory options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add generic PHPDoc annotations to async HTTP and handler APIs
 - Add CIDR notation support for IP no-proxy rules
 - Add network and timeout exception types
+- Add PSR-17 `request_factory`, `stream_factory`, and `uri_factory` request options for client-created requests, request body streams, and URIs
 
 ### Changed
 
@@ -40,6 +41,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject empty or malformed request protocol versions
 - Throw `TimeoutException` for reliably detected transfer timeouts
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
+- Use the configured PSR-17 URI factory when parsing redirect `Location` headers
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "ext-json": "*",
         "guzzlehttp/promises": "^3.0@dev",
         "guzzlehttp/psr7": "^3.0@dev",
-        "psr/http-client": "^1.0"
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -297,7 +297,7 @@ Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More inform
 
 The best way to create a stream is using the `GuzzleHttp\Psr7\Utils::streamFor` method. This method accepts strings, resources returned from `fopen()`, an object that implements `__toString()`, iterators, callables, and instances of `Psr\Http\Message\StreamInterface`.
 
-When Guzzle creates request body streams from options such as `body`, `form_params`, or `json`, the `stream_factory` request option can replace the default PSR-17 stream factory. Streams supplied directly as `Psr\Http\Message\StreamInterface` instances are used as provided.
+When Guzzle creates request body streams from supported `body`, `form_params`, or `json` option values, the `stream_factory` request option can replace the default PSR-17 stream factory. Streams supplied directly as `Psr\Http\Message\StreamInterface` instances are used as provided, while callable and iterator bodies use Guzzle's existing stream handling.
 
 ```php
 use GuzzleHttp\Psr7;

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -6,6 +6,8 @@ Guzzle is an HTTP client that sends HTTP requests to a server and receives HTTP 
 
 Guzzle relies on the `guzzlehttp/psr7` Composer package for its message implementation of PSR-7.
 
+By default, Guzzle uses `GuzzleHttp\Psr7\HttpFactory` as its PSR-17 request, URI, and stream factory when it creates requests through a client. Applications that need another PSR-7 implementation can provide PSR-17 factories with the `request_factory`, `uri_factory`, and `stream_factory` request options.
+
 You can create a request using the `GuzzleHttp\Psr7\Request` class:
 
 ```php
@@ -294,6 +296,8 @@ Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More inform
 ### Creating Streams
 
 The best way to create a stream is using the `GuzzleHttp\Psr7\Utils::streamFor` method. This method accepts strings, resources returned from `fopen()`, an object that implements `__toString()`, iterators, callables, and instances of `Psr\Http\Message\StreamInterface`.
+
+When Guzzle creates request body streams from options such as `body`, `form_params`, or `json`, the `stream_factory` request option can replace the default PSR-17 stream factory. Streams supplied directly as `Psr\Http\Message\StreamInterface` instances are used as provided.
 
 ```php
 use GuzzleHttp\Psr7;

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -204,6 +204,8 @@ This setting can be set to any of the following types:
   $client->request('POST', '/post', ['body' => $stream]);
   ```
 
+Supported non-stream body values are converted to PSR-7 streams using the configured `stream_factory`. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+
 > [!NOTE]
 > This option cannot be used with `form_params`, `multipart`, or `json`
 
@@ -868,6 +870,89 @@ $data = $body->read(1024);
 // Returns false on timeout
 $line = fgets($body->detach());
 ```
+
+## request_factory
+
+Summary
+PSR-17 request factory used when Guzzle creates requests.
+
+Types
+`Psr\Http\Message\RequestFactoryInterface`
+
+Default
+`GuzzleHttp\Psr7\HttpFactory`
+
+Constant
+`GuzzleHttp\RequestOptions::REQUEST_FACTORY`
+
+```php
+$factory = new \GuzzleHttp\Psr7\HttpFactory();
+
+$client->request('GET', '/get', [
+    'request_factory' => $factory,
+]);
+```
+
+This option can be set on a client or per request. It affects request-side object creation only and does not affect response implementations returned by handlers.
+
+> [!NOTE]
+> This option only affects requests created by `request()`, `requestAsync()`, and shortcut methods such as `get()` and `post()`. Requests passed to `send()`, `sendAsync()`, or `sendRequest()` are used as provided.
+
+## stream_factory
+
+Summary
+PSR-17 stream factory used when Guzzle creates request body streams.
+
+Types
+`Psr\Http\Message\StreamFactoryInterface`
+
+Default
+`GuzzleHttp\Psr7\HttpFactory`
+
+Constant
+`GuzzleHttp\RequestOptions::STREAM_FACTORY`
+
+```php
+$factory = new \GuzzleHttp\Psr7\HttpFactory();
+
+$client->request('POST', '/post', [
+    'body' => 'payload',
+    'stream_factory' => $factory,
+]);
+```
+
+This option can be set on a client or per request. It is used when Guzzle converts the `body`, `form_params`, or `json` request options into `Psr\Http\Message\StreamInterface` instances, and when redirect handling resets a request body. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+
+> [!NOTE]
+> This option affects request-side body stream creation only. It does not affect response body implementations returned by handlers, response sinks, callable or iterator bodies, or multipart internals.
+
+## uri_factory
+
+Summary
+PSR-17 URI factory used when Guzzle creates URI objects from strings.
+
+Types
+`Psr\Http\Message\UriFactoryInterface`
+
+Default
+`GuzzleHttp\Psr7\HttpFactory`
+
+Constant
+`GuzzleHttp\RequestOptions::URI_FACTORY`
+
+```php
+$factory = new \GuzzleHttp\Psr7\HttpFactory();
+
+$client = new GuzzleHttp\Client([
+    'base_uri' => 'https://api.example.com',
+    'uri_factory' => $factory,
+]);
+```
+
+This option can be set on a client or per request. It is used for string request URI values, string `base_uri` values, and redirect `Location` header parsing when redirects are enabled. URI objects implementing `Psr\Http\Message\UriInterface` are used as provided.
+
+> [!NOTE]
+> This option affects request-side URI creation only. It does not affect response implementations returned by handlers. `GuzzleHttp\Client::sendRequest()` still returns redirect responses as-is for PSR-18 compliance.
 
 ## sink
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -921,7 +921,7 @@ $client->request('POST', '/post', [
 ]);
 ```
 
-This option can be set on a client or per request. It is used when Guzzle converts the `body`, `form_params`, or `json` request options into `Psr\Http\Message\StreamInterface` instances, and when redirect handling resets a request body. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+This option can be set on a client or per request. It is used when Guzzle converts supported `body`, `form_params`, or `json` request option values into `Psr\Http\Message\StreamInterface` instances, and when redirect handling resets a request body. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
 
 > [!NOTE]
 > This option affects request-side body stream creation only. It does not affect response body implementations returned by handlers, response sinks, callable or iterator bodies, or multipart internals.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -204,7 +204,7 @@ This setting can be set to any of the following types:
   $client->request('POST', '/post', ['body' => $stream]);
   ```
 
-Supported non-stream body values are converted to PSR-7 streams using the configured `stream_factory`. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+Scalar, resource, and object values with `__toString()` are converted to PSR-7 streams using the configured `stream_factory`. Callable and iterator bodies use Guzzle's existing stream handling because PSR-17 does not define factories for those stream types. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
 
 > [!NOTE]
 > This option cannot be used with `form_params`, `multipart`, or `json`

--- a/src/Client.php
+++ b/src/Client.php
@@ -166,9 +166,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             throw $this->invalidBody();
         }
 
-        $factory = new HttpFactory();
-        $uriFactory = self::requireUriFactory($options[RequestOptions::URI_FACTORY] ?? $factory);
-        $requestFactory = self::requireRequestFactory($options[RequestOptions::REQUEST_FACTORY] ?? $factory);
+        $uriFactory = isset($options[RequestOptions::URI_FACTORY])
+            ? self::requireUriFactory($options[RequestOptions::URI_FACTORY])
+            : new HttpFactory();
+        $requestFactory = isset($options[RequestOptions::REQUEST_FACTORY])
+            ? self::requireRequestFactory($options[RequestOptions::REQUEST_FACTORY])
+            : new HttpFactory();
 
         // Merge the URI into the base URI.
         $uriIsString = \is_string($uri);

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,6 +11,8 @@ use GuzzleHttp\Psr7\HttpFactory;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -75,7 +77,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $config[RequestOptions::URI_FACTORY] = $factory;
         }
 
+        if (!isset($config[RequestOptions::STREAM_FACTORY])) {
+            $config[RequestOptions::STREAM_FACTORY] = $factory;
+        }
+
         self::requireRequestFactory($config[RequestOptions::REQUEST_FACTORY]);
+        self::requireStreamFactory($config[RequestOptions::STREAM_FACTORY]);
         $uriFactory = self::requireUriFactory($config[RequestOptions::URI_FACTORY]);
 
         // Convert the base_uri to a UriInterface using the configured URI factory.
@@ -256,6 +263,22 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     }
 
     /**
+     * @param mixed $factory
+     */
+    private static function requireStreamFactory($factory): StreamFactoryInterface
+    {
+        if (!$factory instanceof StreamFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::STREAM_FACTORY,
+                StreamFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    /**
      * @param mixed $uri
      */
     private static function createUri($uri, UriFactoryInterface $uriFactory): UriInterface
@@ -269,6 +292,38 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         throw new InvalidArgumentException(\sprintf('URI must be a string or %s', UriInterface::class));
+    }
+
+    /**
+     * @param mixed $body
+     */
+    private static function createBodyStream($body, StreamFactoryInterface $streamFactory): StreamInterface
+    {
+        if ($body instanceof StreamInterface) {
+            return $body;
+        }
+
+        if (\is_resource($body)) {
+            return $streamFactory->createStreamFromResource($body);
+        }
+
+        if ($body === null) {
+            return $streamFactory->createStream();
+        }
+
+        if (\is_scalar($body)) {
+            return $streamFactory->createStream((string) $body);
+        }
+
+        if ($body instanceof \Iterator || \is_callable($body)) {
+            return Psr7\Utils::streamFor($body);
+        }
+
+        if (\is_object($body) && \method_exists($body, '__toString')) {
+            return $streamFactory->createStream((string) $body);
+        }
+
+        throw new InvalidArgumentException('Invalid resource type: '.\gettype($body));
     }
 
     /**
@@ -451,7 +506,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($options['body'])) {
                 throw $this->invalidBody();
             }
-            $modify['body'] = Psr7\Utils::streamFor($options['body']);
+            $streamFactory = self::requireStreamFactory($options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory());
+            $modify['body'] = self::createBodyStream($options['body'], $streamFactory);
             unset($options['body']);
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,8 +7,11 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\HttpFactory;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -62,9 +65,22 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             throw new InvalidArgumentException('handler must be a callable');
         }
 
-        // Convert the base_uri to a UriInterface
+        $factory = new HttpFactory();
+
+        if (!isset($config[RequestOptions::REQUEST_FACTORY])) {
+            $config[RequestOptions::REQUEST_FACTORY] = $factory;
+        }
+
+        if (!isset($config[RequestOptions::URI_FACTORY])) {
+            $config[RequestOptions::URI_FACTORY] = $factory;
+        }
+
+        self::requireRequestFactory($config[RequestOptions::REQUEST_FACTORY]);
+        $uriFactory = self::requireUriFactory($config[RequestOptions::URI_FACTORY]);
+
+        // Convert the base_uri to a UriInterface using the configured URI factory.
         if (isset($config['base_uri'])) {
-            $config['base_uri'] = Psr7\Utils::uriFor($config['base_uri']);
+            $config['base_uri'] = self::createUri($config['base_uri'], $uriFactory);
         }
 
         $this->configureDefaults($config);
@@ -135,18 +151,21 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     public function requestAsync(string $method, $uri = '', array $options = []): PromiseInterface
     {
         $options = $this->prepareDefaults($options);
-        // Remove request modifying parameter because it can be done up-front.
-        $headers = $options['headers'] ?? [];
-        $body = $options['body'] ?? null;
-        $version = self::normalizeProtocolVersion($options['version'] ?? '1.1');
+
+        $factory = new HttpFactory();
+        $uriFactory = self::requireUriFactory($options[RequestOptions::URI_FACTORY] ?? $factory);
+        $requestFactory = self::requireRequestFactory($options[RequestOptions::REQUEST_FACTORY] ?? $factory);
+
         // Merge the URI into the base URI.
-        $uri = $this->buildUri(Psr7\Utils::uriFor($uri), $options);
-        if (\is_array($body)) {
-            throw $this->invalidBody();
+        $uriIsString = \is_string($uri);
+        $uri = self::createUri($uri, $uriFactory);
+        $builtUri = $this->buildUri($uri, $options);
+        if ($uriIsString && $builtUri !== $uri) {
+            $builtUri = self::createUri((string) $builtUri, $uriFactory);
         }
-        $request = new Psr7\Request($method, $uri, $headers, $body, $version);
-        // Remove the option so that they are not doubly-applied.
-        unset($options['headers'], $options['body'], $options['version']);
+
+        $uri = $builtUri;
+        $request = $requestFactory->createRequest($method, $uri);
 
         return $this->transfer($request, $options);
     }
@@ -192,7 +211,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     private function buildUri(UriInterface $uri, array $config): UriInterface
     {
         if (isset($config['base_uri'])) {
-            $uri = Psr7\UriResolver::resolve(Psr7\Utils::uriFor($config['base_uri']), $uri);
+            $uriFactory = self::requireUriFactory($config[RequestOptions::URI_FACTORY] ?? new HttpFactory());
+            $uri = Psr7\UriResolver::resolve(self::createUri($config['base_uri'], $uriFactory), $uri);
         }
 
         if (isset($config['idn_conversion']) && ($config['idn_conversion'] !== false)) {
@@ -201,6 +221,54 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;
+    }
+
+    /**
+     * @param mixed $factory
+     */
+    private static function requireRequestFactory($factory): RequestFactoryInterface
+    {
+        if (!$factory instanceof RequestFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::REQUEST_FACTORY,
+                RequestFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    /**
+     * @param mixed $factory
+     */
+    private static function requireUriFactory($factory): UriFactoryInterface
+    {
+        if (!$factory instanceof UriFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::URI_FACTORY,
+                UriFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    /**
+     * @param mixed $uri
+     */
+    private static function createUri($uri, UriFactoryInterface $uriFactory): UriInterface
+    {
+        if ($uri instanceof UriInterface) {
+            return $uri;
+        }
+
+        if (\is_string($uri)) {
+            return $uriFactory->createUri($uri);
+        }
+
+        throw new InvalidArgumentException(\sprintf('URI must be a string or %s', UriInterface::class));
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -159,6 +159,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     {
         $options = $this->prepareDefaults($options);
 
+        if (isset($options['body']) && \is_array($options['body'])) {
+            throw $this->invalidBody();
+        }
+
         $factory = new HttpFactory();
         $uriFactory = self::requireUriFactory($options[RequestOptions::URI_FACTORY] ?? $factory);
         $requestFactory = self::requireRequestFactory($options[RequestOptions::REQUEST_FACTORY] ?? $factory);
@@ -315,12 +319,16 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             return $streamFactory->createStream((string) $body);
         }
 
-        if ($body instanceof \Iterator || \is_callable($body)) {
+        if ($body instanceof \Iterator) {
             return Psr7\Utils::streamFor($body);
         }
 
         if (\is_object($body) && \method_exists($body, '__toString')) {
             return $streamFactory->createStream((string) $body);
+        }
+
+        if (\is_callable($body)) {
+            return Psr7\Utils::streamFor($body);
         }
 
         throw new InvalidArgumentException('Invalid resource type: '.\gettype($body));

--- a/src/Client.php
+++ b/src/Client.php
@@ -159,6 +159,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     {
         $options = $this->prepareDefaults($options);
 
+        $version = self::normalizeProtocolVersion($options['version'] ?? '1.1');
+        unset($options['version']);
+
         if (isset($options['body']) && \is_array($options['body'])) {
             throw $this->invalidBody();
         }
@@ -177,6 +180,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
         $uri = $builtUri;
         $request = $requestFactory->createRequest($method, $uri);
+        $request = Psr7\Utils::modifyRequest($request, ['version' => $version]);
 
         return $this->transfer($request, $options);
     }

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -244,19 +244,27 @@ class RedirectMiddleware
         $location = $response->getHeaderLine('Location');
 
         try {
-            $location = Psr7\UriResolver::resolve(
+            $locationUri = $uriFactory->createUri($location);
+            $resolvedUri = Psr7\UriResolver::resolve(
                 $request->getUri(),
-                $uriFactory->createUri($location)
+                $locationUri
             );
+
+            if (!$uriFactory instanceof HttpFactory
+                && $locationUri->getScheme() === ''
+                && $locationUri->getAuthority() === ''
+            ) {
+                $resolvedUri = $uriFactory->createUri((string) $resolvedUri);
+            }
         } catch (\InvalidArgumentException $e) {
             throw new BadResponseException(\sprintf('Redirect URI, %s, is invalid: %s', $location, $e->getMessage()), $request, $response, $e);
         }
 
         // Ensure that the redirect URI is allowed based on the protocols.
-        if (!\in_array($location->getScheme(), $protocols)) {
-            throw new BadResponseException(\sprintf('Redirect URI, %s, does not use one of the allowed redirect protocols: %s', $location, \implode(', ', $protocols)), $request, $response);
+        if (!\in_array($resolvedUri->getScheme(), $protocols)) {
+            throw new BadResponseException(\sprintf('Redirect URI, %s, does not use one of the allowed redirect protocols: %s', $resolvedUri, \implode(', ', $protocols)), $request, $response);
         }
 
-        return $location;
+        return $resolvedUri;
     }
 }

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\HttpFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -180,9 +181,17 @@ class RedirectMiddleware
         ) {
             $safeMethods = ['GET', 'HEAD', 'OPTIONS'];
             $requestMethod = $request->getMethod();
+            $streamFactory = $options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory();
+            if (!$streamFactory instanceof StreamFactoryInterface) {
+                throw new \InvalidArgumentException(\sprintf(
+                    '%s must be an instance of %s',
+                    RequestOptions::STREAM_FACTORY,
+                    StreamFactoryInterface::class
+                ));
+            }
 
             $modify['method'] = \in_array($requestMethod, $safeMethods, true) ? $requestMethod : 'GET';
-            $modify['body'] = '';
+            $modify['body'] = $streamFactory->createStream('');
         }
 
         $uriFactory = $options[RequestOptions::URI_FACTORY] ?? new HttpFactory();

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -5,8 +5,10 @@ namespace GuzzleHttp;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\HttpFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -183,7 +185,16 @@ class RedirectMiddleware
             $modify['body'] = '';
         }
 
-        $uri = self::redirectUri($request, $response, $protocols);
+        $uriFactory = $options[RequestOptions::URI_FACTORY] ?? new HttpFactory();
+        if (!$uriFactory instanceof UriFactoryInterface) {
+            throw new \InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::URI_FACTORY,
+                UriFactoryInterface::class
+            ));
+        }
+
+        $uri = self::redirectUri($uriFactory, $request, $response, $protocols);
         if (isset($options['idn_conversion']) && ($options['idn_conversion'] !== false)) {
             $idnOptions = ($options['idn_conversion'] === true) ? \IDNA_DEFAULT : $options['idn_conversion'];
             $uri = Utils::idnUriConvert($uri, $idnOptions);
@@ -216,6 +227,7 @@ class RedirectMiddleware
      * Set the appropriate URL on the request based on the location header.
      */
     private static function redirectUri(
+        UriFactoryInterface $uriFactory,
         RequestInterface $request,
         ResponseInterface $response,
         array $protocols
@@ -225,7 +237,7 @@ class RedirectMiddleware
         try {
             $location = Psr7\UriResolver::resolve(
                 $request->getUri(),
-                new Psr7\Uri($location)
+                $uriFactory->createUri($location)
             );
         } catch (\InvalidArgumentException $e) {
             throw new BadResponseException(\sprintf('Redirect URI, %s, is invalid: %s', $location, $e->getMessage()), $request, $response, $e);

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -281,7 +281,8 @@ final class RequestOptions
 
     /**
      * uri_factory: (Psr\Http\Message\UriFactoryInterface) PSR-17 URI factory
-     * used when creating URI objects from string request URI and base_uri values.
+     * used when creating URI objects from string request URI, base_uri, and
+     * redirect Location values.
      */
     public const URI_FACTORY = 'uri_factory';
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -43,7 +43,8 @@ final class RequestOptions
 
     /**
      * body: (resource|string|null|int|float|StreamInterface|callable|\Iterator)
-     * Body to send in the request.
+     * Body to send in the request. Supported non-stream values are converted
+     * using the configured stream_factory.
      */
     public const BODY = 'body';
 
@@ -225,6 +226,13 @@ final class RequestOptions
      * requestAsync().
      */
     public const REQUEST_FACTORY = 'request_factory';
+
+    /**
+     * stream_factory: (Psr\Http\Message\StreamFactoryInterface) PSR-17
+     * stream factory used when creating request body streams from body,
+     * form_params, and json request options.
+     */
+    public const STREAM_FACTORY = 'stream_factory';
 
     /**
      * sink: (resource|string|StreamInterface) Where the data of the

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -43,8 +43,9 @@ final class RequestOptions
 
     /**
      * body: (resource|string|null|int|float|StreamInterface|callable|\Iterator)
-     * Body to send in the request. Supported non-stream values are converted
-     * using the configured stream_factory.
+     * Body to send in the request. Scalar, resource, and stringable object
+     * values are converted using the configured stream_factory. Callable and
+     * iterator bodies use Guzzle's existing stream handling.
      */
     public const BODY = 'body';
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -220,6 +220,13 @@ final class RequestOptions
     public const QUERY = 'query';
 
     /**
+     * request_factory: (Psr\Http\Message\RequestFactoryInterface) PSR-17
+     * request factory used when creating requests through request() and
+     * requestAsync().
+     */
+    public const REQUEST_FACTORY = 'request_factory';
+
+    /**
      * sink: (resource|string|StreamInterface) Where the data of the
      * response is written to. Defaults to a PHP temp stream. Providing a
      * string will write data to a file by the given name.
@@ -271,6 +278,12 @@ final class RequestOptions
      * seconds are rejected by the built-in stream handler.
      */
     public const READ_TIMEOUT = 'read_timeout';
+
+    /**
+     * uri_factory: (Psr\Http\Message\UriFactoryInterface) PSR-17 URI factory
+     * used when creating URI objects from string request URI and base_uri values.
+     */
+    public const URI_FACTORY = 'uri_factory';
 
     /**
      * version: (string|float) Specifies the HTTP protocol version to attempt

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -21,6 +21,8 @@ use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -197,6 +199,8 @@ class ClientTest extends TestCase
         self::assertInstanceOf(RequestFactoryInterface::class, $config[RequestOptions::REQUEST_FACTORY]);
         self::assertArrayHasKey(RequestOptions::URI_FACTORY, $config);
         self::assertInstanceOf(UriFactoryInterface::class, $config[RequestOptions::URI_FACTORY]);
+        self::assertArrayHasKey(RequestOptions::STREAM_FACTORY, $config);
+        self::assertInstanceOf(StreamFactoryInterface::class, $config[RequestOptions::STREAM_FACTORY]);
     }
 
     public function testRequestUsesConfiguredRequestAndUriFactories(): void
@@ -243,6 +247,155 @@ class ClientTest extends TestCase
         self::assertSame('payload', (string) $request->getBody());
         self::assertSame('a=b', $request->getUri()->getQuery());
         self::assertSame('2', $request->getProtocolVersion());
+    }
+
+    public function testBodyUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => 'payload',
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame(['payload'], $factory->streamCalls());
+    }
+
+    public function testResourceBodyUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        \fwrite($resource, 'payload');
+        \rewind($resource);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => $resource,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame(1, $factory->streamResourceCalls());
+    }
+
+    public function testStringableBodyUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+        $body = new class {
+            public function __toString(): string
+            {
+                return 'payload';
+            }
+        };
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => $body,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame(['payload'], $factory->streamCalls());
+    }
+
+    public function testStreamBodyIsPreservedWithConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $stream = Psr7\Utils::streamFor('payload');
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => $stream,
+        ]);
+
+        self::assertSame($stream, $mock->getLastRequest()->getBody());
+        self::assertSame([], $factory->streamCalls());
+        self::assertSame(0, $factory->streamResourceCalls());
+    }
+
+    public function testJsonUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::JSON => ['foo' => 'bar'],
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('{"foo":"bar"}', (string) $request->getBody());
+        self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+        self::assertSame(['{"foo":"bar"}'], $factory->streamCalls());
+    }
+
+    public function testFormParamsUseConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::FORM_PARAMS => ['foo' => 'bar baz'],
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('foo=bar+baz', (string) $request->getBody());
+        self::assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        self::assertSame(['foo=bar+baz'], $factory->streamCalls());
+    }
+
+    public function testSendUsesConfiguredStreamFactoryForBodyOption(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->send(new Request('POST', 'http://example.com/path'), [
+            RequestOptions::BODY => 'payload',
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(Request::class, $request);
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame([], $factory->requestCalls());
+        self::assertSame([], $factory->uriCalls());
+        self::assertSame(['payload'], $factory->streamCalls());
     }
 
     public function testRequestPreservesMethodCasingWithConfiguredRequestFactory(): void
@@ -422,6 +575,115 @@ class ClientTest extends TestCase
         self::assertSame(['http://example.com/base/'], $factory->uriCalls());
     }
 
+    public function testPerRequestStreamFactoryOverridesClientStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $clientFactory = new ClientTestFactory();
+        $requestFactory = new ClientTestFactory(ClientTestRequest::class, ClientTestUri::class, ClientTestAlternateStream::class);
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $clientFactory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => 'payload',
+            RequestOptions::STREAM_FACTORY => $requestFactory,
+        ]);
+
+        self::assertSame([], $clientFactory->streamCalls());
+        self::assertSame(['payload'], $requestFactory->streamCalls());
+        self::assertInstanceOf(ClientTestAlternateStream::class, $mock->getLastRequest()->getBody());
+    }
+
+    public function testNullPerRequestStreamFactoryFallsBackToDefaultFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => 'payload',
+            RequestOptions::STREAM_FACTORY => null,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertNotInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame([], $factory->streamCalls());
+    }
+
+    public function testCallableBodyFallsBackToGuzzleStreamHandling(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $called = false;
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => static function (int $length) use (&$called) {
+                if ($called) {
+                    return false;
+                }
+
+                $called = true;
+
+                return 'payload';
+            },
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertNotInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame([], $factory->streamCalls());
+    }
+
+    public function testIteratorBodyFallsBackToGuzzleStreamHandling(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => new \ArrayIterator(['pay', 'load']),
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertNotInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame([], $factory->streamCalls());
+    }
+
+    public function testMultipartBodyDoesNotUseConfiguredStreamFactoryForAggregateBody(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::MULTIPART => [
+                [
+                    'name' => 'foo',
+                    'contents' => 'bar',
+                ],
+            ],
+        ]);
+
+        self::assertInstanceOf(Psr7\MultipartStream::class, $mock->getLastRequest()->getBody());
+        self::assertSame([], $factory->streamCalls());
+    }
+
     public function testInvalidRequestFactoryIsRejected(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -439,6 +701,16 @@ class ClientTest extends TestCase
 
         new Client([
             RequestOptions::URI_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidStreamFactoryIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
+
+        new Client([
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
         ]);
     }
 
@@ -467,6 +739,21 @@ class ClientTest extends TestCase
 
         $client->request('GET', 'http://example.com', [
             RequestOptions::URI_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidPerRequestStreamFactoryIsRejected(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
+
+        $client->request('POST', 'http://example.com', [
+            RequestOptions::BODY => 'payload',
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
         ]);
     }
 
@@ -1520,7 +1807,15 @@ final class ClientTestAlternateUri extends Uri
 {
 }
 
-final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInterface
+final class ClientTestStream extends Psr7\Stream
+{
+}
+
+final class ClientTestAlternateStream extends Psr7\Stream
+{
+}
+
+final class ClientTestFactory implements RequestFactoryInterface, StreamFactoryInterface, UriFactoryInterface
 {
     /** @var class-string<Request> */
     private $requestClass;
@@ -1528,20 +1823,34 @@ final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInte
     /** @var class-string<Uri> */
     private $uriClass;
 
+    /** @var class-string<Psr7\Stream> */
+    private $streamClass;
+
     /** @var array<int, array{0: string, 1: mixed}> */
     private $requestCalls = [];
 
     /** @var string[] */
     private $uriCalls = [];
 
+    /** @var string[] */
+    private $streamCalls = [];
+
+    /** @var int */
+    private $streamResourceCalls = 0;
+
     /**
-     * @param class-string<Request> $requestClass
-     * @param class-string<Uri>     $uriClass
+     * @param class-string<Request>     $requestClass
+     * @param class-string<Uri>         $uriClass
+     * @param class-string<Psr7\Stream> $streamClass
      */
-    public function __construct(string $requestClass = ClientTestRequest::class, string $uriClass = ClientTestUri::class)
-    {
+    public function __construct(
+        string $requestClass = ClientTestRequest::class,
+        string $uriClass = ClientTestUri::class,
+        string $streamClass = ClientTestStream::class
+    ) {
         $this->requestClass = $requestClass;
         $this->uriClass = $uriClass;
+        $this->streamClass = $streamClass;
     }
 
     public function createRequest(string $method, $uri): RequestInterface
@@ -1562,6 +1871,33 @@ final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInte
         return new $class($uri);
     }
 
+    public function createStream(string $content = ''): StreamInterface
+    {
+        $this->streamCalls[] = $content;
+
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        \fwrite($resource, $content);
+        \rewind($resource);
+        $class = $this->streamClass;
+
+        return new $class($resource);
+    }
+
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+    {
+        $class = $this->streamClass;
+
+        return new $class(Psr7\Utils::tryFopen($filename, $mode));
+    }
+
+    public function createStreamFromResource($resource): StreamInterface
+    {
+        ++$this->streamResourceCalls;
+        $class = $this->streamClass;
+
+        return new $class($resource);
+    }
+
     /**
      * @return array<int, array{0: string, 1: mixed}>
      */
@@ -1576,5 +1912,18 @@ final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInte
     public function uriCalls(): array
     {
         return $this->uriCalls;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function streamCalls(): array
+    {
+        return $this->streamCalls;
+    }
+
+    public function streamResourceCalls(): int
+    {
+        return $this->streamResourceCalls;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -315,6 +315,49 @@ class ClientTest extends TestCase
         self::assertSame(['payload'], $factory->streamCalls());
     }
 
+    public function testStringableCallableBodyUsesConfiguredStreamFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ]);
+        $body = new class {
+            /** @var bool */
+            public $called = false;
+
+            public function __toString(): string
+            {
+                return 'stringable';
+            }
+
+            /**
+             * @return string|false
+             */
+            public function __invoke(int $length)
+            {
+                if ($this->called) {
+                    return false;
+                }
+
+                $this->called = true;
+
+                return 'callable';
+            }
+        };
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::BODY => $body,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertFalse($body->called);
+        self::assertInstanceOf(ClientTestStream::class, $request->getBody());
+        self::assertSame('stringable', (string) $request->getBody());
+        self::assertSame(['stringable'], $factory->streamCalls());
+    }
+
     public function testStreamBodyIsPreservedWithConfiguredStreamFactory(): void
     {
         $mock = new MockHandler([new Response()]);
@@ -682,6 +725,44 @@ class ClientTest extends TestCase
 
         self::assertInstanceOf(Psr7\MultipartStream::class, $mock->getLastRequest()->getBody());
         self::assertSame([], $factory->streamCalls());
+    }
+
+    /**
+     * @dataProvider arrayBodyWithDerivedBodyOptionsProvider
+     *
+     * @param array<string, mixed> $options
+     */
+    public function testArrayBodyIsRejectedBeforeDerivedBodyOptions(array $options): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+        $options[RequestOptions::BODY] = ['invalid'];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Passing in the "body" request option as an array');
+
+        $client->request('POST', 'http://example.com/path', $options);
+    }
+
+    public static function arrayBodyWithDerivedBodyOptionsProvider(): array
+    {
+        return [
+            'json' => [
+                [RequestOptions::JSON => ['foo' => 'bar']],
+            ],
+            'form_params' => [
+                [RequestOptions::FORM_PARAMS => ['foo' => 'bar']],
+            ],
+            'multipart' => [
+                [RequestOptions::MULTIPART => [
+                    [
+                        'name' => 'foo',
+                        'contents' => 'bar',
+                    ],
+                ]],
+            ],
+        ];
     }
 
     public function testInvalidRequestFactoryIsRejected(): void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -249,6 +249,25 @@ class ClientTest extends TestCase
         self::assertSame('2', $request->getProtocolVersion());
     }
 
+    public function testRequestUsesDefaultProtocolVersionWithConfiguredRequestFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new class implements RequestFactoryInterface {
+            public function createRequest(string $method, $uri): RequestInterface
+            {
+                return new Request($method, $uri, [], null, '2.0');
+            }
+        };
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path');
+
+        self::assertSame('1.1', $mock->getLastRequest()->getProtocolVersion());
+    }
+
     public function testBodyUsesConfiguredStreamFactory(): void
     {
         $mock = new MockHandler([new Response()]);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -18,8 +18,11 @@ use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriFactoryInterface;
+use Psr\Http\Message\UriInterface;
 
 class ClientTest extends TestCase
 {
@@ -183,6 +186,306 @@ class ClientTest extends TestCase
             'http://bar.com/baz',
             (string) $mock->getLastRequest()->getUri()
         );
+    }
+
+    public function testClientHasDefaultPsr17Factories(): void
+    {
+        $client = new Client(['handler' => new MockHandler()]);
+        $config = self::readClientConfig($client);
+
+        self::assertArrayHasKey(RequestOptions::REQUEST_FACTORY, $config);
+        self::assertInstanceOf(RequestFactoryInterface::class, $config[RequestOptions::REQUEST_FACTORY]);
+        self::assertArrayHasKey(RequestOptions::URI_FACTORY, $config);
+        self::assertInstanceOf(UriFactoryInterface::class, $config[RequestOptions::URI_FACTORY]);
+    }
+
+    public function testRequestUsesConfiguredRequestAndUriFactories(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path');
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame('http://example.com/path', (string) $request->getUri());
+        self::assertSame(['http://example.com/path'], $factory->uriCalls());
+        self::assertSame('GET', $factory->requestCalls()[0][0]);
+        self::assertInstanceOf(ClientTestUri::class, $factory->requestCalls()[0][1]);
+    }
+
+    public function testRequestAppliesHeadersBodyQueryAndVersionAfterFactoryCreation(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('POST', 'http://example.com/path', [
+            RequestOptions::HEADERS => ['X-Test' => '1'],
+            RequestOptions::BODY => 'payload',
+            RequestOptions::QUERY => ['a' => 'b'],
+            RequestOptions::VERSION => '2',
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertSame('1', $request->getHeaderLine('X-Test'));
+        self::assertSame('payload', (string) $request->getBody());
+        self::assertSame('a=b', $request->getUri()->getQuery());
+        self::assertSame('2', $request->getProtocolVersion());
+    }
+
+    public function testRequestPreservesMethodCasingWithConfiguredRequestFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+        ]);
+
+        $client->request('gEt', 'http://example.com/path');
+
+        self::assertSame('gEt', $factory->requestCalls()[0][0]);
+        self::assertSame('gEt', $mock->getLastRequest()->getMethod());
+    }
+
+    public function testStringBaseUriUsesConfiguredUriFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            'base_uri' => 'http://example.com/base/',
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $config = self::readClientConfig($client);
+        self::assertInstanceOf(ClientTestUri::class, $config['base_uri']);
+
+        $client->request('GET', 'relative');
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame('http://example.com/base/relative', (string) $request->getUri());
+        self::assertSame(
+            ['http://example.com/base/', 'relative', 'http://example.com/base/relative'],
+            $factory->uriCalls()
+        );
+    }
+
+    public function testPerRequestFactoriesOverrideClientFactories(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $clientFactory = new ClientTestFactory();
+        $requestFactory = new ClientTestFactory(ClientTestAlternateRequest::class, ClientTestAlternateUri::class);
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $clientFactory,
+            RequestOptions::URI_FACTORY => $clientFactory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path', [
+            RequestOptions::REQUEST_FACTORY => $requestFactory,
+            RequestOptions::URI_FACTORY => $requestFactory,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestAlternateRequest::class, $request);
+        self::assertInstanceOf(ClientTestAlternateUri::class, $request->getUri());
+        self::assertSame([], $clientFactory->requestCalls());
+        self::assertSame([], $clientFactory->uriCalls());
+    }
+
+    public function testPerRequestBaseUriUsesPerRequestUriFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $clientFactory = new ClientTestFactory();
+        $requestFactory = new ClientTestFactory(ClientTestAlternateRequest::class, ClientTestAlternateUri::class);
+        $client = new Client([
+            'handler' => $mock,
+            'base_uri' => 'http://client.example/base/',
+            RequestOptions::REQUEST_FACTORY => $clientFactory,
+            RequestOptions::URI_FACTORY => $clientFactory,
+        ]);
+
+        $client->request('GET', 'relative', [
+            'base_uri' => 'http://request.example/base/',
+            RequestOptions::REQUEST_FACTORY => $requestFactory,
+            RequestOptions::URI_FACTORY => $requestFactory,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestAlternateUri::class, $request->getUri());
+        self::assertSame('http://request.example/base/relative', (string) $request->getUri());
+        self::assertSame(['http://client.example/base/'], $clientFactory->uriCalls());
+        self::assertSame(
+            ['relative', 'http://request.example/base/', 'http://request.example/base/relative'],
+            $requestFactory->uriCalls()
+        );
+    }
+
+    public function testPerRequestUriFactoryControlsResolvedUriWithClientBaseUriString(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            'base_uri' => 'http://example.com/base/',
+        ]);
+
+        $client->request('GET', 'relative', [
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame('http://example.com/base/relative', (string) $request->getUri());
+        self::assertSame(['relative', 'http://example.com/base/relative'], $factory->uriCalls());
+    }
+
+    public function testNullPerRequestRequestFactoryFallsBackToDefaultFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path', [
+            RequestOptions::REQUEST_FACTORY => null,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(Request::class, $request);
+        self::assertNotInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame([], $factory->requestCalls());
+    }
+
+    public function testNullPerRequestUriFactoryFallsBackToDefaultFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path', [
+            RequestOptions::URI_FACTORY => null,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(Uri::class, $request->getUri());
+        self::assertNotInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame([], $factory->uriCalls());
+    }
+
+    public function testNullPerRequestUriFactoryFallsBackToDefaultFactoryWhenResolvingClientBaseUri(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            'base_uri' => 'http://example.com/base/',
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'relative', [
+            RequestOptions::URI_FACTORY => null,
+        ]);
+
+        $request = $mock->getLastRequest();
+        self::assertInstanceOf(ClientTestRequest::class, $request);
+        self::assertInstanceOf(Uri::class, $request->getUri());
+        self::assertNotInstanceOf(ClientTestUri::class, $request->getUri());
+        self::assertSame('http://example.com/base/relative', (string) $request->getUri());
+        self::assertSame(['http://example.com/base/'], $factory->uriCalls());
+    }
+
+    public function testInvalidRequestFactoryIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('request_factory must be an instance of Psr\\Http\\Message\\RequestFactoryInterface');
+
+        new Client([
+            RequestOptions::REQUEST_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidUriFactoryIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('uri_factory must be an instance of Psr\\Http\\Message\\UriFactoryInterface');
+
+        new Client([
+            RequestOptions::URI_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidPerRequestRequestFactoryIsRejected(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('request_factory must be an instance of Psr\\Http\\Message\\RequestFactoryInterface');
+
+        $client->request('GET', 'http://example.com', [
+            RequestOptions::REQUEST_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidPerRequestUriFactoryIsRejected(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('uri_factory must be an instance of Psr\\Http\\Message\\UriFactoryInterface');
+
+        $client->request('GET', 'http://example.com', [
+            RequestOptions::URI_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testSendDoesNotUseRequestFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::REQUEST_FACTORY => $factory,
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->send(new Request('GET', 'http://example.com/path'));
+
+        self::assertInstanceOf(Request::class, $mock->getLastRequest());
+        self::assertNotInstanceOf(ClientTestRequest::class, $mock->getLastRequest());
+        self::assertSame([], $factory->requestCalls());
+        self::assertSame([], $factory->uriCalls());
     }
 
     public function testMergesDefaultOptionsAndDoesNotOverwriteUa(): void
@@ -1207,4 +1510,71 @@ final class ClientTestRequest extends Request
 
 final class ClientTestUri extends Uri
 {
+}
+
+final class ClientTestAlternateRequest extends Request
+{
+}
+
+final class ClientTestAlternateUri extends Uri
+{
+}
+
+final class ClientTestFactory implements RequestFactoryInterface, UriFactoryInterface
+{
+    /** @var class-string<Request> */
+    private $requestClass;
+
+    /** @var class-string<Uri> */
+    private $uriClass;
+
+    /** @var array<int, array{0: string, 1: mixed}> */
+    private $requestCalls = [];
+
+    /** @var string[] */
+    private $uriCalls = [];
+
+    /**
+     * @param class-string<Request> $requestClass
+     * @param class-string<Uri>     $uriClass
+     */
+    public function __construct(string $requestClass = ClientTestRequest::class, string $uriClass = ClientTestUri::class)
+    {
+        $this->requestClass = $requestClass;
+        $this->uriClass = $uriClass;
+    }
+
+    public function createRequest(string $method, $uri): RequestInterface
+    {
+        $this->requestCalls[] = [$method, $uri];
+
+        $class = $this->requestClass;
+
+        return new $class($method, $uri);
+    }
+
+    public function createUri(string $uri = ''): UriInterface
+    {
+        $this->uriCalls[] = $uri;
+
+        $class = $this->uriClass;
+
+        return new $class($uri);
+    }
+
+    /**
+     * @return array<int, array{0: string, 1: mixed}>
+     */
+    public function requestCalls(): array
+    {
+        return $this->requestCalls;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function uriCalls(): array
+    {
+        return $this->uriCalls;
+    }
 }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -14,9 +14,11 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\RedirectMiddleware;
+use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -82,6 +84,140 @@ class RedirectMiddlewareTest extends TestCase
         $response = $promise->wait();
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('http://example.com/foo', (string) $mock->getLastRequest()->getUri());
+    }
+
+    public function testAbsoluteRedirectUsesConfiguredUriFactory(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $factory = new RedirectTestUriFactory();
+        $request = new Request('GET', 'http://example.com');
+
+        $handler($request, [
+            'allow_redirects' => ['max' => 2],
+            RequestOptions::URI_FACTORY => $factory,
+        ])->wait();
+
+        self::assertSame(['http://test.com/foo'], $factory->uriCalls());
+        self::assertInstanceOf(RedirectTestUri::class, $mock->getLastRequest()->getUri());
+        self::assertSame('http://test.com/foo', (string) $mock->getLastRequest()->getUri());
+    }
+
+    public function testRelativeRedirectUsesConfiguredUriFactory(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => '/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $factory = new RedirectTestUriFactory();
+        $request = new Request('GET', 'http://example.com?a=b');
+
+        $handler($request, [
+            'allow_redirects' => ['max' => 2],
+            RequestOptions::URI_FACTORY => $factory,
+        ])->wait();
+
+        self::assertSame(['/foo'], $factory->uriCalls());
+        self::assertSame('http://example.com/foo', (string) $mock->getLastRequest()->getUri());
+    }
+
+    public function testSendUsesClientUriFactoryForRedirects(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com/foo']),
+            new Response(200),
+        ]);
+        $factory = new RedirectTestUriFactory();
+        $client = new Client([
+            'handler' => HandlerStack::create($mock),
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+
+        $client->send(new Request('GET', 'http://example.com'));
+
+        self::assertSame(['http://test.com/foo'], $factory->uriCalls());
+        self::assertInstanceOf(RedirectTestUri::class, $mock->getLastRequest()->getUri());
+        self::assertSame('http://test.com/foo', (string) $mock->getLastRequest()->getUri());
+    }
+
+    public function testPerRequestUriFactoryOverridesClientUriFactoryForRedirects(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com/foo']),
+            new Response(200),
+        ]);
+        $clientFactory = new RedirectTestUriFactory();
+        $requestFactory = new RedirectTestUriFactory();
+        $client = new Client([
+            'handler' => HandlerStack::create($mock),
+            RequestOptions::URI_FACTORY => $clientFactory,
+        ]);
+
+        $client->send(new Request('GET', 'http://example.com'), [
+            RequestOptions::URI_FACTORY => $requestFactory,
+        ]);
+
+        self::assertSame([], $clientFactory->uriCalls());
+        self::assertSame(['http://test.com/foo'], $requestFactory->uriCalls());
+        self::assertInstanceOf(RedirectTestUri::class, $mock->getLastRequest()->getUri());
+        self::assertSame('http://test.com/foo', (string) $mock->getLastRequest()->getUri());
+    }
+
+    public function testNullPerRequestUriFactoryFallsBackForRedirects(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com/foo']),
+            new Response(200),
+        ]);
+        $clientFactory = new RedirectTestUriFactory();
+        $client = new Client([
+            'handler' => HandlerStack::create($mock),
+            RequestOptions::URI_FACTORY => $clientFactory,
+        ]);
+
+        $client->send(new Request('GET', 'http://example.com'), [
+            RequestOptions::URI_FACTORY => null,
+        ]);
+
+        self::assertSame([], $clientFactory->uriCalls());
+        self::assertNotInstanceOf(RedirectTestUri::class, $mock->getLastRequest()->getUri());
+        self::assertSame('http://test.com/foo', (string) $mock->getLastRequest()->getUri());
+    }
+
+    public function testOnRedirectReceivesUriFromConfiguredFactory(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com/foo']),
+            new Response(200),
+        ]);
+        $factory = new RedirectTestUriFactory();
+        $client = new Client([
+            'handler' => HandlerStack::create($mock),
+            RequestOptions::URI_FACTORY => $factory,
+        ]);
+        $called = false;
+
+        $client->send(new Request('GET', 'http://example.com'), [
+            'allow_redirects' => [
+                'on_redirect' => static function (RequestInterface $request, ResponseInterface $response, UriInterface $uri) use (&$called): void {
+                    self::assertSame(302, $response->getStatusCode());
+                    self::assertSame('GET', $request->getMethod());
+                    self::assertInstanceOf(RedirectTestUri::class, $uri);
+                    self::assertSame('http://test.com/foo', (string) $uri);
+                    $called = true;
+                },
+            ],
+        ]);
+
+        self::assertTrue($called);
     }
 
     public function testRelativeRedirectPreservesCustomRequestAndUriImplementations(): void
@@ -162,7 +298,7 @@ class RedirectMiddlewareTest extends TestCase
     public function testRejectsMalformedRedirectUri(): void
     {
         $mock = new MockHandler([
-            new Response(302, ['Location' => 'http://[::1']),
+            new Response(302, ['Location' => 'http://example.com:99999/path']),
         ]);
         $stack = new HandlerStack($mock);
         $stack->push(Middleware::redirect());
@@ -177,6 +313,49 @@ class RedirectMiddlewareTest extends TestCase
             self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
             self::assertStringStartsWith('Redirect URI,', $e->getMessage());
         }
+    }
+
+    public function testWrapsUriFactoryExceptionsForRedirects(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com/foo']),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('GET', 'http://example.com');
+
+        try {
+            $handler($request, [
+                'allow_redirects' => ['max' => 2],
+                RequestOptions::URI_FACTORY => new RedirectTestFailingUriFactory(),
+            ])->wait();
+            self::fail('Expected BadResponseException.');
+        } catch (BadResponseException $e) {
+            self::assertSame(302, $e->getResponse()->getStatusCode());
+            self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
+            self::assertSame('Factory could not create URI.', $e->getPrevious()->getMessage());
+            self::assertStringStartsWith('Redirect URI,', $e->getMessage());
+        }
+    }
+
+    public function testRejectsInvalidUriFactoryOptionForRedirects(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://test.com/foo']),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('GET', 'http://example.com');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('uri_factory must be an instance of Psr\\Http\\Message\\UriFactoryInterface');
+
+        $handler($request, [
+            'allow_redirects' => ['max' => 2],
+            RequestOptions::URI_FACTORY => new \stdClass(),
+        ])->wait();
     }
 
     public function testAddsRefererHeader(): void
@@ -555,11 +734,11 @@ class RedirectMiddlewareTest extends TestCase
     {
         return [
             'DELETE' => [
-                'request' => new Request('DELETE', 'http://example.com/'),
+                'request' => new RedirectTestMethodRequest('DELETE', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'GET',
             ],
             'GET' => [
-                'request' => new Request('GET', 'http://example.com/'),
+                'request' => new RedirectTestMethodRequest('GET', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'GET',
             ],
             'get' => [
@@ -571,7 +750,7 @@ class RedirectMiddlewareTest extends TestCase
                 'expectedFollowRequestMethod' => 'GET',
             ],
             'HEAD' => [
-                'request' => new Request('HEAD', 'http://example.com/'),
+                'request' => new RedirectTestMethodRequest('HEAD', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'HEAD',
             ],
             'head' => [
@@ -583,7 +762,7 @@ class RedirectMiddlewareTest extends TestCase
                 'expectedFollowRequestMethod' => 'GET',
             ],
             'OPTIONS' => [
-                'request' => new Request('OPTIONS', 'http://example.com/'),
+                'request' => new RedirectTestMethodRequest('OPTIONS', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'OPTIONS',
             ],
             'options' => [
@@ -595,15 +774,27 @@ class RedirectMiddlewareTest extends TestCase
                 'expectedFollowRequestMethod' => 'GET',
             ],
             'PATCH' => [
-                'request' => new Request('PATCH', 'http://example.com/'),
+                'request' => new RedirectTestMethodRequest('PATCH', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
+            ],
+            'patch' => [
+                'request' => new RedirectTestMethodRequest('patch', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'GET',
             ],
             'POST' => [
-                'request' => new Request('POST', 'http://example.com/'),
+                'request' => new RedirectTestMethodRequest('POST', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
+            ],
+            'post' => [
+                'request' => new RedirectTestMethodRequest('post', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'GET',
             ],
             'PUT' => [
-                'request' => new Request('PUT', 'http://example.com/'),
+                'request' => new RedirectTestMethodRequest('PUT', 'http://example.com/'),
+                'expectedFollowRequestMethod' => 'GET',
+            ],
+            'put' => [
+                'request' => new RedirectTestMethodRequest('put', 'http://example.com/'),
                 'expectedFollowRequestMethod' => 'GET',
             ],
         ];
@@ -628,7 +819,7 @@ final class RedirectTestMethodRequest extends Request
      */
     public function __construct(string $method, $uri)
     {
-        parent::__construct('GET', $uri);
+        parent::__construct($method, $uri);
 
         $this->method = $method;
     }
@@ -644,5 +835,34 @@ final class RedirectTestMethodRequest extends Request
         $new->method = $method;
 
         return $new;
+    }
+}
+
+final class RedirectTestUriFactory implements UriFactoryInterface
+{
+    /** @var string[] */
+    private $uriCalls = [];
+
+    public function createUri(string $uri = ''): UriInterface
+    {
+        $this->uriCalls[] = $uri;
+
+        return new RedirectTestUri($uri);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function uriCalls(): array
+    {
+        return $this->uriCalls;
+    }
+}
+
+final class RedirectTestFailingUriFactory implements UriFactoryInterface
+{
+    public function createUri(string $uri = ''): UriInterface
+    {
+        throw new \InvalidArgumentException('Factory could not create URI.');
     }
 }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
@@ -18,6 +19,8 @@ use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -218,6 +221,47 @@ class RedirectMiddlewareTest extends TestCase
         ]);
 
         self::assertTrue($called);
+    }
+
+    public function testRedirectBodyResetUsesConfiguredStreamFactory(): void
+    {
+        $redirectMiddleware = new RedirectMiddleware(static function (): void {
+        });
+        $factory = new RedirectTestStreamFactory();
+        $request = new Request('POST', 'http://example.com/', [], 'payload');
+
+        $modifiedRequest = $redirectMiddleware->modifyRequest($request, [
+            'allow_redirects' => [
+                'protocols' => ['http', 'https'],
+                'strict' => false,
+                'referer' => false,
+            ],
+            RequestOptions::STREAM_FACTORY => $factory,
+        ], new Response(302, ['Location' => 'http://example.com/redirected']));
+
+        self::assertSame('GET', $modifiedRequest->getMethod());
+        self::assertInstanceOf(RedirectTestStream::class, $modifiedRequest->getBody());
+        self::assertSame('', (string) $modifiedRequest->getBody());
+        self::assertSame([''], $factory->streamCalls());
+    }
+
+    public function testInvalidStreamFactoryOptionForRedirectBodyResetIsRejected(): void
+    {
+        $redirectMiddleware = new RedirectMiddleware(static function (): void {
+        });
+        $request = new Request('POST', 'http://example.com/', [], 'payload');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
+
+        $redirectMiddleware->modifyRequest($request, [
+            'allow_redirects' => [
+                'protocols' => ['http', 'https'],
+                'strict' => false,
+                'referer' => false,
+            ],
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
+        ], new Response(302, ['Location' => 'http://example.com/redirected']));
     }
 
     public function testRelativeRedirectPreservesCustomRequestAndUriImplementations(): void
@@ -864,5 +908,43 @@ final class RedirectTestFailingUriFactory implements UriFactoryInterface
     public function createUri(string $uri = ''): UriInterface
     {
         throw new \InvalidArgumentException('Factory could not create URI.');
+    }
+}
+
+final class RedirectTestStream extends Psr7\Stream
+{
+}
+
+final class RedirectTestStreamFactory implements StreamFactoryInterface
+{
+    /** @var string[] */
+    private $streamCalls = [];
+
+    public function createStream(string $content = ''): StreamInterface
+    {
+        $this->streamCalls[] = $content;
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        \fwrite($resource, $content);
+        \rewind($resource);
+
+        return new RedirectTestStream($resource);
+    }
+
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+    {
+        return new RedirectTestStream(Psr7\Utils::tryFopen($filename, $mode));
+    }
+
+    public function createStreamFromResource($resource): StreamInterface
+    {
+        return new RedirectTestStream($resource);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function streamCalls(): array
+    {
+        return $this->streamCalls;
     }
 }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -128,7 +128,8 @@ class RedirectMiddlewareTest extends TestCase
             RequestOptions::URI_FACTORY => $factory,
         ])->wait();
 
-        self::assertSame(['/foo'], $factory->uriCalls());
+        self::assertSame(['/foo', 'http://example.com/foo'], $factory->uriCalls());
+        self::assertInstanceOf(RedirectTestUri::class, $mock->getLastRequest()->getUri());
         self::assertSame('http://example.com/foo', (string) $mock->getLastRequest()->getUri());
     }
 
@@ -280,6 +281,24 @@ class RedirectMiddlewareTest extends TestCase
 
         $lastRequest = $mock->getLastRequest();
         self::assertSame(200, $response->getStatusCode());
+        self::assertInstanceOf(RedirectTestRequest::class, $lastRequest);
+        self::assertInstanceOf(RedirectTestUri::class, $lastRequest->getUri());
+        self::assertSame('http://example.com/foo', (string) $lastRequest->getUri());
+    }
+
+    public function testSendPreservesCustomUriImplementationForRelativeRedirectsWithDefaultUriFactory(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => '/foo']),
+            new Response(200),
+        ]);
+        $client = new Client([
+            'handler' => HandlerStack::create($mock),
+        ]);
+
+        $client->send(new RedirectTestRequest('GET', new RedirectTestUri('http://example.com?a=b')));
+
+        $lastRequest = $mock->getLastRequest();
         self::assertInstanceOf(RedirectTestRequest::class, $lastRequest);
         self::assertInstanceOf(RedirectTestUri::class, $lastRequest->getUri());
         self::assertSame('http://example.com/foo', (string) $lastRequest->getUri());


### PR DESCRIPTION
This change adds request-side PSR-17 factory support to Guzzle. Clients can now configure `request_factory`, `uri_factory`, and `stream_factory` options, either as client defaults or per request, while defaulting to `GuzzleHttp\Psr7\HttpFactory`.

The request and URI factories are used when Guzzle creates requests through `request()` and `requestAsync()`, resolves string request URIs and `base_uri` values, and parses redirect `Location` headers. The stream factory is used when Guzzle converts supported request body options such as `body`, `form_params`, and `json` into streams, and when redirect handling resets a request body during non-strict rewrites.

This remains intentionally request-side only. Requests passed directly to `send()`, `sendAsync()`, or `sendRequest()` keep their existing request and URI objects, response implementations returned by handlers are unchanged, and response sinks, callable or iterator bodies, and multipart internals continue to use Guzzle's existing handling.

---

In order to enable this to function, some groundwork has been laid:

* https://github.com/guzzle/guzzle/pull/3135
* https://github.com/guzzle/psr7/pull/655
* https://github.com/guzzle/psr7/pull/657
* https://github.com/guzzle/psr7/pull/658
* https://github.com/guzzle/guzzle/pull/3388

This PR replaces https://github.com/guzzle/guzzle/pull/2525.