### PR TITLE
Adjust HTTP/3 cURL fallback handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject malformed response protocol versions and reason phrases
 - Wrap malformed redirect `Location` values in `BadResponseException`
 - Default HTTPS requests sent by the built-in cURL and stream handlers to TLS 1.2 or newer
-- Adjust HTTP/3 cURL handling to avoid attempting HTTP/3 through effective proxies and to use a TLS 1.2 minimum so libcurl fallback to HTTP/2 or HTTP/1.1 remains viable
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them
 - Classify empty, malformed, or handler-unsupported request protocol versions as request exceptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject malformed response protocol versions and reason phrases
 - Wrap malformed redirect `Location` values in `BadResponseException`
 - Default HTTPS requests sent by the built-in cURL and stream handlers to TLS 1.2 or newer
+- Adjust HTTP/3 cURL handling to avoid attempting HTTP/3 through effective proxies and to use a TLS 1.2 minimum so libcurl fallback to HTTP/2 or HTTP/1.1 remains viable
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them
 - Classify empty, malformed, or handler-unsupported request protocol versions as request exceptions

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1253,7 +1253,11 @@ The built-in stream handler supports only HTTP versions `1.0` and `1.1`.
 
 Empty or malformed `version` request option values are rejected before the request is sent. If a request uses a well-formed HTTP version that a built-in handler cannot send, the transfer fails with `GuzzleHttp\Exception\RequestException`.
 
-HTTP/3 requests sent by the built-in cURL handler use TLS 1.3 or newer. Lower TLS versions requested through `crypto_method` or `curl` options are upgraded to TLS 1.3 for HTTP/3 requests.
+HTTP/3 requests sent by the built-in cURL handler use Guzzle's normal HTTPS guard rail of TLS 1.2 or newer. HTTP/3 itself is negotiated by libcurl over QUIC and requires TLS 1.3 support in the cURL stack. If `crypto_method` explicitly requests TLS 1.3, Guzzle preserves that stricter minimum. Raw `CURLOPT_SSLVERSION` values passed through the `curl` option are rejected because TLS version handling is managed by Guzzle.
+
+When an effective proxy is selected for a request configured with `version => 3.0`, Guzzle does not attempt HTTP/3 through the proxy path. It falls back to HTTP/2 when available, otherwise HTTP/1.1. A matching proxy `no` rule is treated as a direct request and still allows HTTP/3 to be attempted.
 
 > [!NOTE]
-> For HTTP/3, Guzzle uses libcurl's `CURL_HTTP_VERSION_3`, which attempts HTTP/3 and allows libcurl to fall back to an earlier HTTP version if needed.
+> For HTTP/3, Guzzle uses libcurl's `CURL_HTTP_VERSION_3`, which attempts HTTP/3 and allows libcurl to fall back to an earlier HTTP version if needed. The response protocol version may therefore be lower than the requested request protocol version.
+
+Guzzle does not currently expose libcurl's `CURL_HTTP_VERSION_3ONLY` strict HTTP/3 mode.

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1285,26 +1285,9 @@ class CurlFactory implements CurlFactoryInterface
             $isHttp3 = '3' === $protocolVersion || '3.0' === $protocolVersion;
             $isHttp2 = '2' === $protocolVersion || '2.0' === $protocolVersion;
 
