### PR TITLE
Finalize built-in handler classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available
 - Reject cURL multi handler promises when transfer completion callbacks throw during manual event-loop ticks
 - Made `MessageFormatter` final and required `Middleware::log()` formatters to implement `MessageFormatterInterface`
+- Made `GuzzleHttp\Handler\CurlFactory`, `GuzzleHttp\Handler\CurlHandler`, `GuzzleHttp\Handler\CurlMultiHandler`, `GuzzleHttp\Handler\MockHandler`, and `GuzzleHttp\Handler\StreamHandler` final
 - Made static utility classes non-instantiable and declared `GuzzleHttp\Handler\Proxy` final
 
 ### Removed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -548,6 +548,18 @@ final class RedactingFormatter implements MessageFormatterInterface
 $stack->push(Middleware::log($logger, new RedactingFormatter()));
 ```
 
+#### Built-in handler inheritance
+
+`GuzzleHttp\Handler\CurlFactory`, `GuzzleHttp\Handler\CurlHandler`,
+`GuzzleHttp\Handler\CurlMultiHandler`, `GuzzleHttp\Handler\MockHandler`, and
+`GuzzleHttp\Handler\StreamHandler` are now final.
+
+Applications that extended `CurlFactory` should implement
+`GuzzleHttp\Handler\CurlFactoryInterface` instead. Applications that extended
+`CurlHandler`, `CurlMultiHandler`, `MockHandler`, or `StreamHandler` should use
+composition instead: wrap a handler instance in a custom callable or provide a
+custom handler rather than subclassing the built-in handler.
+
 #### CurlMultiHandler select timeout
 
 The `GUZZLE_CURL_SELECT_TIMEOUT` environment variable is no longer read. Pass

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -19,10 +19,8 @@ use Psr\Http\Message\UriInterface;
 
 /**
  * Creates curl resources from a request
- *
- * @final
  */
-class CurlFactory implements CurlFactoryInterface
+final class CurlFactory implements CurlFactoryInterface
 {
     public const CURL_VERSION_STR = 'curl_version';
 

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -12,10 +12,8 @@ use Psr\Http\Message\ResponseInterface;
  * When using the CurlHandler, custom curl options can be specified as an
  * associative array of curl option constants mapping to values in the
  * **curl** key of the "client" key of the request.
- *
- * @final
  */
-class CurlHandler
+final class CurlHandler
 {
     /**
      * @var CurlFactoryInterface

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -17,10 +17,8 @@ use Psr\Http\Message\ResponseInterface;
  * When using the CurlMultiHandler, custom curl options can be specified as an
  * associative array of curl option constants mapping to values in the
  * **curl** key of the provided request options.
- *
- * @final
  */
-class CurlMultiHandler
+final class CurlMultiHandler
 {
     /**
      * @var CurlFactoryInterface

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -14,10 +14,8 @@ use Psr\Http\Message\StreamInterface;
 
 /**
  * Handler that returns responses or rejection reasons from a queue.
- *
- * @final
  */
-class MockHandler implements \Countable
+final class MockHandler implements \Countable
 {
     /**
      * @var list<ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>|callable(RequestInterface, array<array-key, mixed>): (ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>)>

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -19,10 +19,8 @@ use Psr\Http\Message\UriInterface;
 
 /**
  * HTTP handler that uses PHP's HTTP stream wrapper.
- *
- * @final
  */
-class StreamHandler
+final class StreamHandler
 {
     /**
      * @var array

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -6,9 +6,11 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlFactory;
+use GuzzleHttp\Handler\CurlFactoryInterface;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\CurlShare;
 use GuzzleHttp\Handler\CurlShareHandleState;
+use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -16,6 +18,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Server\Server;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @covers \GuzzleHttp\Handler\CurlHandler
@@ -87,15 +90,23 @@ class CurlHandlerTest extends TestCase
 
     public function testCloseDoesNotCloseInjectedFactory(): void
     {
-        $factory = new class(3) extends CurlFactory {
+        $factory = new class implements CurlFactoryInterface {
             /** @var bool */
             public $closeCalled = false;
+
+            public function create(RequestInterface $request, array $options): EasyHandle
+            {
+                throw new \BadMethodCallException('Unexpected create call.');
+            }
+
+            public function release(EasyHandle $easy): void
+            {
+                throw new \BadMethodCallException('Unexpected release call.');
+            }
 
             public function close(): void
             {
                 $this->closeCalled = true;
-
-                parent::close();
             }
         };
         $handler = new CurlHandler(['handle_factory' => $factory]);

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -7,15 +7,18 @@ namespace GuzzleHttp\Tests\Handler;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\HandlerClosedException;
 use GuzzleHttp\Handler\CurlFactory;
+use GuzzleHttp\Handler\CurlFactoryInterface;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\CurlShare;
 use GuzzleHttp\Handler\CurlShareHandleState;
+use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Server\Server;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 
 class CurlMultiHandlerTest extends TestCase
 {
@@ -306,15 +309,23 @@ class CurlMultiHandlerTest extends TestCase
 
     public function testCloseDoesNotCloseInjectedFactory(): void
     {
-        $factory = new class(3) extends CurlFactory {
+        $factory = new class implements CurlFactoryInterface {
             /** @var bool */
             public $closeCalled = false;
+
+            public function create(RequestInterface $request, array $options): EasyHandle
+            {
+                throw new \BadMethodCallException('Unexpected create call.');
+            }
+
+            public function release(EasyHandle $easy): void
+            {
+                throw new \BadMethodCallException('Unexpected release call.');
+            }
 
             public function close(): void
             {
                 $this->closeCalled = true;
-
-                parent::close();
             }
         };
         $handler = new CurlMultiHandler(['handle_factory' => $factory]);


### PR DESCRIPTION
This makes the built-in handler implementation classes that were previously documented as final with `@final` natively final. Applications extending the concrete handler classes should switch to composition or implement CurlFactoryInterface where a custom cURL factory is needed.