### PR TITLE
Classify cURL transport failures as network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them
 - Classify empty, malformed, or handler-unsupported request protocol versions as request exceptions
+- Classify additional cURL transport failures without a response as network exceptions
 - Throw `TimeoutException` for reliably detected transfer timeouts
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,6 +69,11 @@ When a built-in handler can reliably identify a transfer timeout, it now throws
 `ConnectException`, so existing `catch (ConnectException $e)` and
 `catch (TransferException $e)` blocks continue to catch timeout failures.
 
+Additional cURL transport failures, such as proxy resolution failures and send
+or receive failures before a response is received, now throw `ConnectException`.
+If a response object has already been created, these failures continue to throw
+`RequestException` so callers can inspect the response.
+
 #### Request protocol version exceptions
 
 Empty or malformed HTTP protocol versions returned by a `RequestInterface` now

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,10 +69,13 @@ When a built-in handler can reliably identify a transfer timeout, it now throws
 `ConnectException`, so existing `catch (ConnectException $e)` and
 `catch (TransferException $e)` blocks continue to catch timeout failures.
 
-Additional cURL transport failures, such as proxy resolution failures and send
-or receive failures before a response is received, now throw `ConnectException`.
-If a response object has already been created, these failures continue to throw
-`RequestException` so callers can inspect the response.
+Audit `catch (RequestException $e)` blocks that retry, log, or classify cURL
+transport failures. Proxy resolution, send, receive, and TLS verification
+failures before any response is received now throw `ConnectException`, so catch
+`ConnectException`, `NetworkExceptionInterface`, or `TransferException` for
+those network failures. Keep handling `RequestException` when you need to inspect
+a response, because failures after a response object is created still use
+`RequestException`.
 
 #### Request protocol version exceptions
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -398,10 +398,30 @@ class CurlFactory implements CurlFactoryInterface
     {
         static $connectionErrors = [
             \CURLE_COULDNT_RESOLVE_HOST => true,
+            \CURLE_COULDNT_RESOLVE_PROXY => true,
             \CURLE_COULDNT_CONNECT => true,
             \CURLE_SSL_CONNECT_ERROR => true,
             \CURLE_GOT_NOTHING => true,
         ];
+        static $networkErrorsWithoutResponse;
+        if ($networkErrorsWithoutResponse === null) {
+            $networkErrorsWithoutResponse = [
+                \CURLE_SEND_ERROR => true,
+                \CURLE_RECV_ERROR => true,
+            ];
+
+            foreach ([
+                'CURLE_PROXY',
+                'CURLE_QUIC_CONNECT_ERROR',
+                'CURLE_HTTP2',
+                'CURLE_HTTP2_STREAM',
+                'CURLE_HTTP3',
+            ] as $constant) {
+                if (\defined($constant)) {
+                    $networkErrorsWithoutResponse[(int) \constant($constant)] = true;
+                }
+            }
+        }
 
         if ($easy->createResponseException) {
             /** @var PromiseInterface<ResponseInterface, mixed> */
@@ -475,9 +495,12 @@ class CurlFactory implements CurlFactoryInterface
             }
         }
 
