### PR TITLE
Improve HTTP client PHPDoc typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Added
 
 - Add HTTP/3 request support to the built-in cURL handlers when PHP 8.4+ and libcurl provide HTTP/3 support
-- Add generic PHPDoc annotations to async HTTP and handler APIs
+- Add generic and structured PHPDoc annotations to async HTTP, client option, handler, middleware, pool, and mock handler APIs
 - Add CIDR notation support for IP no-proxy rules
 - Add network and timeout exception types
 - Add PSR-17 `request_factory`, `stream_factory`, and `uri_factory` request options for client-created requests, request body streams, and URIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Added
 
 - Add HTTP/3 request support to the built-in cURL handlers when PHP 8.4+ and libcurl provide HTTP/3 support
-- Add generic and structured PHPDoc annotations to async HTTP, client option, handler, middleware, pool, and mock handler APIs
+- Add generic and structured PHPDoc annotations to client request/config option, async promise, handler, middleware, pool, and mock handler APIs
 - Add CIDR notation support for IP no-proxy rules
 - Add network and timeout exception types
 - Add PSR-17 `request_factory`, `stream_factory`, and `uri_factory` request options for client-created requests, request body streams, and URIs

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -394,6 +394,18 @@ implements Guzzle client interfaces, provides custom handlers or middleware, or
 uses stricter static analysis, you may need to update your PHPDoc annotations to
 include promise fulfillment and rejection types.
 
+Public client config, request option, pool option, handler, middleware, mock
+handler, and history middleware PHPDoc now uses structured array and callable
+shapes. This does not change runtime behavior, but stricter static analysis may
+now report invalid option keys, invalid option value types, or lower-arity
+callback annotations that were previously hidden behind loose `array` or
+`callable` PHPDoc.
+
+If your project implements `ClientInterface`, extends client behavior through
+traits, builds custom handlers or middleware, or documents reusable request
+option arrays, update those PHPDoc annotations to match the supported request
+option and callback shapes.
+
 #### Multipart request serialization
 
 Guzzle 8 uses Guzzle PSR-7 3.x for multipart request bodies. Multipart parts

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -382,7 +382,7 @@ declare strict types will throw `TypeError` for non-boolean values.
 `SetCookie::getExpires()` now returns `int|null`. Invalid textual expiration
 dates are treated as `null`.
 
-#### Generic Promise PHPDoc Types
+#### Generic Promise And Structured PHPDoc Types
 
 Guzzle's async client APIs, handlers, and middleware callable annotations now use
 generic `PromiseInterface<ResponseInterface, mixed>` PHPDoc types. This is a

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,16 +9,19 @@ No. Guzzle can use any HTTP handler to send requests. This means that Guzzle can
 
 ## Can Guzzle send asynchronous requests?
 
-Yes. You can use the `requestAsync`, `sendAsync`, `getAsync`, `headAsync`, `putAsync`, `postAsync`, `deleteAsync`, and `patchAsync` methods of a client to send an asynchronous request. The client will return a `GuzzleHttp\Promise\PromiseInterface` object. You can chain `then` functions off of the promise.
+Yes. You can use the `requestAsync`, `sendAsync`, `getAsync`, `headAsync`, `putAsync`, `postAsync`, `deleteAsync`, and `patchAsync` methods of a client to send an asynchronous request. The client will return a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` object. You can chain `then` functions off of the promise for fulfilled responses and rejected reasons.
 
 ```php
 $promise = $client->requestAsync('GET', 'http://httpbin.org/get');
 $promise->then(function ($response) {
     echo 'Got a response! ' . $response->getStatusCode();
+}, function ($reason) {
+    // The rejection reason is often a Guzzle exception, but custom handlers can
+    // reject with other values.
 });
 ```
 
-You can force an asynchronous response to complete using the `wait()` method of the returned promise.
+You can force an asynchronous response to complete using the `wait()` method of the returned promise. It returns the response on fulfillment and throws when the promise is rejected.
 
 ```php
 $promise = $client->requestAsync('GET', 'http://httpbin.org/get');

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,7 +9,7 @@ No. Guzzle can use any HTTP handler to send requests. This means that Guzzle can
 
 ## Can Guzzle send asynchronous requests?
 
-Yes. You can use the `requestAsync`, `sendAsync`, `getAsync`, `headAsync`, `putAsync`, `postAsync`, `deleteAsync`, and `patchAsync` methods of a client to send an asynchronous request. The client will return a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` object. You can chain `then` functions off of the promise for fulfilled responses and rejected reasons.
+Yes. You can use the `requestAsync`, `sendAsync`, `getAsync`, `headAsync`, `putAsync`, `postAsync`, `deleteAsync`, `patchAsync`, and `optionsAsync` methods of a client to send an asynchronous request. The client will return a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` object. You can chain `then` functions off of the promise for fulfilled responses and rejected reasons.
 
 ```php
 $promise = $client->requestAsync('GET', 'http://httpbin.org/get');
@@ -30,7 +30,7 @@ $response = $promise->wait();
 
 ## How can I add custom cURL options?
 
-cURL offers a huge number of [customizable options](https://www.php.net/curl_setopt). While Guzzle normalizes many of these options across different handlers, there are times when you need to set custom cURL options. This can be accomplished by passing an associative array of cURL settings in the **curl** key of a request.
+cURL offers a huge number of [customizable options](https://www.php.net/curl_setopt). While Guzzle normalizes many of these options across different handlers, there are times when you need to set custom cURL options. This can be accomplished by passing an array keyed by integer `CURLOPT_*` constants in the **curl** key of a request. The special `body_as_string` key is also recognized by Guzzle's cURL handler.
 
 For example, let's say you need to customize the outgoing network interface used with a client.
 
@@ -42,7 +42,7 @@ $client->request('GET', '/', [
 ]);
 ```
 
-If you use asynchronous requests with cURL multi handler and want to tweak it, additional options can be specified as an associative array in the **options** key of the `CurlMultiHandler` constructor.
+If you use asynchronous requests with cURL multi handler and want to tweak it, additional options can be specified as an array keyed by integer `CURLMOPT_*` constants in the **options** key of the `CurlMultiHandler` constructor.
 
 ```php
 use GuzzleHttp\Client;
@@ -152,8 +152,8 @@ $initialRequest = '/redirect/3'; // Store the request URI for later use
 $response = $client->request('GET', $initialRequest); // Make your request
 
 // Retrieve both Redirect History headers
-$redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History')[0]; // retrieve Redirect URI history
-$redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History')[0]; // retrieve Redirect HTTP Status history
+$redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History'); // retrieve Redirect URI history
+$redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History'); // retrieve Redirect HTTP Status history
 
 // Add the initial URI requested to the (beginning of) URI history
 array_unshift($redirectUriHistory, $initialRequest);

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,7 +9,7 @@ No. Guzzle can use any HTTP handler to send requests. This means that Guzzle can
 
 ## Can Guzzle send asynchronous requests?
 
-Yes. You can use the `requestAsync`, `sendAsync`, `getAsync`, `headAsync`, `putAsync`, `postAsync`, `deleteAsync`, `patchAsync`, and `optionsAsync` methods of a client to send an asynchronous request. The client will return a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` object. You can chain `then` functions off of the promise for fulfilled responses and rejected reasons.
+Yes. You can use the `requestAsync`, `sendAsync`, `getAsync`, `headAsync`, `putAsync`, `postAsync`, `deleteAsync`, and `patchAsync` methods of a client to send an asynchronous request. For asynchronous requests that do not have a named shortcut method, such as OPTIONS requests, use `requestAsync()` with the method name. The client will return a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` object. You can chain `then` functions off of the promise for fulfilled responses and rejected reasons.
 
 ```php
 $promise = $client->requestAsync('GET', 'http://httpbin.org/get');

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -4,7 +4,7 @@ Guzzle clients use a handler and middleware system to send HTTP requests.
 
 ## Handlers
 
-A handler function accepts a `Psr\Http\Message\RequestInterface` and array of request options and returns a `GuzzleHttp\Promise\PromiseInterface` that is fulfilled with a `Psr\Http\Message\ResponseInterface` or rejected with an exception.
+A handler function accepts a `Psr\Http\Message\RequestInterface` and array of request options and returns a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` that is fulfilled with a `Psr\Http\Message\ResponseInterface` or rejected with a reason.
 
 You can provide a custom handler to a client using the `handler` option of a client constructor. It is important to understand that several request options used by Guzzle require that specific middlewares wrap the handler used by the client. You can ensure that the handler you provide to a client uses the default middlewares by wrapping the handler in the `GuzzleHttp\HandlerStack::create(callable $handler = null)` static method.
 
@@ -403,7 +403,7 @@ does not support cURL sharing.
 
 ## Creating a Handler
 
-As stated earlier, a handler is a function that accepts a `Psr\Http\Message\RequestInterface` and an array of request options. A handler used with Guzzle middleware returns a `GuzzleHttp\Promise\PromiseInterface` that is fulfilled with a `Psr\Http\Message\ResponseInterface` or rejected with an exception.
+As stated earlier, a handler is a function that accepts a `Psr\Http\Message\RequestInterface` and an array of request options. A handler used with Guzzle middleware returns a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` that is fulfilled with a `Psr\Http\Message\ResponseInterface` or rejected with a reason.
 
 ```php
 use GuzzleHttp\Promise\PromiseInterface;

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -157,7 +157,7 @@ provided by the request. Use uppercase standard methods such as `GET`, `POST`,
 and `HEAD` when you want standard method-specific behavior from Guzzle's
 middleware and handlers.
 
-You can create and send a request using methods on a client that map to the HTTP method you wish to use.
+You can create and send a request using named shortcut methods on a client for common HTTP methods.
 
 GET
 `$client->get('http://httpbin.org/get', [/** options **/])`
@@ -175,7 +175,7 @@ DELETE
 `$client->delete('http://httpbin.org/delete', [/** options **/])`
 
 OPTIONS
-`$client->options('http://httpbin.org/get', [/** options **/])`
+`$client->request('OPTIONS', 'http://httpbin.org/get', [/** options **/])`
 
 PATCH
 `$client->patch('http://httpbin.org/put', [/** options **/])`

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -122,7 +122,7 @@ echo $response->getBody();
 
 The body used in request and response objects is a `Psr\Http\Message\StreamInterface`. This stream is used for both uploading data and downloading data. Guzzle will, by default, store the body of a message in a stream that uses PHP temp streams. When the size of the body exceeds 2 MB, the stream will automatically switch to storing data on disk rather than in memory (protecting your application from memory exhaustion).
 
-The easiest way to create a body for a message is using the `streamFor` method from the `GuzzleHttp\Psr7\Utils` class -- `Utils::streamFor`. This method accepts strings, resources, callables, iterators, other streamables, and returns an instance of `Psr\Http\Message\StreamInterface`.
+The easiest way to create a body for a message is using the `streamFor` method from the `GuzzleHttp\Psr7\Utils` class -- `Utils::streamFor`. This method accepts strings, resources, callable arrays, closures, invokable objects, iterators, other streamables, and returns an instance of `Psr\Http\Message\StreamInterface`. Callable sources receive a suggested read length, may return fewer or more bytes, and end the stream by returning `false` or `null`. Strings remain literal body contents, even when they name a callable.
 
 The body of a request or response can be cast to a string or you can read and write bytes off of the stream as needed.
 
@@ -295,7 +295,7 @@ Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More inform
 
 ### Creating Streams
 
-The best way to create a stream is using the `GuzzleHttp\Psr7\Utils::streamFor` method. This method accepts strings, resources returned from `fopen()`, an object that implements `__toString()`, iterators, callables, and instances of `Psr\Http\Message\StreamInterface`.
+The best way to create a stream is using the `GuzzleHttp\Psr7\Utils::streamFor` method. This method accepts strings, resources returned from `fopen()`, an object that implements `__toString()`, iterators, callable arrays, closures, invokable objects, and instances of `Psr\Http\Message\StreamInterface`. Callable sources receive a suggested read length, may return fewer or more bytes, and end the stream by returning `false` or `null`. Strings remain literal body contents, even when they name a callable.
 
 When Guzzle creates request body streams from supported `body`, `form_params`, or `json` option values, the `stream_factory` request option can replace the default PSR-17 stream factory. Streams supplied directly as `Psr\Http\Message\StreamInterface` instances are used as provided, while callable and iterator bodies use Guzzle's existing stream handling.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -207,7 +207,7 @@ $client = new Client();
 $requests = function ($total) use ($client) {
     $uri = 'http://127.0.0.1:8126/guzzle-server/perf';
     for ($i = 0; $i < $total; $i++) {
-        yield function(array $options) use ($client, $uri) {
+        yield function (array $options) use ($client, $uri) {
             return $client->getAsync($uri, $options);
         };
     }
@@ -268,7 +268,7 @@ You can set query string parameters in the request's URI:
 $response = $client->request('GET', 'http://httpbin.org?foo=bar');
 ```
 
