### PR TITLE
Declare strict types in built-in handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers
 - Avoid stale authenticated proxy tunnels on affected libcurl versions
 - Allow built-in cURL handler `progress` callbacks to abort transfers with truthy return values
+- Normalize built-in handler `progress` callback arguments to integer byte counts
 - Reject built-in cURL handler `progress` callback throwables with `RequestException`
 - Release built-in cURL easy handles before invoking `on_stats`
 - Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -560,6 +560,14 @@ Applications that extended `CurlFactory` should implement
 composition instead: wrap a handler instance in a custom callable or provide a
 custom handler rather than subclassing the built-in handler.
 
+#### Progress callback parameter types
+
+The built-in handlers now pass integer byte counts to `progress` callbacks.
+Callbacks with `int` parameter types continue to work, and callbacks with `float`
+parameter types can still receive integer byte counts in PHP. If a callback used
+other scalar parameter types, update it to accept integers or remove the scalar
+parameter declarations.
+
 #### CurlMultiHandler select timeout
 
 The `GUZZLE_CURL_SELECT_TIMEOUT` environment variable is no longer read. Pass

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -791,7 +791,7 @@ None
 Constant
 `GuzzleHttp\RequestOptions::PROGRESS`
 
-The function accepts four integer byte counts:
+The function accepts the following positional arguments:
 
 - the total number of bytes expected to be downloaded, zero if unknown
 - the number of bytes downloaded so far

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -791,7 +791,7 @@ None
 Constant
 `GuzzleHttp\RequestOptions::PROGRESS`
 
-The function accepts the following integer byte-count positional arguments:
+The function accepts four integer byte counts:
 
 - the total number of bytes expected to be downloaded, zero if unknown
 - the number of bytes downloaded so far

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -791,7 +791,7 @@ None
 Constant
 `GuzzleHttp\RequestOptions::PROGRESS`
 
-The function accepts the following positional arguments:
+The function accepts the following integer byte-count positional arguments:
 
 - the total number of bytes expected to be downloaded, zero if unknown
 - the number of bytes downloaded so far
