### PR TITLE
Add persistent cURL share modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Added
 
+- Added persistent cURL share modes for handler-managed cURL sharing
 - Added the `protocols` request option to restrict allowed URI schemes for request transfers
 - Added `cert_type` and `ssl_key_type` request options for TLS certificate and private-key file types
 - Added PHP stream handler support for the `ssl_key` request option

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -340,8 +340,8 @@ $stack->remove('add_foo');
 
 By default, Guzzle does not configure cURL share handles.
 
-Use the `curl_share` client constructor option to share selected cURL cache state
-for the lifetime of Guzzle's cURL handlers:
+Use the `curl_share` client constructor option to share selected cURL cache
+state with Guzzle's built-in cURL handlers:
 
 ```php
 use GuzzleHttp\Client;
@@ -352,11 +352,22 @@ $client = new Client([
 ]);
 ```
 
-`CurlShare::HANDLER` shares cURL DNS and SSL session cache state. It does not
-share cURL connection cache state. Enabling `CurlShare::HANDLER` requires the
-PHP cURL extension with `curl_share_init()` and `curl_share_setopt()`, and a
-libcurl version supported by Guzzle's cURL handler. Pass `null` or
-`CurlShare::NONE` to disable sharing.
+`CurlShare::HANDLER` shares cURL DNS and SSL session cache state for the
+lifetime of Guzzle's cURL handlers. It does not share cURL connection cache
+state.
+
+`CurlShare::PERSISTENT_PREFER` uses PHP persistent cURL share handles when
+available. Persistent sharing shares DNS, connection, and SSL session cache
+state. When persistent cURL share handles are unavailable, it falls back to
+`CurlShare::HANDLER`.
+
+`CurlShare::PERSISTENT_REQUIRE` requires PHP persistent cURL share handles and
+fails if they are unavailable.
+
+Pass `null` or `CurlShare::NONE` to disable sharing. Guzzle does not enable
+cURL cookie sharing because cookies are managed through Guzzle middleware.
+All enabled modes require the PHP cURL extension with share-handle support and a
+libcurl version supported by Guzzle's cURL handler.
 
 When constructing cURL handlers manually, configure sharing with the handler
 `share` option:

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -340,17 +340,19 @@ $stack->remove('add_foo');
 
 By default, Guzzle does not configure cURL share handles.
 
-Use the `curl_share` client constructor option to share selected cURL cache
-state with Guzzle's built-in cURL handlers:
+Use the `curl_share` client constructor option when Guzzle creates the default
+handler:
 
 ```php
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlShare;
 
 $client = new Client([
-    'curl_share' => CurlShare::HANDLER,
+    'curl_share' => CurlShare::PERSISTENT_PREFER,
 ]);
 ```
+
+`CurlShare::NONE` disables cURL sharing. This is the default.
 
 `CurlShare::HANDLER` shares cURL DNS and SSL session cache state for the
 lifetime of Guzzle's cURL handlers. It does not share cURL connection cache
@@ -358,16 +360,22 @@ state.
 
 `CurlShare::PERSISTENT_PREFER` uses PHP persistent cURL share handles when
 available. Persistent sharing shares DNS, connection, and SSL session cache
-state. When persistent cURL share handles are unavailable, it falls back to
-`CurlShare::HANDLER`.
+state. When persistent cURL share handles are unavailable or cannot be created,
+Guzzle falls back to `CurlShare::HANDLER`. This fallback still requires normal
+cURL share support; if handler-lifetime sharing cannot be configured, Guzzle
+fails with the same error as `CurlShare::HANDLER`.
 
 `CurlShare::PERSISTENT_REQUIRE` requires PHP persistent cURL share handles and
-fails if they are unavailable.
+does not fall back to handler-lifetime sharing. If persistent sharing is
+unavailable or cannot be created, Guzzle fails while creating the handler.
 
-Pass `null` or `CurlShare::NONE` to disable sharing. Guzzle does not enable
-cURL cookie sharing because cookies are managed through Guzzle middleware.
-All enabled modes require the PHP cURL extension with share-handle support and a
-libcurl version supported by Guzzle's cURL handler.
+Guzzle chooses the shared cURL cache state for each mode. The shared data is not
+configurable. Guzzle never enables cURL cookie sharing because cookies are
+managed through Guzzle middleware.
+
+Because `CurlShare::PERSISTENT_REQUIRE` requires connection cache sharing,
+Guzzle rejects request-level cURL options or proxy tunnel cases that require a
+fresh connection for safety.
 
 When constructing cURL handlers manually, configure sharing with the handler
 `share` option:
@@ -381,10 +389,13 @@ $handler = new CurlHandler([
 ]);
 ```
 
-The `curl_share` client option can only be used when Guzzle creates the default
-handler. If you provide a custom handler, configure sharing on `CurlHandler` or
-`CurlMultiHandler` directly. Do not pass `CURLOPT_SHARE` in the `curl` request
-option. The PHP stream handler does not support cURL sharing.
+The `share` option is supported by `CurlHandler` and `CurlMultiHandler`. The
+`curl_share` client option can only be used when Guzzle creates the default
+handler. If you provide a custom handler, configure sharing on that handler
+directly.
+
+Do not pass `CURLOPT_SHARE` in the `curl` request option. The PHP stream handler
+does not support cURL sharing.
 
 ## Creating a Handler
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -56,8 +56,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *   default middleware to the handler.
      * - base_uri: (string|UriInterface) Base URI of the client that is merged
      *   into relative URIs. Can be a string or instance of UriInterface.
-     * - curl_share: (string|null) cURL share-handle configuration for the
-     *   default cURL handler. Defaults to null.
+     * - curl_share: (string|null) cURL share-handle mode for the default cURL
+     *   handler. Accepts CurlShare::NONE, CurlShare::HANDLER,
+     *   CurlShare::PERSISTENT_PREFER, or CurlShare::PERSISTENT_REQUIRE.
+     *   Defaults to null.
      * - **: any request option
      *
      * @param array $config Client configuration settings.

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -41,7 +41,7 @@ class CurlFactory implements CurlFactoryInterface
     private $closed = false;
 
     /**
-     * @var resource|\CurlShareHandle|null
+     * @var resource|\CurlShareHandle|\CurlSharePersistentHandle|null
      */
     private $shareHandle;
 
@@ -51,8 +51,8 @@ class CurlFactory implements CurlFactoryInterface
     private $shareMode;
 
     /**
-     * @param int                            $maxHandles  Maximum number of idle handles.
-     * @param resource|\CurlShareHandle|null $shareHandle
+     * @param int                                                       $maxHandles  Maximum number of idle handles.
+     * @param resource|\CurlShareHandle|\CurlSharePersistentHandle|null $shareHandle
      */
     public function __construct(int $maxHandles, string $shareMode = CurlShare::NONE, $shareHandle = null)
     {
@@ -68,7 +68,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if ($shareHandle !== null && !self::isCurlShareHandle($shareHandle)) {
-            throw new \InvalidArgumentException('A cURL share handle must be an instance of CurlShareHandle or a curl_share resource.');
+            throw new \InvalidArgumentException('A cURL share handle must be an instance of CurlShareHandle, CurlSharePersistentHandle, or a curl_share resource.');
         }
 
         $this->shareHandle = $shareHandle;
@@ -83,7 +83,12 @@ class CurlFactory implements CurlFactoryInterface
             return \is_resource($value) && \get_resource_type($value) === 'curl_share';
         }
 
-        return $value instanceof \CurlShareHandle;
+        if ($value instanceof \CurlShareHandle) {
+            return true;
+        }
+
+        return \class_exists('CurlSharePersistentHandle')
+            && $value instanceof \CurlSharePersistentHandle;
     }
 
     public function create(RequestInterface $request, array $options): EasyHandle
@@ -121,6 +126,7 @@ class CurlFactory implements CurlFactoryInterface
 
         self::rejectUnsupportedRequestOptions($options);
         $this->rejectRequestLevelShareConflict($options);
+        $this->rejectPersistentRequireConnectionReuseConflicts($options);
         self::rejectConflictingCurlOptions($options);
 
         $easy = new EasyHandle();
@@ -209,7 +215,7 @@ class CurlFactory implements CurlFactoryInterface
 
     private function rejectRequestLevelShareConflict(array $options): void
     {
-        if ($this->shareHandle === null || $this->shareMode !== CurlShare::HANDLER) {
+        if ($this->shareHandle === null) {
             return;
         }
 
@@ -223,6 +229,25 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         throw new \InvalidArgumentException('The request-level CURLOPT_SHARE cURL option cannot be combined with the "curl_share" client option or the "share" cURL handler option.');
+    }
+
+    private function rejectPersistentRequireConnectionReuseConflicts(array $options): void
+    {
+        if (
+            $this->shareMode !== CurlShare::PERSISTENT_REQUIRE
+            || !isset($options['curl'])
+            || !\is_array($options['curl'])
+        ) {
+            return;
+        }
+
+        if (!empty($options['curl'][\CURLOPT_FRESH_CONNECT])) {
+            throw new \InvalidArgumentException('The CURLOPT_FRESH_CONNECT cURL option cannot be used when persistent cURL sharing is required because it disables connection reuse.');
+        }
+
+        if (!empty($options['curl'][\CURLOPT_FORBID_REUSE])) {
+            throw new \InvalidArgumentException('The CURLOPT_FORBID_REUSE cURL option cannot be used when persistent cURL sharing is required because it disables connection reuse.');
+        }
     }
 
     /**
@@ -1216,6 +1241,10 @@ class CurlFactory implements CurlFactoryInterface
 
         $proxyForConnectionReuse = self::getEffectiveProxyForConnectionReuse($selectedProxy, $options);
         if ($proxyForConnectionReuse !== null && self::requiresFreshConnectionForAuthenticatedProxy($easy->request, $proxyForConnectionReuse, $options)) {
+            if ($this->shareMode === CurlShare::PERSISTENT_REQUIRE) {
+                throw new \InvalidArgumentException('Persistent cURL sharing is required, but this request requires a fresh proxy tunnel connection.');
+            }
+
             $conf[\CURLOPT_FRESH_CONNECT] = true;
             $conf[\CURLOPT_FORBID_REUSE] = true;
         }

--- a/src/Handler/CurlShare.php
+++ b/src/Handler/CurlShare.php
@@ -6,6 +6,8 @@ final class CurlShare
 {
     public const NONE = 'none';
     public const HANDLER = 'handler';
+    public const PERSISTENT_PREFER = 'persistent_prefer';
+    public const PERSISTENT_REQUIRE = 'persistent_require';
 
     private function __construct()
     {

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Utils;
 final class CurlShareHandleState
 {
     /**
-     * @var resource|\CurlShareHandle|null
+     * @var resource|\CurlShareHandle|\CurlSharePersistentHandle|null
      */
     public $handle;
 
@@ -20,7 +20,7 @@ final class CurlShareHandleState
     public $mode;
 
     /**
-     * @param resource|\CurlShareHandle|null $handle
+     * @param resource|\CurlShareHandle|\CurlSharePersistentHandle|null $handle
      */
     private function __construct(string $mode, $handle)
     {
@@ -42,7 +42,15 @@ final class CurlShareHandleState
             return null;
         }
 
-        return self::createHandlerShare($mode);
+        if ($mode === CurlShare::HANDLER) {
+            return self::createHandlerShare($mode);
+        }
+
+        if ($mode === CurlShare::PERSISTENT_PREFER) {
+            return self::createPersistentShareOrFallback();
+        }
+
+        return self::createPersistentShare($mode);
     }
 
     /**
@@ -58,12 +66,16 @@ final class CurlShareHandleState
             return CurlShare::NONE;
         }
 
-        if ($share === CurlShare::HANDLER) {
-            return CurlShare::HANDLER;
+        if (
+            $share === CurlShare::HANDLER
+            || $share === CurlShare::PERSISTENT_PREFER
+            || $share === CurlShare::PERSISTENT_REQUIRE
+        ) {
+            return $share;
         }
 
         throw new \InvalidArgumentException(\sprintf(
-            'The "%s" option must be null, GuzzleHttp\\Handler\\CurlShare::NONE, or GuzzleHttp\\Handler\\CurlShare::HANDLER; received %s.',
+            'The "%s" option must be null or a GuzzleHttp\\Handler\\CurlShare::* constant; received %s.',
             $option,
             Utils::describeType($share)
         ));
@@ -121,6 +133,49 @@ final class CurlShareHandleState
         return new self($mode, $handle);
     }
 
+    private static function createPersistentShareOrFallback(): self
+    {
+        if (!self::supportsPersistentShare()) {
+            return self::createHandlerShare(CurlShare::HANDLER);
+        }
+
+        try {
+            return self::createPersistentShare(CurlShare::PERSISTENT_PREFER);
+        } catch (\Throwable $e) {
+            return self::createHandlerShare(CurlShare::HANDLER);
+        }
+    }
+
+    private static function createPersistentShare(string $mode): self
+    {
+        if (!self::supportsPersistentShare()) {
+            throw new \InvalidArgumentException('The cURL handler option "share" requires persistent cURL share handle support.');
+        }
+
+        self::requireCurlConstant('CURLOPT_SHARE');
+
+        try {
+            $handle = curl_share_init_persistent(self::persistentLocks());
+        } catch (\Throwable $e) {
+            throw new \InvalidArgumentException(
+                'Unable to create persistent cURL share handle: '.$e->getMessage(),
+                0,
+                $e
+            );
+        }
+
+        return new self($mode, $handle);
+    }
+
+    private static function supportsPersistentShare(): bool
+    {
+        return \function_exists('curl_share_init_persistent')
+            && \class_exists('CurlSharePersistentHandle')
+            && \defined('CURL_LOCK_DATA_DNS')
+            && \defined('CURL_LOCK_DATA_CONNECT')
+            && \defined('CURL_LOCK_DATA_SSL_SESSION');
+    }
+
     /**
      * @return int[]
      */
@@ -128,6 +183,18 @@ final class CurlShareHandleState
     {
         return [
             self::requireCurlConstant('CURL_LOCK_DATA_DNS'),
+            self::requireCurlConstant('CURL_LOCK_DATA_SSL_SESSION'),
+        ];
+    }
+
+    /**
+     * @return int[]
+     */
+    private static function persistentLocks(): array
+    {
+        return [
+            self::requireCurlConstant('CURL_LOCK_DATA_DNS'),
+            self::requireCurlConstant('CURL_LOCK_DATA_CONNECT'),
             self::requireCurlConstant('CURL_LOCK_DATA_SSL_SESSION'),
         ];
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -191,15 +191,73 @@ class ClientTest extends TestCase
         }
     }
 
-    public function testCurlShareCannotBeUsedWithCustomHandler(): void
+    public function testCurlSharePersistentPreferCreatesDefaultShareHandle(): void
+    {
+        self::skipIfDefaultCurlHandlerIsUnavailable();
+
+        $_SERVER['curl_test'] = true;
+        unset(
+            $_SERVER['_curl_share'],
+            $_SERVER['_curl_share_init_count'],
+            $_SERVER['_curl_share_init_persistent_count'],
+            $_SERVER['_curl_share_persistent_options']
+        );
+
+        try {
+            new Client([
+                'curl_share' => CurlShare::PERSISTENT_PREFER,
+            ]);
+
+            self::assertPersistentPreferShareWasCreated();
+        } finally {
+            unset(
+                $_SERVER['curl_test'],
+                $_SERVER['_curl_share'],
+                $_SERVER['_curl_share_init_count'],
+                $_SERVER['_curl_share_init_persistent_count'],
+                $_SERVER['_curl_share_persistent_options']
+            );
+        }
+    }
+
+    public function testCurlSharePersistentRequireFailsWhenPersistentSharingIsUnavailable(): void
+    {
+        self::skipIfDefaultCurlHandlerIsUnavailable();
+
+        if (\function_exists('curl_share_init_persistent')) {
+            $_SERVER['curl_share_init_persistent_fail'] = true;
+        }
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+
+            new Client([
+                'curl_share' => CurlShare::PERSISTENT_REQUIRE,
+            ]);
+        } finally {
+            unset($_SERVER['curl_share_init_persistent_fail']);
+        }
+    }
+
+    /**
+     * @dataProvider enabledShareModeProvider
+     */
+    public function testCurlShareCannotBeUsedWithCustomHandler(string $shareMode): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('curl_share');
 
         new Client([
             'handler' => new MockHandler(),
-            'curl_share' => CurlShare::HANDLER,
+            'curl_share' => $shareMode,
         ]);
+    }
+
+    public static function enabledShareModeProvider(): iterable
+    {
+        yield 'handler' => [CurlShare::HANDLER];
+        yield 'persistent prefer' => [CurlShare::PERSISTENT_PREFER];
+        yield 'persistent require' => [CurlShare::PERSISTENT_REQUIRE];
     }
 
     public function testCurlShareNullCanBeUsedWithCustomHandler(): void
@@ -1008,11 +1066,38 @@ class ClientTest extends TestCase
     {
         if (
             !\function_exists('curl_share_init')
+            || !\function_exists('curl_share_setopt')
             || !\function_exists('curl_exec')
             || !CurlVersion::supportsTls12()
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }
+    }
+
+    private static function assertPersistentPreferShareWasCreated(): void
+    {
+        if (
+            \function_exists('curl_share_init_persistent')
+            && \class_exists('CurlSharePersistentHandle')
+            && \defined('CURL_LOCK_DATA_DNS')
+            && \defined('CURL_LOCK_DATA_CONNECT')
+            && \defined('CURL_LOCK_DATA_SSL_SESSION')
+        ) {
+            self::assertSame(1, $_SERVER['_curl_share_init_persistent_count']);
+            self::assertSame([
+                \CURL_LOCK_DATA_DNS,
+                \CURL_LOCK_DATA_CONNECT,
+                \CURL_LOCK_DATA_SSL_SESSION,
+            ], $_SERVER['_curl_share_persistent_options']);
+
+            return;
+        }
+
+        self::assertSame(1, $_SERVER['_curl_share_init_count']);
+        self::assertSame([
+            \CURL_LOCK_DATA_DNS,
+            \CURL_LOCK_DATA_SSL_SESSION,
+        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
     }
 
     public function testDoesNotOverwriteHeaderWithDefaultInRequest(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -211,7 +211,10 @@ class CurlFactoryTest extends TestCase
         }
     }
 
-    public function testRejectsRequestLevelShareWhenConfiguredCurlShareHandleExists(): void
+    /**
+     * @dataProvider enabledShareModeProvider
+     */
+    public function testRejectsRequestLevelShareWhenConfiguredCurlShareHandleExists(string $shareMode): void
     {
         self::skipIfCurlShareIsUnavailable();
 
@@ -219,7 +222,7 @@ class CurlFactoryTest extends TestCase
         $requestShareHandle = \curl_share_init();
         self::assertNotFalse($shareHandle);
         self::assertNotFalse($requestShareHandle);
-        $factory = new CurlFactory(3, CurlShare::HANDLER, $shareHandle);
+        $factory = new CurlFactory(3, $shareMode, $shareHandle);
 
         try {
             $this->expectException(\InvalidArgumentException::class);
@@ -236,6 +239,13 @@ class CurlFactoryTest extends TestCase
                 \curl_share_close($requestShareHandle);
             }
         }
+    }
+
+    public static function enabledShareModeProvider(): iterable
+    {
+        yield 'handler' => [CurlShare::HANDLER];
+        yield 'persistent prefer' => [CurlShare::PERSISTENT_PREFER];
+        yield 'persistent require' => [CurlShare::PERSISTENT_REQUIRE];
     }
 
     public function testRejectsEnabledShareModeWithoutShareHandle(): void
@@ -271,6 +281,97 @@ class CurlFactoryTest extends TestCase
         $this->expectExceptionMessage('cURL share handle');
 
         new CurlFactory(3, CurlShare::HANDLER, false);
+    }
+
+    public function testPersistentRequireRejectsFreshConnect(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, CurlShare::PERSISTENT_REQUIRE, $shareHandle);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('CURLOPT_FRESH_CONNECT');
+
+            $factory->create(new Psr7\Request('GET', 'https://example.com'), [
+                'curl' => [
+                    \CURLOPT_FRESH_CONNECT => true,
+                ],
+            ]);
+        } finally {
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
+    }
+
+    public function testPersistentRequireRejectsForbidReuse(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, CurlShare::PERSISTENT_REQUIRE, $shareHandle);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('CURLOPT_FORBID_REUSE');
+
+            $factory->create(new Psr7\Request('GET', 'https://example.com'), [
+                'curl' => [
+                    \CURLOPT_FORBID_REUSE => true,
+                ],
+            ]);
+        } finally {
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
+    }
+
+    public function testPersistentRequireAllowsExplicitReuseOptionsSetToFalse(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, CurlShare::PERSISTENT_REQUIRE, $shareHandle);
+        $easy = $factory->create(new Psr7\Request('GET', 'https://example.com'), [
+            'curl' => [
+                \CURLOPT_FRESH_CONNECT => false,
+                \CURLOPT_FORBID_REUSE => false,
+            ],
+        ]);
+
+        try {
+            self::assertFalse($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+            self::assertFalse($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        } finally {
+            $factory->release($easy);
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
+    }
+
+    public function testPersistentRequireRejectsRequestsThatRequireFreshProxyTunnelConnections(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $proxyHeaderOption = self::proxyHeaderOption();
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, CurlShare::PERSISTENT_REQUIRE, $shareHandle);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('fresh proxy tunnel connection');
+
+            $factory->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => 'http://proxy.example.com:8080',
+                'curl' => [
+                    $proxyHeaderOption => ['Proxy-Authorization: Basic abc'],
+                ],
+            ]);
+        } finally {
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
     }
 
     public function testCloseReleasesConfiguredCurlShareHandle(): void
@@ -2824,8 +2925,22 @@ class CurlFactoryTest extends TestCase
 
     private static function skipIfCurlShareIsUnavailable(): void
     {
-        if (!\function_exists('curl_share_init') || !\defined('CURLOPT_SHARE')) {
+        if (
+            !\function_exists('curl_share_init')
+            || !\function_exists('curl_share_setopt')
+            || !\defined('CURLOPT_SHARE')
+        ) {
             self::markTestSkipped('cURL share handles are unavailable.');
+        }
+    }
+
+    /**
+     * @param resource|\CurlShareHandle $shareHandle
+     */
+    private static function closeShareHandleOnPhp7($shareHandle): void
+    {
+        if (PHP_VERSION_ID < 80000 && \is_resource($shareHandle)) {
+            \curl_share_close($shareHandle);
         }
     }
 }

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -157,15 +157,61 @@ class CurlHandlerTest extends TestCase
         }
     }
 
-    public function testShareOptionCannotBeUsedWithCustomFactory(): void
+    public function testPersistentPreferShareOptionAppliesCurlShare(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $_SERVER['curl_test'] = true;
+        unset(
+            $_SERVER['_curl'],
+            $_SERVER['_curl_share'],
+            $_SERVER['_curl_share_init_count'],
+            $_SERVER['_curl_share_init_persistent_count'],
+            $_SERVER['_curl_share_persistent_options']
+        );
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
+        try {
+            $handler = new CurlHandler([
+                'share' => CurlShare::PERSISTENT_PREFER,
+            ]);
+
+            $handler(new Request('GET', Server::$url), [])->wait();
+
+            self::assertArrayHasKey(\CURLOPT_SHARE, $_SERVER['_curl']);
+            self::assertPersistentPreferShareWasCreated();
+        } finally {
+            unset(
+                $_SERVER['curl_test'],
+                $_SERVER['_curl'],
+                $_SERVER['_curl_share'],
+                $_SERVER['_curl_share_init_count'],
+                $_SERVER['_curl_share_init_persistent_count'],
+                $_SERVER['_curl_share_persistent_options']
+            );
+        }
+    }
+
+    /**
+     * @dataProvider enabledShareModeProvider
+     */
+    public function testShareOptionCannotBeUsedWithCustomFactory(string $shareMode): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('handle_factory');
 
         new CurlHandler([
             'handle_factory' => new CurlFactory(0),
-            'share' => CurlShare::HANDLER,
+            'share' => $shareMode,
         ]);
+    }
+
+    public static function enabledShareModeProvider(): iterable
+    {
+        yield 'handler' => [CurlShare::HANDLER];
+        yield 'persistent prefer' => [CurlShare::PERSISTENT_PREFER];
+        yield 'persistent require' => [CurlShare::PERSISTENT_REQUIRE];
     }
 
     public function testDisabledShareOptionCanBeUsedWithCustomFactory(): void
@@ -234,8 +280,38 @@ class CurlHandlerTest extends TestCase
 
     private static function skipIfCurlShareIsUnavailable(): void
     {
-        if (!\function_exists('curl_share_init') || !\defined('CURLOPT_SHARE')) {
+        if (
+            !\function_exists('curl_share_init')
+            || !\function_exists('curl_share_setopt')
+            || !\defined('CURLOPT_SHARE')
+        ) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    private static function assertPersistentPreferShareWasCreated(): void
+    {
+        if (
+            \function_exists('curl_share_init_persistent')
+            && \class_exists('CurlSharePersistentHandle')
+            && \defined('CURL_LOCK_DATA_DNS')
+            && \defined('CURL_LOCK_DATA_CONNECT')
+            && \defined('CURL_LOCK_DATA_SSL_SESSION')
+        ) {
+            self::assertSame(1, $_SERVER['_curl_share_init_persistent_count']);
+            self::assertSame([
+                \CURL_LOCK_DATA_DNS,
+                \CURL_LOCK_DATA_CONNECT,
+                \CURL_LOCK_DATA_SSL_SESSION,
+            ], $_SERVER['_curl_share_persistent_options']);
+
+            return;
+        }
+
+        self::assertSame(1, $_SERVER['_curl_share_init_count']);
+        self::assertSame([
+            \CURL_LOCK_DATA_DNS,
+            \CURL_LOCK_DATA_SSL_SESSION,
+        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
     }
 }

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -22,12 +22,27 @@ class CurlMultiHandlerTest extends TestCase
     public function setUp(): void
     {
         $_SERVER['curl_test'] = true;
-        unset($_SERVER['_curl'], $_SERVER['_curl_multi'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
+        unset(
+            $_SERVER['_curl'],
+            $_SERVER['_curl_multi'],
+            $_SERVER['_curl_share'],
+            $_SERVER['_curl_share_init_count'],
+            $_SERVER['_curl_share_init_persistent_count'],
+            $_SERVER['_curl_share_persistent_options']
+        );
     }
 
     public function tearDown(): void
     {
-        unset($_SERVER['_curl'], $_SERVER['_curl_multi'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count'], $_SERVER['curl_test']);
+        unset(
+            $_SERVER['_curl'],
+            $_SERVER['_curl_multi'],
+            $_SERVER['_curl_share'],
+            $_SERVER['_curl_share_init_count'],
+            $_SERVER['_curl_share_init_persistent_count'],
+            $_SERVER['_curl_share_persistent_options'],
+            $_SERVER['curl_test']
+        );
     }
 
     public function testCanAddCustomCurlOptions(): void
@@ -87,15 +102,42 @@ class CurlMultiHandlerTest extends TestCase
         ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
     }
 
-    public function testShareOptionCannotBeUsedWithCustomFactory(): void
+    public function testPersistentPreferShareOptionAppliesCurlShare(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
+        $handler = new CurlMultiHandler([
+            'share' => CurlShare::PERSISTENT_PREFER,
+        ]);
+
+        $handler(new Request('GET', Server::$url), [])->wait();
+
+        self::assertArrayHasKey(\CURLOPT_SHARE, $_SERVER['_curl']);
+        self::assertPersistentPreferShareWasCreated();
+    }
+
+    /**
+     * @dataProvider enabledShareModeProvider
+     */
+    public function testShareOptionCannotBeUsedWithCustomFactory(string $shareMode): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('handle_factory');
 
         new CurlMultiHandler([
             'handle_factory' => new CurlFactory(0),
-            'share' => CurlShare::HANDLER,
+            'share' => $shareMode,
         ]);
+    }
+
+    public static function enabledShareModeProvider(): iterable
+    {
+        yield 'handler' => [CurlShare::HANDLER];
+        yield 'persistent prefer' => [CurlShare::PERSISTENT_PREFER];
+        yield 'persistent require' => [CurlShare::PERSISTENT_REQUIRE];
     }
 
     public function testDisabledShareOptionCanBeUsedWithCustomFactory(): void
@@ -705,8 +747,38 @@ class CurlMultiHandlerTest extends TestCase
 
     private static function skipIfCurlShareIsUnavailable(): void
     {
-        if (!\function_exists('curl_share_init') || !\defined('CURLOPT_SHARE')) {
+        if (
+            !\function_exists('curl_share_init')
+            || !\function_exists('curl_share_setopt')
+            || !\defined('CURLOPT_SHARE')
+        ) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    private static function assertPersistentPreferShareWasCreated(): void
+    {
+        if (
+            \function_exists('curl_share_init_persistent')
+            && \class_exists('CurlSharePersistentHandle')
+            && \defined('CURL_LOCK_DATA_DNS')
+            && \defined('CURL_LOCK_DATA_CONNECT')
+            && \defined('CURL_LOCK_DATA_SSL_SESSION')
+        ) {
+            self::assertSame(1, $_SERVER['_curl_share_init_persistent_count']);
+            self::assertSame([
+                \CURL_LOCK_DATA_DNS,
+                \CURL_LOCK_DATA_CONNECT,
+                \CURL_LOCK_DATA_SSL_SESSION,
+            ], $_SERVER['_curl_share_persistent_options']);
+
+            return;
+        }
+
+        self::assertSame(1, $_SERVER['_curl_share_init_count']);
+        self::assertSame([
+            \CURL_LOCK_DATA_DNS,
+            \CURL_LOCK_DATA_SSL_SESSION,
+        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
     }
 }

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -20,7 +20,10 @@ class CurlShareHandleStateTest extends TestCase
             $_SERVER['_curl_share'],
             $_SERVER['_curl_share_init_count'],
             $_SERVER['_curl_share_close_count'],
-            $_SERVER['curl_share_setopt_fail']
+            $_SERVER['_curl_share_init_persistent_count'],
+            $_SERVER['_curl_share_persistent_options'],
+            $_SERVER['curl_share_setopt_fail'],
+            $_SERVER['curl_share_init_persistent_fail']
         );
     }
 
@@ -31,7 +34,10 @@ class CurlShareHandleStateTest extends TestCase
             $_SERVER['_curl_share'],
             $_SERVER['_curl_share_init_count'],
             $_SERVER['_curl_share_close_count'],
-            $_SERVER['curl_share_setopt_fail']
+            $_SERVER['_curl_share_init_persistent_count'],
+            $_SERVER['_curl_share_persistent_options'],
+            $_SERVER['curl_share_setopt_fail'],
+            $_SERVER['curl_share_init_persistent_fail']
         );
     }
 
@@ -64,6 +70,83 @@ class CurlShareHandleStateTest extends TestCase
         }
     }
 
+    public function testPersistentPreferFallsBackToHandlerSharingWhenPersistentSharingIsUnavailable(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        if (self::persistentCurlShareIsAvailable()) {
+            $_SERVER['curl_share_init_persistent_fail'] = true;
+        }
+
+        $state = CurlShareHandleState::fromOption(CurlShare::PERSISTENT_PREFER);
+
+        self::assertInstanceOf(CurlShareHandleState::class, $state);
+        self::assertSame(CurlShare::HANDLER, $state->mode);
+        self::assertHandlerShareWasCreated();
+    }
+
+    public function testPersistentPreferStillFailsWhenHandlerSharingFallbackFails(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        if (self::persistentCurlShareIsAvailable()) {
+            $_SERVER['curl_share_init_persistent_fail'] = true;
+        }
+        $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to configure cURL share handle');
+
+        CurlShareHandleState::fromOption(CurlShare::PERSISTENT_PREFER);
+    }
+
+    public function testPersistentPreferUsesPersistentSharingWhenAvailable(): void
+    {
+        self::skipIfPersistentCurlShareIsUnavailable();
+
+        $state = CurlShareHandleState::fromOption(CurlShare::PERSISTENT_PREFER);
+
+        self::assertInstanceOf(CurlShareHandleState::class, $state);
+        self::assertSame(CurlShare::PERSISTENT_PREFER, $state->mode);
+        self::assertPersistentShareWasCreated();
+        self::assertArrayNotHasKey('_curl_share_init_count', $_SERVER);
+    }
+
+    public function testPersistentRequireRejectsWhenPersistentSharingIsUnavailable(): void
+    {
+        if (\function_exists('curl_share_init_persistent') && \class_exists('CurlSharePersistentHandle')) {
+            self::markTestSkipped('Persistent cURL share handles are available.');
+        }
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('persistent cURL share handle support');
+
+        CurlShareHandleState::fromOption(CurlShare::PERSISTENT_REQUIRE);
+    }
+
+    public function testPersistentRequireRejectsWhenPersistentInitializationFails(): void
+    {
+        self::skipIfPersistentCurlShareIsUnavailable();
+
+        $_SERVER['curl_share_init_persistent_fail'] = true;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to create persistent cURL share handle');
+
+        CurlShareHandleState::fromOption(CurlShare::PERSISTENT_REQUIRE);
+    }
+
+    public function testPersistentRequireUsesPersistentSharingWhenAvailable(): void
+    {
+        self::skipIfPersistentCurlShareIsUnavailable();
+
+        $state = CurlShareHandleState::fromOption(CurlShare::PERSISTENT_REQUIRE);
+
+        self::assertInstanceOf(CurlShareHandleState::class, $state);
+        self::assertSame(CurlShare::PERSISTENT_REQUIRE, $state->mode);
+        self::assertPersistentShareWasCreated();
+    }
+
     /**
      * @dataProvider invalidShareOptions
      *
@@ -84,15 +167,25 @@ class CurlShareHandleStateTest extends TestCase
         yield 'string' => ['dns'];
     }
 
-    public function testRejectsShareWithCustomFactory(): void
+    /**
+     * @dataProvider enabledShareModes
+     */
+    public function testRejectsShareWithCustomFactory(string $shareMode): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('handle_factory');
 
         CurlShareHandleState::assertNoCustomFactoryConflict([
             'handle_factory' => new CurlFactory(0),
-            'share' => CurlShare::HANDLER,
+            'share' => $shareMode,
         ], 'CurlHandler');
+    }
+
+    public static function enabledShareModes(): iterable
+    {
+        yield 'handler' => [CurlShare::HANDLER];
+        yield 'persistent prefer' => [CurlShare::PERSISTENT_PREFER];
+        yield 'persistent require' => [CurlShare::PERSISTENT_REQUIRE];
     }
 
     public function testAllowsDisabledShareWithCustomFactory(): void
@@ -122,5 +215,40 @@ class CurlShareHandleStateTest extends TestCase
         if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    private static function skipIfPersistentCurlShareIsUnavailable(): void
+    {
+        if (!self::persistentCurlShareIsAvailable()) {
+            self::markTestSkipped('Persistent cURL share handles are unavailable.');
+        }
+    }
+
+    private static function persistentCurlShareIsAvailable(): bool
+    {
+        return \function_exists('curl_share_init_persistent')
+            && \class_exists('CurlSharePersistentHandle')
+            && \defined('CURL_LOCK_DATA_DNS')
+            && \defined('CURL_LOCK_DATA_CONNECT')
+            && \defined('CURL_LOCK_DATA_SSL_SESSION');
+    }
+
+    private static function assertHandlerShareWasCreated(): void
+    {
+        self::assertSame(1, $_SERVER['_curl_share_init_count']);
+        self::assertSame([
+            \CURL_LOCK_DATA_DNS,
+            \CURL_LOCK_DATA_SSL_SESSION,
+        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+    }
+
+    private static function assertPersistentShareWasCreated(): void
+    {
+        self::assertSame(1, $_SERVER['_curl_share_init_persistent_count']);
+        self::assertSame([
+            \CURL_LOCK_DATA_DNS,
+            \CURL_LOCK_DATA_CONNECT,
+            \CURL_LOCK_DATA_SSL_SESSION,
+        ], $_SERVER['_curl_share_persistent_options']);
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -108,6 +108,22 @@ class UtilsTest extends TestCase
         }
     }
 
+    public function testChooseHandlerAcceptsPersistentPreferCurlShareOption(): void
+    {
+        self::skipIfDefaultCurlHandlerIsUnavailable();
+
+        $_SERVER['curl_test'] = true;
+        unset($_SERVER['_curl_share_init_count'], $_SERVER['_curl_share_init_persistent_count']);
+
+        try {
+            $handler = Utils::chooseHandler(['share' => CurlShare::PERSISTENT_PREFER]);
+
+            self::assertIsCallable($handler);
+        } finally {
+            unset($_SERVER['curl_test'], $_SERVER['_curl_share_init_count'], $_SERVER['_curl_share_init_persistent_count']);
+        }
+    }
+
     public function testChooseHandlerAcceptsDisabledCurlShareOption(): void
     {
         $_SERVER['curl_test'] = true;
@@ -373,6 +389,7 @@ class UtilsTest extends TestCase
     {
         if (
             !\function_exists('curl_share_init')
+            || !\function_exists('curl_share_setopt')
             || !\function_exists('curl_exec')
             || !CurlVersion::supportsTls12()
         ) {

--- a/tests/bootstrap-phpstan.php
+++ b/tests/bootstrap-phpstan.php
@@ -15,3 +15,16 @@ if (!\class_exists('CurlShareHandle')) {
     {
     }
 }
+
+if (!\class_exists('CurlSharePersistentHandle')) {
+    class CurlSharePersistentHandle
+    {
+    }
+}
+
+if (!\function_exists('curl_share_init_persistent')) {
+    function curl_share_init_persistent(array $share_options): CurlSharePersistentHandle
+    {
+        return new CurlSharePersistentHandle();
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -96,4 +96,21 @@ namespace GuzzleHttp\Handler {
 
         \curl_share_close($handle);
     }
+
+    if (\function_exists('curl_share_init_persistent')) {
+        function curl_share_init_persistent(array $share_options)
+        {
+            if (!empty($_SERVER['curl_test'])) {
+                $count = $_SERVER['_curl_share_init_persistent_count'] ?? 0;
+                $_SERVER['_curl_share_init_persistent_count'] = $count + 1;
+                $_SERVER['_curl_share_persistent_options'] = $share_options;
+            }
+
+            if (!empty($_SERVER['curl_share_init_persistent_fail'])) {
+                throw new \ValueError('curl_share_init_persistent failed');
+            }
+
+            return \curl_share_init_persistent($share_options);
+        }
+    }
 }


### PR DESCRIPTION
This expands the handler-managed cURL sharing modes introduced for 7.11. Guzzle 8 keeps the existing NONE and HANDLER modes, adds PERSISTENT_PREFER for opportunistic persistent sharing with fallback to handler-lifetime sharing, and adds PERSISTENT_REQUIRE for applications that require persistent cURL share handles. Persistent sharing uses Guzzle-managed DNS, connection, and SSL session sharing when PHP exposes persistent cURL share handles, while cookie sharing remains unsupported because Guzzle manages cookies through middleware.