### PR TITLE
Remove obsolete cURL protocols test skip

### DIFF
--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -398,10 +398,6 @@ class CurlFactoryTest extends TestCase
 
     public function testProtocolsOptionCanRestrictCurlProtocols(): void
     {
-        if (!\defined('CURLOPT_PROTOCOLS')) {
-            self::markTestSkipped('CURLOPT_PROTOCOLS is not available.');
-        }
-
         $f = new CurlFactory(3);
         $f->create(new Psr7\Request('GET', 'https://example.com'), ['protocols' => ['https']]);
 


### PR DESCRIPTION
This removes a stale test skip around CURLOPT_PROTOCOLS. Guzzle 8's cURL handler already configures CURLOPT_PROTOCOLS directly, so the focused test can assert the option without treating it as optional.