### PR TITLE
Make header key casts explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/promises": "^2.3",
-        "guzzlehttp/psr7": "^2.10",
+        "guzzlehttp/psr7": "^2.10.1",
         "psr/http-client": "^1.0",
         "symfony/deprecation-contracts": "^2.2 || ^3.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: '#^Parameter \#1 \$str of function strtolower expects string, int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Client.php
-
-		-
 			message: '#^Parameter \#1 \$str of function strtolower expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -118,12 +112,6 @@ parameters:
 			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 5
-			path: src/Handler/CurlFactory.php
-
-		-
-			message: '#^Parameter \#1 \$str1 of function strcasecmp expects string, int\|string given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Handler/CurlFactory.php
 
 		-

--- a/src/Client.php
+++ b/src/Client.php
@@ -282,7 +282,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         } else {
             // Add the User-Agent header if one was not already set.
             foreach (\array_keys($this->config['headers']) as $name) {
-                if (\strtolower($name) === 'user-agent') {
+                if (\strtolower((string) $name) === 'user-agent') {
                     return;
                 }
             }
@@ -483,8 +483,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             // Build up the changes so it's in a single clone of the message.
             $modify = [];
             foreach ($options['_conditional'] as $k => $v) {
-                if (!$request->hasHeader($k)) {
-                    $modify['set_headers'][$k] = $v;
+                $name = (string) $k;
+                if (!$request->hasHeader($name)) {
+                    $modify['set_headers'][$name] = $v;
                 }
             }
             $request = Psr7\Utils::modifyRequest($request, $modify);

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -768,7 +768,7 @@ class CurlFactory implements CurlFactoryInterface
     private function removeHeader(string $name, array &$options): void
     {
         foreach (\array_keys($options['_headers']) as $key) {
-            if (!\strcasecmp($key, $name)) {
+            if (!\strcasecmp((string) $key, $name)) {
                 unset($options['_headers'][$key]);
 
                 return;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -236,7 +236,7 @@ EOT
     {
         $result = [];
         foreach (\array_keys($headers) as $key) {
-            $result[\strtolower($key)] = $key;
+            $result[\strtolower((string) $key)] = $key;
         }
 
         return $result;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -807,6 +807,35 @@ class ClientTest extends TestCase
         $client->send($request, ['headers' => ['X-Foo: Bar', 'X-Test: Fail']]);
     }
 
+    public function testDefaultHeadersHandleNumericHeaderNames()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client([
+            'handler' => $mock,
+            'headers' => ['0' => 'default'],
+        ]);
+
+        $client->send(new Request('GET', 'http://foo.com', ['0' => 'request']));
+
+        $sent = $mock->getLastRequest();
+        self::assertNotNull($sent);
+        self::assertSame(['request'], $sent->getHeader('0'));
+    }
+
+    public function testRequestHeadersHandleNumericHeaderNames()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $request = new Request('GET', 'http://foo.com');
+
+        $client->send($request, ['headers' => ['X-Foo' => 'bar', '0' => 'zero']]);
+
+        $sent = $mock->getLastRequest();
+        self::assertNotNull($sent);
+        self::assertSame(['bar'], $sent->getHeader('X-Foo'));
+        self::assertSame(['zero'], $sent->getHeader('0'));
+    }
+
     public function testCanSetCustomHandler()
     {
         $mock = new MockHandler([new Response(500)]);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -148,6 +148,14 @@ class UtilsTest extends TestCase
         self::assertSame($expected, GuzzleHttp\normalize_header_keys($input));
     }
 
+    public function testNormalizeHeaderKeysHandlesNumericKeys()
+    {
+        $input = [0 => 'zero', 'HelLo' => 'foo'];
+        $expected = [0 => 0, 'hello' => 'HelLo'];
+
+        self::assertSame($expected, Utils::normalizeHeaderKeys($input));
+    }
+
     public static function noProxyProvider()
     {
         return [


### PR DESCRIPTION
This makes array-key casts explicit where header keys are compared or passed to string APIs so numeric string header names remain safe after PHP normalizes array keys.