### PR TITLE
Defer cURL multi cancellation cleanup during callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.10.5 - Upcoming
+
+### Fixed
+
+- Defer cURL multi cancellation cleanup until after progress callbacks return.
+
+
 ## 7.10.4 - 2025-05-22
 
 ### Fixed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -175,6 +175,12 @@ parameters:
 			path: src/Handler/CurlMultiHandler.php
 
 		-
+			message: '#^Parameter \#1 \$ch of function curl_close expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_add_handle expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 2
@@ -208,6 +214,12 @@ parameters:
 			message: '#^Parameter \#1 \$mh of function curl_multi_select expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 3
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: '#^Parameter \#2 \$ch of function curl_multi_remove_handle expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -58,6 +58,16 @@ class CurlMultiHandler
     private $_mh;
 
     /**
+     * @var bool
+     */
+    private $executingMulti = false;
+
+    /**
+     * @var array<int, EasyHandle>
+     */
+    private $deferredCancels = [];
+
+    /**
      * This handler accepts the following options:
      *
      * - handle_factory: An optional factory  used to create curl handles
@@ -172,10 +182,21 @@ class CurlMultiHandler
             \usleep(250);
         }
 
-        while (\curl_multi_exec($this->_mh, $this->active) === \CURLM_CALL_MULTI_PERFORM) {
+        do {
+            $this->executingMulti = true;
+
+            try {
+                $exec = \curl_multi_exec($this->_mh, $this->active);
+            } finally {
+                $this->executingMulti = false;
+                $this->cleanupDeferredCancels();
+            }
+
             // Prevent busy looping for slow HTTP requests.
-            \curl_multi_select($this->_mh, $this->selectTimeout);
-        }
+            if ($exec === \CURLM_CALL_MULTI_PERFORM) {
+                \curl_multi_select($this->_mh, $this->selectTimeout);
+            }
+        } while ($exec === \CURLM_CALL_MULTI_PERFORM);
 
         $this->processMessages();
     }
@@ -185,7 +206,16 @@ class CurlMultiHandler
      */
     private function tickInQueue(): void
     {
-        if (\curl_multi_exec($this->_mh, $this->active) === \CURLM_CALL_MULTI_PERFORM) {
+        $this->executingMulti = true;
+
+        try {
+            $exec = \curl_multi_exec($this->_mh, $this->active);
+        } finally {
+            $this->executingMulti = false;
+            $this->cleanupDeferredCancels();
+        }
+
+        if ($exec === \CURLM_CALL_MULTI_PERFORM) {
             \curl_multi_select($this->_mh, 0);
             P\Utils::queue()->add(Closure::fromCallable([$this, 'tickInQueue']));
         }
@@ -237,15 +267,42 @@ class CurlMultiHandler
             return false;
         }
 
-        $handle = $this->handles[$id]['easy']->handle;
+        $easy = $this->handles[$id]['easy'];
         unset($this->delays[$id], $this->handles[$id]);
+
+        if ($this->executingMulti) {
+            $this->deferredCancels[$id] = $easy;
+
+            return true;
+        }
+
+        $this->cleanupCancelledHandle($easy);
+
+        return true;
+    }
+
+    private function cleanupDeferredCancels(): void
+    {
+        if ($this->deferredCancels === []) {
+            return;
+        }
+
+        $entries = $this->deferredCancels;
+        $this->deferredCancels = [];
+
+        foreach ($entries as $easy) {
+            $this->cleanupCancelledHandle($easy);
+        }
+    }
+
+    private function cleanupCancelledHandle(EasyHandle $easy): void
+    {
+        $handle = $easy->handle;
         \curl_multi_remove_handle($this->_mh, $handle);
 
         if (PHP_VERSION_ID < 80000) {
             \curl_close($handle);
         }
-
-        return true;
     }
 
     private function processMessages(): void


### PR DESCRIPTION
This defers native cURL cleanup when a CurlMultiHandler transfer is cancelled from inside a PHP callback invoked by curl_multi_exec. Cancelling from a progress callback previously removed and, on PHP 7, closed the easy handle before libcurl had unwound from the callback, which could intermittently leave PHP/libcurl with an invalid callback state.

The normal cancellation behavior is otherwise unchanged. The same cURL multi remove and PHP 7 close cleanup still run, but they now run immediately after curl_multi_exec returns instead of while the callback is still on the stack.