### PR TITLE
Deprecate coerced IDN conversion options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
 - Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE`, which will be rejected in 8.0
-- Deprecated scalar-coerced `idn_conversion` values; pass `true`, `false`, `null`, or an integer `IDNA_*` bitmask
+- Deprecated scalar-coerced `idn_conversion` request option values, which will be rejected in 8.0
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
 - Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE`, which will be rejected in 8.0
+- Deprecated scalar-coerced `idn_conversion` values; pass `true`, `false`, `null`, or an integer `IDNA_*` bitmask
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -229,8 +229,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $uri = Psr7\UriResolver::resolve(Psr7\Utils::uriFor($config['base_uri']), $uri);
         }
 
-        if (isset($config['idn_conversion']) && ($config['idn_conversion'] !== false)) {
-            $idnOptions = ($config['idn_conversion'] === true) ? \IDNA_DEFAULT : $config['idn_conversion'];
+        $idnOptions = Utils::normalizeIdnConversionOption($config['idn_conversion'] ?? null);
+        if ($idnOptions !== null) {
             $uri = Utils::idnUriConvert($uri, $idnOptions);
         }
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -177,8 +177,8 @@ class RedirectMiddleware
         }
 
         $uri = self::redirectUri($request, $response, $protocols);
-        if (isset($options['idn_conversion']) && ($options['idn_conversion'] !== false)) {
-            $idnOptions = ($options['idn_conversion'] === true) ? \IDNA_DEFAULT : $options['idn_conversion'];
+        $idnOptions = Utils::normalizeIdnConversionOption($options['idn_conversion'] ?? null);
+        if ($idnOptions !== null) {
             $uri = Utils::idnUriConvert($uri, $idnOptions);
         }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -534,6 +534,39 @@ EOT
     }
 
     /**
+     * @param mixed $value
+     *
+     * @internal
+     */
+    public static function normalizeIdnConversionOption($value): ?int
+    {
+        if ($value === null || $value === false) {
+            return null;
+        }
+
+        if ($value === true) {
+            return \IDNA_DEFAULT;
+        }
+
+        if (\is_int($value)) {
+            return $value;
+        }
+
+        if ((\is_string($value) && \is_numeric($value)) || (\is_float($value) && \is_finite($value))) {
+            \trigger_deprecation(
+                'guzzlehttp/guzzle',
+                '7.11',
+                'Passing %s as the "idn_conversion" request option is deprecated; guzzlehttp/guzzle 8.0 will reject values that are not true, false, null, or an integer IDNA_* bitmask.',
+                self::describeType($value)
+            );
+
+            return (int) $value;
+        }
+
+        throw new InvalidArgumentException('idn_conversion must be true, false, null, or an integer IDNA_* bitmask');
+    }
+
+    /**
      * @throws InvalidArgumentException
      *
      * @internal

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1050,6 +1050,17 @@ class ClientTest extends TestCase
         self::assertSame('яндекс.рф', (string) $request->getHeaderLine('Host'));
     }
 
+    public function testIdnConversionRejectsInvalidValue()
+    {
+        $mockHandler = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mockHandler]);
+
+        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('idn_conversion must be true, false, null, or an integer IDNA_* bitmask');
+
+        $client->request('GET', 'https://example.com', ['idn_conversion' => 'invalid']);
+    }
+
     /**
      * @requires extension idn
      */


### PR DESCRIPTION
This deprecates idn_conversion values that currently depend on PHP scalar coercion before they are rejected in Guzzle 8. It centralizes option normalization for initial requests and redirects, preserves documented true, false, null, and integer bitmask behavior, and rejects values that PHP cannot coerce to an integer bitmask.