### PR TITLE
Remove cURL share deprecation trigger from 8.0

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -81,14 +81,6 @@ class CurlFactory implements CurlFactoryInterface
             unset($options['curl']['body_as_string']);
         }
 
-        if (
-            isset($options['curl'])
-            && \is_array($options['curl'])
-            && \array_key_exists(\CURLOPT_SHARE, $options['curl'])
-        ) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing CURLOPT_SHARE in the "curl" request option is deprecated; guzzlehttp/guzzle 8.0 will reject request-level CURLOPT_SHARE because pooled easy handles can retain share state.');
-        }
-
         $easy = new EasyHandle();
         $easy->request = $request;
         $easy->options = $options;


### PR DESCRIPTION
This removes the 7.11 deprecation trigger for request-level CURLOPT_SHARE from the 8.0 branch. The deprecation belongs on 7.11 as an upgrade warning, while 8.0 should not keep that compatibility shim after it is merged forward.

The actual 8.0 rejection for request-level CURLOPT_SHARE remains part of the cURL share-handle work, where the handler-owned share option is introduced and pooled easy handles are protected from caller-supplied share state.