### PR TITLE
Remove read_timeout cURL handler test

### DIFF
--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -484,15 +484,6 @@ class CurlFactoryTest extends TestCase
         ]);
     }
 
-    public function testAcceptsReadTimeoutOption(): void
-    {
-        (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
-            'read_timeout' => 1,
-        ]);
-
-        self::assertArrayNotHasKey('read_timeout', $_SERVER['_curl']);
-    }
-
     public function testProtocolsOptionCanRestrictCurlProtocols(): void
     {
         $f = new CurlFactory(3);


### PR DESCRIPTION
This removes the cURL handler read_timeout acceptance test added while merging 7.11. The option is intentionally accepted as shared request configuration, but the behavior does not need dedicated 8.0 coverage.