### PR TITLE
Clarify no-proxy helper removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Removed support for the `GUZZLE_CURL_SELECT_TIMEOUT` environment variable; use `CurlMultiHandler`'s `select_timeout` option
 - Removed `RedirectMiddleware::$defaultSettings`; use `RedirectMiddleware::DEFAULT_SETTINGS`
 - Removed the deprecated `RetryMiddleware::exponentialDelay()` method
-- Removed `Utils::isHostInNoProxy()`; use `ProxyOptions::isHostInNoProxy()`
+- Removed `Utils::isHostInNoProxy()`; use `ProxyOptions` helpers for Guzzle 8 no-proxy matching
 
 
 ## 7.11.0 - Upcoming

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -476,10 +476,15 @@ pass a custom delay callable to `Middleware::retry()`.
 
 #### Removed proxy helper API
 
-`Utils::isHostInNoProxy()` has been removed. Use
-`ProxyOptions::isHostInNoProxy()` instead.
+`Utils::isHostInNoProxy()` has been removed.
 
-The replacement uses Guzzle 8's normalized no-proxy matching. Domain matching is
+Use `ProxyOptions::resolve()` when implementing Guzzle-compatible proxy handling
+in a custom handler. Use `ProxyOptions::isUriInNoProxy()` when checking whether a
+request URI matches a no-proxy list. Use `ProxyOptions::isHostInNoProxy()` only
+when checking a host string directly.
+
+These helpers use Guzzle 8's normalized no-proxy matching rather than preserving
+the old `Utils::isHostInNoProxy()` semantics. Domain matching is
 case-insensitive, IP literals are normalized before comparison, and CIDR entries
 match IP literal hosts.
 


### PR DESCRIPTION
Clarifies the Guzzle 8 migration guidance for the removed no-proxy helper without implying an exact compatibility shim.