### PR TITLE
Define cURL callback semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers
 - Avoid stale authenticated proxy tunnels on affected libcurl versions
+- Allow built-in cURL handler `progress` callbacks to abort transfers with truthy return values
+- Reject built-in cURL handler `progress` callback throwables with `RequestException`
+- Release built-in cURL easy handles before invoking `on_stats`
+- Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,6 +83,21 @@ Destructor cleanup remains best-effort and does not reject pending promises.
 A custom `handle_factory` passed to a built-in cURL handler remains caller-owned.
 Closing the handler does not close an injected factory.
 
+#### Callback semantics
+
+The built-in cURL handlers now treat truthy `progress` callback return values as
+an abort signal. If your progress callback accidentally returns a truthy value,
+return `0`, `false`, or nothing to keep the transfer running. Throwing from a
+cURL `progress` callback now rejects the request with `RequestException` instead
+of letting the throwable escape from the native callback.
+
+The stream handler still ignores `progress` return values.
+
+Exceptions thrown by `on_stats` remain unwrapped, but the built-in cURL handlers
+now release native easy handles before invoking `on_stats`. Raw callbacks passed
+through the `curl` request option remain low-level cURL callbacks and are not
+normalized by Guzzle.
+
 #### Multipart request serialization
 
 Guzzle 8 uses Guzzle PSR-7 3.x for multipart request bodies. Multipart parts

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -85,16 +85,20 @@ Closing the handler does not close an injected factory.
 
 #### Callback semantics
 
-The built-in cURL handlers now treat truthy `progress` callback return values as
-an abort signal. If your progress callback accidentally returns a truthy value,
-return `0`, `false`, or nothing to keep the transfer running. Throwing from a
-cURL `progress` callback now rejects the request with `RequestException` instead
-of letting the throwable escape from the native callback.
+If you use the `progress` request option with the built-in cURL handlers, audit
+callbacks for return values. Any truthy return value now aborts the transfer and
+rejects the request with `RequestException`. Return `0`, `false`, or nothing to
+keep the transfer running.
+
+If a cURL `progress` callback throws, catch `RequestException` and inspect
+`getPrevious()` for the original throwable. The throwable no longer escapes
+directly from the native cURL callback.
 
 The stream handler still ignores `progress` return values.
 
