### PR TITLE
Allow read_timeout with cURL handlers

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -288,10 +288,6 @@ class CurlFactory implements CurlFactoryInterface
         if (\array_key_exists('stream_context', $options)) {
             \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "stream_context" request option to a cURL handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because cURL handlers ignore PHP stream context options.');
         }
-
-        if (\array_key_exists('read_timeout', $options)) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "read_timeout" request option to a cURL handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because cURL handlers ignore stream read timeouts. Use the "timeout" request option instead.');
-        }
     }
 
     /**


### PR DESCRIPTION
This keeps read_timeout accepted by cURL handlers without emitting a deprecation. The option is still meaningful for the stream handler, while cURL continues to ignore it so shared request options can be used across handlers without warning.