### PR TITLE
Declare strict types across the rest of the codebase

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $config = (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
@@ -7,7 +9,6 @@ $config = (new PhpCsFixer\Config())
         '@PHPUnit75Migration:risky' => true,
         '@PSR12:risky' => true,
         '@Symfony' => true,
-        'declare_strict_types' => false,
         'global_namespace_import' => false,
         'no_superfluous_phpdoc_tags' => [
             'allow_mixed' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Normalize no-proxy domain and IP literal matching consistently
 - Pass the request as the second argument to `on_headers` callbacks
+- Declare strict types across remaining source files
+- Reject invalid `idn_conversion`, `retries`, and built-in handler `on_stats` option values before use
 - Reject invalid `SetCookie` constructor field types instead of coercing them
 - Reject conflicting raw cURL request options, including request-level `CURLOPT_SHARE`
 - Reject selected request options ignored by incompatible built-in handlers

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -369,11 +369,6 @@ options, while the stream handler rejects cURL-only options it cannot honor.
 Guzzle 8 adds native parameter and return types where PHP 7.4 allows. Code
 overriding affected methods must update method signatures accordingly.
 
-More Guzzle source files now declare `strict_types=1`. Calls from application
-files that do not declare strict types continue to use PHP's normal weak-call
-behavior when calling Guzzle public APIs. Calls made by Guzzle into custom
-callbacks, middleware, handlers, and helper APIs now use strict scalar typing.
-
 `HandlerStack::__toString()` and `SetCookie::__toString()` now return `string`.
 
 `HandlerStack::remove()` now throws `TypeError` when passed a value that is

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -245,9 +245,10 @@ The stream handler still ignores `progress` return values.
 
 Exceptions thrown by `on_stats` remain unwrapped, so existing catch logic for
 `on_stats` exceptions does not need to change. The built-in cURL handlers now
-release native easy handles before invoking `on_stats`. Raw callbacks passed
-through the `curl` request option remain low-level cURL callbacks and are not
-normalized by Guzzle.
+release native easy handles before invoking `on_stats`. Built-in handlers now
+reject non-callable `on_stats` values before starting the transfer. Raw callbacks
+passed through the `curl` request option remain low-level cURL callbacks and are
+not normalized by Guzzle.
 
 The `on_headers` request option callback now receives the request as its second
 argument. Existing userland callbacks that accept only the response continue to
@@ -368,6 +369,11 @@ options, while the stream handler rejects cURL-only options it cannot honor.
 Guzzle 8 adds native parameter and return types where PHP 7.4 allows. Code
 overriding affected methods must update method signatures accordingly.
 
+More Guzzle source files now declare `strict_types=1`. Calls from application
+files that do not declare strict types continue to use PHP's normal weak-call
+behavior when calling Guzzle public APIs. Calls made by Guzzle into custom
+callbacks, middleware, handlers, and helper APIs now use strict scalar typing.
+
 `HandlerStack::__toString()` and `SetCookie::__toString()` now return `string`.
 
 `HandlerStack::remove()` now throws `TypeError` when passed a value that is
@@ -381,6 +387,15 @@ declare strict types will throw `TypeError` for non-boolean values.
 
 `SetCookie::getExpires()` now returns `int|null`. Invalid textual expiration
 dates are treated as `null`.
+
+#### IDN conversion option types
+
+The `idn_conversion` request option must be `true`, `false`, `null`, or an
+integer `IDNA_*` bitmask. Numeric strings and floats that previously worked
+through PHP scalar coercion are no longer accepted.
+
+Integer `0` remains a valid option bitmask. Use `false` or `null` to disable IDN
+conversion.
 
 #### Generic Promise And Structured PHPDoc Types
 
@@ -515,6 +530,9 @@ Callbacks that accept three arguments continue to receive the retry count, the
 response that triggered the retry when one exists, and the request being retried.
 One-argument callbacks are now called with only the retry count, which also
 allows internal PHP functions with a single-argument signature.
+
+The seeded `retries` request option must be an integer. Delay callbacks must
+return an integer number of milliseconds.
 
 #### Logging middleware formatter types
 

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -268,10 +268,12 @@ $response = $client->request('GET', 'https://example.com', [
 ]);
 ```
 
+The `retries` option must be an integer.
+
 If you do not provide a delay callback, the middleware uses an exponential
 backoff delay. When a retry is scheduled, the middleware writes the computed wait
 time in milliseconds to the `delay` request option before invoking the next
-attempt.
+attempt. Delay callbacks must return an integer number of milliseconds.
 
 ## HandlerStack
 

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -268,10 +268,8 @@ $response = $client->request('GET', 'https://example.com', [
 ]);
 ```
 
-The `retries` option must be an integer.
-
-If you do not provide a delay callback, the middleware uses an exponential
-backoff delay. When a retry is scheduled, the middleware writes the computed wait
+The `retries` option must be an integer. If you do not provide a delay callback,
+the middleware uses an exponential backoff delay and writes the computed wait
 time in milliseconds to the `delay` request option before invoking the next
 attempt. Delay callbacks must return an integer number of milliseconds.
 

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -268,10 +268,11 @@ $response = $client->request('GET', 'https://example.com', [
 ]);
 ```
 
-The `retries` option must be an integer. If you do not provide a delay callback,
-the middleware uses an exponential backoff delay and writes the computed wait
-time in milliseconds to the `delay` request option before invoking the next
-attempt. Delay callbacks must return an integer number of milliseconds.
+The `retries` option must be an integer. If you do not provide a delay
+callback, the middleware uses an exponential backoff delay and writes the
+computed wait time in milliseconds to the `delay` request option before
+invoking the next attempt. Delay callbacks must return an integer number of
+milliseconds.
 
 ## HandlerStack
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -613,7 +613,7 @@ $res = $client->request('GET', 'https://яндекс.рф', ['idn_conversion' =>
 // The domain part (яндекс.рф) stays unmodified
 ```
 
-Enables/disables IDN support, can also be used for precise control by combining `IDNA_*` constants (except `IDNA_ERROR_*`), see the `$options` parameter in the [idn_to_ascii()](https://www.php.net/manual/en/function.idn-to-ascii.php) documentation for more details. Numeric strings and floats are not supported.
+Enables/disables IDN support, can also be used for precise control by combining `IDNA_*` constants (except `IDNA_ERROR_*`), see the `$options` parameter in the [idn_to_ascii()](https://www.php.net/manual/en/function.idn-to-ascii.php) documentation for more details.
 
 ## json
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -613,7 +613,7 @@ $res = $client->request('GET', 'https://яндекс.рф', ['idn_conversion' =>
 // The domain part (яндекс.рф) stays unmodified
 ```
 
-Enables/disables IDN support, can also be used for precise control by combining `IDNA_*` constants (except `IDNA_ERROR_*`), see the `$options` parameter in the [idn_to_ascii()](https://www.php.net/manual/en/function.idn-to-ascii.php) documentation for more details.
+Enables/disables IDN support, can also be used for precise control by combining `IDNA_*` constants (except `IDNA_ERROR_*`), see the `$options` parameter in the [idn_to_ascii()](https://www.php.net/manual/en/function.idn-to-ascii.php) documentation for more details. Numeric strings and floats are not supported.
 
 ## json
 
@@ -748,7 +748,7 @@ Types
 Constant
 `GuzzleHttp\RequestOptions::ON_STATS`
 
-The callable accepts a `GuzzleHttp\TransferStats` object.
+The callable accepts a `GuzzleHttp\TransferStats` object. Built-in handlers reject non-callable `on_stats` values before starting the transfer.
 
 Exceptions thrown by `on_stats` are not wrapped by Guzzle and may escape from the handler wait path. With the built-in cURL handlers, native cURL handles are released before `on_stats` is invoked. cURL handlers emit `on_stats` per low-level transfer attempt, so retries may invoke it more than once for one logical request.
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJar;

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJarInterface;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -126,6 +126,7 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         self::rejectUnsupportedRequestOptions($options);
+        self::assertOnStatsCallable($options);
         $this->rejectRequestLevelShareConflict($options);
         $this->rejectPersistentRequireConnectionReuseConflicts($options);
         self::rejectConflictingCurlOptions($options);
@@ -315,6 +316,13 @@ final class CurlFactory implements CurlFactoryInterface
 
         if (\array_key_exists('stream_context', $options)) {
             throw new \InvalidArgumentException('Passing the "stream_context" request option to a cURL handler is not supported because cURL handlers ignore PHP stream context options.');
+        }
+    }
+
+    private static function assertOnStatsCallable(array $options): void
+    {
+        if (isset($options['on_stats']) && !\is_callable($options['on_stats'])) {
+            throw new \InvalidArgumentException('on_stats must be callable');
         }
     }
 

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -91,6 +91,10 @@ final class MockHandler implements \Countable
             \usleep((int) ($options['delay'] * 1000));
         }
 
+        if (isset($options['on_stats']) && !\is_callable($options['on_stats'])) {
+            throw new \InvalidArgumentException('on_stats must be callable');
+        }
+
         $this->lastRequest = $request;
         $this->lastOptions = $options;
         $response = \array_shift($this->queue);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -65,6 +65,10 @@ final class StreamHandler
             throw new RequestException(sprintf('HTTP/%s is not supported by the stream handler.', $protocolVersion), $request);
         }
 
+        if (isset($options['on_stats']) && !\is_callable($options['on_stats'])) {
+            throw new \InvalidArgumentException('on_stats must be callable');
+        }
+
         $startTime = isset($options['on_stats']) ? Utils::currentTime() : null;
 
         self::rejectUnsupportedRequestOptions($request, $options);

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Promise\PromiseInterface;

--- a/src/MessageFormatter.php
+++ b/src/MessageFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use Psr\Http\Message\MessageInterface;

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJarInterface;

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJarInterface;

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Promise\PromiseInterface;

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\BadResponseException;

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -168,10 +168,9 @@ final class RequestOptions
     public const HTTP_ERRORS = 'http_errors';
 
     /**
-     * idn: (bool|int, default=true) A combination of IDNA_* constants for
-     * idn_to_ascii() PHP's function (see "options" parameter). Set to false to
-     * disable IDN support completely, or to true to use the default
-     * configuration (IDNA_DEFAULT constant).
+     * idn_conversion: (bool|int, default=false) A combination of IDNA_* constants
+     * for PHP's idn_to_ascii() function. Set to false to disable IDN support, or
+     * true to use the default configuration (IDNA_DEFAULT constant).
      */
     public const IDN_CONVERSION = 'idn_conversion';
 
@@ -213,8 +212,9 @@ final class RequestOptions
      * with transfer statistics about the request, the response received, or
      * the error encountered. Included in the data is the total amount of time
      * taken to send the request. Exceptions thrown by on_stats are not wrapped
-     * by Guzzle. The built-in cURL handlers release native easy handles before
-     * invoking on_stats and invoke it per low-level transfer attempt.
+     * by Guzzle. Built-in handlers reject non-callable values before starting
+     * the transfer. The built-in cURL handlers release native easy handles
+     * before invoking on_stats and invoke it per low-level transfer attempt.
      */
     public const ON_STATS = 'on_stats';
 

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Promise as P;
@@ -42,7 +44,7 @@ class RetryMiddleware
         $this->decider = $decider;
         $this->nextHandler = $nextHandler;
         $this->delay = $delay ?: static function (int $retries): int {
-            return (int) 2 ** ($retries - 1) * 1000;
+            return (int) ((2 ** ($retries - 1)) * 1000);
         };
     }
 
@@ -53,6 +55,8 @@ class RetryMiddleware
     {
         if (!isset($options['retries'])) {
             $options['retries'] = 0;
+        } elseif (!\is_int($options['retries'])) {
+            throw new \InvalidArgumentException('retries must be an integer');
         }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */

--- a/src/TransferStats.php
+++ b/src/TransferStats.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\InvalidArgumentException;
@@ -316,17 +318,6 @@ final class Utils
 
         if (\is_int($value)) {
             return $value;
-        }
-
-        if ((\is_string($value) && \is_numeric($value)) || (\is_float($value) && \is_finite($value))) {
-            \trigger_deprecation(
-                'guzzlehttp/guzzle',
-                '7.11',
-                'Passing %s as the "idn_conversion" request option is deprecated; guzzlehttp/guzzle 8.0 will reject values that are not true, false, null, or an integer IDNA_* bitmask.',
-                self::describeType($value)
-            );
-
-            return (int) $value;
         }
 
         throw new InvalidArgumentException('idn_conversion must be true, false, null, or an integer IDNA_* bitmask');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2012,7 +2012,7 @@ class ClientTest extends TestCase
         self::assertSame('яндекс.рф', (string) $request->getHeaderLine('Host'));
     }
 
-    public function testIdnConversionRejectsInvalidValue()
+    public function testIdnConversionRejectsInvalidValue(): void
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
@@ -2020,7 +2020,7 @@ class ClientTest extends TestCase
         $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('idn_conversion must be true, false, null, or an integer IDNA_* bitmask');
 
-        $client->request('GET', 'https://example.com', ['idn_conversion' => 'invalid']);
+        $client->request('GET', 'https://example.com', ['idn_conversion' => '0']);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -600,6 +600,16 @@ class CurlFactoryTest extends TestCase
         );
     }
 
+    public function testRejectsNonCallableOnStats(): void
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('on_stats must be callable');
+
+        $f->create(new Psr7\Request('GET', 'http://example.com'), ['on_stats' => false]);
+    }
+
     public function testValidatesVerify(): void
     {
         $f = new CurlFactory(3);

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Handler\CurlFactory;

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -454,6 +454,16 @@ class MockHandlerTest extends TestCase
         self::assertSame($request, $stats->getRequest());
     }
 
+    public function testRejectsNonCallableOnStats(): void
+    {
+        $mock = new MockHandler([new Response()]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('on_stats must be callable');
+
+        $mock(new Request('GET', 'http://example.com'), ['on_stats' => false])->wait();
+    }
+
     public function testInvokesOnStatsFunctionForError(): void
     {
         $e = new \Exception('a');

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -113,6 +113,16 @@ class StreamHandlerTest extends TestCase
         }
     }
 
+    public function testRejectsNonCallableOnStats(): void
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('on_stats must be callable');
+
+        $handler(new Request('GET', 'http://example.com'), ['on_stats' => false]);
+    }
+
     public function testStreamAttributeKeepsStreamOpen(): void
     {
         $this->queueRes();

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -71,6 +71,24 @@ class RedirectMiddlewareTest extends TestCase
         self::assertSame('http://test.com', (string) $mock->getLastRequest()->getUri());
     }
 
+    public function testRedirectRejectsInvalidIdnConversionOption(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://www.tést.com/whatever']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+
+        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('idn_conversion must be true, false, null, or an integer IDNA_* bitmask');
+
+        $stack->resolve()(new Request('GET', 'http://example.com'), [
+            'allow_redirects' => ['max' => 2],
+            'idn_conversion' => '0',
+        ])->wait();
+    }
+
     public function testRedirectsWithRelativeUri(): void
     {
         $mock = new MockHandler([

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -114,6 +114,21 @@ class RetryMiddlewareTest extends TestCase
         self::assertSame(200, $p->wait()->getStatusCode());
     }
 
+    public function testRejectsNonIntegerRetriesOption(): void
+    {
+        $decider = static function (int $retries): bool {
+            return false;
+        };
+        $m = Middleware::retry($decider);
+        $h = new MockHandler([new Response(200)]);
+        $c = new Client(['handler' => $m($h)]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('retries must be an integer');
+
+        $c->send(new Request('GET', 'http://test.com'), ['retries' => '0']);
+    }
+
     public function testCanRetryExceptions(): void
     {
         $calls = [];


### PR DESCRIPTION
This declares strict types across the remaining Guzzle source and test files and removes the PHP-CS-Fixer override that disabled enforcement. It also rejects invalid idn_conversion, retries, and built-in handler on_stats option values at the boundaries that would otherwise rely on scalar coercion.