-            if ($isHttp3) {
-                // CURLOPT_SSLVERSION also affects fallback HTTPS transfers, so
-                // keep the same TLS 1.2 minimum as HTTP/2 unless TLS 1.3 was
-                // explicitly requested.
-                if (
-                    \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $cryptoMethod
-                    || \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $cryptoMethod
-                    || \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $cryptoMethod
-                ) {
-                    $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
-                } elseif (\STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
-                    if (!CurlVersion::supportsTls13()) {
-                        throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
-                    }
-                    $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;
-                } else {
-                    throw new \InvalidArgumentException('Invalid crypto_method request option: unknown version provided');
-                }
-            } elseif ($isHttp2) {
-                // If HTTP/2, upgrade TLS 1.0 and 1.1 to 1.2.
+            if ($isHttp3 || $isHttp2) {
+                // HTTP/2 requires TLS 1.2. HTTP/3 uses the same guard rail
+                // because CURLOPT_SSLVERSION also affects fallback transfers.
                 if (
                     \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $cryptoMethod
                     || \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $cryptoMethod

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -143,10 +143,6 @@ class CurlFactory implements CurlFactoryInterface
             $conf = \array_replace($conf, $options['curl']);
         }
 
-        if ('3' === $protocolVersion || '3.0' === $protocolVersion) {
-            $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;
-        }
-
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
         if ($this->shareHandle !== null) {
             if (!\defined('CURLOPT_SHARE')) {
@@ -903,6 +899,61 @@ class CurlFactory implements CurlFactoryInterface
     }
 
     /**
+     * @return array{set: bool, proxy: string, no_proxy: string, effective: ?string}
+     */
+    private static function resolveProxy(RequestInterface $request, array $options): array
+    {
+        $resolved = [
+            'set' => false,
+            'proxy' => '',
+            'no_proxy' => '',
+            'effective' => null,
+        ];
+
+        if (!isset($options['proxy'])) {
+            return $resolved;
+        }
+
+        $proxy = $options['proxy'];
+        if (!\is_array($proxy)) {
+            if (!\is_string($proxy)) {
+                throw new \InvalidArgumentException('proxy must be a string or array');
+            }
+
+            $resolved['set'] = true;
+            $resolved['proxy'] = $proxy;
+            $resolved['effective'] = $proxy !== '' ? $proxy : null;
+
+            return $resolved;
+        }
+
+        $scheme = $request->getUri()->getScheme();
+        if (!isset($proxy[$scheme])) {
+            return $resolved;
+        }
+
+        if (!\is_string($proxy[$scheme])) {
+            throw new \InvalidArgumentException('proxy values must be strings');
+        }
+
+        $uri = $request->getUri();
+        $noProxy = isset($proxy['no']) ? Utils::normalizeNoProxy($proxy['no']) : [];
+        if ($noProxy !== [] && Utils::isUriInNoProxy($uri, $noProxy)) {
+            $resolved['set'] = true;
+            $resolved['proxy'] = '';
+            $resolved['no_proxy'] = '*';
+
+            return $resolved;
+        }
+
+        $resolved['set'] = true;
+        $resolved['proxy'] = $proxy[$scheme];
+        $resolved['effective'] = $proxy[$scheme] !== '' ? $proxy[$scheme] : null;
+
+        return $resolved;
+    }
+
+    /**
      * @return array<int|string, mixed>
      */
     private function getDefaultConf(EasyHandle $easy): array
@@ -934,7 +985,11 @@ class CurlFactory implements CurlFactoryInterface
             if (!\defined('CURL_HTTP_VERSION_3')) {
                 throw new \RuntimeException('HTTP/3 is not supported by this cURL installation.');
             }
-            $conf[\CURLOPT_HTTP_VERSION] = (int) \constant('CURL_HTTP_VERSION_3');
+
+            $proxy = self::resolveProxy($easy->request, $easy->options);
+            $conf[\CURLOPT_HTTP_VERSION] = null !== $proxy['effective']
+                ? (CurlVersion::supportsHttp2() ? \CURL_HTTP_VERSION_2_0 : \CURL_HTTP_VERSION_1_1)
+                : (int) \constant('CURL_HTTP_VERSION_3');
         } elseif ('2' === $version || '2.0' === $version) {
             $conf[\CURLOPT_HTTP_VERSION] = \CURL_HTTP_VERSION_2_0;
         } elseif ('1.1' === $version) {
@@ -1202,37 +1257,11 @@ class CurlFactory implements CurlFactoryInterface
             $conf[\CURLOPT_NOSIGNAL] = true;
         }
 
-        $selectedProxy = null;
-
-        if (isset($options['proxy'])) {
-            $proxy = $options['proxy'];
-            if (!\is_array($proxy)) {
-                if (!\is_string($proxy)) {
-                    throw new \InvalidArgumentException('proxy must be a string or array');
-                }
-
-                $selectedProxy = $proxy;
-                $conf[\CURLOPT_PROXY] = $proxy;
-                $conf[\CURLOPT_NOPROXY] = '';
-            } else {
-                $scheme = $easy->request->getUri()->getScheme();
-                if (isset($proxy[$scheme])) {
-                    if (!\is_string($proxy[$scheme])) {
-                        throw new \InvalidArgumentException('proxy values must be strings');
-                    }
-
-                    $uri = $easy->request->getUri();
-                    $noProxy = isset($proxy['no']) ? Utils::normalizeNoProxy($proxy['no']) : [];
-                    if ($noProxy !== [] && Utils::isUriInNoProxy($uri, $noProxy)) {
-                        $conf[\CURLOPT_PROXY] = '';
-                        $conf[\CURLOPT_NOPROXY] = '*';
-                    } else {
-                        $selectedProxy = $proxy[$scheme];
-                        $conf[\CURLOPT_PROXY] = $proxy[$scheme];
-                        $conf[\CURLOPT_NOPROXY] = '';
-                    }
-                }
-            }
+        $proxy = self::resolveProxy($easy->request, $options);
+        $selectedProxy = $proxy['effective'];
+        if ($proxy['set']) {
+            $conf[\CURLOPT_PROXY] = $proxy['proxy'];
+            $conf[\CURLOPT_NOPROXY] = $proxy['no_proxy'];
         }
 
         $proxyForConnectionReuse = self::getEffectiveProxyForConnectionReuse($selectedProxy, $options);
@@ -1257,13 +1286,19 @@ class CurlFactory implements CurlFactoryInterface
             $isHttp2 = '2' === $protocolVersion || '2.0' === $protocolVersion;
 
             if ($isHttp3) {
-                // HTTP/3 runs over QUIC and requires TLS 1.3.
+                // CURLOPT_SSLVERSION also affects fallback HTTPS transfers, so
+                // keep the same TLS 1.2 minimum as HTTP/2 unless TLS 1.3 was
+                // explicitly requested.
                 if (
                     \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT === $cryptoMethod
                     || \STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $cryptoMethod
                     || \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $cryptoMethod
-                    || \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod
                 ) {
+                    $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
+                } elseif (\STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $cryptoMethod) {
+                    if (!CurlVersion::supportsTls13()) {
+                        throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
+                    }
                     $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;
                 } else {
                     throw new \InvalidArgumentException('Invalid crypto_method request option: unknown version provided');

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -327,7 +327,7 @@ final class RequestOptions
      *
      * HTTP/3 is supported by the built-in cURL handler on PHP 8.4 or higher
      * when the PHP cURL extension and linked libcurl support HTTP/3 and
-     * TLS 1.3.
+     * TLS 1.3. HTTP/3 requests use libcurl's fallback-capable HTTP/3 mode.
      */
     public const VERSION = 'version';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1800,7 +1800,154 @@ class CurlFactoryTest extends TestCase
         self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $conf[\CURLOPT_HTTP_VERSION]);
     }
 
-    public function testHttp3UpgradesWeakCryptoMethodToTls13Minimum(): void
+    public function testHttp3WithEffectiveProxyFallsBackToHttp2WhenSupported(): void
+    {
+        self::requireHttp3TestConstants();
+
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3FeatureMask(true),
+        ]);
+
+        try {
+            $factory = new CurlFactory(3);
+            $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+                'proxy' => ['https' => 'http://proxy.example.com:8080'],
+            ]);
+
+            self::assertSame('http://proxy.example.com:8080', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+            self::assertSame(\CURL_HTTP_VERSION_2_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+            self::assertSame(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testHttp3WithStringProxyFallsBackToHttp2WhenSupported(): void
+    {
+        self::requireHttp3TestConstants();
+
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3FeatureMask(true),
+        ]);
+
+        try {
+            $factory = new CurlFactory(3);
+            $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+                'proxy' => 'http://proxy.example.com:8080',
+            ]);
+
+            self::assertSame('http://proxy.example.com:8080', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+            self::assertSame(\CURL_HTTP_VERSION_2_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testHttp3WithEffectiveProxyFallsBackToHttp11WhenHttp2IsUnsupported(): void
+    {
+        self::requireHttp3TestConstants();
+
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3FeatureMask(false),
+        ]);
+
+        try {
+            $factory = new CurlFactory(3);
+            $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+                'proxy' => ['https' => 'http://proxy.example.com:8080'],
+            ]);
+
+            self::assertSame(\CURL_HTTP_VERSION_1_1, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+            self::assertSame(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testHttp3WithMatchingNoProxyKeepsHttp3(): void
+    {
+        self::requireHttp3TestConstants();
+
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3FeatureMask(true),
+        ]);
+
+        try {
+            $factory = new CurlFactory(3);
+            $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+                'proxy' => [
+                    'https' => 'http://proxy.example.com:8080',
+                    'no' => ['example.com'],
+                ],
+            ]);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+            self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+            self::assertSame(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testHttp3WithEmptyProxyOptionKeepsHttp3(): void
+    {
+        self::requireHttp3TestConstants();
+
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3FeatureMask(true),
+        ]);
+
+        try {
+            $factory = new CurlFactory(3);
+            $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+                'proxy' => '',
+            ]);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+            self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testHttp3WithProxyStillRequiresHttp3SupportBeforeDowngrade(): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => 0,
+        ]);
+
+        try {
+            $factory = new CurlFactory(3);
+            $request = new Psr7\Request('GET', 'https://example.com', [], null, '3.0');
+
+            try {
+                $factory->create($request, [
+                    'proxy' => ['https' => 'http://proxy.example.com:8080'],
+                ]);
+                self::fail('Expected request exception.');
+            } catch (RequestException $e) {
+                self::assertSame($request, $e->getRequest());
+                self::assertStringContainsString('HTTP/3 is supported by the cURL handler', $e->getMessage());
+            }
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    /**
+     * @dataProvider http3WeakCryptoMethodProvider
+     */
+    public function testHttp3UpgradesWeakCryptoMethodToTls12Minimum(int $cryptoMethod): void
     {
         if (!CurlVersion::supportsHttp3()) {
             self::markTestSkipped('HTTP/3 is not supported by this cURL installation.');
@@ -1808,10 +1955,52 @@ class CurlFactoryTest extends TestCase
 
         $factory = new CurlFactory(3);
         $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
-            'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT,
+            'crypto_method' => $cryptoMethod,
+        ]);
+
+        self::assertSame(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+    }
+
+    public function testHttp3PreservesExplicitTls13CryptoMethod(): void
+    {
+        if (!CurlVersion::supportsHttp3()) {
+            self::markTestSkipped('HTTP/3 is not supported by this cURL installation.');
+        }
+
+        $factory = new CurlFactory(3);
+        $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+            'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT,
         ]);
 
         self::assertSame(\CURL_SSLVERSION_TLSv1_3, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+    }
