### PR TITLE
Add explicit cURL handler close lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add CIDR notation support for IP no-proxy rules
 - Add network and timeout exception types
 - Add PSR-17 `request_factory`, `stream_factory`, and `uri_factory` request options for client-created requests, request body streams, and URIs
+- Add explicit `close()` lifecycle methods to the built-in cURL handlers and concrete cURL factory
+- Add `HandlerClosedException` for pending transfers rejected by `CurlMultiHandler::close()`
 
 ### Changed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,6 +69,25 @@ When a built-in handler can reliably identify a transfer timeout, it now throws
 `ConnectException`, so existing `catch (ConnectException $e)` and
 `catch (TransferException $e)` blocks continue to catch timeout failures.
 
+#### cURL handler lifecycle
+
+`GuzzleHttp\Handler\CurlHandler`, `GuzzleHttp\Handler\CurlMultiHandler`, and
+`GuzzleHttp\Handler\CurlFactory` now expose `close()` for deterministic cleanup
+of native cURL resources.
+
+After a cURL handler or factory is closed, it is terminal and cannot be reused.
+Calling a closed handler or factory throws `BadMethodCallException`.
+
+Calling `CurlMultiHandler::close()` rejects pending transfers with
+`GuzzleHttp\Exception\HandlerClosedException`. Destructor cleanup remains
+best-effort and does not reject pending promises. Explicit `close()` calls may
+throw if native cleanup fails.
+
+Closing a cURL handler closes only the `CurlFactory` that Guzzle created for
+that handler. If your application passes a custom `handle_factory`, that factory
+remains caller-owned and must be closed by your application if it exposes its own
+lifecycle API.
+
 #### Multipart request serialization
 
 Guzzle 8 uses Guzzle PSR-7 3.x for multipart request bodies. Multipart parts

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -71,22 +71,17 @@ When a built-in handler can reliably identify a transfer timeout, it now throws
 
 #### cURL handler lifecycle
 
-`GuzzleHttp\Handler\CurlHandler`, `GuzzleHttp\Handler\CurlMultiHandler`, and
-`GuzzleHttp\Handler\CurlFactory` now expose `close()` for deterministic cleanup
-of native cURL resources.
+Applications that manage built-in cURL handlers or factories directly should
+treat closed instances as unusable. Reusing a closed `CurlHandler`,
+`CurlMultiHandler`, or `CurlFactory` throws `BadMethodCallException`; create a
+new instance instead.
 
-After a cURL handler or factory is closed, it is terminal and cannot be reused.
-Calling a closed handler or factory throws `BadMethodCallException`.
+If `CurlMultiHandler::close()` is called while transfers are pending, those
+promises are rejected with `GuzzleHttp\Exception\HandlerClosedException`.
+Destructor cleanup remains best-effort and does not reject pending promises.
 
