### PR TITLE
Classify protocol failures as request exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Default HTTPS requests sent by the built-in cURL and stream handlers to TLS 1.2 or newer
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them
-- Reject empty or malformed request protocol versions
+- Classify empty, malformed, or handler-unsupported request protocol versions as request exceptions
 - Throw `TimeoutException` for reliably detected transfer timeouts
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,6 +69,19 @@ When a built-in handler can reliably identify a transfer timeout, it now throws
 `ConnectException`, so existing `catch (ConnectException $e)` and
 `catch (TransferException $e)` blocks continue to catch timeout failures.
 
+#### Request protocol version exceptions
+
+Empty or malformed HTTP protocol versions returned by a `RequestInterface` now
+fail with `GuzzleHttp\Exception\RequestException`. Built-in handlers also
+report well-formed but unsupported request protocol versions, such as HTTP/3
+with the stream handler, as `RequestException`.
+
+Invalid `version` request option values are still rejected as
+`GuzzleHttp\Exception\InvalidArgumentException` before a request is sent. If you
+previously caught `InvalidArgumentException` or `ConnectException` for request
+protocol version failures, catch `RequestException` or `GuzzleException`
+instead.
+
 #### cURL handler lifecycle
 
 Applications that manage built-in cURL handlers or factories directly should

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -456,7 +456,7 @@ The following tree view describes how the Guzzle Exceptions depend on each other
     ├── NetworkException (implements NetworkExceptionInterface)
     │   └── ConnectException
     │       └── TimeoutException
-    └── RequestException
+    └── RequestException (implements RequestExceptionInterface)
         ├── BadResponseException
         │   ├── ServerException
         │   └── ClientException
@@ -469,7 +469,9 @@ Guzzle throws exceptions for errors that occur during a transfer.
 
 - `GuzzleHttp\Exception\HandlerClosedException` is used when a built-in handler rejects a transfer because the handler was explicitly closed before the transfer completed. For example, pending `CurlMultiHandler` transfers are rejected with this exception when `CurlMultiHandler::close()` is called.
 
-- A `GuzzleHttp\Exception\ConnectException` exception is thrown when a connection cannot be established. This exception extends from `GuzzleHttp\Exception\NetworkException`.
+- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `RequestExceptionInterface`, exposes the request with `getRequest()`, and may expose a response with `getResponse()` when one was received.
+
+- A `GuzzleHttp\Exception\ConnectException` exception is thrown when a connection cannot be established. This exception extends from `GuzzleHttp\Exception\NetworkException`. Invalid or handler-unsupported HTTP request protocol versions are reported as `RequestException`, not `ConnectException`.
 
 - A `GuzzleHttp\Exception\TimeoutException` exception is thrown when a transfer timeout can be reliably identified. This exception extends from `GuzzleHttp\Exception\ConnectException`.
 
@@ -491,7 +493,9 @@ Guzzle throws exceptions for errors that occur during a transfer.
 
 - A `GuzzleHttp\Exception\TooManyRedirectsException` is thrown when too many redirects are followed. This exception extends from `GuzzleHttp\Exception\RequestException`.
 
-All of the above exceptions extend from `GuzzleHttp\Exception\TransferException`.
+`Client::sendRequest()` returns redirect, 4xx, and 5xx responses as normal PSR-18 responses. These response-status exceptions are used by Guzzle request methods when the corresponding middleware options are enabled.
+
+All of the above exceptions extend from `GuzzleHttp\Exception\TransferException`. `TransferException` implements `GuzzleHttp\Exception\GuzzleException`, which extends PSR-18's `ClientExceptionInterface`.
 
 ## Environment Variables
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1141,6 +1141,8 @@ The built-in cURL handler supports HTTP versions `1.0`, `1.1`, `2.0`, and `3.0`,
 
 The built-in stream handler supports only HTTP versions `1.0` and `1.1`.
 