+
+    public function testHttp3DefaultsHttpsToTls12Minimum(): void
+    {
+        if (!CurlVersion::supportsHttp3()) {
+            self::markTestSkipped('HTTP/3 is not supported by this cURL installation.');
+        }
+
+        $factory = new CurlFactory(3);
+        $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), []);
+
+        self::assertSame(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+    }
+
+    public function testHttp3ValidatesCryptoMethodInvalidMethod(): void
+    {
+        if (!CurlVersion::supportsHttp3()) {
+            self::markTestSkipped('HTTP/3 is not supported by this cURL installation.');
+        }
+
+        $factory = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid crypto_method request option: unknown version provided');
+
+        $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
+            'crypto_method' => 123,
+        ]);
     }
 
     public function testHttp3RejectsRawCurlSslVersionOption(): void
@@ -1835,6 +2024,15 @@ class CurlFactoryTest extends TestCase
         return [
             ['3'],
             ['3.0'],
+        ];
+    }
+
+    public static function http3WeakCryptoMethodProvider(): array
+    {
+        return [
+            [\STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT],
+            [\STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT],
+            [\STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT],
         ];
     }
 
@@ -2821,6 +3019,31 @@ class CurlFactoryTest extends TestCase
         }
 
         return (int) \constant('CURLOPT_PROXYHEADER');
