### PR TITLE
Reject cURL multi promises when on_stats throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Release built-in cURL easy handles before invoking `on_stats`
 - Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available
 
+### Fixed
+
+- Reject cURL multi handler promises when transfer completion callbacks throw during manual event-loop ticks
+
 ### Removed
 
 - Dropped support for PHP 7.2 and 7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject built-in cURL handler `progress` callback throwables with `RequestException`
 - Release built-in cURL easy handles before invoking `on_stats`
 - Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available
-
-### Fixed
-
 - Reject cURL multi handler promises when transfer completion callbacks throw during manual event-loop ticks
 
 ### Removed

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -477,9 +477,16 @@ class CurlMultiHandler
             $entry = $this->handles[$id];
             unset($this->handles[$id], $this->delays[$id]);
             $entry['easy']->errno = $done['result'];
-            $entry['deferred']->resolve(
-                CurlFactory::finish($this, $entry['easy'], $this->factory)
-            );
+
+            try {
+                $result = CurlFactory::finish($this, $entry['easy'], $this->factory);
+            } catch (\Throwable $e) {
+                $entry['deferred']->reject($e);
+
+                continue;
+            }
+
+            $entry['deferred']->resolve($result);
         }
     }
 

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -346,6 +346,66 @@ class CurlMultiHandlerTest extends TestCase
         self::assertGreaterThanOrEqual($expected, Utils::currentTime());
     }
 
+    public function testManualTickRejectsPromiseWhenFinishThrows(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
+        $handler = new CurlMultiHandler(['select_timeout' => 0]);
+        $previous = new \RuntimeException('stats failed');
+        $promise = $handler(new Request('GET', Server::$url), [
+            'on_stats' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+
+        try {
+            self::tickUntilSettled($handler, $promise);
+
+            self::assertTrue(P\Is::rejected($promise));
+
+            try {
+                $promise->wait();
+                self::fail('Expected RuntimeException');
+            } catch (\RuntimeException $e) {
+                self::assertSame($previous, $e);
+            }
+        } finally {
+            $handler->close();
+            Server::flush();
+        }
+    }
+
+    public function testWaitFalseRejectsPromiseWhenFinishThrows(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
+        $handler = new CurlMultiHandler(['select_timeout' => 0]);
+        $previous = new \RuntimeException('stats failed');
+        $promise = $handler(new Request('GET', Server::$url), [
+            'on_stats' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $promise->wait(false);
+
+            self::assertTrue(P\Is::rejected($promise));
+
+            try {
+                $promise->wait();
+                self::fail('Expected RuntimeException');
+            } catch (\RuntimeException $e) {
+                self::assertSame($previous, $e);
+            }
+        } finally {
+            $handler->close();
+            Server::flush();
+        }
+    }
+
     public function throwsWhenAccessingInvalidProperty(): void
     {
         $h = new CurlMultiHandler();
@@ -382,6 +442,15 @@ class CurlMultiHandlerTest extends TestCase
         self::assertInstanceOf(CurlFactory::class, $factory);
 
         return $factory;
+    }
+
+    private static function tickUntilSettled(CurlMultiHandler $handler, P\PromiseInterface $promise): void
+    {
+        for ($i = 0; $i < 1000 && P\Is::pending($promise); ++$i) {
+            $handler->tick();
+        }
+
+        self::assertFalse(P\Is::pending($promise), 'Promise was not settled after ticking the handler.');
     }
 
     private static function progressCallbackOption(): int


### PR DESCRIPTION
This fixes cURL multi handler promise settlement when CurlFactory::finish() throws while the handler is driven through tick(), execute(), or wait(false). The completed transfer was removed from the multi handler before CurlFactory::finish() ran, so a finish-time throwable could escape before the deferred promise was resolved or rejected, leaving the request promise pending. The handler now rejects the promise with the original throwable, preserving unwrapped on_stats behavior through wait() while keeping non-unwrapping waits and manual event-loop usage consistent.