### PR TITLE
Prefer string cURL protocols option

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -901,7 +901,11 @@ class CurlFactory implements CurlFactoryInterface
             throw new RequestException(\sprintf('The scheme "%s" is not allowed by the protocols request option.', $scheme), $easy->request);
         }
 
-        $conf[\CURLOPT_PROTOCOLS] = self::curlProtocolMask($protocols);
+        if (CurlVersion::supportsProtocolsStr()) {
+            $conf[(int) \constant('CURLOPT_PROTOCOLS_STR')] = \implode(',', $protocols);
+        } else {
+            $conf[\CURLOPT_PROTOCOLS] = self::curlProtocolMask($protocols);
+        }
 
         $version = $easy->request->getProtocolVersion();
 

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -16,6 +16,8 @@ final class CurlVersion
 
     private const HTTP_3_VERSION = '7.66.0';
 
+    private const PROTOCOLS_STR_VERSION = '7.85.0';
+
     private const PROXY_CREDENTIAL_REUSE_VERSION = '8.19.0';
 
     /**
@@ -73,6 +75,15 @@ final class CurlVersion
 
         return null !== $version
             && version_compare($version, self::PROXY_CREDENTIAL_REUSE_VERSION, '>=');
+    }
+
+    public static function supportsProtocolsStr(): bool
+    {
+        $version = self::get();
+
+        return \defined('CURLOPT_PROTOCOLS_STR')
+            && null !== $version
+            && version_compare($version, self::PROTOCOLS_STR_VERSION, '>=');
     }
 
     public static function ensureSupported(RequestInterface $request): void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\CurlShare;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -1008,8 +1009,7 @@ class ClientTest extends TestCase
         if (
             !\function_exists('curl_share_init')
             || !\function_exists('curl_exec')
-            || !\function_exists('curl_version')
-            || version_compare(curl_version()['version'], '7.34.0') < 0
+            || !CurlVersion::supportsTls12()
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -84,10 +84,7 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(0, $_SERVER['_curl'][\CURLOPT_HEADER]);
         self::assertSame(300, $_SERVER['_curl'][\CURLOPT_CONNECTTIMEOUT]);
         self::assertInstanceOf('Closure', $_SERVER['_curl'][\CURLOPT_HEADERFUNCTION]);
-        self::assertSame(
-            \CURLPROTO_HTTP | \CURLPROTO_HTTPS,
-            $_SERVER['_curl'][\CURLOPT_PROTOCOLS]
-        );
+        self::assertCurlProtocols(['http', 'https']);
         self::assertContains('Expect:', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
         self::assertContains('Accept:', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
         self::assertContains('Content-Type:', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
@@ -401,7 +398,49 @@ class CurlFactoryTest extends TestCase
         $f = new CurlFactory(3);
         $f->create(new Psr7\Request('GET', 'https://example.com'), ['protocols' => ['https']]);
 
-        self::assertSame(\CURLPROTO_HTTPS, $_SERVER['_curl'][\CURLOPT_PROTOCOLS]);
+        self::assertCurlProtocols(['https']);
+    }
+
+    public function testProtocolsOptionFallsBackToCurlProtocolsWhenRuntimeDoesNotSupportProtocolsStr(): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.84.0',
+            'features' => 0,
+        ]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), ['protocols' => ['https']]);
+
+            self::assertSame(\CURLPROTO_HTTPS, $_SERVER['_curl'][\CURLOPT_PROTOCOLS]);
+            if (\defined('CURLOPT_PROTOCOLS_STR')) {
+                self::assertArrayNotHasKey((int) \constant('CURLOPT_PROTOCOLS_STR'), $_SERVER['_curl']);
+            }
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testProtocolsOptionUsesProtocolsStrWhenRuntimeSupportsIt(): void
+    {
+        if (!\defined('CURLOPT_PROTOCOLS_STR')) {
+            self::markTestSkipped('CURLOPT_PROTOCOLS_STR is not available.');
+        }
+
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.85.0',
+            'features' => 0,
+        ]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), ['protocols' => ['https']]);
+
+            self::assertSame('https', $_SERVER['_curl'][(int) \constant('CURLOPT_PROTOCOLS_STR')]);
+            self::assertArrayNotHasKey(\CURLOPT_PROTOCOLS, $_SERVER['_curl']);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
     }
 
     public function testProtocolsOptionRejectsDisallowedCurlScheme(): void
@@ -2628,6 +2667,42 @@ class CurlFactoryTest extends TestCase
     {
         self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
         self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    /**
+     * @param string[] $expectedProtocols
+     */
+    private static function assertCurlProtocols(array $expectedProtocols): void
+    {
+        if (CurlVersion::supportsProtocolsStr()) {
+            self::assertSame(
+                \implode(',', $expectedProtocols),
+                $_SERVER['_curl'][(int) \constant('CURLOPT_PROTOCOLS_STR')]
+            );
+            self::assertArrayNotHasKey(\CURLOPT_PROTOCOLS, $_SERVER['_curl']);
+
+            return;
+        }
+
+        self::assertSame(self::curlProtocolMask($expectedProtocols), $_SERVER['_curl'][\CURLOPT_PROTOCOLS]);
+    }
+
+    /**
+     * @param string[] $protocols
+     */
+    private static function curlProtocolMask(array $protocols): int
+    {
+        $mask = 0;
+
+        if (\in_array('http', $protocols, true)) {
+            $mask |= \CURLPROTO_HTTP;
+        }
+
+        if (\in_array('https', $protocols, true)) {
+            $mask |= \CURLPROTO_HTTPS;
+        }
+
+        return $mask;
     }
 
     /**

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -70,10 +70,48 @@ class CurlVersionTest extends TestCase
         self::assertTrue(CurlVersion::supportsHttp3());
     }
 
+    public function testSupportsProtocolsStrReturnsFalseWhenVersionInfoIsUnavailable(): void
+    {
+        self::setVersionInfo(false);
+
+        self::assertFalse(CurlVersion::supportsProtocolsStr());
+    }
+
+    public function testSupportsProtocolsStrRequiresRuntimeVersion(): void
+    {
+        self::requiresProtocolsStrConstant();
+
+        self::setVersionInfo([
+            'version' => '7.84.0',
+            'features' => 0,
+        ]);
+
+        self::assertFalse(CurlVersion::supportsProtocolsStr());
+    }
+
+    public function testSupportsProtocolsStrWhenRuntimeAndConstantAreAvailable(): void
+    {
+        self::requiresProtocolsStrConstant();
+
+        self::setVersionInfo([
+            'version' => '7.85.0',
+            'features' => 0,
+        ]);
+
+        self::assertTrue(CurlVersion::supportsProtocolsStr());
+    }
+
     private static function requiresHttp3Constants(): void
     {
         if (!\defined('CURL_VERSION_HTTP3') || !\defined('CURL_HTTP_VERSION_3')) {
             self::markTestSkipped('HTTP/3 cURL constants are not available.');
+        }
+    }
+
+    private static function requiresProtocolsStrConstant(): void
+    {
+        if (!\defined('CURLOPT_PROTOCOLS_STR')) {
+            self::markTestSkipped('CURLOPT_PROTOCOLS_STR is not available.');
         }
     }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Test;
 
 use GuzzleHttp\Handler\CurlShare;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
@@ -373,8 +374,7 @@ class UtilsTest extends TestCase
         if (
             !\function_exists('curl_share_init')
             || !\function_exists('curl_exec')
-            || !\function_exists('curl_version')
-            || version_compare(curl_version()['version'], '7.34.0') < 0
+            || !CurlVersion::supportsTls12()
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }


### PR DESCRIPTION
This prefers CURLOPT_PROTOCOLS_STR for Guzzle's protocols request option when both the PHP cURL extension exposes the constant and the runtime libcurl version supports it. Older cURL installations continue to use the existing CURLOPT_PROTOCOLS bitmask fallback.