+    }
+
+    private static function requireHttp3TestConstants(): void
+    {
+        foreach (['CURL_VERSION_HTTP3', 'CURL_HTTP_VERSION_3', 'CURL_SSLVERSION_TLSv1_3'] as $constant) {
+            if (!\defined($constant)) {
+                self::markTestSkipped($constant.' is not available.');
+            }
+        }
+    }
+
+    private static function http3FeatureMask(bool $withHttp2): int
+    {
+        self::requireHttp3TestConstants();
+
+        $features = (int) \constant('CURL_VERSION_HTTP3');
+        if ($withHttp2) {
+            if (!\defined('CURL_VERSION_HTTP2')) {
+                self::markTestSkipped('CURL_VERSION_HTTP2 is not available.');
+            }
+
+            $features |= (int) \constant('CURL_VERSION_HTTP2');
+        }
+
+        return $features;
     }
 
     public static function curlHandlerProvider(): array

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1786,16 +1786,10 @@ class CurlFactoryTest extends TestCase
             self::markTestSkipped('HTTP/3 cURL constants are not available.');
         }
 
-        $factory = new CurlFactory(3);
-        $easy = new EasyHandle();
-        $easy->request = new Psr7\Request('GET', 'https://example.com', [], null, $protocolVersion);
-
-        $method = new \ReflectionMethod(CurlFactory::class, 'getDefaultConf');
-        if (\PHP_VERSION_ID < 80100) {
-            $method->setAccessible(true);
-        }
-
-        $conf = $method->invoke($factory, $easy);
+        $conf = self::getDefaultCurlConf(
+            new Psr7\Request('GET', 'https://example.com', [], null, $protocolVersion),
+            []
+        );
 
         self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $conf[\CURLOPT_HTTP_VERSION]);
     }
