### PR TITLE
Defer cURL multi close cleanup during callbacks

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -117,7 +117,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_exec expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -85,6 +85,16 @@ class CurlMultiHandler
     private $deferredCancels = [];
 
     /**
+     * @var bool
+     */
+    private $deferredClose = false;
+
+    /**
+     * @var bool
+     */
+    private $deferredCloseExplicit = false;
+
+    /**
      * This handler accepts the following options:
      *
      * - handle_factory: An optional factory  used to create curl handles
@@ -214,13 +224,10 @@ class CurlMultiHandler
         }
 
         do {
-            $this->executingMulti = true;
+            $exec = $this->executeMulti();
 
-            try {
-                $exec = \curl_multi_exec($this->_mh, $this->active);
-            } finally {
-                $this->executingMulti = false;
-                $this->cleanupDeferredCancels();
+            if ($this->closed || $this->closing || !$this->hasMultiHandle()) {
+                return;
             }
 
             // Prevent busy looping for slow HTTP requests.
@@ -241,13 +248,10 @@ class CurlMultiHandler
             return;
         }
 
-        $this->executingMulti = true;
+        $exec = $this->executeMulti();
 
-        try {
-            $exec = \curl_multi_exec($this->_mh, $this->active);
-        } finally {
-            $this->executingMulti = false;
-            $this->cleanupDeferredCancels();
+        if ($this->closed || $this->closing || !$this->hasMultiHandle()) {
+            return;
         }
 
         if ($exec === \CURLM_CALL_MULTI_PERFORM) {
@@ -301,21 +305,64 @@ class CurlMultiHandler
         $this->closing = true;
         $failure = null;
 
+        if ($this->executingMulti) {
+            $this->deferClose($explicit, $failure);
+
+            if ($explicit && $failure !== null) {
+                throw $failure;
+            }
+
+            return;
+        }
+
         try {
             $this->cleanupPendingTransfers($explicit, $failure);
             $this->closeMultiHandle($failure);
             $this->closeOwnedFactory($failure);
         } finally {
-            $this->handles = [];
-            $this->delays = [];
-            $this->active = 0;
-            $this->closed = true;
-            $this->closing = false;
+            $this->finishClose();
         }
 
         if ($explicit && $failure !== null) {
             throw $failure;
         }
+    }
+
+    private function deferClose(bool $explicit, ?\Throwable &$failure): void
+    {
+        $this->deferredClose = true;
+        $this->deferredCloseExplicit = $this->deferredCloseExplicit || $explicit;
+
+        $entries = $this->handles;
+        $delays = $this->delays;
+
+        $this->handles = [];
+        $this->delays = [];
+
+        foreach ($entries as $id => $entry) {
+            $this->deferredCancels[$id] = [
+                'easy' => $entry['easy'],
+                'attached' => !isset($delays[$id]),
+            ];
+
+            if ($explicit) {
+                $this->captureFailure($failure, function () use ($entry): void {
+                    $entry['deferred']->reject(new HandlerClosedException('The cURL multi handler was closed before the transfer completed.'));
+                });
+            }
+        }
+    }
+
+    private function finishClose(): void
+    {
+        $this->handles = [];
+        $this->delays = [];
+        $this->deferredCancels = [];
+        $this->active = 0;
+        $this->deferredClose = false;
+        $this->deferredCloseExplicit = false;
+        $this->closed = true;
+        $this->closing = false;
     }
 
     private function captureFailure(?\Throwable &$failure, callable $callback): void
@@ -384,6 +431,39 @@ class CurlMultiHandler
         $this->captureFailure($failure, static function () use ($factory): void {
             $factory->close();
         });
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    private function executeMulti(): int
+    {
+        $this->executingMulti = true;
+        $failure = null;
+
+        try {
+            return \curl_multi_exec($this->_mh, $this->active);
+        } finally {
+            $this->executingMulti = false;
+            $this->cleanupDeferredCancels($failure);
+
+            if ($this->deferredClose) {
+                $explicit = $this->deferredCloseExplicit;
+
+                try {
+                    $this->closeMultiHandle($failure);
+                    $this->closeOwnedFactory($failure);
+                } finally {
+                    $this->finishClose();
+                }
+
+                if ($explicit && $failure !== null) {
+                    throw $failure;
+                }
+            } elseif ($failure !== null) {
+                throw $failure;
+            }
+        }
     }
 
     private function disposeEasyHandle(EasyHandle $easy): void
@@ -496,7 +576,7 @@ class CurlMultiHandler
         return true;
     }
 
-    private function cleanupDeferredCancels(): void
+    private function cleanupDeferredCancels(?\Throwable &$failure): void
     {
         if ($this->deferredCancels === []) {
             return;
@@ -509,10 +589,14 @@ class CurlMultiHandler
             $easy = $entry['easy'];
 
             if ($entry['attached'] && $this->hasMultiHandle() && self::hasEasyHandle($easy)) {
-                $this->removeHandleFromMulti($easy->handle);
+                $this->captureFailure($failure, function () use ($easy): void {
+                    $this->removeHandleFromMulti($easy->handle);
+                });
             }
 
-            $this->disposeEasyHandle($easy);
+            $this->captureFailure($failure, function () use ($easy): void {
+                $this->disposeEasyHandle($easy);
+            });
         }
     }
 

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -373,6 +373,130 @@ class CurlMultiHandlerTest extends TestCase
         }
     }
 
+    public function testCanCloseFromProgressCallback(): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Response(200, ['Content-Length' => '1048576'], \str_repeat('x', 1048576)),
+        ]);
+
+        $handler = new CurlMultiHandler(['select_timeout' => 0]);
+        $progressCalls = 0;
+        $closed = false;
+
+        $promise = $handler(new Request('GET', Server::$url), [
+            'timeout' => 5,
+            'progress' => static function (
+                $downloadSize,
+                $downloaded,
+                $uploadSize,
+                $uploaded
+            ) use ($handler, &$progressCalls, &$closed): void {
+                ++$progressCalls;
+
+                if (!$closed) {
+                    $closed = true;
+                    $handler->close();
+                }
+            },
+        ]);
+
+        try {
+            $deadline = \microtime(true) + 5;
+
+            while (P\Is::pending($promise)) {
+                if (\microtime(true) >= $deadline) {
+                    self::fail('Timed out waiting for cURL progress close.');
+                }
+
+                $handler->tick();
+            }
+
+            self::assertGreaterThan(0, $progressCalls);
+            self::assertTrue($closed);
+            self::assertTrue(P\Is::rejected($promise));
+
+            try {
+                $promise->wait();
+                self::fail('Expected HandlerClosedException.');
+            } catch (HandlerClosedException $e) {
+                self::assertSame('The cURL multi handler was closed before the transfer completed.', $e->getMessage());
+            }
+
+            try {
+                $handler->tick();
+                self::fail('Expected BadMethodCallException.');
+            } catch (\BadMethodCallException $e) {
+                self::assertSame('Cannot use the cURL multi handler after it has been closed.', $e->getMessage());
+            }
+        } finally {
+            $handler->close();
+            Server::flush();
+        }
+    }
+
+    public function testCanCloseFromProgressCallbackWithDelayedTransfer(): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Response(200, ['Content-Length' => '1048576'], \str_repeat('x', 1048576)),
+        ]);
+
+        $handler = new CurlMultiHandler(['select_timeout' => 0]);
+        $progressCalls = 0;
+        $closed = false;
+
+        $activePromise = $handler(new Request('GET', Server::$url), [
+            'timeout' => 5,
+            'progress' => static function (
+                $downloadSize,
+                $downloaded,
+                $uploadSize,
+                $uploaded
+            ) use ($handler, &$progressCalls, &$closed): void {
+                ++$progressCalls;
+
+                if (!$closed) {
+                    $closed = true;
+                    $handler->close();
+                }
+            },
+        ]);
+
+        $delayedPromise = $handler(new Request('GET', Server::$url), [
+            'delay' => 10000,
+        ]);
+
+        try {
+            $deadline = \microtime(true) + 5;
+
+            while (P\Is::pending($activePromise)) {
+                if (\microtime(true) >= $deadline) {
+                    self::fail('Timed out waiting for cURL progress close.');
+                }
+
+                $handler->tick();
+            }
+
+            self::assertGreaterThan(0, $progressCalls);
+            self::assertTrue($closed);
+            self::assertTrue(P\Is::rejected($activePromise));
+            self::assertTrue(P\Is::rejected($delayedPromise));
+
+            foreach ([$activePromise, $delayedPromise] as $promise) {
+                try {
+                    $promise->wait();
+                    self::fail('Expected HandlerClosedException.');
+                } catch (HandlerClosedException $e) {
+                    self::assertSame('The cURL multi handler was closed before the transfer completed.', $e->getMessage());
+                }
+            }
+        } finally {
+            $handler->close();
+            Server::flush();
+        }
+    }
+
     public function testCannotCancelFinished(): void
     {
         Server::flush();


### PR DESCRIPTION
This defers native cURL multi cleanup when CurlMultiHandler::close() is called from inside a PHP callback invoked by curl_multi_exec. Explicit close calls still reject pending promises immediately, but removing easy handles, clearing callbacks, closing the multi handle, and closing the owned factory now happens after curl_multi_exec has returned.

This keeps the callback-time lifecycle fix separate from cURL share-handle support, so the share-handle pull request can focus only on the handler-owned share option and share handle ownership.