### PR TITLE
Add PHP 7.4 return types

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1087,7 +1087,7 @@ class CurlFactory implements CurlFactoryInterface
             if ($body->isSeekable()) {
                 $body->rewind();
             }
-            $conf[\CURLOPT_READFUNCTION] = static function ($ch, $fd, $length) use ($body) {
+            $conf[\CURLOPT_READFUNCTION] = static function ($ch, $fd, $length) use ($body): string {
                 return $body->read($length);
             };
         }
@@ -1485,7 +1485,7 @@ class CurlFactory implements CurlFactoryInterface
             $onHeaders,
             $easy,
             &$startingResponse
-        ) {
+        ): int {
             $value = \trim($h);
             if ($value === '') {
                 $startingResponse = true;

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -112,11 +112,9 @@ final class EasyHandle
     /**
      * @param string $name
      *
-     * @return void
-     *
      * @throws \BadMethodCallException
      */
-    public function __get($name)
+    public function __get($name): void
     {
         $msg = $name === 'handle' ? 'The EasyHandle has been released' : 'Invalid property: '.$name;
         throw new \BadMethodCallException($msg);

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -139,7 +139,7 @@ class MockHandler implements \Countable
 
                 return $value;
             },
-            function ($reason) use ($request, $options, $onHeadersResponse) {
+            function ($reason) use ($request, $options, $onHeadersResponse): PromiseInterface {
                 $this->invokeStats($request, $options, $onHeadersResponse, $reason);
                 if ($this->onRejected) {
                     ($this->onRejected)($reason);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -883,7 +883,7 @@ class StreamHandler
 
         self::addNotification(
             $params,
-            static function ($code, $a, $b, $c, $transferred, $total) use ($value) {
+            static function ($code, $a, $b, $c, $transferred, $total) use ($value): void {
                 if ($code == \STREAM_NOTIFY_PROGRESS) {
                     // The upload progress cannot be determined. Use 0 for cURL compatibility:
                     // https://curl.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html
@@ -945,7 +945,7 @@ class StreamHandler
 
     private static function callArray(array $functions): callable
     {
-        return static function (...$args) use ($functions) {
+        return static function (...$args) use ($functions): void {
             foreach ($functions as $fn) {
                 $fn(...$args);
             }

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -189,7 +189,7 @@ class HandlerStack
             $count = \count($this->stack);
             $this->stack = \array_values(\array_filter(
                 $this->stack,
-                static function ($tuple) use ($remove) {
+                static function ($tuple) use ($remove): bool {
                     return $tuple[1] !== $remove;
                 }
             ));
@@ -201,7 +201,7 @@ class HandlerStack
 
         $this->stack = \array_values(\array_filter(
             $this->stack,
-            static function ($tuple) use ($remove) {
+            static function ($tuple) use ($remove): bool {
                 return $tuple[0] !== $remove;
             }
         ));

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -75,7 +75,7 @@ class MessageFormatter implements MessageFormatterInterface
         /** @var string */
         return \preg_replace_callback(
             '/{\s*([A-Za-z_\-\.0-9]+)\s*}/',
-            function (array $matches) use ($request, $response, $error, &$cache) {
+            function (array $matches) use ($request, $response, $error, &$cache): string {
                 if (isset($cache[$matches[1]])) {
                     return $cache[$matches[1]];
                 }
@@ -176,6 +176,7 @@ class MessageFormatter implements MessageFormatterInterface
                         }
                 }
 
+                $result = (string) $result;
                 $cache[$matches[1]] = $result;
 
                 return $result;

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -26,7 +26,7 @@ final class Middleware
     public static function cookies(): callable
     {
         return static function (callable $handler): callable {
-            return static function ($request, array $options) use ($handler) {
+            return static function ($request, array $options) use ($handler): PromiseInterface {
                 if (empty($options['cookies'])) {
                     return $handler($request, $options);
                 } elseif (!$options['cookies'] instanceof CookieJarInterface) {
@@ -58,13 +58,13 @@ final class Middleware
     public static function httpErrors(?BodySummarizerInterface $bodySummarizer = null): callable
     {
         return static function (callable $handler) use ($bodySummarizer): callable {
-            return static function ($request, array $options) use ($handler, $bodySummarizer) {
+            return static function ($request, array $options) use ($handler, $bodySummarizer): PromiseInterface {
                 if (empty($options['http_errors'])) {
                     return $handler($request, $options);
                 }
 
                 return $handler($request, $options)->then(
-                    static function (ResponseInterface $response) use ($request, $bodySummarizer) {
+                    static function (ResponseInterface $response) use ($request, $bodySummarizer): ResponseInterface {
                         $code = $response->getStatusCode();
                         if ($code < 400) {
                             return $response;
@@ -92,9 +92,9 @@ final class Middleware
         }
 
         return static function (callable $handler) use (&$container): callable {
-            return static function (RequestInterface $request, array $options) use ($handler, &$container) {
+            return static function (RequestInterface $request, array $options) use ($handler, &$container): PromiseInterface {
                 return $handler($request, $options)->then(
-                    static function ($value) use ($request, &$container, $options) {
+                    static function ($value) use ($request, &$container, $options): ResponseInterface {
                         $container[] = [
                             'request' => $request,
                             'response' => $value,
@@ -104,7 +104,7 @@ final class Middleware
 
                         return $value;
                     },
-                    static function ($reason) use ($request, &$container, $options) {
+                    static function ($reason) use ($request, &$container, $options): PromiseInterface {
                         $container[] = [
                             'request' => $request,
                             'response' => null,
@@ -135,7 +135,7 @@ final class Middleware
     public static function tap(?callable $before = null, ?callable $after = null): callable
     {
         return static function (callable $handler) use ($before, $after): callable {
-            return static function (RequestInterface $request, array $options) use ($handler, $before, $after) {
+            return static function (RequestInterface $request, array $options) use ($handler, $before, $after): PromiseInterface {
                 if ($before) {
                     $before($request, $options);
                 }
@@ -204,7 +204,7 @@ final class Middleware
         }
 
         return static function (callable $handler) use ($logger, $formatter, $logLevel): callable {
-            return static function (RequestInterface $request, array $options = []) use ($handler, $logger, $formatter, $logLevel) {
+            return static function (RequestInterface $request, array $options = []) use ($handler, $logger, $formatter, $logLevel): PromiseInterface {
                 return $handler($request, $options)->then(
                     static function ($response) use ($logger, $request, $formatter, $logLevel): ResponseInterface {
                         $message = $formatter->format($request, $response);
@@ -248,7 +248,7 @@ final class Middleware
     public static function mapRequest(callable $fn): callable
     {
         return static function (callable $handler) use ($fn): callable {
-            return static function (RequestInterface $request, array $options) use ($handler, $fn) {
+            return static function (RequestInterface $request, array $options) use ($handler, $fn): PromiseInterface {
                 return $handler($fn($request), $options);
             };
         };
@@ -264,7 +264,7 @@ final class Middleware
     public static function mapResponse(callable $fn): callable
     {
         return static function (callable $handler) use ($fn): callable {
-            return static function (RequestInterface $request, array $options) use ($handler, $fn) {
+            return static function (RequestInterface $request, array $options) use ($handler, $fn): PromiseInterface {
                 return $handler($request, $options)->then($fn);
             };
         };

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -52,7 +52,7 @@ class Pool implements PromisorInterface
             $opts = [];
         }
 
-        $requestGenerator = static function () use ($requests, $client, $opts) {
+        $requestGenerator = static function () use ($requests, $client, $opts): \Generator {
             foreach ($requests as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {
                     yield $key => $client->sendAsync($rfn, $opts);
@@ -113,12 +113,12 @@ class Pool implements PromisorInterface
     private static function cmpCallback(array &$options, string $name, array &$results): void
     {
         if (!isset($options[$name])) {
-            $options[$name] = static function ($v, $k) use (&$results) {
+            $options[$name] = static function ($v, $k) use (&$results): void {
                 $results[$k] = $v;
             };
         } else {
             $currentFn = $options[$name];
-            $options[$name] = static function ($v, $k) use (&$results, $currentFn) {
+            $options[$name] = static function ($v, $k) use (&$results, $currentFn): void {
                 $currentFn($v, $k);
                 $results[$k] = $v;
             };

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -134,7 +134,7 @@ class RedirectMiddleware
     private function withTracking(PromiseInterface $promise, string $uri, int $statusCode): PromiseInterface
     {
         return $promise->then(
-            static function (ResponseInterface $response) use ($uri, $statusCode) {
+            static function (ResponseInterface $response) use ($uri, $statusCode): ResponseInterface {
                 // Note that we are pushing to the front of the list as this
                 // would be an earlier response than what is currently present
                 // in the history header.

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -87,7 +87,7 @@ class RetryMiddleware
      */
     private function onRejected(RequestInterface $req, array $options): callable
     {
-        return function ($reason) use ($req, $options) {
+        return function ($reason) use ($req, $options): PromiseInterface {
             if (!($this->decider)(
                 $options['retries'],
                 $req,


### PR DESCRIPTION
This adds PHP 7.4-compatible native return types to internal callbacks, middleware closures, and a final magic method where the existing return values are already explicit. It keeps PHP 7.4 compatibility by avoiding union, mixed, literal, and resource return declarations.