### PR TITLE
Handle cURL multi messages without handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fix IPv6 literal matching in no-proxy rules
+- Handle cURL multi completion messages without handles after cancelled transfers
 - Fix magic client request methods such as `options()` to uppercase inferred HTTP methods
 
 

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -256,8 +256,9 @@ class CurlMultiHandler
                 continue;
             }
             if (!isset($done['handle'])) {
-                // PHP may omit the handle after a cancelled transfer on affected versions.
-                // See https://github.com/php/php-src/pull/16302.
+                // Work around a PHP issue where cancelled transfers may omit the handle.
+                // Remove this once we no longer support PHP versions before the fix in
+                // https://github.com/php/php-src/pull/16302.
                 continue;
             }
             $id = (int) $done['handle'];

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -255,6 +255,10 @@ class CurlMultiHandler
                 // if it's not done, then it would be premature to remove the handle. ref https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216
                 continue;
             }
+            if (!isset($done['handle'])) {
+                // PHP may omit the handle for a completion message after a cancelled transfer.
+                continue;
+            }
             $id = (int) $done['handle'];
             \curl_multi_remove_handle($this->_mh, $done['handle']);
 

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -256,7 +256,8 @@ class CurlMultiHandler
                 continue;
             }
             if (!isset($done['handle'])) {
-                // PHP may omit the handle for a completion message after a cancelled transfer.
+                // PHP may omit the handle after a cancelled transfer on affected versions.
+                // See https://github.com/php/php-src/pull/16302.
                 continue;
             }
             $id = (int) $done['handle'];

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -79,6 +79,58 @@ class CurlMultiHandlerTest extends TestCase
         }
     }
 
+    public function testCanCancelFromProgressCallback()
+    {
+        Server::flush();
+        Server::enqueue([
+            new Response(200, ['Content-Length' => '1048576'], \str_repeat('x', 1048576)),
+        ]);
+
+        $handler = new CurlMultiHandler(['select_timeout' => 0]);
+        $promise = null;
+        $progressCalls = 0;
+        $cancelled = false;
+
+        $promise = $handler(new Request('GET', Server::$url), [
+            'timeout' => 5,
+            'progress' => static function (
+                $downloadSize,
+                $downloaded,
+                $uploadSize,
+                $uploaded
+            ) use (&$promise, &$progressCalls, &$cancelled): void {
+                ++$progressCalls;
+
+                if (!$cancelled) {
+                    $cancelled = true;
+                    $promise->cancel();
+                }
+            },
+        ]);
+
+        try {
+            $deadline = \microtime(true) + 5;
+
+            while (P\Is::pending($promise)) {
+                if (\microtime(true) >= $deadline) {
+                    self::fail('Timed out waiting for cURL progress cancellation.');
+                }
+
+                $handler->tick();
+            }
+
+            self::assertGreaterThan(0, $progressCalls);
+            self::assertTrue($cancelled);
+            self::assertTrue(P\Is::rejected($promise));
+        } finally {
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+
+            Server::flush();
+        }
+    }
+
     public function testCannotCancelFinished()
     {
         Server::flush();


### PR DESCRIPTION
PHP can omit the handle key from a cURL multi completion message after a transfer is cancelled during a cURL callback. The multi handler already treats completed messages for untracked handles as cancelled, so this extends that defensive path to messages where PHP can no longer provide the handle at all. I added coverage for cancelling from a progress callback to keep that path from regressing.