-Calling `CurlMultiHandler::close()` rejects pending transfers with
-`GuzzleHttp\Exception\HandlerClosedException`. Destructor cleanup remains
-best-effort and does not reject pending promises. Explicit `close()` calls may
-throw if native cleanup fails.
-
-Closing a cURL handler closes only the `CurlFactory` that Guzzle created for
-that handler. If your application passes a custom `handle_factory`, that factory
-remains caller-owned and must be closed by your application if it exposes its own
-lifecycle API.
+A custom `handle_factory` passed to a built-in cURL handler remains caller-owned.
+Closing the handler does not close an injected factory.
 
 #### Multipart request serialization
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -56,6 +56,27 @@ $client = new Client(['handler' => HandlerStack::create(new CurlMultiHandler([
 
 Custom cURL request options remain active during redirects unless Guzzle documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
 
+## How can I close cURL resources in long-running applications?
+
+If your application creates a cURL handler directly and needs deterministic cleanup, keep a reference to the handler and call `close()` when the handler is no longer needed.
+
+```php
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\HandlerStack;
+
+$handler = new CurlMultiHandler();
+$client = new Client(['handler' => HandlerStack::create($handler)]);
+
+try {
+    $client->request('GET', 'https://example.com');
+} finally {
+    $handler->close();
+}
+```
+
+After a cURL handler has been closed, it cannot be reused. `Client` and `HandlerStack` do not expose `close()`, so applications that need deterministic cleanup should keep the handler reference. If `CurlMultiHandler::close()` closes pending transfers, their promises are rejected with `GuzzleHttp\Exception\HandlerClosedException`. Explicit `close()` calls may throw if native cleanup fails; destructor cleanup remains best-effort and non-throwing.
+
 ## How can I add custom stream context options?
 
 You can pass custom [stream context options](https://www.php.net/manual/en/context.php) using the **stream_context** key of the request option. The **stream_context** array is an associative array where each key is a PHP transport, and each value is an associative array of transport options.

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -40,6 +40,49 @@ When provided no `$handler` argument, `GuzzleHttp\HandlerStack::create()` will c
 > [!IMPORTANT]
 > The handler provided to a client determines how request options are applied and utilized for each request sent by a client. For example, if you do not have a cookie middleware associated with a client, then setting the `cookies` request option will have no effect on the request.
 
+### Closing cURL Handlers
+
+The cURL handlers own native cURL resources. These resources are normally released automatically when the handler is garbage collected. Applications that need deterministic cleanup may call `close()` on `GuzzleHttp\Handler\CurlHandler` or `GuzzleHttp\Handler\CurlMultiHandler`. Applications that construct `GuzzleHttp\Handler\CurlFactory` directly may also call `close()` on the factory to close idle easy handles.
+
+After `close()` has been called, the handler must not be reused. Create a new handler and handler stack for future requests.
+
+If `CurlMultiHandler::close()` is called while transfers are pending, those promises are rejected with `GuzzleHttp\Exception\HandlerClosedException`. Destructors perform best-effort cleanup and do not reject pending promises. Explicit `close()` calls may throw if native cleanup fails.
+
+`Client` and `HandlerStack` do not expose `close()`. Keep a reference to the cURL handler if your application needs deterministic cleanup. Closing a cURL handler closes only the `CurlFactory` instance that Guzzle created for that handler. If you pass a custom `handle_factory`, Guzzle treats that factory as caller-owned and does not close it.
+
+```php
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\HandlerStack;
+
+$handler = new CurlMultiHandler();
+$stack = HandlerStack::create($handler);
+$client = new Client(['handler' => $stack]);
+
+try {
+    $client->request('GET', 'https://example.com');
+} finally {
+    $handler->close();
+}
+```
+
+When closing a multi handler with in-flight work, handle `HandlerClosedException` like any other transfer failure if the pending promises may still be observed:
+
+```php
+use GuzzleHttp\Exception\HandlerClosedException;
+use GuzzleHttp\Psr7\Request;
+
+$promise = $handler(new Request('GET', 'https://example.com'), []);
+
+$handler->close();
+
+try {
+    $promise->wait();
+} catch (HandlerClosedException $e) {
+    // The handler was closed before this transfer completed.
+}
+```
+
 ## Middleware
 
 Middleware augments the functionality of handlers by invoking them in the process of generating responses. Middleware is implemented as a higher order function that takes the following form.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -452,6 +452,7 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 ```
 . \RuntimeException
 └── TransferException (implements GuzzleException)
+    ├── HandlerClosedException
     ├── NetworkException (implements NetworkExceptionInterface)
     │   └── ConnectException
     │       └── TimeoutException
@@ -465,6 +466,8 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 Guzzle throws exceptions for errors that occur during a transfer.
 
 - `GuzzleHttp\Exception\NetworkException` is the base class for networking errors. This exception extends from `GuzzleHttp\Exception\TransferException`.
+
+- `GuzzleHttp\Exception\HandlerClosedException` is used when a built-in handler rejects a transfer because the handler was explicitly closed before the transfer completed. For example, pending `CurlMultiHandler` transfers are rejected with this exception when `CurlMultiHandler::close()` is called.
 
 - A `GuzzleHttp\Exception\ConnectException` exception is thrown when a connection cannot be established. This exception extends from `GuzzleHttp\Exception\NetworkException`.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: src/Cookie/SetCookie.php
 
 		-
-			message: '#^Parameter \#1 \$ch of function curl_close expects resource, CurlHandle\|resource given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
 			message: '#^Parameter \#1 \$ch of function curl_error expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,7 +21,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$ch of function curl_close expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Handler/CurlFactory.php
 
 		-
@@ -61,6 +61,18 @@ parameters:
 			path: src/Handler/CurlFactory.php
 
 		-
+			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlFactory\:\:clearEasyHandleCallbacks\(\) has invalid type CurlHandle\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlFactory.php
+
+		-
+			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlFactory\:\:discardHandle\(\) has invalid type CurlHandle\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlFactory.php
+
+		-
 			message: '#^Property GuzzleHttp\\Handler\\CurlFactory\:\:\$handles has unknown class CurlHandle as its type\.$#'
 			identifier: class.notFound
 			count: 1
@@ -91,6 +103,12 @@ parameters:
 			path: src/Handler/CurlMultiHandler.php
 
 		-
+			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/Handler/CurlMultiHandler.php
+
+		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_add_handle expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 2
@@ -117,13 +135,31 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_remove_handle expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_select expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 3
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: '#^Parameter \#2 \$ch of function curl_multi_remove_handle expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlMultiHandler\:\:clearEasyHandleCallbacks\(\) has invalid type CurlHandle\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlMultiHandler\:\:removeHandleFromMulti\(\) has invalid type CurlHandle\.$#'
+			identifier: class.notFound
+			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-

--- a/src/Exception/HandlerClosedException.php
+++ b/src/Exception/HandlerClosedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace GuzzleHttp\Exception;
+
+class HandlerClosedException extends TransferException
+{
+}

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -192,9 +192,7 @@ class CurlFactory implements CurlFactoryInterface
         unset($easy->handle);
 
         if (\count($this->handles) >= $this->maxHandles) {
-            if (PHP_VERSION_ID < 80000) {
-                \curl_close($resource);
-            }
+            $this->discardHandle($resource);
         } else {
             // Remove all callback functions as they can hold onto references
             // and are not cleaned up by curl_reset. Using curl_setopt_array
@@ -282,10 +280,10 @@ class CurlFactory implements CurlFactoryInterface
      */
     private function clearEasyHandleCallbacks($handle): void
     {
-        \curl_setopt($handle, \CURLOPT_HEADERFUNCTION, null);
-        \curl_setopt($handle, \CURLOPT_READFUNCTION, null);
-        \curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
-        \curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
+        curl_setopt($handle, \CURLOPT_HEADERFUNCTION, null);
+        curl_setopt($handle, \CURLOPT_READFUNCTION, null);
+        curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
+        curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
     }
 
     /**

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -36,6 +36,11 @@ class CurlFactory implements CurlFactoryInterface
     private $maxHandles;
 
     /**
+     * @var bool
+     */
+    private $closed = false;
+
+    /**
      * @param int $maxHandles Maximum number of idle handles.
      */
     public function __construct(int $maxHandles)
@@ -45,6 +50,8 @@ class CurlFactory implements CurlFactoryInterface
 
     public function create(RequestInterface $request, array $options): EasyHandle
     {
+        $this->assertOpen();
+
         CurlVersion::ensureSupported($request);
 
         $protocolVersion = $request->getProtocolVersion();
@@ -179,6 +186,8 @@ class CurlFactory implements CurlFactoryInterface
 
     public function release(EasyHandle $easy): void
     {
+        $this->assertOpen();
+
         $resource = $easy->handle;
         unset($easy->handle);
 
@@ -191,13 +200,92 @@ class CurlFactory implements CurlFactoryInterface
             // and are not cleaned up by curl_reset. Using curl_setopt_array
             // does not work for some reason, so removing each one
             // individually.
-            \curl_setopt($resource, \CURLOPT_HEADERFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_READFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_WRITEFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_PROGRESSFUNCTION, null);
+            $this->clearEasyHandleCallbacks($resource);
             \curl_reset($resource);
             $this->handles[] = $resource;
         }
+    }
+
+    /**
+     * Closes idle cURL handles owned by this factory.
+     *
+     * After closing, the factory is terminal and must not be reused.
+     */
+    public function close(): void
+    {
+        $this->doClose(true);
+    }
+
+    private function assertOpen(): void
+    {
+        if ($this->closed) {
+            throw new \BadMethodCallException('Cannot use the cURL factory after it has been closed.');
+        }
+    }
+
+    private function doClose(bool $explicit): void
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+        $failure = null;
+
+        foreach ($this->handles as $id => $handle) {
+            try {
+                $this->discardHandle($handle);
+            } catch (\Throwable $e) {
+                if ($failure === null) {
+                    $failure = $e;
+                }
+            } finally {
+                unset($this->handles[$id]);
+            }
+        }
+
+        if ($explicit && $failure !== null) {
+            throw $failure;
+        }
+    }
+
+    /**
+     * @param resource|\CurlHandle $handle
+     */
+    private function discardHandle($handle): void
+    {
+        $failure = null;
+
+        try {
+            $this->clearEasyHandleCallbacks($handle);
+        } catch (\Throwable $e) {
+            $failure = $e;
+        }
+
+        try {
+            if (PHP_VERSION_ID < 80000 && \is_resource($handle)) {
+                \curl_close($handle);
+            }
+        } catch (\Throwable $e) {
+            if ($failure === null) {
+                $failure = $e;
+            }
+        }
+
+        if ($failure !== null) {
+            throw $failure;
+        }
+    }
+
+    /**
+     * @param resource|\CurlHandle $handle
+     */
+    private function clearEasyHandleCallbacks($handle): void
+    {
+        \curl_setopt($handle, \CURLOPT_HEADERFUNCTION, null);
+        \curl_setopt($handle, \CURLOPT_READFUNCTION, null);
+        \curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
+        \curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
     }
 
     /**
@@ -1026,12 +1114,10 @@ class CurlFactory implements CurlFactoryInterface
 
     public function __destruct()
     {
-        foreach ($this->handles as $id => $handle) {
-            if (PHP_VERSION_ID < 80000) {
-                \curl_close($handle);
-            }
-
-            unset($this->handles[$id]);
+        try {
+            $this->doClose(false);
+        } catch (\Throwable $e) {
+            // Destructors must not throw.
         }
     }
 }

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -23,6 +23,16 @@ class CurlHandler
     private $factory;
 
     /**
+     * @var bool
+     */
+    private $ownsFactory;
+
+    /**
+     * @var bool
+     */
+    private $closed = false;
+
+    /**
      * Accepts an associative array of options:
      *
      * - handle_factory: Optional curl factory used to create cURL handles.
@@ -31,8 +41,13 @@ class CurlHandler
      */
     public function __construct(array $options = [])
     {
-        $this->factory = $options['handle_factory']
-            ?? new CurlFactory(3);
+        if (isset($options['handle_factory'])) {
+            $this->factory = $options['handle_factory'];
+            $this->ownsFactory = false;
+        } else {
+            $this->factory = new CurlFactory(3);
+            $this->ownsFactory = true;
+        }
     }
 
     /**
@@ -40,6 +55,8 @@ class CurlHandler
      */
     public function __invoke(RequestInterface $request, array $options): PromiseInterface
     {
+        $this->assertOpen();
+
         if (isset($options['delay'])) {
             \usleep($options['delay'] * 1000);
         }
@@ -49,5 +66,50 @@ class CurlHandler
         $easy->errno = \curl_errno($easy->handle);
 
         return CurlFactory::finish($this, $easy, $this->factory);
+    }
+
+    /**
+     * Closes native cURL resources owned by this handler.
+     *
+     * After closing, the handler is terminal and must not be reused.
+     */
+    public function close(): void
+    {
+        $this->doClose(true);
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->doClose(false);
+        } catch (\Throwable $e) {
+            // Destructors must not throw.
+        }
+    }
+
+    private function assertOpen(): void
+    {
+        if ($this->closed) {
+            throw new \BadMethodCallException('Cannot use the cURL handler after it has been closed.');
+        }
+    }
+
+    private function doClose(bool $explicit): void
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+
+        try {
+            if ($this->ownsFactory && $this->factory instanceof CurlFactory) {
+                $this->factory->close();
+            }
+        } catch (\Throwable $e) {
+            if ($explicit) {
+                throw $e;
+            }
+        }
     }
 }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Handler;
 
 use Closure;
+use GuzzleHttp\Exception\HandlerClosedException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -25,6 +26,11 @@ class CurlMultiHandler
      * @var CurlFactoryInterface
      */
     private $factory;
+
+    /**
+     * @var bool
+     */
+    private $ownsFactory;
 
     /**
      * @var int
@@ -59,6 +65,16 @@ class CurlMultiHandler
     private $_mh;
 
     /**
+     * @var bool
+     */
+    private $closed = false;
+
+    /**
+     * @var bool
+     */
+    private $closing = false;
+
+    /**
      * This handler accepts the following options:
      *
      * - handle_factory: An optional factory  used to create curl handles
@@ -69,7 +85,13 @@ class CurlMultiHandler
      */
     public function __construct(array $options = [])
     {
-        $this->factory = $options['handle_factory'] ?? new CurlFactory(50);
+        if (isset($options['handle_factory'])) {
+            $this->factory = $options['handle_factory'];
+            $this->ownsFactory = false;
+        } else {
+            $this->factory = new CurlFactory(50);
+            $this->ownsFactory = true;
+        }
 
         $this->selectTimeout = $options['select_timeout'] ?? 1;
 
@@ -94,6 +116,8 @@ class CurlMultiHandler
             throw new \BadMethodCallException("Can not get other property as '_mh'.");
         }
 
+        $this->assertOpen();
+
         $multiHandle = \curl_multi_init();
 
         if (false === $multiHandle) {
@@ -112,14 +136,10 @@ class CurlMultiHandler
 
     public function __destruct()
     {
-        if (isset($this->_mh)) {
-            try {
-                \curl_multi_close($this->_mh);
-            } catch (\Throwable $e) {
-                // Destructors must not throw.
-            } finally {
-                unset($this->_mh);
-            }
+        try {
+            $this->doClose(false);
+        } catch (\Throwable $e) {
+            // Destructors must not throw.
         }
     }
 
@@ -128,6 +148,8 @@ class CurlMultiHandler
      */
     public function __invoke(RequestInterface $request, array $options): PromiseInterface
     {
+        $this->assertOpen();
+
         $easy = $this->factory->create($request, $options);
         $id = (int) $easy->handle;
 
@@ -149,6 +171,8 @@ class CurlMultiHandler
      */
     public function tick(): void
     {
+        $this->assertOpen();
+
         // Add any delayed handles if needed.
         if ($this->delays) {
             $currentTime = Utils::currentTime();
@@ -169,6 +193,10 @@ class CurlMultiHandler
         // Step through the task queue which may add additional requests.
         P\Utils::queue()->run();
 
+        if ($this->closed || $this->closing || !$this->hasMultiHandle()) {
+            return;
+        }
+
         if ($this->active && \curl_multi_select($this->_mh, $this->selectTimeout) === -1) {
             // Perform a usleep if a select returns -1.
             // See: https://bugs.php.net/bug.php?id=61141
@@ -188,6 +216,10 @@ class CurlMultiHandler
      */
     private function tickInQueue(): void
     {
+        if ($this->closed || $this->closing || !$this->hasMultiHandle()) {
+            return;
+        }
+
         if (\curl_multi_exec($this->_mh, $this->active) === \CURLM_CALL_MULTI_PERFORM) {
             \curl_multi_select($this->_mh, 0);
             P\Utils::queue()->add(Closure::fromCallable([$this, 'tickInQueue']));
@@ -199,15 +231,190 @@ class CurlMultiHandler
      */
     public function execute(): void
     {
+        $this->assertOpen();
+
         $queue = P\Utils::queue();
 
-        while ($this->handles || !$queue->isEmpty()) {
+        while (!$this->closed && !$this->closing && ($this->handles || !$queue->isEmpty())) {
             // If there are no transfers, then sleep for the next delay
             if (!$this->active && $this->delays) {
                 \usleep($this->timeToNext());
             }
             $this->tick();
         }
+    }
+
+    /**
+     * Closes native cURL resources owned by this handler.
+     *
+     * Pending transfers are rejected with HandlerClosedException. After closing,
+     * the handler is terminal and must not be reused.
+     */
+    public function close(): void
+    {
+        $this->doClose(true);
+    }
+
+    private function assertOpen(): void
+    {
+        if ($this->closed || $this->closing) {
+            throw new \BadMethodCallException('Cannot use the cURL multi handler after it has been closed.');
+        }
+    }
+
+    private function doClose(bool $explicit): void
+    {
+        if ($this->closed || $this->closing) {
+            return;
+        }
+
+        $this->closing = true;
+        $failure = null;
+
+        try {
+            $this->cleanupPendingTransfers($explicit, $failure);
+            $this->closeMultiHandle($failure);
+            $this->closeOwnedFactory($failure);
+        } finally {
+            $this->handles = [];
+            $this->delays = [];
+            $this->active = 0;
+            $this->closed = true;
+            $this->closing = false;
+        }
+
+        if ($explicit && $failure !== null) {
+            throw $failure;
+        }
+    }
+
+    private function captureFailure(?\Throwable &$failure, callable $callback): void
+    {
+        try {
+            $callback();
+        } catch (\Throwable $e) {
+            if ($failure === null) {
+                $failure = $e;
+            }
+        }
+    }
+
+    private function cleanupPendingTransfers(bool $reject, ?\Throwable &$failure): void
+    {
+        $entries = $this->handles;
+        $delays = $this->delays;
+
+        $this->handles = [];
+        $this->delays = [];
+
+        foreach ($entries as $id => $entry) {
+            $easy = $entry['easy'];
+            $attached = !isset($delays[$id]);
+
+            if ($attached && $this->hasMultiHandle() && self::hasEasyHandle($easy)) {
+                $this->captureFailure($failure, function () use ($easy): void {
+                    $this->removeHandleFromMulti($easy->handle);
+                });
+            }
+
+            if ($reject) {
+                $this->captureFailure($failure, function () use ($entry): void {
+                    $entry['deferred']->reject(new HandlerClosedException('The cURL multi handler was closed before the transfer completed.'));
+                });
+            }
+
+            $this->captureFailure($failure, function () use ($easy): void {
+                $this->disposeEasyHandle($easy);
+            });
+        }
+    }
+
+    private function closeMultiHandle(?\Throwable &$failure): void
+    {
+        if (!$this->hasMultiHandle()) {
+            return;
+        }
+
+        $this->captureFailure($failure, function (): void {
+            try {
+                \curl_multi_close($this->_mh);
+            } finally {
+                unset($this->_mh);
+            }
+        });
+    }
+
+    private function closeOwnedFactory(?\Throwable &$failure): void
+    {
+        $factory = $this->factory;
+        if (!$this->ownsFactory || !$factory instanceof CurlFactory) {
+            return;
+        }
+
+        $this->captureFailure($failure, static function () use ($factory): void {
+            $factory->close();
+        });
+    }
+
+    private function disposeEasyHandle(EasyHandle $easy): void
+    {
+        if (!self::hasEasyHandle($easy)) {
+            return;
+        }
+
+        $handle = $easy->handle;
+        unset($easy->handle);
+
+        $failure = null;
+
+        try {
+            $this->clearEasyHandleCallbacks($handle);
+        } catch (\Throwable $e) {
+            $failure = $e;
+        }
+
+        try {
+            if (PHP_VERSION_ID < 80000 && \is_resource($handle)) {
+                \curl_close($handle);
+            }
+        } catch (\Throwable $e) {
+            if ($failure === null) {
+                $failure = $e;
+            }
+        }
+
+        if ($failure !== null) {
+            throw $failure;
+        }
+    }
+
+    /**
+     * @param resource|\CurlHandle $handle
+     */
+    private function clearEasyHandleCallbacks($handle): void
+    {
+        \curl_setopt($handle, \CURLOPT_HEADERFUNCTION, null);
+        \curl_setopt($handle, \CURLOPT_READFUNCTION, null);
+        \curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
+        \curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
+    }
+
+    /**
+     * @param resource|\CurlHandle $handle
+     */
+    private function removeHandleFromMulti($handle): void
+    {
+        \curl_multi_remove_handle($this->_mh, $handle);
+    }
+
+    private function hasMultiHandle(): bool
+    {
+        return isset($this->_mh);
+    }
+
+    private static function hasEasyHandle(EasyHandle $easy): bool
+    {
+        return \array_key_exists('handle', \get_object_vars($easy));
     }
 
     private function addRequest(array $entry): void
@@ -236,12 +443,20 @@ class CurlMultiHandler
             return false;
         }
 
-        $handle = $this->handles[$id]['easy']->handle;
+        $easy = $this->handles[$id]['easy'];
+        $delayed = isset($this->delays[$id]);
         unset($this->delays[$id], $this->handles[$id]);
-        \curl_multi_remove_handle($this->_mh, $handle);
+        if (!$delayed && $this->hasMultiHandle() && self::hasEasyHandle($easy)) {
+            $this->removeHandleFromMulti($easy->handle);
+        }
 
-        if (PHP_VERSION_ID < 80000) {
-            \curl_close($handle);
+        if (self::hasEasyHandle($easy)) {
+            $handle = $easy->handle;
+            unset($easy->handle);
+
+            if (PHP_VERSION_ID < 80000 && \is_resource($handle)) {
+                \curl_close($handle);
+            }
         }
 
         return true;
@@ -255,7 +470,7 @@ class CurlMultiHandler
                 continue;
             }
             $id = (int) $done['handle'];
-            \curl_multi_remove_handle($this->_mh, $done['handle']);
+            $this->removeHandleFromMulti($done['handle']);
 
             if (!isset($this->handles[$id])) {
                 // Probably was cancelled.

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -393,10 +393,10 @@ class CurlMultiHandler
      */
     private function clearEasyHandleCallbacks($handle): void
     {
-        \curl_setopt($handle, \CURLOPT_HEADERFUNCTION, null);
-        \curl_setopt($handle, \CURLOPT_READFUNCTION, null);
-        \curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
-        \curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
+        curl_setopt($handle, \CURLOPT_HEADERFUNCTION, null);
+        curl_setopt($handle, \CURLOPT_READFUNCTION, null);
+        curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
+        curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -94,6 +94,59 @@ class CurlFactoryTest extends TestCase
         self::assertContains('Host: 127.0.0.1:8126', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
     }
 
+    public function testCloseClearsIdleHandles(): void
+    {
+        $factory = new CurlFactory(3);
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), []);
+
+        $factory->release($easy);
+        self::assertCount(1, self::readIdleHandles($factory));
+
+        $factory->close();
+
+        self::assertSame([], self::readIdleHandles($factory));
+    }
+
+    public function testCloseIsIdempotent(): void
+    {
+        $factory = new CurlFactory(3);
+
+        $factory->close();
+        $factory->close();
+
+        self::assertSame([], self::readIdleHandles($factory));
+    }
+
+    public function testCreateAfterCloseThrows(): void
+    {
+        $factory = new CurlFactory(3);
+        $factory->close();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot use the cURL factory after it has been closed.');
+
+        $factory->create(new Psr7\Request('GET', Server::$url), []);
+    }
+
+    public function testReleaseAfterCloseThrows(): void
+    {
+        $factory = new CurlFactory(3);
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), []);
+
+        try {
+            $factory->close();
+
+            $this->expectException(\BadMethodCallException::class);
+            $this->expectExceptionMessage('Cannot use the cURL factory after it has been closed.');
+
+            $factory->release($easy);
+        } finally {
+            if (isset($easy->handle) && \PHP_VERSION_ID < 80000) {
+                \curl_close($easy->handle);
+            }
+        }
+    }
+
     public function testSendsHeadRequests(): void
     {
         Server::flush();

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -107,6 +107,23 @@ class CurlFactoryTest extends TestCase
         self::assertSame([], self::readIdleHandles($factory));
     }
 
+    public function testReleaseClearsCallbacksBeforeDiscardingHandle(): void
+    {
+        $factory = new CurlFactory(0);
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'progress' => static function (): void {
+            },
+        ]);
+
+        $factory->release($easy);
+
+        self::assertArrayNotHasKey(\CURLOPT_HEADERFUNCTION, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_READFUNCTION, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_WRITEFUNCTION, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_PROGRESSFUNCTION, $_SERVER['_curl']);
+        self::assertSame([], self::readIdleHandles($factory));
+    }
+
     public function testCloseIsIdempotent(): void
     {
         $factory = new CurlFactory(3);

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
@@ -58,6 +59,50 @@ class CurlHandlerTest extends TestCase
         self::assertInstanceOf(FulfilledPromise::class, $a($request, []));
     }
 
+    public function testClosePreventsReuse(): void
+    {
+        $handler = new CurlHandler();
+        $handler->close();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot use the cURL handler after it has been closed.');
+
+        $handler(new Request('GET', Server::$url), []);
+    }
+
+    public function testCloseClosesInternallyCreatedFactory(): void
+    {
+        $handler = new CurlHandler();
+        $factory = self::readFactory($handler);
+
+        $handler->close();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot use the cURL factory after it has been closed.');
+
+        $factory->create(new Request('GET', Server::$url), []);
+    }
+
+    public function testCloseDoesNotCloseInjectedFactory(): void
+    {
+        $factory = new class(3) extends CurlFactory {
+            /** @var bool */
+            public $closeCalled = false;
+
+            public function close(): void
+            {
+                $this->closeCalled = true;
+
+                parent::close();
+            }
+        };
+        $handler = new CurlHandler(['handle_factory' => $factory]);
+
+        $handler->close();
+
+        self::assertFalse($factory->closeCalled);
+    }
+
     public function testDoesSleep(): void
     {
         $response = new Response(200);
@@ -99,5 +144,17 @@ class CurlHandlerTest extends TestCase
         $received = Server::received()[0];
         self::assertEquals(1000000, $received->getHeaderLine('Content-Length'));
         self::assertFalse($received->hasHeader('Transfer-Encoding'));
+    }
+
+    private static function readFactory(CurlHandler $handler): CurlFactory
+    {
+        $readFactory = \Closure::bind(static function (CurlHandler $handler) {
+            return $handler->factory;
+        }, null, CurlHandler::class);
+
+        $factory = $readFactory($handler);
+        self::assertInstanceOf(CurlFactory::class, $factory);
+
+        return $factory;
     }
 }

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -247,6 +247,27 @@ class CurlMultiHandlerTest extends TestCase
         }
     }
 
+    public function testCloseActiveTransferLeavesResourceSinkOpen(): void
+    {
+        $sink = \fopen('php://temp', 'w+');
+        self::assertIsResource($sink);
+
+        $handler = new CurlMultiHandler();
+        $promise = $handler(new Request('GET', Server::$url), ['sink' => $sink]);
+
+        try {
+            $handler->close();
+
+            self::assertTrue(P\Is::rejected($promise));
+            self::assertIsResource($sink);
+            self::assertNotFalse(\fwrite($sink, 'still open'));
+        } finally {
+            if (\is_resource($sink)) {
+                \fclose($sink);
+            }
+        }
+    }
+
     public function testCanCancel(): void
     {
         Server::flush();

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\HandlerClosedException;
+use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7\Request;
@@ -87,6 +89,164 @@ class CurlMultiHandlerTest extends TestCase
         self::assertFalse($hasMultiHandle($handler));
     }
 
+    public function testCloseRejectsActiveTransfer(): void
+    {
+        $handler = new CurlMultiHandler();
+        $promise = $handler(new Request('GET', Server::$url), []);
+
+        $handler->close();
+
+        self::assertTrue(P\Is::rejected($promise));
+
+        $this->expectException(HandlerClosedException::class);
+        $this->expectExceptionMessage('The cURL multi handler was closed before the transfer completed.');
+
+        $promise->wait();
+    }
+
+    public function testCloseRejectsDelayedTransferWithoutInitializingMultiHandle(): void
+    {
+        $handler = new CurlMultiHandler();
+        $promise = $handler(new Request('GET', Server::$url), ['delay' => 10000]);
+
+        self::assertFalse(self::hasMultiHandle($handler));
+
+        $handler->close();
+
+        self::assertFalse(self::hasMultiHandle($handler));
+        self::assertTrue(P\Is::rejected($promise));
+    }
+
+    public function testCloseDoesNotRunPromiseQueue(): void
+    {
+        $handler = new CurlMultiHandler();
+        $called = false;
+
+        $promise = $handler(new Request('GET', Server::$url), []);
+        $promise->otherwise(static function () use (&$called): void {
+            $called = true;
+        });
+
+        try {
+            $handler->close();
+
+            self::assertTrue(P\Is::rejected($promise));
+            self::assertFalse($called);
+        } finally {
+            P\Utils::queue()->run();
+        }
+    }
+
+    public function testDestructorDoesNotRejectPendingPromise(): void
+    {
+        $handler = new CurlMultiHandler();
+        $promise = $handler(new Request('GET', Server::$url), ['delay' => 10000]);
+
+        $handler->__destruct();
+
+        self::assertTrue(P\Is::pending($promise));
+    }
+
+    public function testClosePreventsReuse(): void
+    {
+        $handler = new CurlMultiHandler();
+        $handler->close();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot use the cURL multi handler after it has been closed.');
+
+        $handler(new Request('GET', Server::$url), []);
+    }
+
+    public function testTickAfterCloseThrows(): void
+    {
+        $handler = new CurlMultiHandler();
+        $handler->close();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot use the cURL multi handler after it has been closed.');
+
+        $handler->tick();
+    }
+
+    public function testExecuteAfterCloseThrows(): void
+    {
+        $handler = new CurlMultiHandler();
+        $handler->close();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot use the cURL multi handler after it has been closed.');
+
+        $handler->execute();
+    }
+
+    public function testCloseIsIdempotent(): void
+    {
+        $handler = new CurlMultiHandler();
+
+        $handler->close();
+        $handler->close();
+
+        self::assertFalse(self::hasMultiHandle($handler));
+    }
+
+    public function testCloseClosesInternallyCreatedFactory(): void
+    {
+        $handler = new CurlMultiHandler();
+        $factory = self::readFactory($handler);
+
+        $handler->close();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Cannot use the cURL factory after it has been closed.');
+
+        $factory->create(new Request('GET', Server::$url), []);
+    }
+
+    public function testCloseDoesNotCloseInjectedFactory(): void
+    {
+        $factory = new class(3) extends CurlFactory {
+            /** @var bool */
+            public $closeCalled = false;
+
+            public function close(): void
+            {
+                $this->closeCalled = true;
+
+                parent::close();
+            }
+        };
+        $handler = new CurlMultiHandler(['handle_factory' => $factory]);
+
+        $handler->close();
+
+        self::assertFalse($factory->closeCalled);
+    }
+
+    public function testClosePendingTransferLeavesResourceSinkOpen(): void
+    {
+        $sink = \fopen('php://temp', 'w+');
+        self::assertIsResource($sink);
+
+        $handler = new CurlMultiHandler();
+        $promise = $handler(new Request('GET', Server::$url), [
+            'delay' => 10000,
+            'sink' => $sink,
+        ]);
+
+        try {
+            $handler->close();
+
+            self::assertTrue(P\Is::rejected($promise));
+            self::assertIsResource($sink);
+            self::assertNotFalse(\fwrite($sink, 'still open'));
+        } finally {
+            if (\is_resource($sink)) {
+                \fclose($sink);
+            }
+        }
+    }
+
     public function testCanCancel(): void
     {
         Server::flush();
@@ -142,5 +302,26 @@ class CurlMultiHandlerTest extends TestCase
         }, null, CurlMultiHandler::class);
 
         return $readSelectTimeout($handler);
+    }
+
+    private static function hasMultiHandle(CurlMultiHandler $handler): bool
+    {
+        $hasMultiHandle = \Closure::bind(static function (CurlMultiHandler $handler): bool {
+            return isset($handler->_mh);
+        }, null, CurlMultiHandler::class);
+
+        return $hasMultiHandle($handler);
+    }
+
+    private static function readFactory(CurlMultiHandler $handler): CurlFactory
+    {
+        $readFactory = \Closure::bind(static function (CurlMultiHandler $handler) {
+            return $handler->factory;
+        }, null, CurlMultiHandler::class);
+
+        $factory = $readFactory($handler);
+        self::assertInstanceOf(CurlFactory::class, $factory);
+
+        return $factory;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,7 +26,11 @@ namespace GuzzleHttp\Handler {
             if ($option === \CURLOPT_CUSTOMREQUEST) {
                 $_SERVER['_curl'] = [];
             }
-            $_SERVER['_curl'][$option] = $value;
+            if ($value === null) {
+                unset($_SERVER['_curl'][$option]);
+            } else {
+                $_SERVER['_curl'][$option] = $value;
+            }
         } else {
             unset($_SERVER['_curl']);
         }


### PR DESCRIPTION
This adds explicit close() methods to CurlHandler, CurlMultiHandler, and the concrete CurlFactory so long-running applications can deterministically release native cURL resources instead of relying only on destructors. Closed handlers and factories are terminal and fail clearly if reused, while destructors remain best-effort and non-throwing.

For CurlMultiHandler, explicit close rejects pending transfers with HandlerClosedException and safely handles delayed transfers without initializing a multi handle just for cleanup. Handlers close only factories they created themselves, so custom handle_factory dependencies remain caller-owned. The docs and upgrade guide describe the new lifecycle behavior and ownership rules.