### PR TITLE
Remove deprecation contracts upgrade note

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,8 +31,7 @@ files, builds multipart requests, works with URIs, or inspects streams.
 Also read the [Guzzle Promises 3.x upgrade guide][promises-upgrade-guide] if you
 use async requests, custom handlers, middleware, pools, or promise helpers.
 
-Guzzle 8 now requires `psr/http-factory:^1.0` directly and no longer depends on
-`symfony/deprecation-contracts`.
+Guzzle 8 now requires `psr/http-factory:^1.0` directly.
 
 [psr7-upgrade-guide]: https://github.com/guzzle/psr7/blob/3.0/UPGRADING.md
 [promises-upgrade-guide]: https://github.com/guzzle/promises/blob/3.0/UPGRADING.md


### PR DESCRIPTION
This removes the Symfony deprecation contracts dependency removal note from the Guzzle 8 upgrade guide. The guide still documents the new direct PSR HTTP Factory dependency, which is the relevant dependency change for users.