### PR TITLE
Remove auth option on cross-origin redirects

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -294,6 +294,18 @@ $client->request('GET', '/', [
 ]);
 ```
 
+#### Cross-origin redirect auth cleanup
+
+Guzzle 8 no longer forwards the generic `auth` request option when automatic
+redirects cross origin. Guzzle already removed the `Authorization` and `Cookie`
+headers and cURL HTTP authentication options on cross-origin redirects; this now
+also applies to handler-visible `auth` state.
+
+Same-origin redirects continue to preserve `auth`. If an application or custom
+handler intentionally reused `auth` across redirected origins, disable automatic
+redirects or handle redirects manually so each origin receives explicit
+credentials.
+
 #### Handler-specific option overrides
 
 Handler-specific overrides remain available for finer transport control when

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -108,9 +108,9 @@ echo $res->getHeaderLine('X-Guzzle-Redirect-Status-History');
 
 Guzzle considers a redirect cross-origin when the scheme, host, or effective port changes.
 
-On cross-origin redirects, Guzzle removes the `Authorization` and `Cookie` headers and clears cURL HTTP authentication options such as `CURLOPT_HTTPAUTH` and `CURLOPT_USERPWD`.
+On cross-origin redirects, Guzzle removes origin-scoped HTTP credentials before sending the redirected request. This includes the `Authorization` and `Cookie` headers, the generic `auth` request option, and cURL HTTP authentication options such as `CURLOPT_HTTPAUTH` and `CURLOPT_USERPWD`.
 
-Guzzle does not automatically remove other request options or headers solely because the redirect is cross-origin. This matches curl's redirect model. In particular, TLS client authentication options such as `cert`, `ssl_key`, custom cURL TLS options, and stream context TLS options are not removed automatically on cross-origin redirects.
+Same-origin redirects preserve those values. Guzzle does not automatically remove transport identity or TLS client credential options solely because the redirect is cross-origin. In particular, TLS client authentication options such as `cert`, `ssl_key`, custom cURL TLS options, and stream context TLS options are not removed automatically on cross-origin redirects.
 
 If TLS client credentials are only trusted for the original origin, disable automatic redirects and handle redirect responses manually, or use separate clients and request options for trusted origins.
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -94,12 +94,16 @@ class RedirectMiddleware
         $this->guardMax($request, $response, $options);
         $nextRequest = $this->modifyRequest($request, $options, $response);
 
-        // If authorization is handled by curl, unset it if URI is cross-origin.
-        if (Psr7\UriComparator::isCrossOrigin($request->getUri(), $nextRequest->getUri()) && defined('\CURLOPT_HTTPAUTH')) {
-            unset(
-                $options['curl'][\CURLOPT_HTTPAUTH],
-                $options['curl'][\CURLOPT_USERPWD]
-            );
+        // Remove HTTP origin credentials if URI is cross-origin.
+        if (Psr7\UriComparator::isCrossOrigin($request->getUri(), $nextRequest->getUri())) {
+            unset($options['auth']);
+
+            if (defined('\CURLOPT_HTTPAUTH')) {
+                unset(
+                    $options['curl'][\CURLOPT_HTTPAUTH],
+                    $options['curl'][\CURLOPT_USERPWD]
+                );
+            }
         }
 
         if (isset($options['allow_redirects']['on_redirect'])) {

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -710,6 +710,31 @@ class RedirectMiddlewareTest extends TestCase
         $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
     }
 
+    /**
+     * @dataProvider crossOriginRedirectProvider
+     */
+    public function testAuthOptionTreatmentOnRedirect(string $originalUri, string $targetUri, bool $isCrossOrigin): void
+    {
+        $auth = ['testuser', 'testpass'];
+
+        $mock = new MockHandler([
+            new Response(302, ['Location' => $targetUri]),
+            static function (RequestInterface $request, array $options) use ($auth, $isCrossOrigin): ResponseInterface {
+                if ($isCrossOrigin) {
+                    self::assertArrayNotHasKey('auth', $options);
+                } else {
+                    self::assertArrayHasKey('auth', $options);
+                    self::assertSame($auth, $options['auth']);
+                }
+
+                return new Response(200);
+            },
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $client->get($originalUri, ['auth' => $auth]);
+    }
+
     public static function crossOriginRedirectProvider(): array
     {
         return [


### PR DESCRIPTION
This prevents the generic auth request option from being forwarded when Guzzle follows a cross-origin redirect. It aligns custom handler behavior with the existing Authorization header and cURL auth cleanup semantics while preserving same-origin redirect behavior.