### PR TITLE
Enable strict types in low-risk files

### DIFF
--- a/src/BodySummarizer.php
+++ b/src/BodySummarizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use Psr\Http\Message\MessageInterface;

--- a/src/BodySummarizerInterface.php
+++ b/src/BodySummarizerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use Psr\Http\Message\MessageInterface;

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\GuzzleException;

--- a/src/Exception/BadResponseException.php
+++ b/src/Exception/BadResponseException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 /**

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/Exception/GuzzleException.php
+++ b/src/Exception/GuzzleException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 use Psr\Http\Client\ClientExceptionInterface;

--- a/src/Exception/HandlerClosedException.php
+++ b/src/Exception/HandlerClosedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 class HandlerClosedException extends TransferException

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 final class InvalidArgumentException extends \InvalidArgumentException implements GuzzleException

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 use Psr\Http\Client\NetworkExceptionInterface;

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 use GuzzleHttp\BodySummarizer;

--- a/src/Exception/ServerException.php
+++ b/src/Exception/ServerException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 /**

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 /**

--- a/src/Exception/TooManyRedirectsException.php
+++ b/src/Exception/TooManyRedirectsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 class TooManyRedirectsException extends RequestException

--- a/src/Exception/TransferException.php
+++ b/src/Exception/TransferException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Exception;
 
 class TransferException extends \RuntimeException implements GuzzleException

--- a/src/Handler/CurlFactoryInterface.php
+++ b/src/Handler/CurlFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/Handler/CurlShare.php
+++ b/src/Handler/CurlShare.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 final class CurlShare

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Utils;

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Psr7\Response;

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Utils;

--- a/src/Handler/Proxy.php
+++ b/src/Handler/Proxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Promise\PromiseInterface;

--- a/src/MessageFormatterInterface.php
+++ b/src/MessageFormatterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 /**


### PR DESCRIPTION
This enables strict types in exception classes, simple interfaces, and low-risk internal helper files where scalar coercion is not part of the public behavior.