+Empty or malformed `version` request option values are rejected before the request is sent. If a request uses a well-formed HTTP version that a built-in handler cannot send, the transfer fails with `GuzzleHttp\Exception\RequestException`.
+
 HTTP/3 requests sent by the built-in cURL handler use TLS 1.3 or newer. Lower TLS versions requested through `crypto_method` or `curl` options are upgraded to TLS 1.3 for HTTP/3 requests.
 
 > [!NOTE]

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace GuzzleHttp;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\InvalidArgumentException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\HttpFactory;
@@ -450,7 +451,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     {
         $request = $this->applyOptions($request, $options);
 
-        self::assertProtocolVersion($request->getProtocolVersion());
+        self::assertRequestProtocolVersion($request);
 
         /** @var HandlerStack $handler */
         $handler = $options['handler'];
@@ -638,6 +639,19 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
         if (1 !== \preg_match('/^\d+(?:\.\d+)?$/D', $version)) {
             throw new InvalidArgumentException('HTTP protocol version must be a valid HTTP version number.');
+        }
+    }
+
+    private static function assertRequestProtocolVersion(RequestInterface $request): void
+    {
+        $version = $request->getProtocolVersion();
+
+        if ('' === $version) {
+            throw new RequestException('HTTP protocol version must not be empty.', $request);
+        }
+
+        if (1 !== \preg_match('/^\d+(?:\.\d+)?$/D', $version)) {
+            throw new RequestException('HTTP protocol version must be a valid HTTP version number.', $request);
         }
     }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -52,28 +52,28 @@ class CurlFactory implements CurlFactoryInterface
     {
         $this->assertOpen();
 
-        CurlVersion::ensureSupported($request);
-
         $protocolVersion = $request->getProtocolVersion();
 
         if ('' === $protocolVersion) {
-            throw new ConnectException('HTTP protocol version must not be empty.', $request);
+            throw new RequestException('HTTP protocol version must not be empty.', $request);
         }
 
         if (1 !== \preg_match('/^\d+(?:\.\d+)?$/D', $protocolVersion)) {
-            throw new ConnectException('HTTP protocol version must be a valid HTTP version number.', $request);
+            throw new RequestException('HTTP protocol version must be a valid HTTP version number.', $request);
         }
+
+        CurlVersion::ensureSupported($request);
 
         if ('3' === $protocolVersion || '3.0' === $protocolVersion) {
             if (!CurlVersion::supportsHttp3()) {
-                throw new ConnectException('HTTP/3 is supported by the cURL handler, however the installed PHP cURL extension or libcurl does not support HTTP/3.', $request);
+                throw new RequestException('HTTP/3 is supported by the cURL handler, however the installed PHP cURL extension or libcurl does not support HTTP/3.', $request);
             }
         } elseif ('2' === $protocolVersion || '2.0' === $protocolVersion) {
             if (!CurlVersion::supportsHttp2()) {
-                throw new ConnectException('HTTP/2 is supported by the cURL handler, however libcurl is built without HTTP/2 support.', $request);
+                throw new RequestException('HTTP/2 is supported by the cURL handler, however libcurl is built without HTTP/2 support.', $request);
             }
         } elseif ('1.0' !== $protocolVersion && '1.1' !== $protocolVersion) {
-            throw new ConnectException(sprintf('HTTP/%s is not supported by the cURL handler.', $protocolVersion), $request);
+            throw new RequestException(sprintf('HTTP/%s is not supported by the cURL handler.', $protocolVersion), $request);
         }
 
         if (isset($options['curl']['body_as_string'])) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -46,15 +46,15 @@ class StreamHandler
         $protocolVersion = $request->getProtocolVersion();
 
         if ('' === $protocolVersion) {
-            throw new ConnectException('HTTP protocol version must not be empty.', $request);
+            throw new RequestException('HTTP protocol version must not be empty.', $request);
         }
 
         if (1 !== \preg_match('/^\d+(?:\.\d+)?$/D', $protocolVersion)) {
-            throw new ConnectException('HTTP protocol version must be a valid HTTP version number.', $request);
+            throw new RequestException('HTTP protocol version must be a valid HTTP version number.', $request);
         }
 
         if ('1.0' !== $protocolVersion && '1.1' !== $protocolVersion) {
-            throw new ConnectException(sprintf('HTTP/%s is not supported by the stream handler.', $protocolVersion), $request);
+            throw new RequestException(sprintf('HTTP/%s is not supported by the stream handler.', $protocolVersion), $request);
         }
 
         $startTime = isset($options['on_stats']) ? Utils::currentTime() : null;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -17,6 +18,7 @@ use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Server\Server;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -69,16 +71,21 @@ class ClientTest extends TestCase
         $client->get('http://example.com', ['version' => '']);
     }
 