@@ -807,10 +807,10 @@ $result = $client->request(
     '/',
     [
         'progress' => function(
-            $downloadTotal,
-            $downloadedBytes,
-            $uploadTotal,
-            $uploadedBytes
+            int $downloadTotal,
+            int $downloadedBytes,
+            int $uploadTotal,
+            int $uploadedBytes
         ) {
             //do something
         },

--- a/src/Client.php
+++ b/src/Client.php
@@ -107,7 +107,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -226,7 +226,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -314,7 +314,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -418,7 +418,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -534,7 +534,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -72,7 +72,7 @@ interface ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -152,7 +152,7 @@ interface ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -237,7 +237,7 @@ interface ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -322,7 +322,7 @@ interface ClientInterface
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -70,7 +70,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -154,7 +154,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -241,7 +241,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -328,7 +328,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -415,7 +415,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -502,7 +502,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -589,7 +589,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -677,7 +677,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -761,7 +761,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -848,7 +848,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -935,7 +935,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -1022,7 +1022,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -1109,7 +1109,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,
@@ -1196,7 +1196,7 @@ trait ClientTrait
      *     }>,
      *     on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *     on_stats?: callable(TransferStats): mixed,
-     *     progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *     progress?: callable(int, int, int, int): mixed,
      *     protocols?: array<array-key, string>,
      *     proxy?: string|array{
      *         http?: string,

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
@@ -1337,11 +1339,11 @@ final class CurlFactory implements CurlFactoryInterface
             if (!\is_callable($progress)) {
                 throw new \InvalidArgumentException('progress client option must be callable');
             }
-            /** @var callable(int|float, int|float, int|float, int|float): mixed $progress */
+            /** @var callable(int, int, int, int): mixed $progress */
             $conf[\CURLOPT_NOPROGRESS] = false;
             $progressCallback = static function ($resource, $downloadSize, $downloaded, $uploadSize, $uploaded) use ($easy, $progress): int {
                 try {
-                    if ($progress($downloadSize, $downloaded, $uploadSize, $uploaded)) {
+                    if ($progress((int) $downloadSize, (int) $downloaded, (int) $uploadSize, (int) $uploaded)) {
                         $easy->progressAborted = true;
 
                         return 1;

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Promise\PromiseInterface;
@@ -69,7 +71,7 @@ final class CurlHandler
         $this->assertOpen();
 
         if (isset($options['delay'])) {
-            \usleep($options['delay'] * 1000);
+            \usleep((int) ($options['delay'] * 1000));
         }
 
         $easy = $this->factory->create($request, $options);

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use Closure;
@@ -36,7 +38,7 @@ final class CurlMultiHandler
     private $shareHandleState;
 
     /**
-     * @var int
+     * @var float
      */
     private $selectTimeout;
 
@@ -124,9 +126,19 @@ final class CurlMultiHandler
             $this->ownsFactory = true;
         }
 
-        $this->selectTimeout = $options['select_timeout'] ?? 1;
+        $selectTimeout = $options['select_timeout'] ?? 1.0;
+        if (!\is_int($selectTimeout) && !\is_float($selectTimeout) && (!\is_string($selectTimeout) || !\is_numeric($selectTimeout))) {
+            throw new \InvalidArgumentException('select_timeout must be a number of seconds');
+        }
 
-        $this->options = $options['options'] ?? [];
+        $this->selectTimeout = (float) $selectTimeout;
+
+        $multiOptions = $options['options'] ?? [];
+        if (!\is_array($multiOptions)) {
+            throw new \InvalidArgumentException('options must be an array of cURL multi options');
+        }
+
+        $this->options = $multiOptions;
 
         // unsetting the property forces the first access to go through
         // __get().
@@ -158,6 +170,10 @@ final class CurlMultiHandler
         $this->_mh = $multiHandle;
 
         foreach ($this->options as $option => $value) {
+            if (!\is_int($option)) {
+                throw new \InvalidArgumentException(\sprintf('Invalid cURL multi option "%s".', $option));
+            }
+
             // A warning is raised in case of a wrong option.
             curl_multi_setopt($this->_mh, $option, $value);
         }

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\RequestException;
@@ -86,7 +88,7 @@ final class MockHandler implements \Countable
         }
 
         if (isset($options['delay']) && \is_numeric($options['delay'])) {
-            \usleep((int) $options['delay'] * 1000);
+            \usleep((int) ($options['delay'] * 1000));
         }
 
         $this->lastRequest = $request;
@@ -229,8 +231,12 @@ final class MockHandler implements \Countable
         $reason = null
     ): void {
         if (isset($options['on_stats'])) {
-            $transferTime = $options['transfer_time'] ?? 0;
-            $stats = new TransferStats($request, $response, $transferTime, $reason);
+            $transferTime = $options['transfer_time'] ?? 0.0;
+            if (!\is_int($transferTime) && !\is_float($transferTime) && (!\is_string($transferTime) || !\is_numeric($transferTime))) {
+                throw new \InvalidArgumentException('transfer_time must be a number of seconds');
+            }
+
+            $stats = new TransferStats($request, $response, (float) $transferTime, $reason);
             ($options['on_stats'])($stats);
         }
     }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
@@ -46,7 +48,7 @@ final class StreamHandler
 
         // Sleep if there is a delay specified.
         if (isset($options['delay'])) {
-            \usleep($options['delay'] * 1000);
+            \usleep((int) ($options['delay'] * 1000));
         }
 
         $protocolVersion = $request->getProtocolVersion();
@@ -866,7 +868,7 @@ final class StreamHandler
                 if ($code == \STREAM_NOTIFY_PROGRESS) {
                     // The upload progress cannot be determined. Use 0 for cURL compatibility:
                     // https://curl.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html
-                    $value($total, $transferred, 0, 0);
+                    $value((int) $total, (int) $transferred, 0, 0);
                 }
             }
         );

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -84,7 +84,7 @@ class Pool implements PromisorInterface
      *         }>,
      *         on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *         on_stats?: callable(TransferStats): mixed,
-     *         progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *         progress?: callable(int, int, int, int): mixed,
      *         protocols?: array<array-key, string>,
      *         proxy?: string|array{
      *             http?: string,
@@ -209,7 +209,7 @@ class Pool implements PromisorInterface
      *         }>,
      *         on_headers?: callable(ResponseInterface, RequestInterface): mixed,
      *         on_stats?: callable(TransferStats): mixed,