-Exceptions thrown by `on_stats` remain unwrapped, but the built-in cURL handlers
-now release native easy handles before invoking `on_stats`. Raw callbacks passed
+Exceptions thrown by `on_stats` remain unwrapped, so existing catch logic for
+`on_stats` exceptions does not need to change. The built-in cURL handlers now
+release native easy handles before invoking `on_stats`. Raw callbacks passed
 through the `curl` request option remain low-level cURL callbacks and are not
 normalized by Guzzle.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -56,6 +56,8 @@ $client = new Client(['handler' => HandlerStack::create(new CurlMultiHandler([
 
 Custom cURL request options remain active during redirects unless Guzzle documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
 
+Callbacks supplied directly through the `curl` request option are passed to PHP's cURL extension as low-level callbacks. Guzzle does not normalize exception or abort behavior for raw cURL callbacks. Prefer Guzzle's `progress`, `on_headers`, and `on_stats` request options when you want Guzzle's documented callback semantics.
+
 ## How can I close cURL resources in long-running applications?
 
 If your application creates a cURL handler directly and needs deterministic cleanup, keep a reference to the handler and call `close()` when the handler is no longer needed.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -679,14 +679,17 @@ Types
 Constant
 `GuzzleHttp\RequestOptions::ON_HEADERS`
 
-The callable accepts a `Psr\Http\Message\ResponseInterface` object. If an exception is thrown by the callable, then the promise associated with the response will be rejected with a `GuzzleHttp\Exception\RequestException` that wraps the exception that was thrown.
+The callable accepts a `Psr\Http\Message\ResponseInterface` object and the corresponding `Psr\Http\Message\RequestInterface` object. If an exception is thrown by the callable, then the promise associated with the response will be rejected with a `GuzzleHttp\Exception\RequestException` that wraps the exception that was thrown.
 
 You may need to know what headers and status codes were received before data can be written to the sink.
 
 ```php
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
 // Reject responses that are greater than 1024 bytes.
 $client->request('GET', 'http://httpbin.org/stream/1024', [
-    'on_headers' => function (ResponseInterface $response) {
+    'on_headers' => function (ResponseInterface $response, RequestInterface $request) {
         if ($response->getHeaderLine('Content-Length') > 1024) {
             throw new \Exception('The file is too big!');
         }
@@ -709,6 +712,8 @@ Constant
 `GuzzleHttp\RequestOptions::ON_STATS`
 
 The callable accepts a `GuzzleHttp\TransferStats` object.
+
+Exceptions thrown by `on_stats` are not wrapped by Guzzle and may escape from the handler wait path. With the built-in cURL handlers, native cURL handles are released before `on_stats` is invoked. cURL handlers emit `on_stats` per low-level transfer attempt, so retries may invoke it more than once for one logical request.
 
 ```php
 use GuzzleHttp\TransferStats;
@@ -755,6 +760,8 @@ The function accepts the following positional arguments:
 - the number of bytes downloaded so far
 - the total number of bytes expected to be uploaded
 - the number of bytes uploaded so far
+
+With the built-in cURL handlers, returning a truthy value aborts the transfer and rejects the request promise with a `GuzzleHttp\Exception\RequestException`. If the callable throws, the built-in cURL handlers abort the transfer and reject the promise with a `RequestException` wrapping the thrown exception. The built-in stream handler treats progress callbacks as notifications only and ignores return values.
 
 ```php
 // Send a GET request to /get?foo=bar

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -39,7 +39,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 5
+			count: 6
 			path: src/Handler/CurlFactory.php
 
 		-
@@ -99,7 +99,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 4
+			count: 5
 			path: src/Handler/CurlMultiHandler.php
 
 		-

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -284,6 +284,10 @@ class CurlFactory implements CurlFactoryInterface
         curl_setopt($handle, \CURLOPT_READFUNCTION, null);
         curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
         curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
+
+        if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+            curl_setopt($handle, (int) \constant('CURLOPT_XFERINFOFUNCTION'), null);
+        }
     }
 
     /**
@@ -297,19 +301,23 @@ class CurlFactory implements CurlFactoryInterface
      */
     public static function finish(callable $handler, EasyHandle $easy, CurlFactoryInterface $factory): PromiseInterface
     {
-        if (isset($easy->options['on_stats'])) {
-            self::invokeStats($easy);
-        }
+        /** @var callable|null $onStats */
+        $onStats = $easy->options['on_stats'] ?? null;
+        $stats = $onStats !== null ? self::createStats($easy) : null;
 
         if (!$easy->response || $easy->errno) {
-            return self::finishError($handler, $easy, $factory);
+            return self::finishError($handler, $easy, $factory, $stats, $onStats);
         }
+
+        /** @var ResponseInterface $response */
+        $response = $easy->response;
 
         // Return the response if it is present and there is no error.
         $factory->release($easy);
 
-        /** @var ResponseInterface $response */
-        $response = $easy->response;
+        if ($onStats !== null) {
+            $onStats($stats);
+        }
 
         // Rewind the body of the response if possible.
         $body = $response->getBody();
@@ -321,7 +329,7 @@ class CurlFactory implements CurlFactoryInterface
         return P\Create::promiseFor($response);
     }
 
-    private static function invokeStats(EasyHandle $easy): void
+    private static function createStats(EasyHandle $easy): TransferStats
     {
         $curlStats = \curl_getinfo($easy->handle);
         $curlStats['appconnect_time'] = \curl_getinfo($easy->handle, \CURLINFO_APPCONNECT_TIME);
@@ -333,26 +341,30 @@ class CurlFactory implements CurlFactoryInterface
             ];
         }
 
-        $stats = new TransferStats(
+        return new TransferStats(
             $easy->request,
             $easy->response,
             $curlStats['total_time'],
             $easy->errno,
             $curlStats
         );
-        ($easy->options['on_stats'])($stats);
     }
 
     /**
      * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $handler
+     * @param callable|null                                                                 $onStats
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
-    private static function finishError(callable $handler, EasyHandle $easy, CurlFactoryInterface $factory): PromiseInterface
+    private static function finishError(callable $handler, EasyHandle $easy, CurlFactoryInterface $factory, ?TransferStats $stats, $onStats): PromiseInterface
     {
         // Get error information and release the handle to the factory.
         $ctx = self::createErrorContext($easy);
         $factory->release($easy);
+
+        if ($onStats !== null) {
+            $onStats($stats);
+        }
 
         // Retry when nothing is present or when curl failed to rewind.
         if (empty($easy->options['_err_message']) && (!$easy->errno || $easy->errno == 65)) {
@@ -414,6 +426,32 @@ class CurlFactory implements CurlFactoryInterface
                     $easy->request,
                     $easy->response,
                     $easy->onHeadersException,
+                    $ctx
+                )
+            );
+        }
+
+        if ($easy->progressException) {
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(
+                new RequestException(
+                    'An error was encountered during the progress event',
+                    $easy->request,
+                    $easy->response,
+                    $easy->progressException,
+                    $ctx
+                )
+            );
+        }
+
+        if ($easy->progressAborted && $easy->errno === \CURLE_ABORTED_BY_CALLBACK) {
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(
+                new RequestException(
+                    'The transfer was aborted by the progress callback',
+                    $easy->request,
+                    $easy->response,
+                    null,
                     $ctx
                 )
             );
@@ -1000,9 +1038,27 @@ class CurlFactory implements CurlFactoryInterface
                 throw new \InvalidArgumentException('progress client option must be callable');
             }
             $conf[\CURLOPT_NOPROGRESS] = false;
-            $conf[\CURLOPT_PROGRESSFUNCTION] = static function ($resource, int $downloadSize, int $downloaded, int $uploadSize, int $uploaded) use ($progress) {
-                $progress($downloadSize, $downloaded, $uploadSize, $uploaded);
+            $progressCallback = static function ($resource, $downloadSize, $downloaded, $uploadSize, $uploaded) use ($easy, $progress): int {
+                try {
+                    if ($progress($downloadSize, $downloaded, $uploadSize, $uploaded)) {
+                        $easy->progressAborted = true;
+
+                        return 1;
+                    }
+
+                    return 0;
+                } catch (\Throwable $e) {
+                    $easy->progressException = $e;
+
+                    return 1;
+                }
             };
+
+            if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+                $conf[(int) \constant('CURLOPT_XFERINFOFUNCTION')] = $progressCallback;
+            } else {
+                $conf[\CURLOPT_PROGRESSFUNCTION] = $progressCallback;
+            }
         }
 
         if (!empty($options['debug'])) {

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -397,6 +397,10 @@ class CurlMultiHandler
         curl_setopt($handle, \CURLOPT_READFUNCTION, null);
         curl_setopt($handle, \CURLOPT_WRITEFUNCTION, null);
         curl_setopt($handle, \CURLOPT_PROGRESSFUNCTION, null);
+
+        if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+            curl_setopt($handle, (int) \constant('CURLOPT_XFERINFOFUNCTION'), null);
+        }
     }
 
     /**
@@ -450,14 +454,7 @@ class CurlMultiHandler
             $this->removeHandleFromMulti($easy->handle);
         }
 
-        if (self::hasEasyHandle($easy)) {
-            $handle = $easy->handle;
-            unset($easy->handle);
-
-            if (PHP_VERSION_ID < 80000 && \is_resource($handle)) {
-                \curl_close($handle);
-            }
-        }
+        $this->disposeEasyHandle($easy);
 
         return true;
     }

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -56,6 +56,16 @@ final class EasyHandle
     public $onHeadersException;
 
     /**
+     * @var \Throwable|null Exception during progress callback (if any)
+     */
+    public $progressException;
+
+    /**
+     * @var bool Whether the progress callback requested abort
+     */
+    public $progressAborted = false;
+
+    /**
      * @var \Throwable|null Exception during createResponse (if any)
      */
     public $createResponseException;

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -93,6 +93,7 @@ class MockHandler implements \Countable
         $this->lastRequest = $request;
         $this->lastOptions = $options;
         $response = \array_shift($this->queue);
+        $onHeadersResponse = null;
 
         if (isset($options['on_headers'])) {
             if (!\is_callable($options['on_headers'])) {
@@ -102,7 +103,8 @@ class MockHandler implements \Countable
                 $options['on_headers']($response, $request);
             } catch (\Throwable $e) {
                 $msg = 'An error was encountered during the on_headers event';
-                $response = new RequestException($msg, $request, $response, $e);
+                $onHeadersResponse = $response instanceof ResponseInterface ? $response : null;
+                $response = new RequestException($msg, $request, $onHeadersResponse, $e);
             }
         }
 
@@ -137,8 +139,8 @@ class MockHandler implements \Countable
 
                 return $value;
             },
-            function ($reason) use ($request, $options) {
-                $this->invokeStats($request, $options, null, $reason);
+            function ($reason) use ($request, $options, $onHeadersResponse) {
+                $this->invokeStats($request, $options, $onHeadersResponse, $reason);
                 if ($this->onRejected) {
                     ($this->onRejected)($reason);
                 }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -29,6 +29,11 @@ class StreamHandler
     private $lastHeaders = [];
 
     /**
+     * @var \Throwable|null
+     */
+    private $onStatsException;
+
+    /**
      * Sends an HTTP request.
      *
      * @param RequestInterface $request Request to send.
@@ -38,6 +43,8 @@ class StreamHandler
      */
     public function __invoke(RequestInterface $request, array $options): PromiseInterface
     {
+        $this->onStatsException = null;
+
         // Sleep if there is a delay specified.
         if (isset($options['delay'])) {
             \usleep($options['delay'] * 1000);
@@ -78,6 +85,10 @@ class StreamHandler
         } catch (\InvalidArgumentException $e) {
             throw $e;
         } catch (\Exception $e) {
+            if ($this->isOnStatsException($e)) {
+                throw $e;
+            }
+
             // Determine if the error was a networking error.
             $message = $e->getMessage();
             // This list can probably get more comprehensive.
@@ -99,6 +110,17 @@ class StreamHandler
         }
     }
 
+    private function isOnStatsException(\Throwable $e): bool
+    {
+        if ($this->onStatsException !== $e) {
+            return false;
+        }
+
+        $this->onStatsException = null;
+
+        return true;
+    }
+
     private function invokeStats(
         array $options,
         RequestInterface $request,
@@ -108,7 +130,13 @@ class StreamHandler
     ): void {
         if (isset($options['on_stats'])) {
             $stats = new TransferStats($request, $response, Utils::currentTime() - $startTime, $error, []);
-            ($options['on_stats'])($stats);
+            try {
+                ($options['on_stats'])($stats);
+            } catch (\Throwable $e) {
+                $this->onStatsException = $e;
+
+                throw $e;
+            }
         }
     }
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -146,10 +146,11 @@ class StreamHandler
             try {
                 $options['on_headers']($response, $request);
             } catch (\Throwable $e) {
+                $reason = new RequestException('An error was encountered during the on_headers event', $request, $response, $e);
+                $this->invokeStats($options, $request, $startTime, $response, $reason);
+
                 /** @var PromiseInterface<ResponseInterface, mixed> */
-                return P\Create::rejectionFor(
-                    new RequestException('An error was encountered during the on_headers event', $request, $response, $e)
-                );
+                return P\Create::rejectionFor($reason);
             }
         }
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -177,7 +177,9 @@ final class RequestOptions
      * of the response have been received but the body has not yet begun to
      * download. The callable is passed the response and request as
      * {@see \Psr\Http\Message\ResponseInterface} and
-     * {@see \Psr\Http\Message\RequestInterface} objects, respectively.
+     * {@see \Psr\Http\Message\RequestInterface} objects, respectively. If it
+     * throws, the request promise is rejected with a RequestException wrapping
+     * the thrown exception.
      */
     public const ON_HEADERS = 'on_headers';
 
@@ -188,7 +190,9 @@ final class RequestOptions
      * when a handler has finished sending a request. The callback is invoked
      * with transfer statistics about the request, the response received, or
      * the error encountered. Included in the data is the total amount of time
-     * taken to send the request.
+     * taken to send the request. Exceptions thrown by on_stats are not wrapped
+     * by Guzzle. The built-in cURL handlers release native easy handles before
+     * invoking on_stats and invoke it per low-level transfer attempt.
      */
     public const ON_STATS = 'on_stats';
 
@@ -197,7 +201,10 @@ final class RequestOptions
      * progress is made. The function accepts the following positional
      * arguments: the total number of bytes expected to be downloaded, the
      * number of bytes downloaded so far, the number of bytes expected to be
-     * uploaded, the number of bytes uploaded so far.
+     * uploaded, the number of bytes uploaded so far. With the built-in cURL
+     * handlers, returning a truthy value aborts the transfer and throwing
+     * rejects the promise with a RequestException. The built-in stream handler
+     * ignores return values.
      */
     public const PROGRESS = 'progress';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -121,6 +121,9 @@ class CurlFactoryTest extends TestCase
         self::assertArrayNotHasKey(\CURLOPT_READFUNCTION, $_SERVER['_curl']);
         self::assertArrayNotHasKey(\CURLOPT_WRITEFUNCTION, $_SERVER['_curl']);
         self::assertArrayNotHasKey(\CURLOPT_PROGRESSFUNCTION, $_SERVER['_curl']);
+        if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+            self::assertArrayNotHasKey((int) \constant('CURLOPT_XFERINFOFUNCTION'), $_SERVER['_curl']);
+        }
         self::assertSame([], self::readIdleHandles($factory));
     }
 
@@ -824,6 +827,173 @@ class CurlFactoryTest extends TestCase
         $f->create(new Psr7\Request('GET', Server::$url), ['progress' => 'foo']);
     }
 
+    public function testUsesXferInfoFunctionForProgressWhenAvailable(): void
+    {
+        $f = new CurlFactory(3);
+        $easy = $f->create(new Psr7\Request('GET', Server::$url), [
+            'progress' => static function (): void {
+            },
+        ]);
+
+        try {
+            if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+                self::assertArrayHasKey((int) \constant('CURLOPT_XFERINFOFUNCTION'), $_SERVER['_curl']);
+                self::assertArrayNotHasKey(\CURLOPT_PROGRESSFUNCTION, $_SERVER['_curl']);
+            } else {
+                self::assertArrayHasKey(\CURLOPT_PROGRESSFUNCTION, $_SERVER['_curl']);
+            }
+        } finally {
+            $f->release($easy);
+        }
+    }
+
+    public function testProgressReturnValueControlsCurlAbort(): void
+    {
+        $f = new CurlFactory(3);
+        $called = [];
+        $easy = $f->create(new Psr7\Request('GET', Server::$url), [
+            'progress' => static function ($downloadTotal, $downloadedBytes, $uploadTotal, $uploadedBytes) use (&$called): bool {
+                $called = [$downloadTotal, $downloadedBytes, $uploadTotal, $uploadedBytes];
+
+                return $downloadedBytes > 0;
+            },
+        ]);
+
+        try {
+            $callback = $_SERVER['_curl'][self::progressCallbackOption()];
+
+            self::assertSame(0, $callback($easy->handle, 10, 0, 2, 0));
+            self::assertFalse($easy->progressAborted);
+            self::assertSame([10, 0, 2, 0], $called);
+
+            self::assertSame(1, $callback($easy->handle, 10, 1, 2, 0));
+            self::assertTrue($easy->progressAborted);
+            self::assertSame([10, 1, 2, 0], $called);
+        } finally {
+            $f->release($easy);
+        }
+    }
+
+    public function testProgressAbortRejectsWithRequestException(): void
+    {
+        $factory = new CurlFactory(1);
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'progress' => static function (): bool {
+                return true;
+            },
+        ]);
+
+        $callback = $_SERVER['_curl'][self::progressCallbackOption()];
+        self::assertSame(1, $callback($easy->handle, 0, 0, 0, 0));
+        $easy->errno = \CURLE_ABORTED_BY_CALLBACK;
+
+        try {
+            CurlFactory::finish(
+                static function (): void {
+                },
+                $easy,
+                $factory
+            )->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('The transfer was aborted by the progress callback', $e->getMessage());
+            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
+        }
+    }
+
+    public function testProgressThrowableRejectsWithRequestException(): void
+    {
+        $factory = new CurlFactory(1);
+        $previous = new \RuntimeException('boom');
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'progress' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+
+        $callback = $_SERVER['_curl'][self::progressCallbackOption()];
+        self::assertSame(1, $callback($easy->handle, 0, 0, 0, 0));
+        $easy->errno = \CURLE_ABORTED_BY_CALLBACK;
+
+        try {
+            CurlFactory::finish(
+                static function (): void {
+                },
+                $easy,
+                $factory
+            )->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('An error was encountered during the progress event', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
+        }
+    }
+
+    public function testProgressExceptionWinsOverAbortMarker(): void
+    {
+        $factory = new CurlFactory(1);
+        $previous = new \RuntimeException('boom');
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), []);
+        $easy->progressAborted = true;
+        $easy->progressException = $previous;
+        $easy->errno = \CURLE_ABORTED_BY_CALLBACK;
+
+        try {
+            CurlFactory::finish(
+                static function (): void {
+                },
+                $easy,
+                $factory
+            )->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('An error was encountered during the progress event', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        }
+    }
+
+    public function testAbortedByCallbackWithoutProgressMarkerUsesGenericCurlError(): void
+    {
+        $factory = new CurlFactory(1);
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), []);
+        $easy->errno = \CURLE_ABORTED_BY_CALLBACK;
+
+        try {
+            CurlFactory::finish(
+                static function (): void {
+                },
+                $easy,
+                $factory
+            )->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringStartsWith('cURL error '.\CURLE_ABORTED_BY_CALLBACK.':', $e->getMessage());
+        }
+    }
+
+    public function testReleaseClearsRawXferInfoCallbackBeforeDiscardingHandle(): void
+    {
+        if (!\defined('CURLOPT_XFERINFOFUNCTION')) {
+            self::markTestSkipped('CURLOPT_XFERINFOFUNCTION is not available.');
+        }
+
+        $option = (int) \constant('CURLOPT_XFERINFOFUNCTION');
+        $factory = new CurlFactory(0);
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'curl' => [
+                $option => static function (): int {
+                    return 0;
+                },
+            ],
+        ]);
+
+        $factory->release($easy);
+
+        self::assertArrayNotHasKey($option, $_SERVER['_curl']);
+        self::assertSame([], self::readIdleHandles($factory));
+    }
+
     public function testEmitsDebugInfoToStream(): void
     {
         $res = \fopen('php://temp', 'r+');
@@ -1297,7 +1467,9 @@ class CurlFactoryTest extends TestCase
             static function (): void {
             },
             $easy,
-            $factory
+            $factory,
+            null,
+            null
         );
 
         try {
@@ -1327,7 +1499,9 @@ class CurlFactoryTest extends TestCase
             static function (): void {
             },
             $easy,
-            $factory
+            $factory,
+            null,
+            null
         );
 
         try {
@@ -1568,6 +1742,35 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public function testInvokesOnStatsWhenOnHeadersFails(): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, ['X-Foo' => 'bar'], 'abc 123'),
+        ]);
+        $req = new Psr7\Request('GET', Server::$url);
+        $gotStats = null;
+        $handler = new Handler\CurlHandler();
+        $promise = $handler($req, [
+            'on_headers' => static function (): void {
+                throw new \RuntimeException('test');
+            },
+            'on_stats' => static function (TransferStats $stats) use (&$gotStats): void {
+                $gotStats = $stats;
+            },
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringContainsString('An error was encountered during the on_headers event', $e->getMessage());
+            self::assertInstanceOf(TransferStats::class, $gotStats);
+            self::assertTrue($gotStats->hasResponse());
+            self::assertSame(200, $gotStats->getResponse()->getStatusCode());
+        }
+    }
+
     public function testSuccessfullyCallsOnHeadersBeforeWritingToSink(): void
     {
         Server::flush();
@@ -1660,6 +1863,89 @@ class CurlFactoryTest extends TestCase
         self::assertIsFloat($gotStats->getTransferTime());
         self::assertIsInt($gotStats->getHandlerErrorData());
         self::assertArrayHasKey('appconnect_time', $gotStats->getHandlerStats());
+    }
+
+    public function testInvokesOnStatsAfterSuccessHandleRelease(): void
+    {
+        $factory = new CurlFactory(1);
+        $easy = null;
+        $called = false;
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'on_stats' => static function (TransferStats $stats) use (&$easy, $factory, &$called): void {
+                $called = true;
+                self::assertInstanceOf(EasyHandle::class, $easy);
+                self::assertTrue($stats->hasResponse());
+                self::assertArrayNotHasKey('handle', \get_object_vars($easy));
+                self::assertCount(1, self::readIdleHandles($factory));
+            },
+        ]);
+        $easy->response = new Psr7\Response(200);
+
+        $promise = CurlFactory::finish(
+            static function (): void {
+            },
+            $easy,
+            $factory
+        );
+
+        self::assertTrue($called);
+        self::assertSame(200, $promise->wait()->getStatusCode());
+    }
+
+    public function testInvokesOnStatsAfterErrorHandleRelease(): void
+    {
+        $factory = new CurlFactory(1);
+        $easy = null;
+        $called = false;
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'on_stats' => static function (TransferStats $stats) use (&$easy, $factory, &$called): void {
+                $called = true;
+                self::assertInstanceOf(EasyHandle::class, $easy);
+                self::assertFalse($stats->hasResponse());
+                self::assertSame(\CURLE_COULDNT_CONNECT, $stats->getHandlerErrorData());
+                self::assertArrayNotHasKey('handle', \get_object_vars($easy));
+                self::assertCount(1, self::readIdleHandles($factory));
+            },
+        ]);
+        $easy->errno = \CURLE_COULDNT_CONNECT;
+
+        CurlFactory::finish(
+            static function (): void {
+            },
+            $easy,
+            $factory
+        )->wait(false);
+
+        self::assertTrue($called);
+    }
+
+    public function testOnStatsExceptionEscapesAfterHandleRelease(): void
+    {
+        $factory = new CurlFactory(1);
+        $previous = new \RuntimeException('stats failed');
+        $easy = null;
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'on_stats' => static function () use (&$easy, $factory, $previous): void {
+                self::assertInstanceOf(EasyHandle::class, $easy);
+                self::assertArrayNotHasKey('handle', \get_object_vars($easy));
+                self::assertCount(1, self::readIdleHandles($factory));
+
+                throw $previous;
+            },
+        ]);
+        $easy->response = new Psr7\Response(200);
+
+        try {
+            CurlFactory::finish(
+                static function (): void {
+                },
+                $easy,
+                $factory
+            );
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            self::assertSame($previous, $e);
+        }
     }
 
     public function testRewindsBodyIfPossible(): void
@@ -1797,6 +2083,15 @@ class CurlFactoryTest extends TestCase
         }
 
         return (int) \constant('CURLOPT_PROXYHEADER');
+    }
+
+    private static function progressCallbackOption(): int
+    {
+        if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+            return (int) \constant('CURLOPT_XFERINFOFUNCTION');
+        }
+
+        return \CURLOPT_PROGRESSFUNCTION;
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -874,6 +874,66 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testProgressTruthyReturnRejectsThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([new Psr7\Response(200, [], 'abc')]);
+        $handler = $handlerFactory();
+
+        try {
+            $handler(new Psr7\Request('GET', Server::$url), [
+                'progress' => static function (): bool {
+                    return true;
+                },
+            ])->wait();
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('The transfer was aborted by the progress callback', $e->getMessage());
+            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+    }
+
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testProgressThrowableRejectsThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([new Psr7\Response(200, [], 'abc')]);
+        $handler = $handlerFactory();
+        $previous = new \RuntimeException('progress failed');
+
+        try {
+            $handler(new Psr7\Request('GET', Server::$url), [
+                'progress' => static function () use ($previous): void {
+                    throw $previous;
+                },
+            ])->wait();
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('An error was encountered during the progress event', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+    }
+
     public function testProgressAbortRejectsWithRequestException(): void
     {
         $factory = new CurlFactory(1);
@@ -992,6 +1052,28 @@ class CurlFactoryTest extends TestCase
 
         self::assertArrayNotHasKey($option, $_SERVER['_curl']);
         self::assertSame([], self::readIdleHandles($factory));
+    }
+
+    public function testReleaseClearsRawXferInfoCallbackBeforeReusingHandle(): void
+    {
+        if (!\defined('CURLOPT_XFERINFOFUNCTION')) {
+            self::markTestSkipped('CURLOPT_XFERINFOFUNCTION is not available.');
+        }
+
+        $option = (int) \constant('CURLOPT_XFERINFOFUNCTION');
+        $factory = new CurlFactory(1);
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'curl' => [
+                $option => static function (): int {
+                    return 0;
+                },
+            ],
+        ]);
+
+        $factory->release($easy);
+
+        self::assertArrayNotHasKey($option, $_SERVER['_curl']);
+        self::assertCount(1, self::readIdleHandles($factory));
     }
 
     public function testEmitsDebugInfoToStream(): void
@@ -1768,6 +1850,9 @@ class CurlFactoryTest extends TestCase
             self::assertInstanceOf(TransferStats::class, $gotStats);
             self::assertTrue($gotStats->hasResponse());
             self::assertSame(200, $gotStats->getResponse()->getStatusCode());
+            self::assertSame($req, $gotStats->getRequest());
+            self::assertSame(Server::$url, (string) $gotStats->getEffectiveUri());
+            self::assertIsInt($gotStats->getHandlerErrorData());
         }
     }
 
@@ -2083,6 +2168,18 @@ class CurlFactoryTest extends TestCase
         }
 
         return (int) \constant('CURLOPT_PROXYHEADER');
+    }
+
+    public static function curlHandlerProvider(): array
+    {
+        return [
+            'curl' => [static function (): callable {
+                return new Handler\CurlHandler();
+            }],
+            'curl_multi' => [static function (): callable {
+                return new Handler\CurlMultiHandler();
+            }],
+        ];
     }
 
     private static function progressCallbackOption(): int

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -20,12 +20,12 @@ class CurlMultiHandlerTest extends TestCase
     public function setUp(): void
     {
         $_SERVER['curl_test'] = true;
-        unset($_SERVER['_curl_multi']);
+        unset($_SERVER['_curl'], $_SERVER['_curl_multi']);
     }
 
     public function tearDown(): void
     {
-        unset($_SERVER['_curl_multi'], $_SERVER['curl_test']);
+        unset($_SERVER['_curl'], $_SERVER['_curl_multi'], $_SERVER['curl_test']);
     }
 
     public function testCanAddCustomCurlOptions(): void
@@ -268,6 +268,25 @@ class CurlMultiHandlerTest extends TestCase
         }
     }
 
+    public function testCloseActiveTransferClearsProgressCallbacks(): void
+    {
+        $handler = new CurlMultiHandler();
+        $promise = $handler(new Request('GET', Server::$url), [
+            'progress' => static function (): void {
+            },
+        ]);
+
+        self::assertArrayHasKey(self::progressCallbackOption(), $_SERVER['_curl']);
+
+        $handler->close();
+
+        self::assertTrue(P\Is::rejected($promise));
+        self::assertArrayNotHasKey(\CURLOPT_PROGRESSFUNCTION, $_SERVER['_curl']);
+        if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+            self::assertArrayNotHasKey((int) \constant('CURLOPT_XFERINFOFUNCTION'), $_SERVER['_curl']);
+        }
+    }
+
     public function testCanCancel(): void
     {
         Server::flush();
@@ -283,6 +302,25 @@ class CurlMultiHandlerTest extends TestCase
 
         foreach ($responses as $r) {
             self::assertTrue(P\Is::rejected($r));
+        }
+    }
+
+    public function testCancelClearsProgressCallbacks(): void
+    {
+        $handler = new CurlMultiHandler();
+        $promise = $handler(new Request('GET', Server::$url), [
+            'progress' => static function (): void {
+            },
+        ]);
+
+        self::assertArrayHasKey(self::progressCallbackOption(), $_SERVER['_curl']);
+
+        $promise->cancel();
+
+        self::assertTrue(P\Is::rejected($promise));
+        self::assertArrayNotHasKey(\CURLOPT_PROGRESSFUNCTION, $_SERVER['_curl']);
+        if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+            self::assertArrayNotHasKey((int) \constant('CURLOPT_XFERINFOFUNCTION'), $_SERVER['_curl']);
         }
     }
 
@@ -344,5 +382,14 @@ class CurlMultiHandlerTest extends TestCase
         self::assertInstanceOf(CurlFactory::class, $factory);
 
         return $factory;
+    }
+
+    private static function progressCallbackOption(): int
+    {
+        if (\defined('CURLOPT_XFERINFOFUNCTION')) {
+            return (int) \constant('CURLOPT_XFERINFOFUNCTION');
+        }
+
+        return \CURLOPT_PROGRESSFUNCTION;
     }
 }

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -205,7 +205,8 @@ class MockHandlerTest extends TestCase
             self::assertSame('An error was encountered during the on_headers event', $e->getMessage());
             self::assertInstanceOf(TransferStats::class, $stats);
             self::assertSame($request, $stats->getRequest());
-            self::assertNull($stats->getResponse());
+            self::assertTrue($stats->hasResponse());
+            self::assertSame($res, $stats->getResponse());
             self::assertSame($e, $stats->getHandlerErrorData());
         }
     }

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -183,6 +183,33 @@ class MockHandlerTest extends TestCase
         }
     }
 
+    public function testInvokesOnStatsWhenOnHeadersFails(): void
+    {
+        $res = new Response(200);
+        $mock = new MockHandler([$res]);
+        $request = new Request('GET', 'http://example.com');
+        $stats = null;
+        $promise = $mock($request, [
+            'on_headers' => static function (): void {
+                throw new \RuntimeException('test');
+            },
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
+            },
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('An error was encountered during the on_headers event', $e->getMessage());
+            self::assertInstanceOf(TransferStats::class, $stats);
+            self::assertSame($request, $stats->getRequest());
+            self::assertNull($stats->getResponse());
+            self::assertSame($e, $stats->getHandlerErrorData());
+        }
+    }
+
     public function testInvokesOnHeadersWithResponseAndRequest(): void
     {
         $res = new Response(201, ['X-Foo' => 'bar']);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1115,6 +1115,61 @@ class StreamHandlerTest extends TestCase
         self::assertGreaterThan(0, $gotStats->getTransferTime());
     }
 
+    public function testOnStatsExceptionEscapesOnSuccessWithoutWrapping(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+        $req = new Request('GET', Server::$url);
+        $handler = new StreamHandler();
+        $previous = new \RuntimeException('stats failed');
+        $called = 0;
+
+        try {
+            $handler($req, [
+                'on_stats' => static function (TransferStats $stats) use (&$called, $previous): void {
+                    ++$called;
+                    self::assertTrue($stats->hasResponse());
+
+                    throw $previous;
+                },
+            ]);
+
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            self::assertSame($previous, $e);
+            self::assertSame(1, $called);
+        }
+    }
+
+    public function testOnStatsExceptionEscapesWhenOnHeadersFails(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200, ['X-Foo' => 'bar'], 'abc 123')]);
+        $req = new Request('GET', Server::$url);
+        $handler = new StreamHandler();
+        $previous = new \RuntimeException('stats failed');
+        $called = 0;
+
+        try {
+            $handler($req, [
+                'on_headers' => static function (): void {
+                    throw new \RuntimeException('headers failed');
+                },
+                'on_stats' => static function (TransferStats $stats) use (&$called, $previous): void {
+                    ++$called;
+                    self::assertTrue($stats->hasResponse());
+
+                    throw $previous;
+                },
+            ]);
+
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            self::assertSame($previous, $e);
+            self::assertSame(1, $called);
+        }
+    }
+
     public function testInvokesOnStatsOnError(): void
     {
         $req = new Request('GET', 'http://127.0.0.1:123');

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -815,6 +815,20 @@ class StreamHandlerTest extends TestCase
         self::assertEquals(0, $called[0][1]);
     }
 
+    public function testProgressReturnValueDoesNotAbortTransfer(): void
+    {
+        $this->queueRes();
+
+        $response = $this->getSendResult([
+            'progress' => static function (): bool {
+                return true;
+            },
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('hi there', (string) $response->getBody());
+    }
+
     public function testEmitsProgressInformationAndDebugInformation(): void
     {
         $called = [];
@@ -1002,6 +1016,36 @@ class StreamHandlerTest extends TestCase
                 $e->getMessage()
             );
             self::assertInstanceOf(\Error::class, $e->getPrevious());
+        }
+    }
+
+    public function testInvokesOnStatsWhenOnHeadersFails(): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Response(200, ['X-Foo' => 'bar'], 'abc 123'),
+        ]);
+        $req = new Request('GET', Server::$url);
+        $gotStats = null;
+        $handler = new StreamHandler();
+        $promise = $handler($req, [
+            'on_headers' => static function (): void {
+                throw new \RuntimeException('test');
+            },
+            'on_stats' => static function (TransferStats $stats) use (&$gotStats): void {
+                $gotStats = $stats;
+            },
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertStringContainsString('An error was encountered during the on_headers event', $e->getMessage());
+            self::assertInstanceOf(TransferStats::class, $gotStats);
+            self::assertTrue($gotStats->hasResponse());
+            self::assertSame(200, $gotStats->getResponse()->getStatusCode());
+            self::assertSame($e, $gotStats->getHandlerErrorData());
         }
     }
 


### PR DESCRIPTION
This defines the remaining callback behavior for the built-in handlers in Guzzle 8. cURL progress callbacks can now abort transfers by returning a truthy value, and throwables from Guzzle-managed cURL progress callbacks are converted into RequestException rejections instead of escaping from native callbacks.

The cURL handlers now prefer CURLOPT_XFERINFOFUNCTION when available and clear both progress callback options during handle cleanup. cURL on_stats callbacks are invoked after the easy handle has been released, while on_stats exceptions remain unwrapped. The stream and mock handlers are aligned so on_stats is invoked consistently for on_headers failures, and the documentation and upgrade notes describe the new contracts.