### PR TITLE
Make static utility classes non-instantiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Release built-in cURL easy handles before invoking `on_stats`
 - Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available
 - Reject cURL multi handler promises when transfer completion callbacks throw during manual event-loop ticks
+- Made static utility classes non-instantiable and declared `GuzzleHttp\Handler\Proxy` final
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -474,6 +474,16 @@ pass a custom delay callable to `Middleware::retry()`.
 `RedirectMiddleware::$defaultSettings` has been removed. Use
 `RedirectMiddleware::DEFAULT_SETTINGS` instead.
 
+#### Non-instantiable utility classes
+
+Static utility and constant classes such as `GuzzleHttp\Middleware`,
+`GuzzleHttp\Utils`, `GuzzleHttp\RequestOptions`,
+`GuzzleHttp\Handler\HeaderProcessor`, and `GuzzleHttp\Handler\Proxy` now have
+private constructors. `GuzzleHttp\Handler\Proxy` is also declared `final`.
+
+These classes only expose static members. Replace any accidental instantiation
+with static method calls or constant access.
+
 6.0 to 7.0
 ----------
 

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -11,6 +11,10 @@ use GuzzleHttp\Utils;
  */
 final class HeaderProcessor
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Returns the HTTP version, status code, reason phrase, and headers.
      *

--- a/src/Handler/Proxy.php
+++ b/src/Handler/Proxy.php
@@ -11,11 +11,13 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * Provides basic proxies for handlers.
- *
- * @final
  */
-class Proxy
+final class Proxy
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Sends synchronous requests to a specific handler while sending all other
      * requests to another handler.

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -15,6 +15,10 @@ use Psr\Log\LoggerInterface;
  */
 final class Middleware
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Middleware that adds cookies to requests.
      *

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -11,6 +11,10 @@ namespace GuzzleHttp;
  */
 final class RequestOptions
 {
+    private function __construct()
+    {
+    }
+
     /**
      * allow_redirects: (bool|array) Controls redirect behavior. Pass false
      * to disable redirects, pass true to enable redirects, pass an

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -15,6 +15,10 @@ use Psr\Http\Message\UriInterface;
 
 final class Utils
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Debug function used to describe the provided value type and class.
      *


### PR DESCRIPTION
This makes Guzzle static utility and constant classes non-instantiable and declares the handler proxy utility final. These classes only expose static members, so callers should use static method calls or constant access.