### PR TITLE
Fix magic request method casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fix IPv6 literal matching in no-proxy rules
-- Fix magic client request methods such as `options()` to uppercase inferred HTTP method names before request creation
+- Fix magic client request methods such as `options()` to uppercase inferred HTTP methods
 
 
 ## 7.10.3 - 2025-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fix IPv6 literal matching in no-proxy rules
+- Fix magic client request methods such as `options()` to uppercase inferred HTTP method names before request creation
 
 
 ## 7.10.3 - 2025-05-20

--- a/src/Client.php
+++ b/src/Client.php
@@ -87,8 +87,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         $uri = $args[0];
         $opts = $args[1] ?? [];
 
-        return \substr($method, -5) === 'Async'
-            ? $this->requestAsync(\substr($method, 0, -5), $uri, $opts)
+        $isAsync = \substr($method, -5) === 'Async';
+        $method = $isAsync ? \substr($method, 0, -5) : $method;
+        $method = \strtoupper($method);
+
+        return $isAsync
+            ? $this->requestAsync($method, $uri, $opts)
             : $this->request($method, $uri, $opts);
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -34,6 +35,53 @@ class ClientTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Magic request methods require a URI and optional options array');
         $client->options();
+    }
+
+    /**
+     * @dataProvider magicRequestMethodProvider
+     */
+    public function testMagicRequestMethodsNormalizeInferredMethodName($method, $expectedMethod)
+    {
+        $client = new ClientTestMagicClient();
+        $options = ['headers' => ['X-Test' => '1']];
+
+        $client->{$method}('/resource', $options);
+
+        self::assertSame([
+            ['request', $expectedMethod, '/resource', $options],
+        ], $client->calls);
+    }
+
+    /**
+     * @dataProvider magicAsyncRequestMethodProvider
+     */
+    public function testMagicAsyncRequestMethodsNormalizeInferredMethodName($method, $expectedMethod)
+    {
+        $client = new ClientTestMagicClient();
+        $options = ['headers' => ['X-Test' => '1']];
+
+        $promise = $client->{$method}('/resource', $options);
+
+        self::assertInstanceOf(PromiseInterface::class, $promise);
+        self::assertSame([
+            ['requestAsync', $expectedMethod, '/resource', $options],
+        ], $client->calls);
+    }
+
+    public static function magicRequestMethodProvider()
+    {
+        return [
+            ['options', 'OPTIONS'],
+            ['purge', 'PURGE'],
+        ];
+    }
+
+    public static function magicAsyncRequestMethodProvider()
+    {
+        return [
+            ['optionsAsync', 'OPTIONS'],
+            ['purgeAsync', 'PURGE'],
+        ];
     }
 
     public function testCanSendAsyncGetRequests()
@@ -894,5 +942,24 @@ class ClientTest extends TestCase
         $request = $requests[0]['request'];
         self::assertSame('https://xn--d1acpjx3f.xn--p1ai/images', (string) $request->getUri());
         self::assertSame('xn--d1acpjx3f.xn--p1ai', (string) $request->getHeaderLine('Host'));
+    }
+}
+
+final class ClientTestMagicClient extends Client
+{
+    public $calls = [];
+
+    public function request(string $method, $uri = '', array $options = []): ResponseInterface
+    {
+        $this->calls[] = ['request', $method, $uri, $options];
+
+        return new Response();
+    }
+
+    public function requestAsync(string $method, $uri = '', array $options = []): PromiseInterface
+    {
+        $this->calls[] = ['requestAsync', $method, $uri, $options];
+
+        return new FulfilledPromise(new Response());
     }
 }


### PR DESCRIPTION
This changes Client::__call() so magic request methods uppercase the inferred HTTP method before forwarding to request() or requestAsync(). That keeps calls such as options(), optionsAsync(), and other custom magic methods from relying on PSR-7 request construction to normalize the method casing. The regression coverage checks both synchronous and asynchronous magic methods before a PSR-7 request can normalize the method.