### PR TITLE
Deprecate raw cURL cookie option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Deprecated
 
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
-- Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE` and `CURLOPT_COOKIE`, which will be rejected in 8.0
+- Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE`, which will be rejected in 8.0
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Deprecated
 
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
-- Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE`, which will be rejected in 8.0
+- Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE` and `CURLOPT_COOKIE`, which will be rejected in 8.0
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -832,9 +832,8 @@ $client->request('GET', 'https://example.com', [
 > Guzzle-managed request handling trigger deprecation warnings. Use Guzzle
 > request options instead when configuring the request method, URI, body,
 > headers, timeouts, redirects, proxy, TLS, progress, debug output, sinks,
-> cookies, and protocols. Redirect middleware also validates
-> redirect targets with `allow_redirects.protocols` before creating each
-> redirect request.
+> cookies, and protocols. Redirect middleware also validates redirect targets
+> with `allow_redirects.protocols` before creating each redirect request.
 
 ## proxy
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -832,7 +832,7 @@ $client->request('GET', 'https://example.com', [
 > Guzzle-managed request handling trigger deprecation warnings. Use Guzzle
 > request options instead when configuring the request method, URI, body,
 > headers, timeouts, redirects, proxy, TLS, progress, debug output, sinks,
-> cookie storage, and protocols. Redirect middleware also validates
+> cookies, and protocols. Redirect middleware also validates
 > redirect targets with `allow_redirects.protocols` before creating each
 > redirect request.
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -364,6 +364,7 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_SSLKEYPASSWD', 'the "ssl_key" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_KEYPASSWD', 'the "ssl_key" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_SSLKEYTYPE', 'the "ssl_key_type" request option');
+        self::addConflictingCurlOption($options, 'CURLOPT_COOKIE', 'the "Cookie" request header or Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIEFILE', 'Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIEJAR', 'Guzzle cookie middleware');
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIELIST', 'Guzzle cookie middleware');


### PR DESCRIPTION
This extends the 7.11 raw cURL option deprecations to cover `CURLOPT_COOKIE`, since it bypasses Guzzle's Cookie header handling and cookie middleware. Use the Cookie request header for one-off cookie values or Guzzle's cookie middleware for managed cookies.