### PR TITLE
Reject conflicting cURL request options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Normalize no-proxy domain and IP literal matching consistently
 - Pass the request as the second argument to `on_headers` callbacks
 - Reject invalid `SetCookie` constructor field types instead of coercing them
+- Reject conflicting raw cURL request options, including request-level `CURLOPT_SHARE`
+- Reject selected request options ignored by incompatible built-in handlers
 - Support retry delay callbacks with retry count only or full retry context
 - Treat only `null` as an omitted path or name when clearing cookies
 - Validate malformed `auth` request option arrays

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -194,8 +194,14 @@ $client->request('GET', 'https://legacy.example.com', [
 ]);
 ```
 
-Handler-specific overrides through the `curl` and `stream_context` request
-options remain available for applications that need finer transport control.
+Handler-specific overrides remain available for finer transport control when
+they do not conflict with Guzzle-managed behavior. The built-in cURL handlers
+now reject raw cURL options that override request method, URI, body, headers,
+authentication, timeouts, redirects, proxy URLs, TLS verification or client
+credentials, progress/debug callbacks, sink handling, cookies, protocols, or
+cURL share handles. Use first-class Guzzle request options for those settings.
+The cURL handlers also reject stream-only `stream_context` and `read_timeout`
+options, while the stream handler rejects cURL-only options it cannot honor.
 
 #### Native type declarations
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -197,9 +197,9 @@ $client->request('GET', 'https://legacy.example.com', [
 Handler-specific overrides remain available for finer transport control when
 they do not conflict with Guzzle-managed behavior. The built-in cURL handlers
 now reject raw cURL options that override request method, URI, body, headers,
-authentication, timeouts, redirects, proxy URLs, TLS verification or client
-credentials, progress/debug callbacks, sink handling, cookies, protocols, or
-cURL share handles. Use first-class Guzzle request options for those settings.
+timeouts, redirects, proxy URLs, TLS verification or client credentials,
+progress/debug callbacks, sink handling, cookies, protocols, or cURL share
+handles. Use first-class Guzzle request options for those settings.
 The cURL handlers also reject stream-only `stream_context` and `read_timeout`
 options, while the stream handler rejects cURL-only options it cannot honor.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -839,9 +839,9 @@ $client->request('GET', 'https://example.com', [
 > `protocols` replaces raw cURL `CURLOPT_PROTOCOLS` when restricting request
 > schemes. Raw cURL options that conflict with Guzzle-managed request handling
 > are rejected. Use Guzzle request options instead when configuring the request
-> method, URI, body, headers, timeouts, redirects, proxy, TLS, progress, debug
-> output, sinks, cookies, and protocols. Redirect middleware
-> also validates redirect targets with `allow_redirects.protocols` before
+> method, URI, body, headers, timeouts, redirects, proxy, TLS, progress,
+> debug output, sinks, cookies, and protocols. Redirect middleware also
+> validates redirect targets with `allow_redirects.protocols` before
 > creating each redirect request.
 
 ## proxy

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -839,8 +839,8 @@ $client->request('GET', 'https://example.com', [
 > `protocols` replaces raw cURL `CURLOPT_PROTOCOLS` when restricting request
 > schemes. Raw cURL options that conflict with Guzzle-managed request handling
 > are rejected. Use Guzzle request options instead when configuring the request
-> method, URI, body, headers, timeouts, redirects, proxy, TLS, authentication,
-> progress, debug output, sinks, cookies, and protocols. Redirect middleware
+> method, URI, body, headers, timeouts, redirects, proxy, TLS, progress, debug
+> output, sinks, cookies, and protocols. Redirect middleware
 > also validates redirect targets with `allow_redirects.protocols` before
 > creating each redirect request.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -837,13 +837,12 @@ $client->request('GET', 'https://example.com', [
 
 > [!NOTE]
 > `protocols` replaces raw cURL `CURLOPT_PROTOCOLS` when restricting request
-> schemes. Starting in Guzzle 7.11, raw cURL options that conflict with
-> Guzzle-managed request handling trigger deprecation warnings. Use Guzzle
-> request options instead when configuring the request method, URI, body,
-> headers, timeouts, redirects, proxy, TLS, authentication, progress, debug
-> output, sinks, cookies, and protocols. Redirect middleware also validates
-> redirect targets with `allow_redirects.protocols` before creating each
-> redirect request.
+> schemes. Raw cURL options that conflict with Guzzle-managed request handling
+> are rejected. Use Guzzle request options instead when configuring the request
+> method, URI, body, headers, timeouts, redirects, proxy, TLS, authentication,
+> progress, debug output, sinks, cookies, and protocols. Redirect middleware
+> also validates redirect targets with `allow_redirects.protocols` before
+> creating each redirect request.
 
 ## proxy
 
@@ -885,7 +884,21 @@ $client->request('GET', '/', [
 > You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
 
 > [!NOTE]
-> When sending HTTPS requests, or requests explicitly tunneled with `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy, libcurl versions before 8.19.0 could reuse an existing proxy tunnel even after proxy credentials changed. Guzzle avoids that reuse on affected libcurl versions when the proxy is configured through the `proxy` option or raw cURL `CURLOPT_PROXY` option, including cURL proxy credential options. Custom proxy authentication sent with `CURLOPT_PROXYHEADER` also avoids tunnel reuse because libcurl does not include those header values in its connection matching. Fixed libcurl versions keep normal connection reuse behavior for proxy URL and cURL proxy credential options. Advanced users can still control cURL connection reuse explicitly with the `curl` request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`; raw `CURLOPT_PROXYTYPE` is respected when deciding whether a scheme-less raw cURL proxy is an HTTP(S) proxy.
+> When sending HTTPS requests, or requests explicitly tunneled with
+> `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy,
+> libcurl versions before 8.19.0 could reuse an existing proxy tunnel even
+> after proxy credentials changed. Guzzle avoids that reuse on affected libcurl
+> versions when the proxy URL is configured through the `proxy` option,
+> including cURL proxy credential options supplied through the `curl` request
+> option. Raw `CURLOPT_PROXY` is rejected; use the `proxy` request option for
+> the proxy URL. Custom proxy authentication sent with `CURLOPT_PROXYHEADER`
+> also avoids tunnel reuse because libcurl does not include those header values
+> in its connection matching. Fixed libcurl versions keep normal connection
+> reuse behavior for proxy URL and cURL proxy credential options. Advanced
+> users can still control cURL connection reuse explicitly with the `curl`
+> request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`; raw
+> `CURLOPT_PROXYTYPE` is respected when deciding whether a scheme-less `proxy`
+> option value is an HTTP(S) proxy.
 
 ## query
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -119,9 +119,9 @@ class CurlFactory implements CurlFactoryInterface
             unset($options['curl']['body_as_string']);
         }
 
-        self::triggerUnsupportedRequestOptionDeprecations($options);
+        self::rejectUnsupportedRequestOptions($options);
         $this->rejectRequestLevelShareConflict($options);
-        self::triggerConflictingCurlOptionDeprecations($options);
+        self::rejectConflictingCurlOptions($options);
 
         $easy = new EasyHandle();
         $easy->request = $request;
@@ -252,7 +252,7 @@ class CurlFactory implements CurlFactoryInterface
         return (string) $option;
     }
 
-    private static function triggerConflictingCurlOptionDeprecations(array $options): void
+    private static function rejectConflictingCurlOptions(array $options): void
     {
         if (!isset($options['curl']) || !\is_array($options['curl']) || $options['curl'] === []) {
             return;
@@ -265,48 +265,79 @@ class CurlFactory implements CurlFactoryInterface
                 continue;
             }
 
-            $name = self::formatCurlOption($option);
-            $replacement = $conflictingOptions[$option];
-            if ($replacement !== null) {
-                \trigger_deprecation(
-                    'guzzlehttp/guzzle',
-                    '7.11',
-                    \sprintf(
-                        'Passing %s in the "curl" request option is deprecated; guzzlehttp/guzzle 8.0 will reject this option because it conflicts with Guzzle-managed request handling. Use %s instead.',
-                        $name,
-                        $replacement
-                    )
-                );
-
+            if (self::isCurlAuthOptionGeneratedByAuth($options, $option)) {
                 continue;
             }
 
-            \trigger_deprecation(
-                'guzzlehttp/guzzle',
-                '7.11',
-                \sprintf(
-                    'Passing %s in the "curl" request option is deprecated; guzzlehttp/guzzle 8.0 will reject this option because it conflicts with Guzzle-managed cURL internals.',
-                    $name
-                )
-            );
+            $name = self::formatCurlOption($option);
+            $replacement = $conflictingOptions[$option];
+            if ($replacement !== null) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Passing %s in the "curl" request option is not supported because it conflicts with Guzzle-managed request handling. Use %s instead.',
+                    $name,
+                    $replacement
+                ));
+            }
+
+            throw new \InvalidArgumentException(\sprintf(
+                'Passing %s in the "curl" request option is not supported because it conflicts with Guzzle-managed cURL internals.',
+                $name
+            ));
         }
     }
 
-    private static function triggerUnsupportedRequestOptionDeprecations(array $options): void
+    /**
+     * @param int|string $option
+     */
+    private static function isCurlAuthOptionGeneratedByAuth(array $options, $option): bool
+    {
+        if (!\is_int($option) || !\defined('CURLOPT_HTTPAUTH') || !\defined('CURLOPT_USERPWD')) {
+            return false;
+        }
+
+        if ($option !== \CURLOPT_HTTPAUTH && $option !== \CURLOPT_USERPWD) {
+            return false;
+        }
+
+        if (!isset($options['auth']) || !\is_array($options['auth']) || !isset($options['curl']) || !\is_array($options['curl'])) {
+            return false;
+        }
+
+        if (!isset($options['auth'][0], $options['auth'][1], $options['auth'][2]) || !\is_string($options['auth'][0]) || !\is_string($options['auth'][1]) || !\is_string($options['auth'][2])) {
+            return false;
+        }
+
+        $type = \strtolower($options['auth'][2]);
+        if ($type === 'digest') {
+            $httpAuth = \defined('CURLAUTH_DIGEST') ? \constant('CURLAUTH_DIGEST') : null;
+        } elseif ($type === 'ntlm') {
+            $httpAuth = \defined('CURLAUTH_NTLM') ? \constant('CURLAUTH_NTLM') : null;
+        } else {
+            return false;
+        }
+
+        return $httpAuth !== null
+            && \array_key_exists(\CURLOPT_HTTPAUTH, $options['curl'])
+            && \array_key_exists(\CURLOPT_USERPWD, $options['curl'])
+            && $options['curl'][\CURLOPT_HTTPAUTH] === $httpAuth
+            && $options['curl'][\CURLOPT_USERPWD] === $options['auth'][0].':'.$options['auth'][1];
+    }
+
+    private static function rejectUnsupportedRequestOptions(array $options): void
     {
         if (
             \array_key_exists('curl_share', $options)
             && CurlShareHandleState::normalizeMode($options['curl_share'], 'curl_share') !== CurlShare::NONE
         ) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "curl_share" request option to a cURL handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because cURL sharing must be configured when creating the Client, CurlHandler, or CurlMultiHandler.');
+            throw new \InvalidArgumentException('The "curl_share" option is a client constructor option, not a request option. Configure cURL sharing when creating the Client, CurlHandler, or CurlMultiHandler.');
         }
 
         if (\array_key_exists('stream_context', $options)) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "stream_context" request option to a cURL handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because cURL handlers ignore PHP stream context options.');
+            throw new \InvalidArgumentException('Passing the "stream_context" request option to a cURL handler is not supported because cURL handlers ignore PHP stream context options.');
         }
 
         if (\array_key_exists('read_timeout', $options)) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "read_timeout" request option to a cURL handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because cURL handlers ignore stream read timeouts. Use the "timeout" request option instead.');
+            throw new \InvalidArgumentException('Passing the "read_timeout" request option to a cURL handler is not supported because cURL handlers ignore stream read timeouts. Use the "timeout" request option instead.');
         }
     }
 
@@ -326,6 +357,7 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_SHARE', 'the "curl_share" client option or the "share" cURL handler option');
         self::addConflictingCurlOption($options, 'CURLOPT_URL', 'the request URI');
         self::addConflictingCurlOption($options, 'CURLOPT_PORT', 'the request URI');
+        self::addConflictingCurlOption($options, 'CURLOPT_REQUEST_TARGET', 'the request URI');
         self::addConflictingCurlOption($options, 'CURLOPT_CUSTOMREQUEST', 'the request method');
         self::addConflictingCurlOption($options, 'CURLOPT_HTTPGET', 'the request method');
         self::addConflictingCurlOption($options, 'CURLOPT_POST', 'the request method and body');
@@ -341,6 +373,10 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_HTTPHEADER', 'the request headers');
         self::addConflictingCurlOption($options, 'CURLOPT_USERAGENT', 'the request headers');
         self::addConflictingCurlOption($options, 'CURLOPT_REFERER', 'the request headers');
+        self::addConflictingCurlOption($options, 'CURLOPT_HTTPAUTH', 'the "auth" request option');
+        self::addConflictingCurlOption($options, 'CURLOPT_USERPWD', 'the "auth" request option');
+        self::addConflictingCurlOption($options, 'CURLOPT_USERNAME', 'the "auth" request option');
+        self::addConflictingCurlOption($options, 'CURLOPT_PASSWORD', 'the "auth" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_HEADERFUNCTION', 'the "on_headers" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_WRITEFUNCTION', 'the "sink" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_FILE', 'the "sink" request option');
@@ -380,6 +416,7 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_SSLKEYPASSWD', 'the "ssl_key" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_KEYPASSWD', 'the "ssl_key" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_SSLKEYTYPE', 'the "ssl_key_type" request option');
+        self::addConflictingCurlOption($options, 'CURLOPT_COOKIE', 'Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIEFILE', 'Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIEJAR', 'Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIELIST', 'Guzzle cookie middleware');
@@ -449,16 +486,21 @@ class CurlFactory implements CurlFactoryInterface
         $this->closed = true;
         $failure = null;
 
-        foreach ($this->handles as $id => $handle) {
-            try {
-                $this->discardHandle($handle);
-            } catch (\Throwable $e) {
-                if ($failure === null) {
-                    $failure = $e;
+        try {
+            foreach ($this->handles as $id => $handle) {
+                try {
+                    $this->discardHandle($handle);
+                } catch (\Throwable $e) {
+                    if ($failure === null) {
+                        $failure = $e;
+                    }
+                } finally {
+                    unset($this->handles[$id]);
                 }
-            } finally {
-                unset($this->handles[$id]);
             }
+        } finally {
+            $this->shareMode = CurlShare::NONE;
+            $this->shareHandle = null;
         }
 
         if ($explicit && $failure !== null) {

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -265,10 +265,6 @@ class CurlFactory implements CurlFactoryInterface
                 continue;
             }
 
-            if (self::isCurlAuthOptionGeneratedByAuth($options, $option)) {
-                continue;
-            }
-
             $name = self::formatCurlOption($option);
             $replacement = $conflictingOptions[$option];
             if ($replacement !== null) {
@@ -284,43 +280,6 @@ class CurlFactory implements CurlFactoryInterface
                 $name
             ));
         }
-    }
-
-    /**
-     * @param int|string $option
-     */
-    private static function isCurlAuthOptionGeneratedByAuth(array $options, $option): bool
-    {
-        if (!\is_int($option) || !\defined('CURLOPT_HTTPAUTH') || !\defined('CURLOPT_USERPWD')) {
-            return false;
-        }
-
-        if ($option !== \CURLOPT_HTTPAUTH && $option !== \CURLOPT_USERPWD) {
-            return false;
-        }
-
-        if (!isset($options['auth']) || !\is_array($options['auth']) || !isset($options['curl']) || !\is_array($options['curl'])) {
-            return false;
-        }
-
-        if (!isset($options['auth'][0], $options['auth'][1], $options['auth'][2]) || !\is_string($options['auth'][0]) || !\is_string($options['auth'][1]) || !\is_string($options['auth'][2])) {
-            return false;
-        }
-
-        $type = \strtolower($options['auth'][2]);
-        if ($type === 'digest') {
-            $httpAuth = \defined('CURLAUTH_DIGEST') ? \constant('CURLAUTH_DIGEST') : null;
-        } elseif ($type === 'ntlm') {
-            $httpAuth = \defined('CURLAUTH_NTLM') ? \constant('CURLAUTH_NTLM') : null;
-        } else {
-            return false;
-        }
-
-        return $httpAuth !== null
-            && \array_key_exists(\CURLOPT_HTTPAUTH, $options['curl'])
-            && \array_key_exists(\CURLOPT_USERPWD, $options['curl'])
-            && $options['curl'][\CURLOPT_HTTPAUTH] === $httpAuth
-            && $options['curl'][\CURLOPT_USERPWD] === $options['auth'][0].':'.$options['auth'][1];
     }
 
     private static function rejectUnsupportedRequestOptions(array $options): void
@@ -373,10 +332,6 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_HTTPHEADER', 'the request headers');
         self::addConflictingCurlOption($options, 'CURLOPT_USERAGENT', 'the request headers');
         self::addConflictingCurlOption($options, 'CURLOPT_REFERER', 'the request headers');
-        self::addConflictingCurlOption($options, 'CURLOPT_HTTPAUTH', 'the "auth" request option');
-        self::addConflictingCurlOption($options, 'CURLOPT_USERPWD', 'the "auth" request option');
-        self::addConflictingCurlOption($options, 'CURLOPT_USERNAME', 'the "auth" request option');
-        self::addConflictingCurlOption($options, 'CURLOPT_PASSWORD', 'the "auth" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_HEADERFUNCTION', 'the "on_headers" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_WRITEFUNCTION', 'the "sink" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_FILE', 'the "sink" request option');

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -316,7 +316,6 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_SHARE', 'the "curl_share" client option or the "share" cURL handler option');
         self::addConflictingCurlOption($options, 'CURLOPT_URL', 'the request URI');
         self::addConflictingCurlOption($options, 'CURLOPT_PORT', 'the request URI');
-        self::addConflictingCurlOption($options, 'CURLOPT_REQUEST_TARGET', 'the request URI');
         self::addConflictingCurlOption($options, 'CURLOPT_CUSTOMREQUEST', 'the request method');
         self::addConflictingCurlOption($options, 'CURLOPT_HTTPGET', 'the request method');
         self::addConflictingCurlOption($options, 'CURLOPT_POST', 'the request method and body');
@@ -371,7 +370,7 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_SSLKEYPASSWD', 'the "ssl_key" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_KEYPASSWD', 'the "ssl_key" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_SSLKEYTYPE', 'the "ssl_key_type" request option');
-        self::addConflictingCurlOption($options, 'CURLOPT_COOKIE', 'Guzzle cookie middleware');
+        self::addConflictingCurlOption($options, 'CURLOPT_COOKIE', 'the "Cookie" request header or Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIEFILE', 'Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIEJAR', 'Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIELIST', 'Guzzle cookie middleware');

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -123,6 +123,8 @@ class CurlHandler
             if ($explicit) {
                 throw $e;
             }
+        } finally {
+            $this->shareHandleState = null;
         }
     }
 }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -372,6 +372,7 @@ class CurlMultiHandler
         $this->delays = [];
         $this->deferredCancels = [];
         $this->active = 0;
+        $this->shareHandleState = null;
         $this->deferredClose = false;
         $this->deferredCloseExplicit = false;
         $this->closed = true;

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -66,7 +66,7 @@ class StreamHandler
 
         $startTime = isset($options['on_stats']) ? Utils::currentTime() : null;
 
-        self::triggerUnsupportedRequestOptionDeprecations($request, $options);
+        self::rejectUnsupportedRequestOptions($request, $options);
 
         try {
             // Does not support the expect header.
@@ -571,13 +571,13 @@ class StreamHandler
         return $context;
     }
 
-    private static function triggerUnsupportedRequestOptionDeprecations(RequestInterface $request, array $options): void
+    private static function rejectUnsupportedRequestOptions(RequestInterface $request, array $options): void
     {
         if (
             \array_key_exists('curl_share', $options)
             && CurlShareHandleState::normalizeMode($options['curl_share'], 'curl_share') !== CurlShare::NONE
         ) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "curl_share" option to the stream handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because the stream handler does not support cURL sharing.');
+            throw new \InvalidArgumentException('The "curl_share" option is not supported by the stream handler because the stream handler does not support cURL sharing.');
         }
 
         if (
@@ -586,15 +586,15 @@ class StreamHandler
             && $options['curl'] !== []
             && !self::isCurlOptionGeneratedByAuth($options)
         ) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "curl" request option to the stream handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because the stream handler ignores cURL options.');
+            throw new \InvalidArgumentException('Passing the "curl" request option to the stream handler is not supported because the stream handler ignores cURL options.');
         }
 
         if (self::usesDigestAuth($options)) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing digest authentication to the stream handler is deprecated; guzzlehttp/guzzle 8.0 will reject digest authentication with the stream handler because it is only supported by cURL handlers.');
+            throw new \InvalidArgumentException('Digest authentication is not supported by the stream handler because it is only supported by cURL handlers.');
         }
 
         if (\array_key_exists('expect', $options) && $options['expect'] !== false && $request->hasHeader('Expect')) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "expect" request option to the stream handler is deprecated when it adds an Expect header; guzzlehttp/guzzle 8.0 will reject this option because the stream handler does not support Expect: 100-Continue.');
+            throw new \InvalidArgumentException('Passing the "expect" request option to the stream handler is not supported when it adds an Expect header because the stream handler does not support Expect: 100-Continue.');
         }
     }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -329,10 +329,6 @@ class CurlFactoryTest extends TestCase
         $cases = [
             'request target' => ['CURLOPT_REQUEST_TARGET', '/', 'the request URI'],
             'cookie header' => ['CURLOPT_COOKIE', 'name=value', 'Guzzle cookie middleware'],
-            'http auth type' => ['CURLOPT_HTTPAUTH', 1, 'the "auth" request option'],
-            'user password' => ['CURLOPT_USERPWD', 'user:pass', 'the "auth" request option'],
-            'username' => ['CURLOPT_USERNAME', 'user', 'the "auth" request option'],
-            'password' => ['CURLOPT_PASSWORD', 'pass', 'the "auth" request option'],
         ];
 
         $available = [];
@@ -344,39 +340,6 @@ class CurlFactoryTest extends TestCase
         }
 
         return $available;
-    }
-
-    /**
-     * @dataProvider generatedCurlAuthOptionProvider
-     */
-    public function testAllowsCurlAuthOptionsGeneratedByAuth(string $type, int $httpAuth): void
-    {
-        (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
-            'auth' => ['user', 'pass', $type],
-            'curl' => [
-                \CURLOPT_HTTPAUTH => $httpAuth,
-                \CURLOPT_USERPWD => 'user:pass',
-            ],
-        ]);
-
-        self::assertSame($httpAuth, $_SERVER['_curl'][\CURLOPT_HTTPAUTH]);
-        self::assertSame('user:pass', $_SERVER['_curl'][\CURLOPT_USERPWD]);
-    }
-
-    public static function generatedCurlAuthOptionProvider(): array
-    {
-        $cases = [];
-        if (\defined('CURLAUTH_DIGEST')) {
-            $cases['digest'] = ['digest', (int) \constant('CURLAUTH_DIGEST')];
-        }
-
-        $hasNtlmSupport = \defined('CURL_VERSION_NTLM')
-            && (((int) \curl_version()['features'] & (int) \constant('CURL_VERSION_NTLM')) !== 0);
-        if (\defined('CURLAUTH_NTLM') && $hasNtlmSupport) {
-            $cases['ntlm'] = ['ntlm', (int) \constant('CURLAUTH_NTLM')];
-        }
-
-        return $cases;
     }
 
     public function testRejectsRequestLevelCurlShareOption(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -327,8 +327,7 @@ class CurlFactoryTest extends TestCase
     public static function additionalConflictingCurlOptionProvider(): array
     {
         $cases = [
-            'request target' => ['CURLOPT_REQUEST_TARGET', '/', 'the request URI'],
-            'cookie header' => ['CURLOPT_COOKIE', 'name=value', 'Guzzle cookie middleware'],
+            'cookie header' => ['CURLOPT_COOKIE', 'name=value', 'the "Cookie" request header or Guzzle cookie middleware'],
         ];
 
         $available = [];

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -276,17 +276,165 @@ class CurlFactoryTest extends TestCase
         new CurlFactory(3, CurlShare::HANDLER, false);
     }
 
-    public function testCanChangeCurlOptions(): void
+    public function testCloseReleasesConfiguredCurlShareHandle(): void
     {
-        Server::flush();
-        Server::enqueue([new Psr7\Response()]);
-        $a = new Handler\CurlMultiHandler();
-        $req = new Psr7\Request('GET', Server::$url);
-        $a($req, ['curl' => [\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_1_0]]);
-        self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+        self::skipIfCurlShareIsUnavailable();
+
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, CurlShare::HANDLER, $shareHandle);
+
+        self::assertSame($shareHandle, self::readShareHandle($factory));
+
+        $factory->close();
+
+        self::assertNull(self::readShareHandle($factory));
     }
 
-    public function testProtocolsOptionCanRestrictCurlProtocols()
+    public function testRejectsConflictingCurlOptions(): void
+    {
+        $a = new Handler\CurlMultiHandler();
+        $req = new Psr7\Request('GET', Server::$url);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_HTTP_VERSION');
+        $this->expectExceptionMessage('request protocol version');
+
+        $a($req, ['curl' => [\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_1_0]]);
+    }
+
+    /**
+     * @dataProvider additionalConflictingCurlOptionProvider
+     *
+     * @param mixed $value
+     */
+    public function testRejectsAdditionalConflictingCurlOptions(string $constant, int $option, $value, string $replacement): void
+    {
+        try {
+            (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+                'curl' => [
+                    $option => $value,
+                ],
+            ]);
+
+            self::fail('Expected InvalidArgumentException.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertStringContainsString($constant, $e->getMessage());
+            self::assertStringContainsString($replacement, $e->getMessage());
+        }
+    }
+
+    public static function additionalConflictingCurlOptionProvider(): array
+    {
+        $cases = [
+            'request target' => ['CURLOPT_REQUEST_TARGET', '/', 'the request URI'],
+            'cookie header' => ['CURLOPT_COOKIE', 'name=value', 'Guzzle cookie middleware'],
+            'http auth type' => ['CURLOPT_HTTPAUTH', 1, 'the "auth" request option'],
+            'user password' => ['CURLOPT_USERPWD', 'user:pass', 'the "auth" request option'],
+            'username' => ['CURLOPT_USERNAME', 'user', 'the "auth" request option'],
+            'password' => ['CURLOPT_PASSWORD', 'pass', 'the "auth" request option'],
+        ];
+
+        $available = [];
+        foreach ($cases as $name => $case) {
+            [$constant, $value, $replacement] = $case;
+            if (\defined($constant)) {
+                $available[$name] = [$constant, (int) \constant($constant), $value, $replacement];
+            }
+        }
+
+        return $available;
+    }
+
+    /**
+     * @dataProvider generatedCurlAuthOptionProvider
+     */
+    public function testAllowsCurlAuthOptionsGeneratedByAuth(string $type, int $httpAuth): void
+    {
+        (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+            'auth' => ['user', 'pass', $type],
+            'curl' => [
+                \CURLOPT_HTTPAUTH => $httpAuth,
+                \CURLOPT_USERPWD => 'user:pass',
+            ],
+        ]);
+
+        self::assertSame($httpAuth, $_SERVER['_curl'][\CURLOPT_HTTPAUTH]);
+        self::assertSame('user:pass', $_SERVER['_curl'][\CURLOPT_USERPWD]);
+    }
+
+    public static function generatedCurlAuthOptionProvider(): array
+    {
+        $cases = [];
+        if (\defined('CURLAUTH_DIGEST')) {
+            $cases['digest'] = ['digest', (int) \constant('CURLAUTH_DIGEST')];
+        }
+
+        $hasNtlmSupport = \defined('CURL_VERSION_NTLM')
+            && (((int) \curl_version()['features'] & (int) \constant('CURL_VERSION_NTLM')) !== 0);
+        if (\defined('CURLAUTH_NTLM') && $hasNtlmSupport) {
+            $cases['ntlm'] = ['ntlm', (int) \constant('CURLAUTH_NTLM')];
+        }
+
+        return $cases;
+    }
+
+    public function testRejectsRequestLevelCurlShareOption(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('CURLOPT_SHARE');
+            $this->expectExceptionMessage('curl_share');
+
+            (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+                'curl' => [
+                    \CURLOPT_SHARE => $shareHandle,
+                ],
+            ]);
+        } finally {
+            if (PHP_VERSION_ID < 80000) {
+                \curl_share_close($shareHandle);
+            }
+        }
+    }
+
+    public function testRejectsRequestLevelCurlShareClientOption(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('curl_share');
+        $this->expectExceptionMessage('client constructor option');
+
+        (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+            'curl_share' => CurlShare::HANDLER,
+        ]);
+    }
+
+    public function testRejectsStreamContextOption(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_context');
+
+        (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+            'stream_context' => [],
+        ]);
+    }
+
+    public function testRejectsReadTimeoutOption(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('read_timeout');
+
+        (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+            'read_timeout' => 1,
+        ]);
+    }
+
+    public function testProtocolsOptionCanRestrictCurlProtocols(): void
     {
         if (!\defined('CURLOPT_PROTOCOLS')) {
             self::markTestSkipped('CURLOPT_PROTOCOLS is not available.');
@@ -298,7 +446,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame(\CURLPROTO_HTTPS, $_SERVER['_curl'][\CURLOPT_PROTOCOLS]);
     }
 
-    public function testProtocolsOptionRejectsDisallowedCurlScheme()
+    public function testProtocolsOptionRejectsDisallowedCurlScheme(): void
     {
         $f = new CurlFactory(3);
 
@@ -313,7 +461,7 @@ class CurlFactoryTest extends TestCase
      *
      * @param mixed $protocols
      */
-    public function testProtocolsOptionRejectsInvalidValues($protocols)
+    public function testProtocolsOptionRejectsInvalidValues($protocols): void
     {
         $f = new CurlFactory(3);
 
@@ -499,27 +647,29 @@ class CurlFactoryTest extends TestCase
         self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
-    public function testForcesFreshConnectionForAuthenticatedHttpsProxyWithRawCurlProxyUrlOnAffectedCurlVersion(): void
+    public function testRejectsRawCurlProxyUrl(): void
     {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXY');
+
+        (new CurlFactory(3))->create(new Psr7\Request('GET', 'https://example.com'), [
             'curl' => [
                 \CURLOPT_PROXY => 'http://username:password@proxy.example.com:8080',
             ],
         ]);
-
-        self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
-    public function testForcesFreshConnectionForAuthenticatedHttpsProxyWithRawCurlProxyCredentialsOnAffectedCurlVersion(): void
+    public function testRejectsRawCurlProxyUrlWithCredentials(): void
     {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXY');
+
+        (new CurlFactory(3))->create(new Psr7\Request('GET', 'https://example.com'), [
             'curl' => [
                 \CURLOPT_PROXY => 'http://proxy.example.com:8080',
                 \CURLOPT_PROXYUSERPWD => 'username:password',
             ],
         ]);
-
-        self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
     public function testForcesFreshConnectionForAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
@@ -578,7 +728,7 @@ class CurlFactoryTest extends TestCase
         self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
     }
 
-    public function testDoesNotForceFreshConnectionForAuthenticatedRawSocksProxyType(): void
+    public function testRejectsRawCurlSocksProxyTypeWithProxyUrl(): void
     {
         if (!\defined('CURLPROXY_SOCKS5')) {
             self::markTestSkipped('CURLPROXY_SOCKS5 is not available.');
@@ -586,46 +736,46 @@ class CurlFactoryTest extends TestCase
 
         $proxyType = (int) \constant('CURLPROXY_SOCKS5');
 
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXY');
+
+        (new CurlFactory(3))->create(new Psr7\Request('GET', 'https://example.com'), [
             'curl' => [
                 \CURLOPT_PROXY => 'proxy.example.com:1080',
                 \CURLOPT_PROXYTYPE => $proxyType,
                 \CURLOPT_PROXYUSERPWD => 'username:password',
             ],
         ]);
-
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
     }
 
-    public function testRawCurlProxyOverrideControlsAuthenticatedProxyReuseDetection(): void
+    public function testRejectsRawCurlProxyOverride(): void
     {
         $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXY');
+
         $f->create(new Psr7\Request('GET', 'https://example.com'), [
             'proxy' => 'http://username:password@proxy-one.example.com:8080',
             'curl' => [
                 \CURLOPT_PROXY => 'http://proxy-two.example.com:8080',
             ],
         ]);
-
-        self::assertSame('http://proxy-two.example.com:8080', $_SERVER['_curl'][\CURLOPT_PROXY]);
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
     }
 
-    public function testRawCurlProxyDisableControlsAuthenticatedProxyReuseDetection(): void
+    public function testRejectsRawCurlProxyDisable(): void
     {
         $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXY');
+
         $f->create(new Psr7\Request('GET', 'https://example.com'), [
             'proxy' => 'http://username:password@proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_PROXY => '',
             ],
         ]);
-
-        self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
     }
 
     public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
@@ -775,14 +925,16 @@ class CurlFactoryTest extends TestCase
         self::assertArrayNotHasKey(\CURLOPT_SSLVERSION, $_SERVER['_curl']);
     }
 
-    public function testCurlSslVersionOptionOverridesDefaultTlsMinimum(): void
+    public function testRejectsRawCurlSslVersionOption(): void
     {
         $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_SSLVERSION');
+
         $f->create(new Psr7\Request('GET', 'https://example.com'), [
             'curl' => [\CURLOPT_SSLVERSION => \CURL_SSLVERSION_TLSv1_1],
         ]);
-
-        self::assertEquals(\CURL_SSLVERSION_TLSv1_1, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
     }
 
     public function testValidatesCryptoMethodInvalidMethod(): void
@@ -858,7 +1010,7 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(__FILE__, $_SERVER['_curl'][\CURLOPT_SSLKEY]);
     }
 
-    public function testAddsSslKeyType()
+    public function testAddsSslKeyType(): void
     {
         $f = new CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), [
@@ -869,7 +1021,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame('PEM', $_SERVER['_curl'][\CURLOPT_SSLKEYTYPE]);
     }
 
-    public function testAllowsEngineSslKeyIdentifiers()
+    public function testAllowsEngineSslKeyIdentifiers(): void
     {
         $f = new CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), [
@@ -886,7 +1038,7 @@ class CurlFactoryTest extends TestCase
      *
      * @param mixed $sslKeyType
      */
-    public function testValidatesSslKeyType($sslKeyType)
+    public function testValidatesSslKeyType($sslKeyType): void
     {
         $f = new CurlFactory(3);
 
@@ -909,7 +1061,7 @@ class CurlFactoryTest extends TestCase
      *
      * @param mixed $sslKey
      */
-    public function testValidatesSslKeyOptionShape($sslKey)
+    public function testValidatesSslKeyOptionShape($sslKey): void
     {
         $f = new CurlFactory(3);
 
@@ -967,7 +1119,7 @@ class CurlFactoryTest extends TestCase
         }
     }
 
-    public function testAddsCertType()
+    public function testAddsCertType(): void
     {
         $f = new CurlFactory(3);
         $f->create(new Psr7\Request('GET', Server::$url), [
@@ -983,7 +1135,7 @@ class CurlFactoryTest extends TestCase
      *
      * @param mixed $certType
      */
-    public function testValidatesCertType($certType)
+    public function testValidatesCertType($certType): void
     {
         $f = new CurlFactory(3);
 
@@ -1284,7 +1436,7 @@ class CurlFactoryTest extends TestCase
         }
     }
 
-    public function testReleaseClearsRawXferInfoCallbackBeforeDiscardingHandle(): void
+    public function testReleaseClearsXferInfoCallbackBeforeDiscardingHandle(): void
     {
         if (!\defined('CURLOPT_XFERINFOFUNCTION')) {
             self::markTestSkipped('CURLOPT_XFERINFOFUNCTION is not available.');
@@ -1293,11 +1445,8 @@ class CurlFactoryTest extends TestCase
         $option = (int) \constant('CURLOPT_XFERINFOFUNCTION');
         $factory = new CurlFactory(0);
         $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
-            'curl' => [
-                $option => static function (): int {
-                    return 0;
-                },
-            ],
+            'progress' => static function (): void {
+            },
         ]);
 
         $factory->release($easy);
@@ -1306,7 +1455,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame([], self::readIdleHandles($factory));
     }
 
-    public function testReleaseClearsRawXferInfoCallbackBeforeReusingHandle(): void
+    public function testReleaseClearsXferInfoCallbackBeforeReusingHandle(): void
     {
         if (!\defined('CURLOPT_XFERINFOFUNCTION')) {
             self::markTestSkipped('CURLOPT_XFERINFOFUNCTION is not available.');
@@ -1315,11 +1464,8 @@ class CurlFactoryTest extends TestCase
         $option = (int) \constant('CURLOPT_XFERINFOFUNCTION');
         $factory = new CurlFactory(1);
         $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
-            'curl' => [
-                $option => static function (): int {
-                    return 0;
-                },
-            ],
+            'progress' => static function (): void {
+            },
         ]);
 
         $factory->release($easy);
@@ -1580,18 +1726,20 @@ class CurlFactoryTest extends TestCase
         self::assertSame(\CURL_SSLVERSION_TLSv1_3, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
     }
 
-    public function testHttp3UpgradesCurlSslVersionOptionToTls13Minimum(): void
+    public function testHttp3RejectsRawCurlSslVersionOption(): void
     {
         if (!CurlVersion::supportsHttp3()) {
             self::markTestSkipped('HTTP/3 is not supported by this cURL installation.');
         }
 
         $factory = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_SSLVERSION');
+
         $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
             'curl' => [\CURLOPT_SSLVERSION => \CURL_SSLVERSION_TLSv1_2],
         ]);
-
-        self::assertSame(\CURL_SSLVERSION_TLSv1_3, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
     }
 
     public static function http3ProtocolVersionProvider(): array
@@ -2598,6 +2746,15 @@ class CurlFactoryTest extends TestCase
         }, null, CurlFactory::class);
 
         return $readHandles($factory);
+    }
+
+    private static function readShareHandle(CurlFactory $factory)
+    {
+        $readShareHandle = \Closure::bind(static function (CurlFactory $factory) {
+            return $factory->shareHandle;
+        }, null, CurlFactory::class);
+
+        return $readShareHandle($factory);
     }
 
     private static function requestWithProtocolVersion(string $protocolVersion): RequestInterface

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\CurlShare;
+use GuzzleHttp\Handler\CurlShareHandleState;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -177,6 +178,21 @@ class CurlHandlerTest extends TestCase
         self::assertInstanceOf(CurlHandler::class, $handler);
     }
 
+    public function testCloseReleasesShareHandleState(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $handler = new CurlHandler([
+            'share' => CurlShare::HANDLER,
+        ]);
+
+        self::assertNotNull(self::readShareHandleState($handler));
+
+        $handler->close();
+
+        self::assertNull(self::readShareHandleState($handler));
+    }
+
     public function testUsesContentLengthWhenOverInMemorySize(): void
     {
         Server::flush();
@@ -205,6 +221,15 @@ class CurlHandlerTest extends TestCase
         self::assertInstanceOf(CurlFactory::class, $factory);
 
         return $factory;
+    }
+
+    private static function readShareHandleState(CurlHandler $handler): ?CurlShareHandleState
+    {
+        $readShareHandleState = \Closure::bind(static function (CurlHandler $handler): ?CurlShareHandleState {
+            return $handler->shareHandleState;
+        }, null, CurlHandler::class);
+
+        return $readShareHandleState($handler);
     }
 
     private static function skipIfCurlShareIsUnavailable(): void

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\HandlerClosedException;
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\CurlShare;
+use GuzzleHttp\Handler\CurlShareHandleState;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -105,6 +106,21 @@ class CurlMultiHandlerTest extends TestCase
         ]);
 
         self::assertInstanceOf(CurlMultiHandler::class, $handler);
+    }
+
+    public function testCloseReleasesShareHandleState(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $handler = new CurlMultiHandler([
+            'share' => CurlShare::HANDLER,
+        ]);
+
+        self::assertNotNull(self::readShareHandleState($handler));
+
+        $handler->close();
+
+        self::assertNull(self::readShareHandleState($handler));
     }
 
     public function testDestructorDoesNotThrowWhenCurlMultiCloseFails(): void
@@ -658,6 +674,15 @@ class CurlMultiHandlerTest extends TestCase
         self::assertInstanceOf(CurlFactory::class, $factory);
 
         return $factory;
+    }
+
+    private static function readShareHandleState(CurlMultiHandler $handler): ?CurlShareHandleState
+    {
+        $readShareHandleState = \Closure::bind(static function (CurlMultiHandler $handler): ?CurlShareHandleState {
+            return $handler->shareHandleState;
+        }, null, CurlMultiHandler::class);
+
+        return $readShareHandleState($handler);
     }
 
     private static function tickUntilSettled(CurlMultiHandler $handler, P\PromiseInterface $promise): void

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -760,14 +760,14 @@ class StreamHandlerTest extends TestCase
         self::assertArrayNotHasKey('passphrase', $options['ssl']);
     }
 
-    public function testCanSetCertTypeToPem()
+    public function testCanSetCertTypeToPem(): void
     {
         $response = $this->getSendResult(['cert_type' => 'pem']);
 
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testRejectsNonPemCertType()
+    public function testRejectsNonPemCertType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The stream handler only supports "PEM" for the cert_type request option.');
@@ -775,7 +775,7 @@ class StreamHandlerTest extends TestCase
         $this->getSendResult(['cert_type' => 'DER']);
     }
 
-    public function testCanSetSslKey()
+    public function testCanSetSslKey(): void
     {
         $path = __FILE__;
         $res = $this->getSendResult(['ssl_key' => $path]);
@@ -783,7 +783,7 @@ class StreamHandlerTest extends TestCase
         self::assertSame($path, $opts['ssl']['local_pk']);
     }
 
-    public function testCanSetPasswordWhenSettingSslKey()
+    public function testCanSetPasswordWhenSettingSslKey(): void
     {
         $path = __FILE__;
         $res = $this->getSendResult(['ssl_key' => [$path, 'foo']]);
@@ -792,7 +792,7 @@ class StreamHandlerTest extends TestCase
         self::assertSame('foo', $opts['ssl']['passphrase']);
     }
 
-    public function testCanSetCertAndSslKeyWithSamePassword()
+    public function testCanSetCertAndSslKeyWithSamePassword(): void
     {
         $path = __FILE__;
         $res = $this->getSendResult([
@@ -805,7 +805,7 @@ class StreamHandlerTest extends TestCase
         self::assertSame('foo', $opts['ssl']['passphrase']);
     }
 
-    public function testRejectsCertAndSslKeyWithDifferentPasswords()
+    public function testRejectsCertAndSslKeyWithDifferentPasswords(): void
     {
         $path = __FILE__;
 
@@ -818,7 +818,7 @@ class StreamHandlerTest extends TestCase
         ]);
     }
 
-    public function testCanSetSslKeyWithArrayPathOnly()
+    public function testCanSetSslKeyWithArrayPathOnly(): void
     {
         $path = __FILE__;
         $handler = new StreamHandler();
@@ -835,14 +835,14 @@ class StreamHandlerTest extends TestCase
         self::assertArrayNotHasKey('passphrase', $options['ssl']);
     }
 
-    public function testCanSetSslKeyTypeToPem()
+    public function testCanSetSslKeyTypeToPem(): void
     {
         $response = $this->getSendResult(['ssl_key_type' => 'pem']);
 
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testRejectsNonPemSslKeyType()
+    public function testRejectsNonPemSslKeyType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The stream handler only supports "PEM" for the ssl_key_type request option.');
@@ -1367,6 +1367,55 @@ class StreamHandlerTest extends TestCase
         ])->wait();
 
         self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testStreamRejectsEnabledCurlShareOption(): void
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('curl_share');
+
+        $handler(new Request('GET', Server::$url), [
+            'curl_share' => CurlShare::HANDLER,
+        ]);
+    }
+
+    public function testStreamRejectsCurlOption(): void
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('curl');
+
+        $handler(new Request('GET', Server::$url), [
+            'curl' => [\CURLOPT_LOW_SPEED_LIMIT => 10],
+        ]);
+    }
+
+    public function testStreamRejectsDigestAuth(): void
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Digest authentication');
+
+        $handler(new Request('GET', Server::$url), [
+            'auth' => ['user', 'pass', 'digest'],
+        ]);
+    }
+
+    public function testStreamRejectsExpectOptionWhenHeaderIsPresent(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('PUT', Server::$url, ['Expect' => '100-Continue'], 'test');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('expect');
+
+        $handler($request, [
+            'expect' => true,
+        ]);
     }
 
     public function testDrainsResponseAndReadsAllContentWhenContentLengthIsZero(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Test;
 
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Handler\CurlShare;
+use GuzzleHttp\Psr7;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
This follows up the 7.11 deprecations by making Guzzle 8 reject raw cURL request options and handler-specific request options that conflict with Guzzle-managed behavior. It also releases handler-owned cURL share state during close and updates the documentation to describe the 8.0 rejection behavior.