### PR TITLE
Treat resource sinks as caller-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject empty or malformed request protocol versions
 - Throw `TimeoutException` for reliably detected transfer timeouts
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
+- Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers
 
 ### Removed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -33,6 +33,13 @@ Guzzle 8 requires PHP `^7.4 || ^8.0`. Guzzle 7 supported PHP
 Guzzle 8 also requires `guzzlehttp/promises` 3.x and `guzzlehttp/psr7` 3.x. If
 your application uses those packages directly, review their upgrade guides.
 
+#### Sink resource ownership
+
+PHP resources passed as the `sink` request option are no longer closed when the
+response body is closed or garbage-collected by the built-in cURL and stream
+handlers. Applications that relied on Guzzle closing a raw resource sink should
+close the resource explicitly or pass a string path instead.
+
 #### Request method casing
 
 Guzzle 8 uses Guzzle PSR-7 3.x, whose request implementations preserve method

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -991,17 +991,13 @@ $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
 $client->request('GET', '/stream/20', ['sink' => $stream]);
 ```
 
-With Guzzle's built-in cURL and PHP stream handlers, non-streaming responses use the sink stream as the response body. If you pass a PHP resource, Guzzle wraps it in a PSR-7 stream before writing to it. Closing or garbage-collecting the response body can close that wrapped resource.
+With Guzzle's built-in cURL and PHP stream handlers, non-streaming responses use the sink stream as the response body.
 
-If you need to keep using a resource after the response is no longer referenced, keep the response body alive or detach the resource before the body is destroyed:
+If `sink` is a string path, Guzzle opens the file and owns that stream.
 
-```php
-$response = $client->request('GET', '/stream/20', ['sink' => $resource]);
-$resource = $response->getBody()->detach();
-```
+If `sink` is a PHP resource, the caller owns the resource and is responsible for closing it. Closing or destroying the response body detaches Guzzle's wrapper without closing the original resource.
 
-> [!NOTE]
-> `save_to` was deprecated in Guzzle 6 and removed in Guzzle 7. Use `sink`.
+If `sink` is a `Psr\Http\Message\StreamInterface`, Guzzle uses that stream object as-is and its own `close()` behavior applies.
 
 ## ssl_key
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -7,11 +7,13 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TimeoutException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -518,6 +520,25 @@ class CurlFactory implements CurlFactoryInterface
         }
     }
 
+    /**
+     * Creates a response body stream for a caller-owned sink resource.
+     *
+     * Closing the response body must detach Guzzle's wrapper without closing
+     * the original PHP resource.
+     *
+     * @param resource $resource
+     */
+    private static function streamForResourceSink($resource): StreamInterface
+    {
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
+
+        return FnStream::decorate($stream, [
+            'close' => static function () use ($stream): void {
+                $stream->detach();
+            },
+        ]);
+    }
+
     private function applyHandlerOptions(EasyHandle $easy, array &$conf): void
     {
         $options = $easy->options;
@@ -568,12 +589,15 @@ class CurlFactory implements CurlFactoryInterface
             }
         }
 
-        if (!isset($options['sink'])) {
+        $hasSink = isset($options['sink']);
+        if (!$hasSink) {
             // Use a default temp stream if no sink was set.
             $options['sink'] = \GuzzleHttp\Psr7\Utils::tryFopen('php://temp', 'w+');
         }
         $sink = $options['sink'];
-        if (!\is_string($sink)) {
+        if ($hasSink && \is_resource($sink)) {
+            $sink = self::streamForResourceSink($sink);
+        } elseif (!\is_string($sink)) {
             $sink = \GuzzleHttp\Psr7\Utils::streamFor($sink);
         } elseif (!\is_dir(\dirname($sink))) {
             // Ensure that the directory exists before failing in curl.

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -193,9 +193,33 @@ class StreamHandler
             return $stream;
         }
 
-        $sink = $options['sink'] ?? Psr7\Utils::tryFopen('php://temp', 'r+');
+        $hasSink = isset($options['sink']);
+        $sink = $hasSink ? $options['sink'] : Psr7\Utils::tryFopen('php://temp', 'r+');
+
+        if ($hasSink && \is_resource($sink)) {
+            return self::streamForResourceSink($sink);
+        }
 
         return \is_string($sink) ? new Psr7\LazyOpenStream($sink, 'w+') : Psr7\Utils::streamFor($sink);
+    }
+
+    /**
+     * Creates a response body stream for a caller-owned sink resource.
+     *
+     * Closing the response body must detach Guzzle's wrapper without closing
+     * the original PHP resource.
+     *
+     * @param resource $resource
+     */
+    private static function streamForResourceSink($resource): StreamInterface
+    {
+        $stream = Psr7\Utils::streamFor($resource);
+
+        return Psr7\FnStream::decorate($stream, [
+            'close' => static function () use ($stream): void {
+                $stream->detach();
+            },
+        ]);
     }
 
     /**

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -238,7 +238,9 @@ final class RequestOptions
     /**
      * sink: (resource|string|StreamInterface) Where the data of the
      * response is written to. Defaults to a PHP temp stream. Providing a
-     * string will write data to a file by the given name.
+     * string will write data to a file by the given name. Built-in handlers
+     * treat PHP resources as caller-owned; callers are responsible for closing
+     * resource sinks.
      */
     public const SINK = 'sink';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -775,6 +775,64 @@ class CurlFactoryTest extends TestCase
         self::assertEquals('test', \stream_get_contents($stream));
     }
 
+    public function testDoesNotCloseResourceSinkWhenResponseIsDestroyed(): void
+    {
+        $stream = (function () {
+            $stream = \tmpfile();
+            self::assertIsResource($stream);
+
+            $this->addDecodeResponse();
+            $handler = new Handler\CurlHandler();
+            $request = new Psr7\Request('GET', Server::$url);
+            $response = $handler($request, [
+                'decode_content' => true,
+                'sink' => $stream,
+            ])->wait();
+
+            self::assertSame(200, $response->getStatusCode());
+
+            return $stream;
+        })();
+
+        \gc_collect_cycles();
+
+        try {
+            self::assertIsResource($stream);
+            \rewind($stream);
+            self::assertSame('test', \stream_get_contents($stream));
+        } finally {
+            if (\is_resource($stream)) {
+                \fclose($stream);
+            }
+        }
+    }
+
+    public function testDoesNotCloseResourceSinkWhenResponseBodyIsClosed(): void
+    {
+        $stream = \tmpfile();
+        self::assertIsResource($stream);
+
+        try {
+            $this->addDecodeResponse();
+            $handler = new Handler\CurlHandler();
+            $request = new Psr7\Request('GET', Server::$url);
+            $response = $handler($request, [
+                'decode_content' => true,
+                'sink' => $stream,
+            ])->wait();
+
+            $response->getBody()->close();
+
+            self::assertIsResource($stream);
+            \rewind($stream);
+            self::assertSame('test', \stream_get_contents($stream));
+        } finally {
+            if (\is_resource($stream)) {
+                \fclose($stream);
+            }
+        }
+    }
+
     public function testSavesToGuzzleStream(): void
     {
         $stream = Psr7\Utils::streamFor();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -152,6 +152,58 @@ class StreamHandlerTest extends TestCase
         \fclose($r);
     }
 
+    public function testDoesNotCloseResourceSinkWhenResponseIsDestroyed(): void
+    {
+        $stream = (function () {
+            $stream = \tmpfile();
+            self::assertIsResource($stream);
+
+            $this->queueRes();
+            $handler = new StreamHandler();
+            $request = new Request('GET', Server::$url);
+            $response = $handler($request, ['sink' => $stream])->wait();
+
+            self::assertSame(200, $response->getStatusCode());
+
+            return $stream;
+        })();
+
+        \gc_collect_cycles();
+
+        try {
+            self::assertIsResource($stream);
+            \rewind($stream);
+            self::assertSame('hi there', \stream_get_contents($stream));
+        } finally {
+            if (\is_resource($stream)) {
+                \fclose($stream);
+            }
+        }
+    }
+
+    public function testDoesNotCloseResourceSinkWhenResponseBodyIsClosed(): void
+    {
+        $stream = \tmpfile();
+        self::assertIsResource($stream);
+
+        try {
+            $this->queueRes();
+            $handler = new StreamHandler();
+            $request = new Request('GET', Server::$url);
+            $response = $handler($request, ['sink' => $stream])->wait();
+
+            $response->getBody()->close();
+
+            self::assertIsResource($stream);
+            \rewind($stream);
+            self::assertSame('hi there', \stream_get_contents($stream));
+        } finally {
+            if (\is_resource($stream)) {
+                \fclose($stream);
+            }
+        }
+    }
+
     public function testDrainsResponseIntoSaveToBodyAtPath(): void
     {
         $tmpfname = \tempnam(\sys_get_temp_dir(), 'save_to_path');


### PR DESCRIPTION
This treats raw PHP resources passed as sink as caller-owned in the built-in cURL and stream handlers. Applications that relied on Guzzle closing raw resource sinks should close them explicitly or pass a string path instead.