@@ -1879,18 +1873,17 @@ class CurlFactoryTest extends TestCase
         ]);
 
         try {
-            $factory = new CurlFactory(3);
-            $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
-                'proxy' => [
-                    'https' => 'http://proxy.example.com:8080',
-                    'no' => ['example.com'],
-                ],
-            ]);
+            $conf = self::getDefaultCurlConf(
+                new Psr7\Request('GET', 'https://example.com', [], null, '3.0'),
+                [
+                    'proxy' => [
+                        'https' => 'http://proxy.example.com:8080',
+                        'no' => ['example.com'],
+                    ],
+                ]
+            );
 
-            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
-            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
-            self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
-            self::assertSame(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+            self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $conf[\CURLOPT_HTTP_VERSION]);
         } finally {
             self::setCurlVersionInfo($previousVersionInfo);
         }
@@ -1906,14 +1899,12 @@ class CurlFactoryTest extends TestCase
         ]);
 
         try {
-            $factory = new CurlFactory(3);
-            $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), [
-                'proxy' => '',
-            ]);
+            $conf = self::getDefaultCurlConf(
+                new Psr7\Request('GET', 'https://example.com', [], null, '3.0'),
+                ['proxy' => '']
+            );
 
-            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
-            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
-            self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+            self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $conf[\CURLOPT_HTTP_VERSION]);
         } finally {
             self::setCurlVersionInfo($previousVersionInfo);
         }
@@ -3019,6 +3010,26 @@ class CurlFactoryTest extends TestCase
         }
 
         return (int) \constant('CURLOPT_PROXYHEADER');
+    }
+
+    /**
+     * @param array<int|string, mixed> $options
+     *
+     * @return array<int|string, mixed>
+     */
+    private static function getDefaultCurlConf(RequestInterface $request, array $options): array
+    {
+        $factory = new CurlFactory(3);
+        $easy = new EasyHandle();
+        $easy->request = $request;
+        $easy->options = $options;
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'getDefaultConf');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        return $method->invoke($factory, $easy);
     }
 
     private static function requireHttp3TestConstants(): void


### PR DESCRIPTION
This keeps HTTP/3 support detection strict while making the cURL transfer options safer for fallback cases. Requests using HTTP/3 no longer attempt HTTP/3 through an effective proxy, and the TLS guard rail now stays at TLS 1.2 or newer unless TLS 1.3 is explicitly requested, so libcurl can fall back to HTTP/2 or HTTP/1.1 more reliably.