-     *         progress?: callable(int|float, int|float, int|float, int|float): mixed,
+     *         progress?: callable(int, int, int, int): mixed,
      *         protocols?: array<array-key, string>,
      *         proxy?: string|array{
      *             http?: string,

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -219,7 +219,7 @@ final class RequestOptions
     public const ON_STATS = 'on_stats';
 
     /**
-     * progress: (callable(int|float, int|float, int|float, int|float): mixed)
+     * progress: (callable(int, int, int, int): mixed)
      * Defines a function to invoke when transfer progress is made. The function accepts the following positional
      * arguments: the total number of bytes expected to be downloaded, the
      * number of bytes downloaded so far, the number of bytes expected to be

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1344,7 +1344,7 @@ class CurlFactoryTest extends TestCase
         $f = new CurlFactory(3);
         $called = [];
         $easy = $f->create(new Psr7\Request('GET', Server::$url), [
-            'progress' => static function ($downloadTotal, $downloadedBytes, $uploadTotal, $uploadedBytes) use (&$called): bool {
+            'progress' => static function (int $downloadTotal, int $downloadedBytes, int $uploadTotal, int $uploadedBytes) use (&$called): bool {
                 $called = [$downloadTotal, $downloadedBytes, $uploadTotal, $uploadedBytes];
 
                 return $downloadedBytes > 0;
@@ -1354,12 +1354,14 @@ class CurlFactoryTest extends TestCase
         try {
             $callback = $_SERVER['_curl'][self::progressCallbackOption()];
 
-            self::assertSame(0, $callback($easy->handle, 10, 0, 2, 0));
+            self::assertSame(0, $callback($easy->handle, 10.0, 0.0, 2.0, 0.0));
             self::assertFalse($easy->progressAborted);
+            self::assertNull($easy->progressException);
             self::assertSame([10, 0, 2, 0], $called);
 
-            self::assertSame(1, $callback($easy->handle, 10, 1, 2, 0));
+            self::assertSame(1, $callback($easy->handle, 10.0, 1.0, 2.0, 0.0));
             self::assertTrue($easy->progressAborted);
+            self::assertNull($easy->progressException);
             self::assertSame([10, 1, 2, 0], $called);
         } finally {
             $f->release($easy);

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -60,6 +60,20 @@ class CurlMultiHandlerTest extends TestCase
         self::assertEquals(5, $_SERVER['_curl_multi'][\CURLMOPT_MAXCONNECTS]);
     }
 
+    public function testThrowsWhenCurlMultiOptionNameIsInvalid(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response()]);
+        $a = new CurlMultiHandler(['options' => [
+            'not-a-curlmopt-option' => true,
+        ]]);
+        $request = new Request('GET', Server::$url);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid cURL multi option "not-a-curlmopt-option".');
+        $a($request, []);
+    }
+
     public function testSendsRequest(): void
     {
         Server::enqueue([new Response()]);
@@ -82,6 +96,12 @@ class CurlMultiHandlerTest extends TestCase
     {
         $a = new CurlMultiHandler(['select_timeout' => 2]);
         self::assertEquals(2, self::readSelectTimeout($a));
+    }
+
+    public function testCanSetNumericStringSelectTimeout(): void
+    {
+        $a = new CurlMultiHandler(['select_timeout' => '0.5']);
+        self::assertSame(0.5, self::readSelectTimeout($a));
     }
 
     public function testShareOptionAppliesCurlShare(): void

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -490,6 +490,20 @@ class MockHandlerTest extends TestCase
         self::assertEquals(0.4, $stats->getTransferTime());
     }
 
+    public function testTransferTimeAcceptsNumericString(): void
+    {
+        $e = new \Exception('a');
+        $mock = new MockHandler([$e]);
+        $request = new Request('GET', 'http://example.com');
+        $stats = null;
+        $onStats = static function (TransferStats $s) use (&$stats): void {
+            $stats = $s;
+        };
+        $mock($request, ['on_stats' => $onStats, 'transfer_time' => '0.4'])->wait(false);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertSame(0.4, $stats->getTransferTime());
+    }
+
     public function testResetQueue(): void
     {
         $mock = new MockHandler([new Response(200), new Response(204)]);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -938,6 +938,22 @@ class StreamHandlerTest extends TestCase
         self::assertEquals(0, $called[0][1]);
     }
 
+    public function testEmitsIntegerProgressInformation(): void
+    {
+        $called = [];
+        $this->queueRes();
+        $this->getSendResult([
+            'progress' => static function (int $downloadTotal, int $downloadedBytes, int $uploadTotal, int $uploadedBytes) use (&$called): void {
+                $called[] = [$downloadTotal, $downloadedBytes, $uploadTotal, $uploadedBytes];
+            },
+        ]);
+        self::assertNotEmpty($called);
+        self::assertSame(8, $called[0][0]);
+        self::assertSame(0, $called[0][1]);
+        self::assertSame(0, $called[0][2]);
+        self::assertSame(0, $called[0][3]);
+    }
+
     public function testProgressReturnValueDoesNotAbortTransfer(): void
     {
         $this->queueRes();


### PR DESCRIPTION
This declares strict types in the remaining built-in handler implementation files. The implementation normalises scalar values at strict call sites so existing handler behaviour remains consistent while avoiding raw `TypeError` failures from internal function calls and progress callbacks.