-    public function testRejectsEmptyRequestProtocolVersion(): void
+    public function testSendRequestRejectsEmptyRequestProtocolVersion(): void
     {
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $request = self::requestWithProtocolVersion('');
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP protocol version must not be empty.');
+        try {
+            $client->sendRequest($request);
+            self::fail('Expected request exception.');
+        } catch (RequestExceptionInterface $e) {
+            self::assertSame('', $e->getRequest()->getProtocolVersion());
+            self::assertSame('HTTP protocol version must not be empty.', $e->getMessage());
+        }
 
-        $client->send($request);
+        self::assertCount(1, $mock);
     }
 
     /**
@@ -102,11 +109,18 @@ class ClientTest extends TestCase
     {
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
+        $request = self::requestWithProtocolVersion($version);
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('HTTP protocol version must be a valid HTTP version number.');
+        try {
+            $client->send($request);
+            self::fail('Expected request exception.');
+        } catch (RequestException $e) {
+            self::assertSame($version, $e->getRequest()->getProtocolVersion());
+            self::assertFalse($e->hasResponse());
+            self::assertSame('HTTP protocol version must be a valid HTTP version number.', $e->getMessage());
+        }
 
-        $client->send(self::requestWithProtocolVersion($version));
+        self::assertCount(1, $mock);
     }
 
     public static function malformedProtocolVersionProvider(): iterable

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -968,10 +968,14 @@ class CurlFactoryTest extends TestCase
         $factory = new CurlFactory(3);
         $request = self::requestWithProtocolVersion('');
 
-        $this->expectException(ConnectException::class);
-        $this->expectExceptionMessage('HTTP protocol version must not be empty.');
-
-        $factory->create($request, []);
+        try {
+            $factory->create($request, []);
+            self::fail('Expected request exception.');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertFalse($e->hasResponse());
+            self::assertSame('HTTP protocol version must not be empty.', $e->getMessage());
+        }
     }
 
     public function testRejectsMalformedProtocolVersion(): void
@@ -979,10 +983,37 @@ class CurlFactoryTest extends TestCase
         $factory = new CurlFactory(3);
         $request = self::requestWithProtocolVersion('HTTP/1.1');
 
-        $this->expectException(ConnectException::class);
-        $this->expectExceptionMessage('HTTP protocol version must be a valid HTTP version number.');
+        try {
+            $factory->create($request, []);
+            self::fail('Expected request exception.');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertFalse($e->hasResponse());
+            self::assertSame('HTTP protocol version must be a valid HTTP version number.', $e->getMessage());
+        }
+    }
 
-        $factory->create($request, []);
+    public function testThrowsWhenHttp2IsUnsupported(): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => 0,
+        ]);
+
+        try {
+            $factory = new CurlFactory(3);
+            $request = new Psr7\Request('GET', Server::$url, [], null, '2.0');
+
+            try {
+                $factory->create($request, []);
+                self::fail('Expected request exception.');
+            } catch (RequestException $e) {
+                self::assertSame($request, $e->getRequest());
+                self::assertStringContainsString('HTTP/2 is supported by the cURL handler', $e->getMessage());
+            }
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
     }
 
     public function testThrowsWhenHttp3IsUnsupported(): void
@@ -994,11 +1025,15 @@ class CurlFactoryTest extends TestCase
 
         try {
             $factory = new CurlFactory(3);
+            $request = new Psr7\Request('GET', Server::$url, [], null, '3.0');
 
-            $this->expectException(ConnectException::class);
-            $this->expectExceptionMessage('HTTP/3 is supported by the cURL handler');
-
-            $factory->create(new Psr7\Request('GET', Server::$url, [], null, '3.0'), []);
+            try {
+                $factory->create($request, []);
+                self::fail('Expected request exception.');
+            } catch (RequestException $e) {
+                self::assertSame($request, $e->getRequest());
+                self::assertStringContainsString('HTTP/3 is supported by the cURL handler', $e->getMessage());
+            }
         } finally {
             self::setCurlVersionInfo($previousVersionInfo);
         }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -60,21 +60,31 @@ class StreamHandlerTest extends TestCase
     public function testRejectsEmptyProtocolVersion(): void
     {
         $handler = new StreamHandler();
+        $request = self::requestWithProtocolVersion('');
 
-        $this->expectException(ConnectException::class);
-        $this->expectExceptionMessage('HTTP protocol version must not be empty.');
-
-        $handler(self::requestWithProtocolVersion(''), []);
+        try {
+            $handler($request, []);
+            self::fail('Expected request exception.');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertFalse($e->hasResponse());
+            self::assertSame('HTTP protocol version must not be empty.', $e->getMessage());
+        }
     }
 
     public function testRejectsMalformedProtocolVersion(): void
     {
         $handler = new StreamHandler();
+        $request = self::requestWithProtocolVersion('HTTP/1.1');
 
-        $this->expectException(ConnectException::class);
-        $this->expectExceptionMessage('HTTP protocol version must be a valid HTTP version number.');
-
-        $handler(self::requestWithProtocolVersion('HTTP/1.1'), []);
+        try {
+            $handler($request, []);
+            self::fail('Expected request exception.');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertFalse($e->hasResponse());
+            self::assertSame('HTTP protocol version must be a valid HTTP version number.', $e->getMessage());
+        }
     }
 
     public function testAddsErrorToResponse(): void
@@ -91,11 +101,15 @@ class StreamHandlerTest extends TestCase
     public function testRejectsHttp3(): void
     {
         $handler = new StreamHandler();
+        $request = new Request('GET', 'https://example.com', [], null, '3.0');
 
-        $this->expectException(ConnectException::class);
-        $this->expectExceptionMessage('HTTP/3.0 is not supported by the stream handler.');
-
-        $handler(new Request('GET', 'https://example.com', [], null, '3.0'), []);
+        try {
+            $handler($request, []);
+            self::fail('Expected request exception.');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('HTTP/3.0 is not supported by the stream handler.', $e->getMessage());
+        }
     }
 
     public function testStreamAttributeKeepsStreamOpen(): void


### PR DESCRIPTION
This classifies empty, malformed, and handler-unsupported request protocol versions as request exceptions. Invalid version request option values continue to throw InvalidArgumentException.