-You can specify the query string parameters using the `query` request option as an array.
+You can specify the query string parameters using the `query` request option as an array. PHP stores numeric-string parameter names as integer array keys before building the query string.
 
 ```php
 $client->request('GET', 'http://httpbin.org', [
@@ -321,7 +321,7 @@ In addition to specifying the raw data of a request using the `body` request opt
 
 #### Sending form fields
 
-Sending `application/x-www-form-urlencoded` POST requests requires that you specify the POST fields as an array in the `form_params` request options.
+Sending `application/x-www-form-urlencoded` POST requests requires that you specify the POST fields as an array in the `form_params` request options. PHP stores numeric-string form field names as integer array keys before encoding the request body.
 
 ```php
 $response = $client->request('POST', 'http://httpbin.org/post', [
@@ -337,10 +337,10 @@ $response = $client->request('POST', 'http://httpbin.org/post', [
 
 #### Sending form files
 
-You can send files along with a form (`multipart/form-data` POST requests), using the `multipart` request option. `multipart` accepts an array of associative arrays, where each associative array contains the following keys:
+You can send files along with a form (`multipart/form-data` POST requests), using the `multipart` request option. `multipart` accepts an array of part arrays, where each part array contains the following keys:
 
-- name: (required, string) key mapping to the form field name.
-- contents: (required, mixed) Provide a string to send the contents of the file as a string, provide an fopen resource to stream the contents from a PHP stream, or provide a `Psr\Http\Message\StreamInterface` to stream the contents from a PSR-7 stream.
+- name: (required, string|int) key mapping to the form field name.
+- contents: (required, mixed) Provide a string to send the contents of the file as a string, provide an fopen resource to stream the contents from a PHP stream, provide a `Psr\Http\Message\StreamInterface` to stream the contents from a PSR-7 stream, or provide an array to expand nested multipart fields.
 
 ```php
 use GuzzleHttp\Psr7;

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,16 +55,21 @@ Don't feel like reading RFC 3986? Here are some quick examples on how a `base_ur
 
 ### Sending Requests
 
-Magic methods on the client make it easy to send synchronous requests:
+Named shortcut methods on the client make common synchronous requests concise:
 
 ```php
 $response = $client->get('http://httpbin.org/get');
 $response = $client->delete('http://httpbin.org/delete');
 $response = $client->head('http://httpbin.org/get');
-$response = $client->options('http://httpbin.org/get');
 $response = $client->patch('http://httpbin.org/patch');
 $response = $client->post('http://httpbin.org/post');
 $response = $client->put('http://httpbin.org/put');
+```
+
+For other HTTP methods, use `request()` with the method name:
+
+```php
+$response = $client->request('OPTIONS', 'http://httpbin.org/get');
 ```
 
 You can create a request and then send the request with the client when you're ready:
@@ -82,19 +87,18 @@ You can find out more about client middleware in [Handlers and Middleware](handl
 
 ### Async Requests
 
-You can send asynchronous requests using the magic methods provided by a client:
+You can send asynchronous requests using the named async shortcut methods provided by a client:
 
 ```php
 $promise = $client->getAsync('http://httpbin.org/get');
 $promise = $client->deleteAsync('http://httpbin.org/delete');
 $promise = $client->headAsync('http://httpbin.org/get');
-$promise = $client->optionsAsync('http://httpbin.org/get');
 $promise = $client->patchAsync('http://httpbin.org/patch');
 $promise = $client->postAsync('http://httpbin.org/post');
 $promise = $client->putAsync('http://httpbin.org/put');
 ```
 
-You can also use the `sendAsync()` and `requestAsync()` methods of a client:
+You can also use the `sendAsync()` and `requestAsync()` methods of a client. Use `requestAsync()` for asynchronous requests that do not have a named shortcut method:
 
 ```php
 use GuzzleHttp\Psr7\Request;
@@ -107,6 +111,7 @@ $promise = $client->sendAsync($request);
 
 // Or, if you don't need to pass in a request instance:
 $promise = $client->requestAsync('GET', 'http://httpbin.org/get');
+$promise = $client->requestAsync('OPTIONS', 'http://httpbin.org/get');
 ```
 
 The promise returned by these methods is a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` provided by the [Guzzle promises library](https://github.com/guzzle/promises). This means that you can chain `then()` calls off of the promise. These then calls are either fulfilled with a successful `Psr\Http\Message\ResponseInterface` or rejected with a reason. The reason is often an exception from Guzzle's exception hierarchy, but custom handlers can reject with other values.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -109,7 +109,7 @@ $promise = $client->sendAsync($request);
 $promise = $client->requestAsync('GET', 'http://httpbin.org/get');
 ```
 
-The promise returned by these methods implements the [Promises/A+ spec](https://promisesaplus.com/), provided by the [Guzzle promises library](https://github.com/guzzle/promises). This means that you can chain `then()` calls off of the promise. These then calls are either fulfilled with a successful `Psr\Http\Message\ResponseInterface` or rejected with an exception.
+The promise returned by these methods is a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` provided by the [Guzzle promises library](https://github.com/guzzle/promises). This means that you can chain `then()` calls off of the promise. These then calls are either fulfilled with a successful `Psr\Http\Message\ResponseInterface` or rejected with a reason. The reason is often an exception from Guzzle's exception hierarchy, but custom handlers can reject with other values.
 
 ```php
 use Psr\Http\Message\ResponseInterface;
@@ -120,9 +120,11 @@ $promise->then(
     function (ResponseInterface $res) {
         echo $res->getStatusCode() . "\n";
     },
-    function (RequestException $e) {
-        echo $e->getMessage() . "\n";
-        echo $e->getRequest()->getMethod();
+    function ($reason) {
+        if ($reason instanceof RequestException) {
+            echo $reason->getMessage() . "\n";
+            echo $reason->getRequest()->getMethod();
+        }
     }
 );
 ```
@@ -145,8 +147,7 @@ $promises = [
     'webp'  => $client->getAsync('/image/webp')
 ];
 
-// Wait for the requests to complete; throws a ConnectException
-// if any of the requests fail
+// Wait for the requests to complete; throws if any request is rejected.
 $responses = Promise\Utils::unwrap($promises);
 
 // You can access each response using the key of the promise
@@ -156,7 +157,8 @@ echo $responses['png']->getHeader('Content-Length')[0];
 // Wait for the requests to complete, even if some of them fail
 $responses = Promise\Utils::settle($promises)->wait();
 
-// Values returned above are wrapped in an array with 2 keys: "state" (either fulfilled or rejected) and "value" (contains the response)
+// Values returned above are wrapped in an array with "state" (either fulfilled or rejected),
+// plus "value" for fulfilled responses or "reason" for rejected requests.
 echo $responses['image']['state']; // returns "fulfilled"
 echo $responses['image']['value']->getHeader('Content-Length')[0];
 echo $responses['png']['value']->getHeader('Content-Length')[0];
@@ -166,10 +168,10 @@ You can use the `GuzzleHttp\Pool` object when you have an indeterminate amount o
 
 ```php
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Pool;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
 
 $client = new Client();
 
@@ -182,10 +184,10 @@ $requests = function ($total) {
 
 $pool = new Pool($client, $requests(100), [
     'concurrency' => 5,
-    'fulfilled' => function (Response $response, $index) {
+    'fulfilled' => function (ResponseInterface $response, $index, PromiseInterface $aggregate) {
         // this is delivered each successful response
     },
-    'rejected' => function (RequestException $reason, $index) {
+    'rejected' => function ($reason, $index, PromiseInterface $aggregate) {
         // this is delivered each failed request
     },
 ]);
@@ -197,7 +199,7 @@ $promise = $pool->promise();
 $promise->wait();
 ```
 
-Or using a closure that will return a promise once the pool calls the closure.
+Or using a closure that will receive the merged request options and return either a response or a promise once the pool calls the closure.
 
 ```php
 $client = new Client();
@@ -205,8 +207,8 @@ $client = new Client();
 $requests = function ($total) use ($client) {
     $uri = 'http://127.0.0.1:8126/guzzle-server/perf';
     for ($i = 0; $i < $total; $i++) {
-        yield function() use ($client, $uri) {
-            return $client->getAsync($uri);
+        yield function(array $options) use ($client, $uri) {
+            return $client->getAsync($uri, $options);
         };
     }
 };

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -58,7 +58,7 @@ You can also pass an associative array containing the following key value pairs:
 
 - protocols: (array, default=`['http', 'https']`) Specified which protocols are allowed for redirect requests.
 
-- on_redirect: (callable) PHP callable that is invoked when a redirect is encountered. The callable is invoked with the original request and the redirect response that was received. Any return value from the on_redirect function is ignored.
+- on_redirect: (callable) PHP callable that is invoked when a redirect is encountered. The callable is invoked with the original request, the redirect response that was received, and the effective URI. Any return value from the on_redirect function is ignored.
 
 - track_redirects: (bool) When set to `true`, each redirected URI and status code encountered will be tracked in the `X-Guzzle-Redirect-History` and `X-Guzzle-Redirect-Status-History` headers respectively. All URIs and status codes will be stored in the order which the redirects were encountered.
 
@@ -172,6 +172,13 @@ Types
 - string
 - `fopen()` resource
 - `Psr\Http\Message\StreamInterface`
+- callable
+- `Iterator`
+- `Stringable`
+- int
+- float
+- bool
+- null
 
 Default
 None
@@ -204,7 +211,7 @@ This setting can be set to any of the following types:
   $client->request('POST', '/post', ['body' => $stream]);
   ```
 
-Scalar, resource, and object values with `__toString()` are converted to PSR-7 streams using the configured `stream_factory`. Callable and iterator bodies use Guzzle's existing stream handling because PSR-17 does not define factories for those stream types. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+Scalar, resource, and object values with `__toString()` are converted to PSR-7 streams using the configured `stream_factory`. Callable and iterator bodies use Guzzle's existing PSR-7 stream handling because PSR-17 does not define factories for those stream types. Callable bodies may be closures, callable arrays, or invokable objects. Strings are always used as literal body contents, even when they name a callable. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
 
 > [!NOTE]
 > This option cannot be used with `form_params`, `multipart`, or `json`
@@ -666,7 +673,7 @@ Constant
 The value of `multipart` is an array of associative arrays, each containing the following key value pairs:
 
 - `name`: (string, required) the form field name
-- `contents`: (StreamInterface/resource/string, required) The data to use in the form element.
+- `contents`: (mixed, required) Any non-array value accepted by `GuzzleHttp\Psr7\Utils::streamFor()`, including strings, resources, streams, iterators, closures, and invokable objects.
 - `headers`: (array) Optional associative array of custom headers to use with the form element.
 - `filename`: (string) Optional string to send as the filename in the part.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -121,7 +121,6 @@ Pass an array of HTTP authentication parameters to use with the request. The arr
 
 Types
 - array
-- string
 - null
 
 Default
@@ -211,7 +210,7 @@ This setting can be set to any of the following types:
   $client->request('POST', '/post', ['body' => $stream]);
   ```
 
-Scalar, resource, and object values with `__toString()` are converted to PSR-7 streams using the configured `stream_factory`. Callable and iterator bodies use Guzzle's existing PSR-7 stream handling because PSR-17 does not define factories for those stream types. Callable bodies may be closures, callable arrays, or invokable objects. Strings are always used as literal body contents, even when they name a callable. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+Scalar, resource, and object values with `__toString()` are converted to PSR-7 streams using the configured `stream_factory`. Callable and iterator bodies use Guzzle's existing PSR-7 stream handling because PSR-17 does not define factories for those stream types. Callable bodies may be closures or invokable objects. Strings are always used as literal body contents, even when they name a callable. Callable arrays are arrays, and arrays are not valid `body` values. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
 
 > [!NOTE]
 > This option cannot be used with `form_params`, `multipart`, or `json`
@@ -270,7 +269,8 @@ Summary
 Specifies whether or not cookies are used in a request or what cookie jar to use or what cookies to send.
 
 Types
-`GuzzleHttp\Cookie\CookieJarInterface`
+- `GuzzleHttp\Cookie\CookieJarInterface`
+- false
 
 Default
 None
@@ -496,7 +496,7 @@ array
 Constant
 `GuzzleHttp\RequestOptions::FORM_PARAMS`
 
-Associative array of form field names to values where each value is a string or array of strings. Sets the Content-Type header to application/x-www-form-urlencoded when no Content-Type header is already present.
+Array mapping form field names, represented by PHP array keys, to values where each value is a string or array of strings. Numeric-string field names are stored as integer keys by PHP before `http_build_query()` encodes them. Sets the Content-Type header to application/x-www-form-urlencoded when no Content-Type header is already present.
 
 ```php
 $client->request('POST', '/post', [
@@ -515,7 +515,7 @@ $client->request('POST', '/post', [
 ## headers
 
 Summary
-Associative array of headers to add to the request. Each key is the name of a header, and each value is a string or array of strings representing the header field values.
+Array keyed by header names to add to the request. Numeric-string header names are stored as integer keys by PHP, and Guzzle casts header keys back to strings when applying them. Each value is a string or array of strings representing the header field values.
 
 Types
 array
@@ -670,11 +670,11 @@ array
 Constant
 `GuzzleHttp\RequestOptions::MULTIPART`
 
-The value of `multipart` is an array of associative arrays, each containing the following key value pairs:
+The value of `multipart` is an array of part arrays, each containing the following key value pairs:
 
-- `name`: (string, required) the form field name
-- `contents`: (mixed, required) Any non-array value accepted by `GuzzleHttp\Psr7\Utils::streamFor()`, including strings, resources, streams, iterators, closures, and invokable objects.
-- `headers`: (array) Optional associative array of custom headers to use with the form element.
+- `name`: (string|int, required) the form field name
+- `contents`: (mixed, required) Any non-array value accepted by `GuzzleHttp\Psr7\Utils::streamFor()`, including strings, resources, streams, iterators, closures, and invokable objects. Arrays are expanded as nested multipart fields; `headers` and `filename` cannot be used when `contents` is an array.
+- `headers`: (array) Optional array of custom string header values to use with the form element.
 - `filename`: (string) Optional string to send as the filename in the part.
 
 ```php
@@ -925,7 +925,7 @@ $client->request('GET', '/', [
 ## query
 
 Summary
-Associative array of query string values or query string to add to the request.
+Array of query string values or query string to add to the request. When the option is an array, keys are PHP array keys; numeric-string parameter names are stored as integer keys before `http_build_query()` encodes them.
 
 Types
 - array

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,6 +54,8 @@ When no more responses are in the queue and a request is sent, an `OutOfBoundsEx
 
 Queued callables receive the `Psr\Http\Message\RequestInterface` and request options array passed to the mock handler. They may return a `Psr\Http\Message\ResponseInterface`, a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>`, or a throwable rejection reason.
 
+The `on_headers` request option is invoked when a queued response or fulfilled response promise is available. It is not invoked for queued throwables or rejected promises.
+
 The optional `MockHandler` constructor callbacks are invoked with the fulfilled response or rejected reason after the queued value has settled.
 
 ## History Middleware

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ Guzzle provides several tools that will enable you to easily mock the HTTP layer
 
 When testing HTTP clients, you often need to simulate specific scenarios like returning a successful response, returning an error, or returning specific responses in a certain order. Because unit tests need to be predictable, easy to bootstrap, and fast, hitting an actual remote API is a test smell.
 
-Guzzle provides a mock handler that can be used to fulfill HTTP requests with a response or exception by shifting return values off of a queue.
+Guzzle provides a mock handler that can be used to fulfill HTTP requests with queued responses, response promises, request-aware callables, or reject them with queued throwables by shifting return values off of a queue.
 
 ```php
 use GuzzleHttp\Client;
@@ -52,6 +52,10 @@ echo $client->request('GET', '/')->getStatusCode();
 
 When no more responses are in the queue and a request is sent, an `OutOfBoundsException` is thrown.
 
+Queued callables receive the `Psr\Http\Message\RequestInterface` and request options array passed to the mock handler. They may return a `Psr\Http\Message\ResponseInterface`, a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>`, or a throwable rejection reason.
+
+The optional `MockHandler` constructor callbacks are invoked with the fulfilled response or rejected reason after the queued value has settled.
+
 ## History Middleware
 
 When using things like the `Mock` handler, you often need to know if the requests you expected to send were sent exactly as you intended. While the mock handler responds with mocked responses, the history middleware maintains a history of the requests that were sent by a client.
@@ -79,7 +83,11 @@ $client->request('HEAD', 'http://httpbin.org/get');
 echo count($container);
 //> 2
 
-// Iterate over the requests and responses
+// Iterate over the transaction history. Each transaction contains:
+// - request: the request that was sent
+// - response: the response, or null when the transfer was rejected
+// - error: the rejection reason, or null when the transfer succeeded
+// - options: the request options used for the transfer
 foreach ($container as $transaction) {
     echo $transaction['request']->getMethod();
     //> GET, HEAD

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: src/Client.php
+
+		-
 			message: '#^Result of && is always false\.$#'
 			identifier: booleanAnd.alwaysFalse
 			count: 1
@@ -181,7 +187,7 @@ parameters:
 			path: src/Handler/StreamHandler.php
 
 		-
-			message: '#^Call to function is_callable\(\) with callable\(\)\: mixed will always evaluate to true\.$#'
+			message: '#^Call to function is_callable\(\) with callable\(callable&THandler\)\: \(callable&THandler\) will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/HandlerStack.php
@@ -193,7 +199,7 @@ parameters:
 			path: src/HandlerStack.php
 
 		-
-			message: '#^Instanceof between ArrayAccess\<int, array\> and ArrayAccess will always evaluate to true\.$#'
+			message: '#^Instanceof between ArrayAccess\<int, array\<string, mixed\>\> and ArrayAccess will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1
 			path: src/Middleware.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\RequestException;
@@ -62,7 +63,77 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *   Defaults to null.
      * - **: any request option
      *
-     * @param array $config Client configuration settings.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     curl_share?: string|null,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $config Client configuration settings and default request options.
      *
      * @see RequestOptions for a list of available request options.
      */
@@ -111,8 +182,76 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     /**
      * Asynchronously send an HTTP request.
      *
-     * @param array $options Request options to apply to the given
-     *                       request and to the transfer. See {@see RequestOptions}.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply to the given request and to the transfer. See {@see RequestOptions}.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -130,8 +269,76 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     /**
      * Send an HTTP request.
      *
-     * @param array $options Request options to apply to the given
-     *                       request and to the transfer. See {@see RequestOptions}.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply to the given request and to the transfer. See {@see RequestOptions}.
      *
      * @throws GuzzleException
      */
@@ -164,9 +371,78 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string              $method  HTTP method
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply. See {@see RequestOptions}.
+     * @param string              $method HTTP method
+     * @param string|UriInterface $uri    URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply. See {@see RequestOptions}.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -210,9 +486,78 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string              $method  HTTP method.
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply. See {@see RequestOptions}.
+     * @param string              $method HTTP method.
+     * @param string|UriInterface $uri    URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply. See {@see RequestOptions}.
      *
      * @throws GuzzleException
      */
@@ -468,7 +813,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
         self::assertRequestProtocolVersion($request);
 
-        /** @var HandlerStack $handler */
+        /** @var callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler */
         $handler = $options['handler'];
 
         try {

--- a/src/Client.php
+++ b/src/Client.php
@@ -80,7 +80,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
@@ -100,9 +100,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -116,6 +116,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -198,14 +199,14 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -218,9 +219,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -234,6 +235,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -285,14 +287,14 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -305,9 +307,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -321,6 +323,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -368,8 +371,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string              $method HTTP method
      * @param string|UriInterface $uri    URI object or string.
@@ -389,14 +391,14 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -409,9 +411,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -425,6 +427,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -504,14 +507,14 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -524,9 +527,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -540,6 +543,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -45,14 +45,14 @@ interface ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -65,9 +65,9 @@ interface ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -81,6 +81,7 @@ interface ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -124,14 +125,14 @@ interface ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -144,9 +145,9 @@ interface ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -160,6 +161,7 @@ interface ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -208,14 +210,14 @@ interface ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -228,9 +230,9 @@ interface ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -244,6 +246,7 @@ interface ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -272,8 +275,7 @@ interface ClientInterface
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string              $method HTTP method
      * @param string|UriInterface $uri    URI object or string.
@@ -293,14 +295,14 @@ interface ClientInterface
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -313,9 +315,9 @@ interface ClientInterface
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -329,6 +331,7 @@ interface ClientInterface
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace GuzzleHttp;
 
+use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -24,8 +29,76 @@ interface ClientInterface
      * Send an HTTP request.
      *
      * @param RequestInterface $request Request to send
-     * @param array            $options Request options to apply to the given
-     *                                  request and to the transfer.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply to the given request and to the transfer.
      *
      * @throws GuzzleException
      */
@@ -35,8 +108,76 @@ interface ClientInterface
      * Asynchronously send an HTTP request.
      *
      * @param RequestInterface $request Request to send
-     * @param array            $options Request options to apply to the given
-     *                                  request and to the transfer.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply to the given request and to the transfer.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -49,9 +190,78 @@ interface ClientInterface
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string              $method  HTTP method.
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string              $method HTTP method.
+     * @param string|UriInterface $uri    URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -65,9 +275,78 @@ interface ClientInterface
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string              $method  HTTP method
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string              $method HTTP method
+     * @param string|UriInterface $uri    URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -43,14 +43,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -63,9 +63,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -79,6 +79,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -126,14 +127,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -146,9 +147,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -162,6 +163,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -212,14 +214,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -232,9 +234,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -248,6 +250,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -298,14 +301,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -318,9 +321,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -334,6 +337,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -384,14 +388,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -404,9 +408,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -420,6 +424,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -470,14 +475,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -490,9 +495,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -506,6 +511,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -556,14 +562,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -576,9 +582,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -592,6 +598,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -623,8 +630,7 @@ trait ClientTrait
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string              $method HTTP method
      * @param string|UriInterface $uri    URI object or string.
@@ -644,14 +650,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -664,9 +670,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -680,6 +686,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -708,8 +715,7 @@ trait ClientTrait
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
@@ -728,14 +734,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -748,9 +754,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -764,6 +770,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -795,8 +802,7 @@ trait ClientTrait
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
@@ -815,14 +821,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -835,9 +841,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -851,6 +857,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -882,8 +889,7 @@ trait ClientTrait
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
@@ -902,14 +908,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -922,9 +928,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -938,6 +944,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -969,8 +976,7 @@ trait ClientTrait
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
@@ -989,14 +995,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -1009,9 +1015,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -1025,6 +1031,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -1056,8 +1063,7 @@ trait ClientTrait
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
@@ -1076,14 +1082,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -1096,9 +1102,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -1112,6 +1118,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
@@ -1143,8 +1150,7 @@ trait ClientTrait
      *
      * Use an absolute path to override the base path of the client, or a
      * relative path to append to the base path of the client. The URL can
-     * contain the query string as well. Use an array to provide a URL
-     * template and additional variables to use in the URL template expansion.
+     * contain the query string as well.
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
@@ -1163,14 +1169,14 @@ trait ClientTrait
      *         1: string,
      *         2?: string
      *     }|null,
-     *     body?: mixed,
+     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string
      *     },
      *     cert_type?: string,
      *     connect_timeout?: int|float,
-     *     cookies?: bool|CookieJarInterface,
+     *     cookies?: false|CookieJarInterface,
      *     crypto_method?: int,
      *     debug?: bool|resource,
      *     decode_content?: bool|string,
@@ -1183,9 +1189,9 @@ trait ClientTrait
      *     idn_conversion?: bool|int,
      *     json?: mixed,
      *     multipart?: array<array-key, array{
-     *         name: string,
+     *         name: string|int,
      *         contents: mixed,
-     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         headers?: array<array-key, string>,
      *         filename?: string
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -1199,6 +1205,7 @@ trait ClientTrait
      *     },
      *     query?: array<array-key, mixed>|string,
      *     read_timeout?: int|float,
+     *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -2,9 +2,15 @@
 
 namespace GuzzleHttp;
 
+use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -19,9 +25,78 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string              $method  HTTP method.
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string              $method HTTP method.
+     * @param string|UriInterface $uri    URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -34,8 +109,77 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -51,8 +195,77 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -68,8 +281,77 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -85,8 +367,77 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -102,8 +453,77 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -119,8 +539,77 @@ trait ClientTrait
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @throws GuzzleException
      */
@@ -137,9 +626,78 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string              $method  HTTP method
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string              $method HTTP method
+     * @param string|UriInterface $uri    URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -153,8 +711,77 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -171,8 +798,77 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -189,8 +885,77 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -207,8 +972,77 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -225,8 +1059,77 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -243,8 +1146,77 @@ trait ClientTrait
      * contain the query string as well. Use an array to provide a URL
      * template and additional variables to use in the URL template expansion.
      *
-     * @param string|UriInterface $uri     URI object or string.
-     * @param array               $options Request options to apply.
+     * @param string|UriInterface $uri URI object or string.
+     * @param array{
+     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *     base_uri?: string|UriInterface,
+     *     allow_redirects?: bool|array{
+     *         max?: int,
+     *         strict?: bool,
+     *         referer?: bool,
+     *         protocols?: array<array-key, string>,
+     *         on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *         track_redirects?: bool
+     *     },
+     *     auth?: array{
+     *         0: string,
+     *         1: string,
+     *         2?: string
+     *     }|null,
+     *     body?: mixed,
+     *     cert?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     cert_type?: string,
+     *     connect_timeout?: int|float,
+     *     cookies?: bool|CookieJarInterface,
+     *     crypto_method?: int,
+     *     debug?: bool|resource,
+     *     decode_content?: bool|string,
+     *     delay?: int|float,
+     *     expect?: bool|int,
+     *     form_params?: array<array-key, mixed>,
+     *     force_ip_resolve?: string,
+     *     headers?: array<array-key, string|array<array-key, string>>|null,
+     *     http_errors?: bool,
+     *     idn_conversion?: bool|int,
+     *     json?: mixed,
+     *     multipart?: array<array-key, array{
+     *         name: string,
+     *         contents: mixed,
+     *         headers?: array<array-key, string|array<array-key, string>>,
+     *         filename?: string
+     *     }>,
+     *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *     on_stats?: callable(TransferStats): mixed,
+     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     protocols?: array<array-key, string>,
+     *     proxy?: string|array{
+     *         http?: string,
+     *         https?: string,
+     *         no?: string|array<array-key, string>
+     *     },
+     *     query?: array<array-key, mixed>|string,
+     *     read_timeout?: int|float,
+     *     request_factory?: RequestFactoryInterface,
+     *     sink?: resource|string|StreamInterface,
+     *     ssl_key?: string|array{
+     *         0: string,
+     *         1?: string
+     *     },
+     *     ssl_key_type?: string,
+     *     stream?: bool,
+     *     stream_factory?: StreamFactoryInterface,
+     *     stream_context?: array<array-key, mixed>,
+     *     synchronous?: bool,
+     *     timeout?: int|float,
+     *     uri_factory?: UriFactoryInterface,
+     *     verify?: bool|string,
+     *     version?: string|float,
+     *     curl?: array<int|string, mixed>,
+     *     ...
+     * } $options Request options to apply.
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -527,14 +527,14 @@ class CurlFactory implements CurlFactoryInterface
      * Completes a cURL transaction, either returning a response promise or a
      * rejected promise.
      *
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $handler
-     * @param CurlFactoryInterface                                                          $factory Dictates how the handle is released
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler
+     * @param CurlFactoryInterface                                                                            $factory Dictates how the handle is released
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
     public static function finish(callable $handler, EasyHandle $easy, CurlFactoryInterface $factory): PromiseInterface
     {
-        /** @var callable|null $onStats */
+        /** @var (callable(TransferStats): mixed)|null $onStats */
         $onStats = $easy->options['on_stats'] ?? null;
         $stats = $onStats !== null ? self::createStats($easy) : null;
 
@@ -548,7 +548,7 @@ class CurlFactory implements CurlFactoryInterface
         // Return the response if it is present and there is no error.
         $factory->release($easy);
 
-        if ($onStats !== null) {
+        if ($onStats !== null && $stats !== null) {
             $onStats($stats);
         }
 
@@ -584,8 +584,8 @@ class CurlFactory implements CurlFactoryInterface
     }
 
     /**
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $handler
-     * @param callable|null                                                                 $onStats
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler
+     * @param (callable(TransferStats): mixed)|null                                                           $onStats
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
@@ -595,7 +595,7 @@ class CurlFactory implements CurlFactoryInterface
         $ctx = self::createErrorContext($easy);
         $factory->release($easy);
 
-        if ($onStats !== null) {
+        if ($onStats !== null && $stats !== null) {
             $onStats($stats);
         }
 
@@ -1339,6 +1339,7 @@ class CurlFactory implements CurlFactoryInterface
             if (!\is_callable($progress)) {
                 throw new \InvalidArgumentException('progress client option must be callable');
             }
+            /** @var callable(int|float, int|float, int|float, int|float): mixed $progress */
             $conf[\CURLOPT_NOPROGRESS] = false;
             $progressCallback = static function ($resource, $downloadSize, $downloaded, $uploadSize, $uploaded) use ($easy, $progress): int {
                 try {
@@ -1378,7 +1379,7 @@ class CurlFactory implements CurlFactoryInterface
      * error, causing the request to be sent through curl_multi_info_read()
      * without an error status.
      *
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $handler
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -13,14 +13,14 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
 /**
- * Handler that returns responses or throw exceptions from a queue.
+ * Handler that returns responses or rejection reasons from a queue.
  *
  * @final
  */
 class MockHandler implements \Countable
 {
     /**
-     * @var array
+     * @var list<ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>|callable(RequestInterface, array<array-key, mixed>): (ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>)>
      */
     private $queue = [];
 
@@ -30,17 +30,17 @@ class MockHandler implements \Countable
     private $lastRequest;
 
     /**
-     * @var array
+     * @var array<array-key, mixed>
      */
     private $lastOptions = [];
 
     /**
-     * @var callable|null
+     * @var (callable(ResponseInterface|null): mixed)|null
      */
     private $onFulfilled;
 
     /**
-     * @var callable|null
+     * @var (callable(mixed): mixed)|null
      */
     private $onRejected;
 
@@ -48,9 +48,11 @@ class MockHandler implements \Countable
      * Creates a new MockHandler that uses the default handler stack list of
      * middlewares.
      *
-     * @param array|null    $queue       Array of responses, callables, or exceptions.
-     * @param callable|null $onFulfilled Callback to invoke when the return value is fulfilled.
-     * @param callable|null $onRejected  Callback to invoke when the return value is rejected.
+     * @param array<array-key, ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>|callable(RequestInterface, array<array-key, mixed>): (ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>)>|null $queue       Array of responses, promises, callables, or throwables.
+     * @param (callable(ResponseInterface|null): mixed)|null                                                                                                                                                                                $onFulfilled Callback to invoke when the return value is fulfilled.
+     * @param (callable(mixed): mixed)|null                                                                                                                                                                                                 $onRejected  Callback to invoke when the return value is rejected.
+     *
+     * @return HandlerStack<callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>>
      */
     public static function createWithMiddleware(?array $queue = null, ?callable $onFulfilled = null, ?callable $onRejected = null): HandlerStack
     {
@@ -59,12 +61,11 @@ class MockHandler implements \Countable
 
     /**
      * The passed in value must be an array of
-     * {@see ResponseInterface} objects, Exceptions,
-     * callables, or Promises.
+     * {@see ResponseInterface} objects, throwables, callables, or promises.
      *
-     * @param array<int, mixed>|null $queue       The parameters to be passed to the append function, as an indexed array.
-     * @param callable|null          $onFulfilled Callback to invoke when the return value is fulfilled.
-     * @param callable|null          $onRejected  Callback to invoke when the return value is rejected.
+     * @param array<array-key, ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>|callable(RequestInterface, array<array-key, mixed>): (ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>)>|null $queue       The parameters to be passed to the append function, as an indexed array.
+     * @param (callable(ResponseInterface|null): mixed)|null                                                                                                                                                                                $onFulfilled Callback to invoke when the return value is fulfilled.
+     * @param (callable(mixed): mixed)|null                                                                                                                                                                                                 $onRejected  Callback to invoke when the return value is rejected.
      */
     public function __construct(?array $queue = null, ?callable $onFulfilled = null, ?callable $onRejected = null)
     {
@@ -157,7 +158,7 @@ class MockHandler implements \Countable
      * Adds one or more variadic requests, exceptions, callables, or promises
      * to the queue.
      *
-     * @param mixed ...$values
+     * @param mixed ...$values Responses, promises, throwables, or request-aware callables.
      */
     public function append(...$values): void
     {

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -94,19 +94,15 @@ class MockHandler implements \Countable
         $this->lastRequest = $request;
         $this->lastOptions = $options;
         $response = \array_shift($this->queue);
+        $onHeaders = null;
         $onHeadersResponse = null;
 
         if (isset($options['on_headers'])) {
             if (!\is_callable($options['on_headers'])) {
                 throw new \InvalidArgumentException('on_headers must be callable');
             }
-            try {
-                $options['on_headers']($response, $request);
-            } catch (\Throwable $e) {
-                $msg = 'An error was encountered during the on_headers event';
-                $onHeadersResponse = $response instanceof ResponseInterface ? $response : null;
-                $response = new RequestException($msg, $request, $onHeadersResponse, $e);
-            }
+
+            $onHeaders = $options['on_headers'];
         }
 
         if (\is_callable($response)) {
@@ -116,6 +112,27 @@ class MockHandler implements \Countable
         $response = $response instanceof \Throwable
             ? P\Create::rejectionFor($response)
             : P\Create::promiseFor($response);
+
+        if (\is_callable($onHeaders)) {
+            $response = $response->then(
+                static function ($value) use ($onHeaders, $request, &$onHeadersResponse) {
+                    if (!$value instanceof ResponseInterface) {
+                        return $value;
+                    }
+
+                    try {
+                        $onHeaders($value, $request);
+                    } catch (\Throwable $e) {
+                        $msg = 'An error was encountered during the on_headers event';
+                        $onHeadersResponse = $value;
+
+                        throw new RequestException($msg, $request, $value, $e);
+                    }
+
+                    return $value;
+                }
+            );
+        }
 
         $promise = $response->then(
             function ($value) use ($request, $options) {
@@ -140,7 +157,7 @@ class MockHandler implements \Countable
 
                 return $value;
             },
-            function ($reason) use ($request, $options, $onHeadersResponse): PromiseInterface {
+            function ($reason) use ($request, $options, &$onHeadersResponse): PromiseInterface {
                 $this->invokeStats($request, $options, $onHeadersResponse, $reason);
                 if ($this->onRejected) {
                     ($this->onRejected)($reason);

--- a/src/Handler/Proxy.php
+++ b/src/Handler/Proxy.php
@@ -22,10 +22,10 @@ final class Proxy
      * Sends synchronous requests to a specific handler while sending all other
      * requests to another handler.
      *
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $default Handler used for normal responses
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $sync    Handler used for synchronous responses.
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $default Handler used for normal responses
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $sync    Handler used for synchronous responses.
      *
-     * @return callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> Returns the composed handler.
+     * @return callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> Returns the composed handler.
      */
     public static function wrapSync(callable $default, callable $sync): callable
     {
@@ -42,10 +42,10 @@ final class Proxy
      * performance benefits of curl while still supporting true streaming
      * through the StreamHandler.
      *
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $default   Handler used for non-streaming responses
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $streaming Handler used for streaming responses
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $default   Handler used for non-streaming responses
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $streaming Handler used for streaming responses
      *
-     * @return callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> Returns the composed handler.
+     * @return callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> Returns the composed handler.
      */
     public static function wrapStreaming(callable $default, callable $streaming): callable
     {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -330,11 +330,11 @@ class StreamHandler
     /**
      * Create a resource and check to ensure it was created successfully
      *
-     * @param callable $callback Callable that returns stream resource
+     * @param callable(): (resource|false) $callback Callable that returns a stream resource, or false when resource creation fails.
      *
      * @return resource
      *
-     * @throws \RuntimeException on error
+     * @throws \RuntimeException when the callback returns false or resource creation emits an error.
      */
     private function createResource(callable $callback)
     {

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -10,22 +10,24 @@ use Psr\Http\Message\ResponseInterface;
  * Creates a composed Guzzle handler function by stacking middlewares on top of
  * an HTTP handler function.
  *
+ * @template THandler
+ *
  * @final
  */
 class HandlerStack
 {
     /**
-     * @var (callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>)|null
+     * @var (callable&THandler)|null
      */
     private $handler;
 
     /**
-     * @var array{(callable(callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>): callable), (string|null)}[]
+     * @var array<int, array{0: callable(callable&THandler): (callable&THandler), 1: string|null}>
      */
     private $stack = [];
 
     /**
-     * @var (callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>)|null
+     * @var (callable&THandler)|null
      */
     private $cached;
 
@@ -40,9 +42,11 @@ class HandlerStack
      * The returned handler stack can be passed to a client in the "handler"
      * option.
      *
-     * @param (callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>)|null $handler HTTP handler function to use with the stack. If no
-     *                                                                                                      handler is provided, the best handler for your
-     *                                                                                                      system will be utilized.
+     * @param (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)|null $handler HTTP handler function to use with the stack. If no
+     *                                                                                                                        handler is provided, the best handler for your
+     *                                                                                                                        system will be utilized.
+     *
+     * @return self<callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>>
      */
     public static function create(?callable $handler = null): self
     {
@@ -56,7 +60,7 @@ class HandlerStack
     }
 
     /**
-     * @param (callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>)|null $handler Underlying HTTP handler.
+     * @param (callable&THandler)|null $handler Underlying handler.
      */
     public function __construct(?callable $handler = null)
     {
@@ -66,7 +70,7 @@ class HandlerStack
     /**
      * Invokes the handler stack as a composed handler
      *
-     * @return ResponseInterface|PromiseInterface<ResponseInterface, mixed>
+     * @return PromiseInterface<ResponseInterface, mixed>
      */
     public function __invoke(RequestInterface $request, array $options)
     {
@@ -106,8 +110,7 @@ class HandlerStack
     /**
      * Set the HTTP handler that actually returns a promise.
      *
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $handler Accepts a request and array of options and
-     *                                                                                               returns a Promise.
+     * @param callable&THandler $handler Accepts a request and array of options and returns a value expected by the stack.
      */
     public function setHandler(callable $handler): void
     {
@@ -126,8 +129,8 @@ class HandlerStack
     /**
      * Unshift a middleware to the bottom of the stack.
      *
-     * @param callable(callable): callable $middleware Middleware function
-     * @param string                       $name       Name to register for this middleware.
+     * @param callable(callable&THandler): (callable&THandler) $middleware Middleware function
+     * @param string                                           $name       Name to register for this middleware.
      */
     public function unshift(callable $middleware, ?string $name = null): void
     {
@@ -138,8 +141,8 @@ class HandlerStack
     /**
      * Push a middleware to the top of the stack.
      *
-     * @param callable(callable): callable $middleware Middleware function
-     * @param string                       $name       Name to register for this middleware.
+     * @param callable(callable&THandler): (callable&THandler) $middleware Middleware function
+     * @param string                                           $name       Name to register for this middleware.
      */
     public function push(callable $middleware, string $name = ''): void
     {
@@ -150,9 +153,9 @@ class HandlerStack
     /**
      * Add a middleware before another middleware by name.
      *
-     * @param string                       $findName   Middleware to find
-     * @param callable(callable): callable $middleware Middleware function
-     * @param string                       $withName   Name to register for this middleware.
+     * @param string                                           $findName   Middleware to find
+     * @param callable(callable&THandler): (callable&THandler) $middleware Middleware function
+     * @param string                                           $withName   Name to register for this middleware.
      */
     public function before(string $findName, callable $middleware, string $withName = ''): void
     {
@@ -162,9 +165,9 @@ class HandlerStack
     /**
      * Add a middleware after another middleware by name.
      *
-     * @param string                       $findName   Middleware to find
-     * @param callable(callable): callable $middleware Middleware function
-     * @param string                       $withName   Name to register for this middleware.
+     * @param string                                           $findName   Middleware to find
+     * @param callable(callable&THandler): (callable&THandler) $middleware Middleware function
+     * @param string                                           $withName   Name to register for this middleware.
      */
     public function after(string $findName, callable $middleware, string $withName = ''): void
     {
@@ -174,7 +177,7 @@ class HandlerStack
     /**
      * Remove a middleware by instance or name from the stack.
      *
-     * @param callable|string $remove Middleware to remove by instance or name.
+     * @param (callable(callable&THandler): (callable&THandler))|string $remove Middleware to remove by instance or name.
      */
     public function remove($remove): void
     {
@@ -210,7 +213,7 @@ class HandlerStack
     /**
      * Compose the middleware and handler into a single callable function.
      *
-     * @return callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>
+     * @return callable&THandler
      */
     public function resolve(): callable
     {
@@ -220,7 +223,6 @@ class HandlerStack
             }
 
             foreach (\array_reverse($this->stack) as $fn) {
-                /** @var callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $prev */
                 $prev = $fn[0]($prev);
             }
 
@@ -243,6 +245,8 @@ class HandlerStack
 
     /**
      * Splices a function into the middleware list at a specific position.
+     *
+     * @param callable(callable&THandler): (callable&THandler) $middleware
      */
     private function splice(string $findName, string $withName, callable $middleware, bool $before): void
     {

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -70,7 +70,7 @@ class HandlerStack
     /**
      * Invokes the handler stack as a composed handler
      *
-     * @return PromiseInterface<ResponseInterface, mixed>
+     * @return ResponseInterface|PromiseInterface<ResponseInterface, mixed>
      */
     public function __invoke(RequestInterface $request, array $options)
     {

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -25,7 +25,7 @@ final class Middleware
      * The options array must be set to a CookieJarInterface in order to use
      * cookies. This is typically handled for you by a client.
      *
-     * @return callable Returns a function that accepts the next handler.
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function cookies(): callable
     {
@@ -57,7 +57,7 @@ final class Middleware
      *
      * @param BodySummarizerInterface|null $bodySummarizer The body summarizer to use in exception messages.
      *
-     * @return callable(callable): callable Returns a function that accepts the next handler.
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function httpErrors(?BodySummarizerInterface $bodySummarizer = null): callable
     {
@@ -83,9 +83,9 @@ final class Middleware
     /**
      * Middleware that pushes history data to an ArrayAccess container.
      *
-     * @param array|\ArrayAccess<int, array> $container Container to hold the history (by reference).
+     * @param array<array-key, array{request: RequestInterface, response: ResponseInterface|null, error: mixed, options: array<array-key, mixed>}>|\ArrayAccess<int, array{request: RequestInterface, response: ResponseInterface|null, error: mixed, options: array<array-key, mixed>}> $container Container to hold the history (by reference).
      *
-     * @return callable(callable): callable Returns a function that accepts the next handler.
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      *
      * @throws \InvalidArgumentException if container is not an array or ArrayAccess.
      */
@@ -131,10 +131,10 @@ final class Middleware
      * before listener accepts a request and options array, and the after
      * listener accepts a request, options array, and response promise.
      *
-     * @param (callable(RequestInterface, array): mixed)|null                                             $before Function to invoke before forwarding the request.
-     * @param (callable(RequestInterface, array, PromiseInterface<ResponseInterface, mixed>): mixed)|null $after  Function invoked after forwarding.
+     * @param (callable(RequestInterface, array<array-key, mixed>): mixed)|null                                             $before Function to invoke before forwarding the request.
+     * @param (callable(RequestInterface, array<array-key, mixed>, PromiseInterface<ResponseInterface, mixed>): mixed)|null $after  Function invoked after forwarding.
      *
-     * @return callable Returns a function that accepts the next handler.
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function tap(?callable $before = null, ?callable $after = null): callable
     {
@@ -156,7 +156,7 @@ final class Middleware
     /**
      * Middleware that handles request redirects.
      *
-     * @return callable Returns a function that accepts the next handler.
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function redirect(): callable
     {
@@ -179,7 +179,7 @@ final class Middleware
      *                                                                                                          or retry context and returns the number of
      *                                                                                                          milliseconds to delay.
      *
-     * @return callable Returns a function that accepts the next handler.
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function retry(callable $decider, ?callable $delay = null): callable
     {
@@ -196,9 +196,7 @@ final class Middleware
      * @param MessageFormatterInterface|MessageFormatter $formatter Formatter used to create message strings.
      * @param string                                     $logLevel  Level at which to log requests.
      *
-     * @phpstan-param \Psr\Log\LogLevel::* $logLevel Level at which to log requests.
-     *
-     * @return callable Returns a function that accepts the next handler.
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function log(LoggerInterface $logger, $formatter, string $logLevel = 'info'): callable
     {
@@ -234,6 +232,8 @@ final class Middleware
     /**
      * This middleware adds a default content-type if possible, a default
      * content-length or transfer-encoding header, and the expect header.
+     *
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function prepareBody(): callable
     {
@@ -248,6 +248,8 @@ final class Middleware
      *
      * @param callable(RequestInterface): RequestInterface $fn Function that accepts a RequestInterface and returns
      *                                                         a RequestInterface.
+     *
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function mapRequest(callable $fn): callable
     {
@@ -264,6 +266,8 @@ final class Middleware
      *
      * @param callable(ResponseInterface): ResponseInterface $fn Function that accepts a ResponseInterface and
      *                                                           returns a ResponseInterface.
+     *
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
      */
     public static function mapResponse(callable $fn): callable
     {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -2,21 +2,28 @@
 
 namespace GuzzleHttp;
 
+use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriFactoryInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Sends an iterator of requests concurrently using a capped pool size.
  *
  * The pool will read from an iterator until it is cancelled or until the
  * iterator is consumed. When a request is yielded, the request is sent after
- * applying the "request_options" request options (if provided in the ctor).
+ * applying the "options" request options (if provided in the ctor).
  *
  * When a function is yielded by the iterator, the function is provided the
- * "request_options" array that should be merged on top of any existing
- * options, and the function MUST then return a wait-able promise.
+ * "options" array that should be merged on top of any existing options, and
+ * the function MUST then return a response or a wait-able response promise.
  *
  * @final
  *
@@ -25,19 +32,88 @@ use Psr\Http\Message\RequestInterface;
 class Pool implements PromisorInterface
 {
     /**
-     * @var EachPromise<array-key, mixed, mixed>
+     * @var EachPromise<array-key, ResponseInterface, mixed>
      */
     private $each;
 
     /**
-     * @param ClientInterface $client   Client used to send the requests.
-     * @param iterable        $requests Requests or functions that return
-     *                                  requests to send concurrently.
-     * @param array           $config   Associative array of options
-     *                                  - concurrency: (int) Maximum number of requests to send concurrently
-     *                                  - options: Array of request options to apply to each request.
-     *                                  - fulfilled: (callable) Function to invoke when a request completes.
-     *                                  - rejected: (callable) Function to invoke when a request is rejected.
+     * @param ClientInterface                                                                                                                         $client   Client used to send the requests.
+     * @param iterable<array-key, RequestInterface|callable(array<array-key, mixed>): (ResponseInterface|PromiseInterface<ResponseInterface, mixed>)> $requests Requests or functions that return responses or response promises.
+     * @param array{
+     *     concurrency?: int|(callable(int): int),
+     *     options?: array{
+     *         handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *         base_uri?: string|UriInterface,
+     *         allow_redirects?: bool|array{
+     *             max?: int,
+     *             strict?: bool,
+     *             referer?: bool,
+     *             protocols?: array<array-key, string>,
+     *             on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *             track_redirects?: bool
+     *         },
+     *         auth?: array{
+     *             0: string,
+     *             1: string,
+     *             2?: string
+     *         }|null,
+     *         body?: mixed,
+     *         cert?: string|array{
+     *             0: string,
+     *             1?: string
+     *         },
+     *         cert_type?: string,
+     *         connect_timeout?: int|float,
+     *         cookies?: bool|CookieJarInterface,
+     *         crypto_method?: int,
+     *         debug?: bool|resource,
+     *         decode_content?: bool|string,
+     *         delay?: int|float,
+     *         expect?: bool|int,
+     *         form_params?: array<array-key, mixed>,
+     *         force_ip_resolve?: string,
+     *         headers?: array<array-key, string|array<array-key, string>>|null,
+     *         http_errors?: bool,
+     *         idn_conversion?: bool|int,
+     *         json?: mixed,
+     *         multipart?: array<array-key, array{
+     *             name: string,
+     *             contents: mixed,
+     *             headers?: array<array-key, string|array<array-key, string>>,
+     *             filename?: string
+     *         }>,
+     *         on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *         on_stats?: callable(TransferStats): mixed,
+     *         progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *         protocols?: array<array-key, string>,
+     *         proxy?: string|array{
+     *             http?: string,
+     *             https?: string,
+     *             no?: string|array<array-key, string>
+     *         },
+     *         query?: array<array-key, mixed>|string,
+     *         read_timeout?: int|float,
+     *         request_factory?: RequestFactoryInterface,
+     *         sink?: resource|string|StreamInterface,
+     *         ssl_key?: string|array{
+     *             0: string,
+     *             1?: string
+     *         },
+     *         ssl_key_type?: string,
+     *         stream?: bool,
+     *         stream_factory?: StreamFactoryInterface,
+     *         stream_context?: array<array-key, mixed>,
+     *         synchronous?: bool,
+     *         timeout?: int|float,
+     *         uri_factory?: UriFactoryInterface,
+     *         verify?: bool|string,
+     *         version?: string|float,
+     *         curl?: array<int|string, mixed>,
+     *         ...
+     *     },
+     *     fulfilled?: callable(ResponseInterface, array-key, PromiseInterface<mixed, mixed>): mixed,
+     *     rejected?: callable(mixed, array-key, PromiseInterface<mixed, mixed>): mixed
+     * } $config Pool configuration.
      */
     public function __construct(ClientInterface $client, iterable $requests, array $config = [])
     {
@@ -85,13 +161,85 @@ class Pool implements PromisorInterface
      * as such, is NOT recommended when sending a large number or an
      * indeterminate number of requests concurrently.
      *
-     * @param ClientInterface $client   Client used to send the requests
-     * @param iterable        $requests Requests to send concurrently.
-     * @param array           $options  Passes through the options available in
-     *                                  {@see Pool::__construct}
+     * @param ClientInterface                                                                                                                         $client   Client used to send the requests
+     * @param iterable<array-key, RequestInterface|callable(array<array-key, mixed>): (ResponseInterface|PromiseInterface<ResponseInterface, mixed>)> $requests Requests or functions that return responses or response promises.
+     * @param array{
+     *     concurrency?: int|(callable(int): int),
+     *     options?: array{
+     *         handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
+     *         base_uri?: string|UriInterface,
+     *         allow_redirects?: bool|array{
+     *             max?: int,
+     *             strict?: bool,
+     *             referer?: bool,
+     *             protocols?: array<array-key, string>,
+     *             on_redirect?: callable(RequestInterface, ResponseInterface, UriInterface): mixed,
+     *             track_redirects?: bool
+     *         },
+     *         auth?: array{
+     *             0: string,
+     *             1: string,
+     *             2?: string
+     *         }|null,
+     *         body?: mixed,
+     *         cert?: string|array{
+     *             0: string,
+     *             1?: string
+     *         },
+     *         cert_type?: string,
+     *         connect_timeout?: int|float,
+     *         cookies?: bool|CookieJarInterface,
+     *         crypto_method?: int,
+     *         debug?: bool|resource,
+     *         decode_content?: bool|string,
+     *         delay?: int|float,
+     *         expect?: bool|int,
+     *         form_params?: array<array-key, mixed>,
+     *         force_ip_resolve?: string,
+     *         headers?: array<array-key, string|array<array-key, string>>|null,
+     *         http_errors?: bool,
+     *         idn_conversion?: bool|int,
+     *         json?: mixed,
+     *         multipart?: array<array-key, array{
+     *             name: string,
+     *             contents: mixed,
+     *             headers?: array<array-key, string|array<array-key, string>>,
+     *             filename?: string
+     *         }>,
+     *         on_headers?: callable(ResponseInterface, RequestInterface): mixed,
+     *         on_stats?: callable(TransferStats): mixed,
+     *         progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *         protocols?: array<array-key, string>,
+     *         proxy?: string|array{
+     *             http?: string,
+     *             https?: string,
+     *             no?: string|array<array-key, string>
+     *         },
+     *         query?: array<array-key, mixed>|string,
+     *         read_timeout?: int|float,
+     *         request_factory?: RequestFactoryInterface,
+     *         sink?: resource|string|StreamInterface,
+     *         ssl_key?: string|array{
+     *             0: string,
+     *             1?: string
+     *         },
+     *         ssl_key_type?: string,
+     *         stream?: bool,
+     *         stream_factory?: StreamFactoryInterface,
+     *         stream_context?: array<array-key, mixed>,
+     *         synchronous?: bool,
+     *         timeout?: int|float,
+     *         uri_factory?: UriFactoryInterface,
+     *         verify?: bool|string,
+     *         version?: string|float,
+     *         curl?: array<int|string, mixed>,
+     *         ...
+     *     },
+     *     fulfilled?: callable(ResponseInterface, array-key): mixed,
+     *     rejected?: callable(mixed, array-key): mixed
+     * } $options Passes through the options available in {@see Pool::__construct}.
      *
-     * @return array Returns an array containing the response or an exception
-     *               in the same order that the requests were sent.
+     * @return array<array-key, mixed> Returns an array containing the response or rejection reason in the same order that the requests were sent.
      *
      * @throws \InvalidArgumentException if the event format is incorrect.
      */

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -57,14 +57,14 @@ class Pool implements PromisorInterface
      *             1: string,
      *             2?: string
      *         }|null,
-     *         body?: mixed,
+     *         body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *         cert?: string|array{
      *             0: string,
      *             1?: string
      *         },
      *         cert_type?: string,
      *         connect_timeout?: int|float,
-     *         cookies?: bool|CookieJarInterface,
+     *         cookies?: false|CookieJarInterface,
      *         crypto_method?: int,
      *         debug?: bool|resource,
      *         decode_content?: bool|string,
@@ -77,9 +77,9 @@ class Pool implements PromisorInterface
      *         idn_conversion?: bool|int,
      *         json?: mixed,
      *         multipart?: array<array-key, array{
-     *             name: string,
+     *             name: string|int,
      *             contents: mixed,
-     *             headers?: array<array-key, string|array<array-key, string>>,
+     *             headers?: array<array-key, string>,
      *             filename?: string
      *         }>,
      *         on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -93,6 +93,7 @@ class Pool implements PromisorInterface
      *         },
      *         query?: array<array-key, mixed>|string,
      *         read_timeout?: int|float,
+     *         retries?: int,
      *         request_factory?: RequestFactoryInterface,
      *         sink?: resource|string|StreamInterface,
      *         ssl_key?: string|array{
@@ -181,14 +182,14 @@ class Pool implements PromisorInterface
      *             1: string,
      *             2?: string
      *         }|null,
-     *         body?: mixed,
+     *         body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *         cert?: string|array{
      *             0: string,
      *             1?: string
      *         },
      *         cert_type?: string,
      *         connect_timeout?: int|float,
-     *         cookies?: bool|CookieJarInterface,
+     *         cookies?: false|CookieJarInterface,
      *         crypto_method?: int,
      *         debug?: bool|resource,
      *         decode_content?: bool|string,
@@ -201,9 +202,9 @@ class Pool implements PromisorInterface
      *         idn_conversion?: bool|int,
      *         json?: mixed,
      *         multipart?: array<array-key, array{
-     *             name: string,
+     *             name: string|int,
      *             contents: mixed,
-     *             headers?: array<array-key, string|array<array-key, string>>,
+     *             headers?: array<array-key, string>,
      *             filename?: string
      *         }>,
      *         on_headers?: callable(ResponseInterface, RequestInterface): mixed,
@@ -217,6 +218,7 @@ class Pool implements PromisorInterface
      *         },
      *         query?: array<array-key, mixed>|string,
      *         read_timeout?: int|float,
+     *         retries?: int,
      *         request_factory?: RequestFactoryInterface,
      *         sink?: resource|string|StreamInterface,
      *         ssl_key?: string|array{

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -15,12 +15,12 @@ use Psr\Http\Message\ResponseInterface;
 class PrepareBodyMiddleware
 {
     /**
-     * @var callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>
+     * @var callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>
      */
     private $nextHandler;
 
     /**
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $nextHandler Next handler to invoke.
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $nextHandler Next handler to invoke.
      */
     public function __construct(callable $nextHandler)
     {

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -38,12 +38,12 @@ class RedirectMiddleware
     ];
 
     /**
-     * @var callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>
+     * @var callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>
      */
     private $nextHandler;
 
     /**
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed> $nextHandler Next handler to invoke.
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $nextHandler Next handler to invoke.
      */
     public function __construct(callable $nextHandler)
     {

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -56,11 +56,12 @@ final class RequestOptions
     public const AUTH = 'auth';
 
     /**
-     * body: (resource|string|null|int|float|bool|StreamInterface|callable|\Iterator|\Stringable)
+     * body: (resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable)
      * Body to send in the request. Scalar, resource, and stringable object
      * values are converted using the configured stream_factory. Callable and
      * iterator bodies use Guzzle's existing stream handling. Strings are used
-     * as literal body contents, even when they name a callable.
+     * as literal body contents, even when they name a callable. Callable bodies
+     * may be closures or invokable objects; arrays are not valid body values.
      */
     public const BODY = 'body';
 
@@ -80,7 +81,7 @@ final class RequestOptions
     public const CERT_TYPE = 'cert_type';
 
     /**
-     * cookies: (bool|GuzzleHttp\Cookie\CookieJarInterface, default=false)
+     * cookies: (false|GuzzleHttp\Cookie\CookieJarInterface, default=false)
      * Specifies whether or not cookies are used in a request or what cookie
      * jar to use or what cookies to send. This option only works if your
      * handler has the `cookie` middleware. Valid values are `false` and
@@ -183,13 +184,13 @@ final class RequestOptions
     public const JSON = 'json';
 
     /**
-     * multipart: (array) Array of associative arrays, each containing a
-     * required "name" key mapping to the form field, name, a required
+     * multipart: (array) Array of part arrays, each containing a required
+     * "name" key mapping to the string or integer form field name, a required
      * "contents" key mapping to any non-array value accepted by PSR-7
-     * Utils::streamFor(), an optional "headers" associative array of custom headers, and an
-     * optional "filename" key mapping to a string to send as the filename in
-     * the part. If no "filename" key is present, then no "filename" attribute
-     * will be added to the part.
+     * Utils::streamFor() or a nested array of field values, an optional
+     * "headers" array of string custom header values, and an optional
+     * "filename" key mapping to a string to send as the filename in the part.
+     * "headers" and "filename" cannot be used when "contents" is an array.
      */
     public const MULTIPART = 'multipart';
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace GuzzleHttp;
 
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
 /**
  * This class contains a list of built-in Guzzle request options.
  *
@@ -17,8 +22,9 @@ final class RequestOptions
 
     /**
      * allow_redirects: (bool|array) Controls redirect behavior. Pass false
-     * to disable redirects, pass true to enable redirects, pass an
-     * associative to provide custom redirect settings. Defaults to "false".
+     * to disable redirects, pass true to enable redirects, or pass an
+     * associative array to provide custom redirect settings. Clients enable
+     * redirects by default when the default redirect middleware is present.
      * This option only works if your handler has the RedirectMiddleware. When
      * passing an associative array, you can provide the following key value
      * pairs:
@@ -31,10 +37,12 @@ final class RequestOptions
      *   header.
      * - protocols: (array, default=['http', 'https']) Allowed redirect
      *   protocols.
-     * - on_redirect: (callable) PHP callable that is invoked when a redirect
-     *   is encountered. The callable is invoked with the request, the redirect
-     *   response that was received, and the effective URI. Any return value
-     *   from the on_redirect function is ignored.
+     * - on_redirect: (callable(RequestInterface, ResponseInterface, UriInterface): mixed)
+     *   PHP callable that is invoked when a redirect is encountered. The
+     *   callable is invoked with the request, the redirect response that was
+     *   received, and the effective URI. Any return value is ignored.
+     * - track_redirects: (bool, default=false) Track redirected URI and status
+     *   history in response headers.
      */
     public const ALLOW_REDIRECTS = 'allow_redirects';
 
@@ -48,10 +56,11 @@ final class RequestOptions
     public const AUTH = 'auth';
 
     /**
-     * body: (resource|string|null|int|float|StreamInterface|callable|\Iterator)
+     * body: (resource|string|null|int|float|bool|StreamInterface|callable|\Iterator|\Stringable)
      * Body to send in the request. Scalar, resource, and stringable object
      * values are converted using the configured stream_factory. Callable and
-     * iterator bodies use Guzzle's existing stream handling.
+     * iterator bodies use Guzzle's existing stream handling. Strings are used
+     * as literal body contents, even when they name a callable.
      */
     public const BODY = 'body';
 
@@ -176,8 +185,8 @@ final class RequestOptions
     /**
      * multipart: (array) Array of associative arrays, each containing a
      * required "name" key mapping to the form field, name, a required
-     * "contents" key mapping to a StreamInterface|resource|string, an
-     * optional "headers" associative array of custom headers, and an
+     * "contents" key mapping to any non-array value accepted by PSR-7
+     * Utils::streamFor(), an optional "headers" associative array of custom headers, and an
      * optional "filename" key mapping to a string to send as the filename in
      * the part. If no "filename" key is present, then no "filename" attribute
      * will be added to the part.
@@ -185,18 +194,18 @@ final class RequestOptions
     public const MULTIPART = 'multipart';
 
     /**
-     * on_headers: (callable) A callable that is invoked when the HTTP headers
+     * on_headers: (callable(ResponseInterface, RequestInterface): mixed) A callable that is invoked when the HTTP headers
      * of the response have been received but the body has not yet begun to
      * download. The callable is passed the response and request as
-     * {@see \Psr\Http\Message\ResponseInterface} and
-     * {@see \Psr\Http\Message\RequestInterface} objects, respectively. If it
+     * {@see ResponseInterface} and
+     * {@see RequestInterface} objects, respectively. If it
      * throws, the request promise is rejected with a RequestException wrapping
      * the thrown exception.
      */
     public const ON_HEADERS = 'on_headers';
 
     /**
-     * on_stats: (callable) allows you to get access to transfer statistics of
+     * on_stats: (callable(TransferStats): mixed) allows you to get access to transfer statistics of
      * a request and access the lower level transfer details of the handler
      * associated with your client. ``on_stats`` is a callable that is invoked
      * when a handler has finished sending a request. The callback is invoked
@@ -209,8 +218,8 @@ final class RequestOptions
     public const ON_STATS = 'on_stats';
 
     /**
-     * progress: (callable) Defines a function to invoke when transfer
-     * progress is made. The function accepts the following positional
+     * progress: (callable(int|float, int|float, int|float, int|float): mixed)
+     * Defines a function to invoke when transfer progress is made. The function accepts the following positional
      * arguments: the total number of bytes expected to be downloaded, the
      * number of bytes downloaded so far, the number of bytes expected to be
      * uploaded, the number of bytes uploaded so far. With the built-in cURL
@@ -233,7 +242,8 @@ final class RequestOptions
      * pairs, IP literals, IP CIDR rules, or wildcard rules that should not be
      * proxied. Domain rules are matched case-insensitively. Exact IP literals
      * are normalized before matching. CIDR rules match IP literals only and
-     * are not port-specific.
+     * are not port-specific. Custom handlers can use ProxyOptions::resolve()
+     * to apply Guzzle-compatible proxy selection.
      */
     public const PROXY = 'proxy';
 
@@ -338,7 +348,8 @@ final class RequestOptions
     public const VERSION = 'version';
 
     /**
-     * force_ip_resolve: (bool) Force client to use only ipv4 or ipv6 protocol
+     * force_ip_resolve: (string) Set to "v4" to force IPv4 resolution or "v6"
+     * to force IPv6 resolution when supported by the handler.
      */
     public const FORCE_IP_RESOLVE = 'force_ip_resolve';
 }

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 class RetryMiddleware
 {
     /**
-     * @var callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>
+     * @var callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>
      */
     private $nextHandler;
 
@@ -31,11 +31,11 @@ class RetryMiddleware
     private $delay;
 
     /**
-     * @param callable(int, RequestInterface, ResponseInterface|null, mixed): bool                     $decider     Function that accepts the number of retries,
-     *                                                                                                              a request, [response], and [rejection reason]
-     *                                                                                                              and returns true if the request is to be retried.
-     * @param callable(RequestInterface, array): PromiseInterface<ResponseInterface, mixed>            $nextHandler Next handler to invoke.
-     * @param (callable(int): int)|(callable(int, ResponseInterface|null, RequestInterface): int)|null $delay       Function that returns the number of milliseconds to delay.
+     * @param callable(int, RequestInterface, ResponseInterface|null, mixed): bool                            $decider     Function that accepts the number of retries,
+     *                                                                                                                     a request, [response], and [rejection reason]
+     *                                                                                                                     and returns true if the request is to be retried.
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $nextHandler Next handler to invoke.
+     * @param (callable(int): int)|(callable(int, ResponseInterface|null, RequestInterface): int)|null        $delay       Function that returns the number of milliseconds to delay.
      */
     public function __construct(callable $decider, callable $nextHandler, ?callable $delay = null)
     {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -10,7 +10,9 @@ use GuzzleHttp\Handler\CurlShareHandleState;
 use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Handler\StreamHandler;
+use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 
 final class Utils
@@ -89,7 +91,7 @@ final class Utils
      *
      * @param array{share?: mixed} $curlOptions cURL handler constructor options.
      *
-     * @return callable(RequestInterface, array): Promise\PromiseInterface<\Psr\Http\Message\ResponseInterface, mixed> Returns the best handler for the given system.
+     * @return callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> Returns the best handler for the given system.
      *
      * @throws \RuntimeException if no viable Handler is available.
      */
@@ -139,9 +141,14 @@ final class Utils
         return $handler;
     }
 
+    /**
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler
+     *
+     * @return callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>
+     */
     private static function wrapStreamHandlerCurlShare(callable $handler, string $shareMode): callable
     {
-        return static function (RequestInterface $request, array $options) use ($handler, $shareMode): Promise\PromiseInterface {
+        return static function (RequestInterface $request, array $options) use ($handler, $shareMode): PromiseInterface {
             if (\array_key_exists('curl_share', $options)) {
                 CurlShareHandleState::normalizeMode($options['curl_share'], 'curl_share');
             }

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
@@ -265,6 +266,115 @@ class MockHandlerTest extends TestCase
         self::assertSame($res, $promise->wait());
         self::assertSame($res, $gotResponse);
         self::assertSame($request, $gotRequest);
+    }
+
+    public function testInvokesOnHeadersWithQueuedPromiseResponse(): void
+    {
+        $res = new Response(202, ['X-Foo' => 'bar']);
+        $mock = new MockHandler([Create::promiseFor($res)]);
+        $request = new Request('GET', 'http://example.com');
+        $gotResponse = null;
+
+        $promise = $mock($request, [
+            'on_headers' => static function (ResponseInterface $response) use (&$gotResponse): void {
+                $gotResponse = $response;
+            },
+        ]);
+
+        self::assertSame($res, $promise->wait());
+        self::assertSame($res, $gotResponse);
+    }
+
+    public function testInvokesOnHeadersAfterQueuedCallableReturnsResponse(): void
+    {
+        $res = new Response(203, ['X-Foo' => 'bar']);
+        $mock = new MockHandler([
+            static function () use ($res): ResponseInterface {
+                return $res;
+            },
+        ]);
+        $request = new Request('GET', 'http://example.com');
+        $gotResponse = null;
+
+        $promise = $mock($request, [
+            'on_headers' => static function (ResponseInterface $response) use (&$gotResponse): void {
+                $gotResponse = $response;
+            },
+        ]);
+
+        self::assertSame($res, $promise->wait());
+        self::assertSame($res, $gotResponse);
+    }
+
+    public function testInvokesOnHeadersAfterQueuedCallableReturnsPromise(): void
+    {
+        $res = new Response(204, ['X-Foo' => 'bar']);
+        $mock = new MockHandler([
+            static function () use ($res): PromiseInterface {
+                return Create::promiseFor($res);
+            },
+        ]);
+        $request = new Request('GET', 'http://example.com');
+        $gotResponse = null;
+
+        $promise = $mock($request, [
+            'on_headers' => static function (ResponseInterface $response) use (&$gotResponse): void {
+                $gotResponse = $response;
+            },
+        ]);
+
+        self::assertSame($res, $promise->wait());
+        self::assertSame($res, $gotResponse);
+    }
+
+    public function testDoesNotInvokeOnHeadersForQueuedThrowable(): void
+    {
+        $reason = new \RuntimeException('failed');
+        $mock = new MockHandler([$reason]);
+        $called = false;
+
+        $promise = $mock(new Request('GET', 'http://example.com'), [
+            'on_headers' => static function () use (&$called): void {
+                $called = true;
+            },
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            self::assertSame($reason, $e);
+            self::assertFalse($called);
+        }
+    }
+
+    public function testInvokesOnStatsWhenPromiseOnHeadersFails(): void
+    {
+        $res = new Response(200);
+        $mock = new MockHandler([Create::promiseFor($res)]);
+        $request = new Request('GET', 'http://example.com');
+        $stats = null;
+        $promise = $mock($request, [
+            'on_headers' => static function (): void {
+                throw new \RuntimeException('test');
+            },
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
+            },
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('An error was encountered during the on_headers event', $e->getMessage());
+            self::assertSame($res, $e->getResponse());
+            self::assertInstanceOf(TransferStats::class, $stats);
+            self::assertSame($request, $stats->getRequest());
+            self::assertTrue($stats->hasResponse());
+            self::assertSame($res, $stats->getResponse());
+            self::assertSame($e, $stats->getHandlerErrorData());
+        }
     }
 
     public function testInvokesOnFulfilled(): void

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -7,6 +7,7 @@ namespace GuzzleHttp\Test\Handler;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
@@ -135,6 +136,37 @@ class MockHandlerTest extends TestCase
         $request = new Request('GET', 'http://example.com');
         $p = $mock($request, ['foo' => 'bar']);
         self::assertSame($r, $p->wait());
+    }
+
+    public function testQueuedCallableCanReturnPromise(): void
+    {
+        $response = new Response(201);
+        $mock = new MockHandler([
+            static function () use ($response) {
+                return Create::promiseFor($response);
+            },
+        ]);
+
+        $promise = $mock(new Request('GET', 'http://example.com'), []);
+
+        self::assertSame($response, $promise->wait());
+    }
+
+    public function testQueuedCallableCanReturnThrowable(): void
+    {
+        $reason = new \RuntimeException('failed');
+        $mock = new MockHandler([
+            static function () use ($reason): \Throwable {
+                return $reason;
+            },
+        ]);
+
+        $promise = $mock(new Request('GET', 'http://example.com'), []);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('failed');
+
+        $promise->wait();
     }
 
     public function testEnsuresOnHeadersIsCallable(): void

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Server\Server;
@@ -139,8 +140,57 @@ class PoolTest extends TestCase
         $opts = ['options' => ['headers' => ['x-foo' => 'bar']]];
         $p = new Pool($c, [$fn], $opts);
         $p->promise()->wait();
+        self::assertSame($opts['options'], $optHistory);
         self::assertCount(1, $h);
         self::assertTrue($h[0]->hasHeader('x-foo'));
+    }
+
+    public function testConstructorCallbacksCanReceiveAggregatePromise(): void
+    {
+        $reason = new \RuntimeException('failed');
+        $client = new Client(['handler' => new MockHandler([new Response(200), $reason])]);
+        $seen = [];
+
+        $pool = new Pool($client, [
+            'ok' => new Request('GET', 'http://example.com/ok'),
+            'fail' => new Request('GET', 'http://example.com/fail'),
+        ], [
+            'fulfilled' => static function (ResponseInterface $response, string $index, PromiseInterface $aggregate) use (&$seen): void {
+                $seen['fulfilled'] = [$index, $response->getStatusCode(), $aggregate instanceof PromiseInterface];
+            },
+            'rejected' => static function ($value, string $index, PromiseInterface $aggregate) use (&$seen): void {
+                $seen['rejected'] = [$index, $value->getMessage(), $aggregate instanceof PromiseInterface];
+            },
+        ]);
+
+        $pool->promise()->wait(false);
+
+        self::assertSame(['ok', 200, true], $seen['fulfilled']);
+        self::assertSame(['fail', 'failed', true], $seen['rejected']);
+    }
+
+    public function testBatchCallbacksCanReceiveResultAndIndex(): void
+    {
+        $reason = new \RuntimeException('failed');
+        $client = new Client(['handler' => new MockHandler([new Response(200), $reason])]);
+        $seen = [];
+
+        $results = Pool::batch($client, [
+            'ok' => new Request('GET', 'http://example.com/ok'),
+            'fail' => new Request('GET', 'http://example.com/fail'),
+        ], [
+            'fulfilled' => static function (ResponseInterface $response, string $index) use (&$seen): void {
+                $seen['fulfilled'] = [$index, $response->getStatusCode()];
+            },
+            'rejected' => static function ($value, string $index) use (&$seen): void {
+                $seen['rejected'] = [$index, $value->getMessage()];
+            },
+        ]);
+
+        self::assertSame(['ok', 200], $seen['fulfilled']);
+        self::assertSame(['fail', 'failed'], $seen['rejected']);
+        self::assertInstanceOf(ResponseInterface::class, $results['ok']);
+        self::assertSame($reason, $results['fail']);
     }
 
     public function testBatchesResults(): void

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -145,6 +145,31 @@ class PoolTest extends TestCase
         self::assertTrue($h[0]->hasHeader('x-foo'));
     }
 
+    public function testCanProvideCallablesThatReturnResponsePromises(): void
+    {
+        $h = [];
+        $handler = new MockHandler([
+            static function (RequestInterface $request) use (&$h): ResponseInterface {
+                $h[] = $request;
+
+                return new Response();
+            },
+        ]);
+        $c = new Client(['handler' => $handler]);
+        $optHistory = [];
+        $fn = static function (array $opts) use (&$optHistory, $c): PromiseInterface {
+            $optHistory = $opts;
+
+            return $c->requestAsync('GET', 'http://example.com', $opts);
+        };
+        $opts = ['options' => ['headers' => ['x-foo' => 'bar']]];
+        $p = new Pool($c, [$fn], $opts);
+        $p->promise()->wait();
+        self::assertSame($opts['options'], $optHistory);
+        self::assertCount(1, $h);
+        self::assertTrue($h[0]->hasHeader('x-foo'));
+    }
+
     public function testConstructorCallbacksCanReceiveAggregatePromise(): void
     {
         $reason = new \RuntimeException('failed');


### PR DESCRIPTION
This adds structured PHPDoc shapes for client config, request options, pool options, handlers, middleware, and mock handlers. It also updates the docs to describe callable callback contracts and mixed rejection reasons more accurately.