### PR TITLE
Avoid stale authenticated proxy tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers
+- Avoid stale authenticated proxy tunnels on affected libcurl versions
 
 ### Removed
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -814,7 +814,7 @@ $client->request('GET', '/', [
 > You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
 
 > [!NOTE]
-> When sending HTTPS requests through an authenticated HTTP or HTTPS proxy, libcurl versions before 8.19.0 could reuse an existing proxy tunnel even after proxy credentials changed. Guzzle avoids that reuse on affected libcurl versions. Fixed libcurl versions keep normal connection reuse behavior. Advanced users can still control cURL connection reuse explicitly with the `curl` request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
+> When sending HTTPS requests through an authenticated HTTP or HTTPS proxy, libcurl versions before 8.19.0 could reuse an existing proxy tunnel even after proxy credentials changed. Guzzle avoids that reuse on affected libcurl versions when proxy credentials are configured in the proxy URL or alongside the proxy option using cURL proxy credential options. Fixed libcurl versions keep normal connection reuse behavior. Advanced users can still control cURL connection reuse explicitly with the `curl` request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
 
 ## query
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -813,6 +813,9 @@ $client->request('GET', '/', [
 > [!NOTE]
 > You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
 
+> [!NOTE]
+> When sending HTTPS requests through an authenticated HTTP or HTTPS proxy, libcurl versions before 8.19.0 could reuse an existing proxy tunnel even after proxy credentials changed. Guzzle avoids that reuse on affected libcurl versions. Fixed libcurl versions keep normal connection reuse behavior. Advanced users can still control cURL connection reuse explicitly with the `curl` request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
+
 ## query
 
 Summary

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -814,7 +814,7 @@ $client->request('GET', '/', [
 > You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
 
 > [!NOTE]
-> When sending HTTPS requests, or requests explicitly tunneled with `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy, libcurl versions before 8.19.0 could reuse an existing proxy tunnel even after proxy credentials changed. Guzzle avoids that reuse on affected libcurl versions when the proxy is configured through the `proxy` option or raw cURL `CURLOPT_PROXY` option. Fixed libcurl versions keep normal connection reuse behavior. Advanced users can still control cURL connection reuse explicitly with the `curl` request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
+> When sending HTTPS requests, or requests explicitly tunneled with `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy, libcurl versions before 8.19.0 could reuse an existing proxy tunnel even after proxy credentials changed. Guzzle avoids that reuse on affected libcurl versions when the proxy is configured through the `proxy` option or raw cURL `CURLOPT_PROXY` option, including cURL proxy credential options. Custom proxy authentication sent with `CURLOPT_PROXYHEADER` also avoids tunnel reuse because libcurl does not include those header values in its connection matching. Fixed libcurl versions keep normal connection reuse behavior for proxy URL and cURL proxy credential options. Advanced users can still control cURL connection reuse explicitly with the `curl` request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`; raw `CURLOPT_PROXYTYPE` is respected when deciding whether a scheme-less raw cURL proxy is an HTTP(S) proxy.
 
 ## query
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -814,7 +814,7 @@ $client->request('GET', '/', [
 > You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
 
 > [!NOTE]
-> When sending HTTPS requests through an authenticated HTTP or HTTPS proxy, libcurl versions before 8.19.0 could reuse an existing proxy tunnel even after proxy credentials changed. Guzzle avoids that reuse on affected libcurl versions when proxy credentials are configured in the proxy URL or alongside the proxy option using cURL proxy credential options. Fixed libcurl versions keep normal connection reuse behavior. Advanced users can still control cURL connection reuse explicitly with the `curl` request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
+> When sending HTTPS requests, or requests explicitly tunneled with `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy, libcurl versions before 8.19.0 could reuse an existing proxy tunnel even after proxy credentials changed. Guzzle avoids that reuse on affected libcurl versions when the proxy is configured through the `proxy` option or raw cURL `CURLOPT_PROXY` option. Fixed libcurl versions keep normal connection reuse behavior. Advanced users can still control cURL connection reuse explicitly with the `curl` request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
 
 ## query
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -381,9 +381,9 @@ class CurlFactory implements CurlFactoryInterface
         return str_replace($baseUriString, $redactedUriString, $error);
     }
 
-    private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy): bool
+    private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy, array $options): bool
     {
-        if ('https' !== $request->getUri()->getScheme() || CurlVersion::supportsProxyCredentialAwareReuse()) {
+        if ('https' !== $request->getUri()->getScheme() || CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
             return false;
         }
 
@@ -398,7 +398,19 @@ class CurlFactory implements CurlFactoryInterface
             return false;
         }
 
-        return \array_key_exists('user', $proxyParts) || \array_key_exists('pass', $proxyParts);
+        return \array_key_exists('user', $proxyParts)
+            || \array_key_exists('pass', $proxyParts)
+            || self::hasCurlProxyCredentials($options);
+    }
+
+    private static function hasCurlProxyCredentials(array $options): bool
+    {
+        return isset($options['curl'])
+            && (
+                \array_key_exists(\CURLOPT_PROXYUSERPWD, $options['curl'])
+                || \array_key_exists(\CURLOPT_PROXYUSERNAME, $options['curl'])
+                || \array_key_exists(\CURLOPT_PROXYPASSWORD, $options['curl'])
+            );
     }
 
     /**
@@ -687,7 +699,7 @@ class CurlFactory implements CurlFactoryInterface
                 }
             }
 
-            if ($selectedProxy !== null && self::requiresFreshConnectionForAuthenticatedProxy($easy->request, $selectedProxy)) {
+            if ($selectedProxy !== null && self::requiresFreshConnectionForAuthenticatedProxy($easy->request, $selectedProxy, $options)) {
                 $conf[\CURLOPT_FRESH_CONNECT] = true;
                 $conf[\CURLOPT_FORBID_REUSE] = true;
             }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -383,7 +383,7 @@ class CurlFactory implements CurlFactoryInterface
 
     private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy, array $options): bool
     {
-        if (!self::usesProxyTunnel($request, $options) || CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
+        if (!self::usesProxyTunnel($request, $options) || !self::isHttpProxyForConnectionReuse($proxy, $options)) {
             return false;
         }
 
@@ -393,14 +393,16 @@ class CurlFactory implements CurlFactoryInterface
             return false;
         }
 
-        $proxyScheme = isset($proxyParts['scheme']) ? \strtolower($proxyParts['scheme']) : 'http';
-        if ($proxyScheme !== 'http' && $proxyScheme !== 'https') {
-            return false;
+        if (self::hasCurlProxyAuthorizationHeader($options)) {
+            return true;
         }
 
-        return \array_key_exists('user', $proxyParts)
-            || \array_key_exists('pass', $proxyParts)
-            || self::hasCurlProxyCredentials($options);
+        return !CurlVersion::supportsProxyCredentialAwareConnectionReuse()
+            && (
+                \array_key_exists('user', $proxyParts)
+                || \array_key_exists('pass', $proxyParts)
+                || self::hasCurlProxyCredentials($options)
+            );
     }
 
     private static function usesProxyTunnel(RequestInterface $request, array $options): bool
@@ -424,6 +426,46 @@ class CurlFactory implements CurlFactoryInterface
         return \is_string($proxy) && $proxy !== '' ? $proxy : null;
     }
 
+    private static function isHttpProxyForConnectionReuse(string $proxy, array $options): bool
+    {
+        if (\strpos($proxy, '://') !== false) {
+            $proxyParts = \parse_url($proxy);
+            if (!\is_array($proxyParts) || !isset($proxyParts['scheme'])) {
+                return false;
+            }
+
+            $proxyScheme = \strtolower($proxyParts['scheme']);
+
+            return $proxyScheme === 'http' || $proxyScheme === 'https';
+        }
+
+        return !self::isSocksProxyType($options['curl'][\CURLOPT_PROXYTYPE] ?? null);
+    }
+
+    /**
+     * @param mixed $proxyType
+     */
+    private static function isSocksProxyType($proxyType): bool
+    {
+        if (!\is_int($proxyType)) {
+            return false;
+        }
+
+        foreach ([
+            'CURLPROXY_SOCKS4' => 4,
+            'CURLPROXY_SOCKS5' => 5,
+            'CURLPROXY_SOCKS4A' => 6,
+            'CURLPROXY_SOCKS5_HOSTNAME' => 7,
+        ] as $name => $fallback) {
+            $value = \defined($name) ? (int) \constant($name) : $fallback;
+            if ($proxyType === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static function hasCurlProxyCredentials(array $options): bool
     {
         return isset($options['curl'])
@@ -432,6 +474,43 @@ class CurlFactory implements CurlFactoryInterface
                 || \array_key_exists(\CURLOPT_PROXYUSERNAME, $options['curl'])
                 || \array_key_exists(\CURLOPT_PROXYPASSWORD, $options['curl'])
             );
+    }
+
+    private static function hasCurlProxyAuthorizationHeader(array $options): bool
+    {
+        if (!\defined('CURLOPT_PROXYHEADER')) {
+            return false;
+        }
+
+        $option = (int) \constant('CURLOPT_PROXYHEADER');
+        if (!isset($options['curl']) || !\array_key_exists($option, $options['curl'])) {
+            return false;
+        }
+
+        $headers = $options['curl'][$option];
+        if (!\is_array($headers)) {
+            return false;
+        }
+
+        foreach ($headers as $header) {
+            if (!\is_string($header)) {
+                continue;
+            }
+
+            $parts = \explode(':', $header, 2);
+            if (\count($parts) !== 2) {
+                continue;
+            }
+
+            if (
+                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
+                && \trim($parts[1]) !== ''
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -381,6 +381,26 @@ class CurlFactory implements CurlFactoryInterface
         return str_replace($baseUriString, $redactedUriString, $error);
     }
 
+    private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy): bool
+    {
+        if ('https' !== $request->getUri()->getScheme() || CurlVersion::supportsProxyCredentialAwareReuse()) {
+            return false;
+        }
+
+        $proxyForParsing = \strpos($proxy, '://') === false ? 'http://'.$proxy : $proxy;
+        $proxyParts = \parse_url($proxyForParsing);
+        if (!\is_array($proxyParts)) {
+            return false;
+        }
+
+        $proxyScheme = isset($proxyParts['scheme']) ? \strtolower($proxyParts['scheme']) : 'http';
+        if ($proxyScheme !== 'http' && $proxyScheme !== 'https') {
+            return false;
+        }
+
+        return \array_key_exists('user', $proxyParts) || \array_key_exists('pass', $proxyParts);
+    }
+
     /**
      * @return array<int|string, mixed>
      */
@@ -638,11 +658,13 @@ class CurlFactory implements CurlFactoryInterface
 
         if (isset($options['proxy'])) {
             $proxy = $options['proxy'];
+            $selectedProxy = null;
             if (!\is_array($proxy)) {
                 if (!\is_string($proxy)) {
                     throw new \InvalidArgumentException('proxy must be a string or array');
                 }
 
+                $selectedProxy = $proxy;
                 $conf[\CURLOPT_PROXY] = $proxy;
                 $conf[\CURLOPT_NOPROXY] = '';
             } else {
@@ -658,10 +680,16 @@ class CurlFactory implements CurlFactoryInterface
                         $conf[\CURLOPT_PROXY] = '';
                         $conf[\CURLOPT_NOPROXY] = '*';
                     } else {
+                        $selectedProxy = $proxy[$scheme];
                         $conf[\CURLOPT_PROXY] = $proxy[$scheme];
                         $conf[\CURLOPT_NOPROXY] = '';
                     }
                 }
+            }
+
+            if ($selectedProxy !== null && self::requiresFreshConnectionForAuthenticatedProxy($easy->request, $selectedProxy)) {
+                $conf[\CURLOPT_FRESH_CONNECT] = true;
+                $conf[\CURLOPT_FORBID_REUSE] = true;
             }
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -383,7 +383,7 @@ class CurlFactory implements CurlFactoryInterface
 
     private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy, array $options): bool
     {
-        if ('https' !== $request->getUri()->getScheme() || CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
+        if (!self::usesProxyTunnel($request, $options) || CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
             return false;
         }
 
@@ -401,6 +401,27 @@ class CurlFactory implements CurlFactoryInterface
         return \array_key_exists('user', $proxyParts)
             || \array_key_exists('pass', $proxyParts)
             || self::hasCurlProxyCredentials($options);
+    }
+
+    private static function usesProxyTunnel(RequestInterface $request, array $options): bool
+    {
+        return 'https' === $request->getUri()->getScheme()
+            || (
+                isset($options['curl'])
+                && \array_key_exists(\CURLOPT_HTTPPROXYTUNNEL, $options['curl'])
+                && (bool) $options['curl'][\CURLOPT_HTTPPROXYTUNNEL]
+            );
+    }
+
+    private static function getEffectiveProxyForConnectionReuse(?string $selectedProxy, array $options): ?string
+    {
+        if (!isset($options['curl']) || !\array_key_exists(\CURLOPT_PROXY, $options['curl'])) {
+            return $selectedProxy;
+        }
+
+        $proxy = $options['curl'][\CURLOPT_PROXY];
+
+        return \is_string($proxy) && $proxy !== '' ? $proxy : null;
     }
 
     private static function hasCurlProxyCredentials(array $options): bool
@@ -668,9 +689,10 @@ class CurlFactory implements CurlFactoryInterface
             $conf[\CURLOPT_NOSIGNAL] = true;
         }
 
+        $selectedProxy = null;
+
         if (isset($options['proxy'])) {
             $proxy = $options['proxy'];
-            $selectedProxy = null;
             if (!\is_array($proxy)) {
                 if (!\is_string($proxy)) {
                     throw new \InvalidArgumentException('proxy must be a string or array');
@@ -698,11 +720,12 @@ class CurlFactory implements CurlFactoryInterface
                     }
                 }
             }
+        }
 
-            if ($selectedProxy !== null && self::requiresFreshConnectionForAuthenticatedProxy($easy->request, $selectedProxy, $options)) {
-                $conf[\CURLOPT_FRESH_CONNECT] = true;
-                $conf[\CURLOPT_FORBID_REUSE] = true;
-            }
+        $proxyForConnectionReuse = self::getEffectiveProxyForConnectionReuse($selectedProxy, $options);
+        if ($proxyForConnectionReuse !== null && self::requiresFreshConnectionForAuthenticatedProxy($easy->request, $proxyForConnectionReuse, $options)) {
+            $conf[\CURLOPT_FRESH_CONNECT] = true;
+            $conf[\CURLOPT_FORBID_REUSE] = true;
         }
 
         $cryptoMethod = $options['crypto_method'] ?? null;

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -67,7 +67,7 @@ final class CurlVersion
             && 0 !== ((int) \constant('CURL_VERSION_HTTP3') & $versionInfo['features']);
     }
 
-    public static function supportsProxyCredentialAwareReuse(): bool
+    public static function supportsProxyCredentialAwareConnectionReuse(): bool
     {
         $version = self::get();
 

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -72,12 +72,7 @@ final class CurlVersion
         $version = self::get();
 
         return null !== $version
-            && self::isProxyCredentialAwareReuseFixed($version);
-    }
-
-    public static function isProxyCredentialAwareReuseFixed(string $version): bool
-    {
-        return version_compare($version, self::PROXY_CREDENTIAL_REUSE_VERSION, '>=');
+            && version_compare($version, self::PROXY_CREDENTIAL_REUSE_VERSION, '>=');
     }
 
     public static function ensureSupported(RequestInterface $request): void

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -16,6 +16,8 @@ final class CurlVersion
 
     private const HTTP_3_VERSION = '7.66.0';
 
+    private const PROXY_CREDENTIAL_REUSE_VERSION = '8.19.0';
+
     /**
      * @var array{version: string, features: int}|false|null
      */
@@ -63,6 +65,19 @@ final class CurlVersion
 
         return version_compare($versionInfo['version'], self::HTTP_3_VERSION, '>=')
             && 0 !== ((int) \constant('CURL_VERSION_HTTP3') & $versionInfo['features']);
+    }
+
+    public static function supportsProxyCredentialAwareReuse(): bool
+    {
+        $version = self::get();
+
+        return null !== $version
+            && self::isProxyCredentialAwareReuseFixed($version);
+    }
+
+    public static function isProxyCredentialAwareReuseFixed(string $version): bool
+    {
+        return version_compare($version, self::PROXY_CREDENTIAL_REUSE_VERSION, '>=');
     }
 
     public static function ensureSupported(RequestInterface $request): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -274,6 +274,74 @@ class CurlFactoryTest extends TestCase
         self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
+    public function testAuthenticatedHttpsProxyReuseDependsOnCurlVersionWithRawCurlProxyUrl(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'curl' => [
+                \CURLOPT_PROXY => 'http://username:password@proxy.example.com:8080',
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testAuthenticatedHttpsProxyReuseDependsOnCurlVersionWithRawCurlProxyCredentials(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'curl' => [
+                \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+                \CURLOPT_PROXYUSERPWD => 'username:password',
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testAuthenticatedHttpProxyTunnelReuseDependsOnCurlVersion(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'http://example.com'), [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_HTTPPROXYTUNNEL => true,
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testRawCurlProxyOverrideControlsAuthenticatedProxyReuseDetection(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => 'http://username:password@proxy-one.example.com:8080',
+            'curl' => [
+                \CURLOPT_PROXY => 'http://proxy-two.example.com:8080',
+            ],
+        ]);
+
+        self::assertSame('http://proxy-two.example.com:8080', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testRawCurlProxyDisableControlsAuthenticatedProxyReuseDetection(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_PROXY => '',
+            ],
+        ]);
+
+        self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
     public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
     {
         $f = new CurlFactory(3);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -251,6 +251,88 @@ class CurlFactoryTest extends TestCase
         $this->checkNoProxyForHost('http://[fe80::1]', ['fd00::/8'], true);
     }
 
+    public function testAuthenticatedHttpsProxyReuseDependsOnCurlVersion(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        if (CurlVersion::supportsProxyCredentialAwareReuse()) {
+            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+
+            return;
+        }
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'http://example.com'), [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForUnauthenticatedHttpsProxy(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => 'http://proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedSocksProxy(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => 'socks5://username:password@proxy.example.com:1080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionWhenNoProxyMatches(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => [
+                'https' => 'http://username:password@proxy.example.com:8080',
+                'no' => ['example.com'],
+            ],
+        ]);
+
+        self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testAuthenticatedHttpsProxyReuseOptionsCanBeOverridden(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_FRESH_CONNECT => false,
+                \CURLOPT_FORBID_REUSE => false,
+            ],
+        ]);
+
+        self::assertFalse($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertFalse($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
     /**
      * @dataProvider invalidProxyOptionProvider
      *

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -258,15 +258,20 @@ class CurlFactoryTest extends TestCase
             'proxy' => 'http://username:password@proxy.example.com:8080',
         ]);
 
-        if (CurlVersion::supportsProxyCredentialAwareReuse()) {
-            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
 
-            return;
-        }
+    public function testAuthenticatedHttpsProxyReuseDependsOnCurlVersionWithCurlProxyCredentials(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_PROXYUSERPWD => 'username:password',
+            ],
+        ]);
 
-        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
-        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
     public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
@@ -1543,6 +1548,19 @@ class CurlFactoryTest extends TestCase
         self::assertArrayNotHasKey('http_code', $context);
         self::assertArrayNotHasKey('header_size', $context);
         self::assertArrayNotHasKey('content_type', $context);
+    }
+
+    private static function assertAuthenticatedProxyConnectionReuseOptions(): void
+    {
+        if (CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
+            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+
+            return;
+        }
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -251,20 +251,41 @@ class CurlFactoryTest extends TestCase
         $this->checkNoProxyForHost('http://[fe80::1]', ['fd00::/8'], true);
     }
 
-    public function testAuthenticatedHttpsProxyReuseDependsOnCurlVersion(): void
+    public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
         ]);
 
         self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
-    public function testAuthenticatedHttpsProxyReuseDependsOnCurlVersionWithCurlProxyCredentials(): void
+    public function testDoesNotForceFreshConnectionForAuthenticatedHttpsProxyOnFixedCurlVersion(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForCurlProxyCredentialsOnFixedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_PROXYUSERPWD => 'username:password',
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testForcesFreshConnectionForAuthenticatedHttpsProxyWithCurlProxyCredentialsOnAffectedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_PROXYUSERPWD => 'username:password',
@@ -274,10 +295,9 @@ class CurlFactoryTest extends TestCase
         self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
-    public function testAuthenticatedHttpsProxyReuseDependsOnCurlVersionWithRawCurlProxyUrl(): void
+    public function testForcesFreshConnectionForAuthenticatedHttpsProxyWithRawCurlProxyUrlOnAffectedCurlVersion(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
             'curl' => [
                 \CURLOPT_PROXY => 'http://username:password@proxy.example.com:8080',
             ],
@@ -286,10 +306,9 @@ class CurlFactoryTest extends TestCase
         self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
-    public function testAuthenticatedHttpsProxyReuseDependsOnCurlVersionWithRawCurlProxyCredentials(): void
+    public function testForcesFreshConnectionForAuthenticatedHttpsProxyWithRawCurlProxyCredentialsOnAffectedCurlVersion(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
             'curl' => [
                 \CURLOPT_PROXY => 'http://proxy.example.com:8080',
                 \CURLOPT_PROXYUSERPWD => 'username:password',
@@ -299,10 +318,9 @@ class CurlFactoryTest extends TestCase
         self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
-    public function testAuthenticatedHttpProxyTunnelReuseDependsOnCurlVersion(): void
+    public function testForcesFreshConnectionForAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'http://example.com'), [
+        self::createWithCurlVersion('8.18.0', 'http://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_HTTPPROXYTUNNEL => true,
@@ -310,6 +328,70 @@ class CurlFactoryTest extends TestCase
         ]);
 
         self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testForcesFreshConnectionForProxyAuthorizationProxyHeaderOnFixedCurlVersion(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testDoesNotForceFreshConnectionForUnrelatedProxyHeader(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['X-Proxy-Header: value'],
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForEmptyProxyAuthorizationProxyHeader(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['Proxy-Authorization:'],
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedRawSocksProxyType(): void
+    {
+        if (!\defined('CURLPROXY_SOCKS5')) {
+            self::markTestSkipped('CURLPROXY_SOCKS5 is not available.');
+        }
+
+        $proxyType = (int) \constant('CURLPROXY_SOCKS5');
+
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+            'curl' => [
+                \CURLOPT_PROXY => 'proxy.example.com:1080',
+                \CURLOPT_PROXYTYPE => $proxyType,
+                \CURLOPT_PROXYUSERPWD => 'username:password',
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
     }
 
     public function testRawCurlProxyOverrideControlsAuthenticatedProxyReuseDetection(): void
@@ -344,8 +426,7 @@ class CurlFactoryTest extends TestCase
 
     public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'http://example.com'), [
+        self::createWithCurlVersion('8.18.0', 'http://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
         ]);
 
@@ -355,8 +436,7 @@ class CurlFactoryTest extends TestCase
 
     public function testDoesNotForceFreshConnectionForUnauthenticatedHttpsProxy(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
         ]);
 
@@ -366,8 +446,7 @@ class CurlFactoryTest extends TestCase
 
     public function testDoesNotForceFreshConnectionForAuthenticatedSocksProxy(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
             'proxy' => 'socks5://username:password@proxy.example.com:1080',
         ]);
 
@@ -377,8 +456,7 @@ class CurlFactoryTest extends TestCase
 
     public function testDoesNotForceFreshConnectionWhenNoProxyMatches(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
             'proxy' => [
                 'https' => 'http://username:password@proxy.example.com:8080',
                 'no' => ['example.com'],
@@ -1620,15 +1698,35 @@ class CurlFactoryTest extends TestCase
 
     private static function assertAuthenticatedProxyConnectionReuseOptions(): void
     {
-        if (CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
-            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
-
-            return;
-        }
-
         self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
         self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    /**
+     * @param array<int|string, mixed> $options
+     */
+    private static function createWithCurlVersion(string $version, string $uri, array $options): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => 0,
+        ]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', $uri), $options);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    private static function proxyHeaderOption(): int
+    {
+        if (!\defined('CURLOPT_PROXYHEADER')) {
+            self::markTestSkipped('CURLOPT_PROXYHEADER is not available.');
+        }
+
+        return (int) \constant('CURLOPT_PROXYHEADER');
     }
 
     /**

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -70,23 +70,6 @@ class CurlVersionTest extends TestCase
         self::assertTrue(CurlVersion::supportsHttp3());
     }
 
-    /**
-     * @dataProvider proxyCredentialAwareReuseVersionProvider
-     */
-    public function testDetectsProxyCredentialAwareReuseFix(string $version, bool $expected): void
-    {
-        self::assertSame($expected, CurlVersion::isProxyCredentialAwareReuseFixed($version));
-    }
-
-    public static function proxyCredentialAwareReuseVersionProvider(): array
-    {
-        return [
-            ['8.18.0', false],
-            ['8.19.0', true],
-            ['8.20.0', true],
-        ];
-    }
-
     private static function requiresHttp3Constants(): void
     {
         if (!\defined('CURL_VERSION_HTTP3') || !\defined('CURL_HTTP_VERSION_3')) {

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -70,6 +70,23 @@ class CurlVersionTest extends TestCase
         self::assertTrue(CurlVersion::supportsHttp3());
     }
 
+    /**
+     * @dataProvider proxyCredentialAwareReuseVersionProvider
+     */
+    public function testDetectsProxyCredentialAwareReuseFix(string $version, bool $expected): void
+    {
+        self::assertSame($expected, CurlVersion::isProxyCredentialAwareReuseFixed($version));
+    }
+
+    public static function proxyCredentialAwareReuseVersionProvider(): array
+    {
+        return [
+            ['8.18.0', false],
+            ['8.19.0', true],
+            ['8.20.0', true],
+        ];
+    }
+
     private static function requiresHttp3Constants(): void
     {
         if (!\defined('CURL_VERSION_HTTP3') || !\defined('CURL_HTTP_VERSION_3')) {


### PR DESCRIPTION
Avoids reusing authenticated HTTP proxy tunnels on libcurl versions before 8.19.0, where credential changes were not considered during tunnel reuse. This covers Guzzle proxy options and raw cURL proxy options, while fixed libcurl versions keep normal reuse behaviour.

---

Fixes https://github.com/guzzle/guzzle/issues/3302.