### PR TITLE
Deprecate request-level cURL share handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Deprecated
 
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
+- Deprecated passing `CURLOPT_SHARE` through the `curl` request option, which will be rejected in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -69,6 +69,14 @@ class CurlFactory implements CurlFactoryInterface
             unset($options['curl']['body_as_string']);
         }
 
+        if (
+            isset($options['curl'])
+            && \is_array($options['curl'])
+            && \array_key_exists(\CURLOPT_SHARE, $options['curl'])
+        ) {
+            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing CURLOPT_SHARE in the "curl" request option is deprecated; guzzlehttp/guzzle 8.0 will reject request-level CURLOPT_SHARE because pooled easy handles can retain share state.');
+        }
+
         $easy = new EasyHandle();
         $easy->request = $request;
         $easy->options = $options;


### PR DESCRIPTION
This deprecates passing CURLOPT_SHARE through the raw curl request option. Guzzle 8 rejects that option because pooled easy handles can retain share state, so 7.11 now warns users before the behavior changes.