+        $isNetworkError = isset($connectionErrors[$easy->errno])
+            || (!$easy->response && isset($networkErrorsWithoutResponse[$easy->errno]));
+
         if ($easy->errno === \CURLE_OPERATION_TIMEOUTED) {
             $error = new TimeoutException($message, $easy->request, null, $ctx);
-        } elseif (isset($connectionErrors[$easy->errno])) {
+        } elseif ($isNetworkError) {
             $error = new ConnectException($message, $easy->request, null, $ctx);
         } else {
             $error = new RequestException($message, $easy->request, $easy->response, null, $ctx);

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -416,6 +416,12 @@ class CurlFactory implements CurlFactoryInterface
                 'CURLE_HTTP2',
                 'CURLE_HTTP2_STREAM',
                 'CURLE_HTTP3',
+                'CURLE_PEER_FAILED_VERIFICATION',
+                'CURLE_SSL_CACERT',
+                'CURLE_SSL_PEER_CERTIFICATE',
+                'CURLE_SSL_PINNEDPUBKEYNOTMATCH',
+                'CURLE_SSL_INVALIDCERTSTATUS',
+                'CURLE_SSL_CLIENTCERT',
             ] as $constant) {
                 if (\defined($constant)) {
                     $networkErrorsWithoutResponse[(int) \constant($constant)] = true;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1568,7 +1568,19 @@ class CurlFactoryTest extends TestCase
         self::assertSame('test', (string) $response->getBody());
     }
 
-    public function testCreatesConnectException(): void
+    public static function curlConnectionErrorProvider(): iterable
+    {
+        yield 'resolve host' => [\CURLE_COULDNT_RESOLVE_HOST];
+        yield 'resolve proxy' => [\CURLE_COULDNT_RESOLVE_PROXY];
+        yield 'connect' => [\CURLE_COULDNT_CONNECT];
+        yield 'ssl connect' => [\CURLE_SSL_CONNECT_ERROR];
+        yield 'got nothing' => [\CURLE_GOT_NOTHING];
+    }
+
+    /**
+     * @dataProvider curlConnectionErrorProvider
+     */
+    public function testCreatesConnectExceptionForConnectionErrors(int $errno): void
     {
         $m = new \ReflectionMethod(CurlFactory::class, 'finishError');
 
@@ -1578,7 +1590,7 @@ class CurlFactoryTest extends TestCase
 
         $factory = new CurlFactory(1);
         $easy = $factory->create(new Psr7\Request('GET', Server::$url), []);
-        $easy->errno = \CURLE_COULDNT_CONNECT;
+        $easy->errno = $errno;
         $response = $m->invoke(
             null,
             static function (): void {
@@ -1595,7 +1607,83 @@ class CurlFactoryTest extends TestCase
         } catch (TimeoutException $e) {
             self::fail('Expected non-timeout ConnectException');
         } catch (ConnectException $e) {
-            self::assertSame(\CURLE_COULDNT_CONNECT, $e->getHandlerContext()['errno']);
+            self::assertSame($errno, $e->getHandlerContext()['errno']);
+        }
+    }
+
+    public static function curlResponseSensitiveNetworkErrorProvider(): iterable
+    {
+        yield 'send' => [\CURLE_SEND_ERROR];
+        yield 'receive' => [\CURLE_RECV_ERROR];
+
+        foreach ([
+            'CURLE_PROXY',
+            'CURLE_QUIC_CONNECT_ERROR',
+            'CURLE_HTTP2',
+            'CURLE_HTTP2_STREAM',
+            'CURLE_HTTP3',
+        ] as $constant) {
+            if (\defined($constant)) {
+                yield $constant => [(int) \constant($constant)];
+            }
+        }
+    }
+
+    /**
+     * @dataProvider curlResponseSensitiveNetworkErrorProvider
+     */
+    public function testCreatesConnectExceptionForNetworkErrorsWithoutResponse(int $errno): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $easy = $factory->create($request, []);
+        $easy->errno = $errno;
+        $easy->response = null;
+
+        $promise = CurlFactory::finish(
+            static function (): void {
+            },
+            $easy,
+            $factory
+        );
+
+        try {
+            $promise->wait();
+            self::fail('Expected ConnectException');
+        } catch (TimeoutException $e) {
+            self::fail('Expected non-timeout ConnectException');
+        } catch (ConnectException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($errno, $e->getHandlerContext()['errno']);
+        }
+    }
+
+    /**
+     * @dataProvider curlResponseSensitiveNetworkErrorProvider
+     */
+    public function testNetworkErrorsWithResponseStayRequestExceptions(int $errno): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $response = new Psr7\Response(200);
+        $easy = $factory->create($request, []);
+        $easy->errno = $errno;
+        $easy->response = $response;
+
+        $promise = CurlFactory::finish(
+            static function (): void {
+            },
+            $easy,
+            $factory
+        );
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($response, $e->getResponse());
+            self::assertSame($errno, $e->getHandlerContext()['errno']);
         }
     }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1622,6 +1622,12 @@ class CurlFactoryTest extends TestCase
             'CURLE_HTTP2',
             'CURLE_HTTP2_STREAM',
             'CURLE_HTTP3',
+            'CURLE_PEER_FAILED_VERIFICATION',
+            'CURLE_SSL_CACERT',
+            'CURLE_SSL_PEER_CERTIFICATE',
+            'CURLE_SSL_PINNEDPUBKEYNOTMATCH',
+            'CURLE_SSL_INVALIDCERTSTATUS',
+            'CURLE_SSL_CLIENTCERT',
         ] as $constant) {
             if (\defined($constant)) {
                 yield $constant => [(int) \constant($constant)];


### PR DESCRIPTION
This classifies additional cURL transport failures without a response as network exceptions. Failures with an existing response continue to use request exceptions. Paired with guzzle/command#70.