### PR TITLE
Remove curl multi magic handle access

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -79,18 +79,6 @@ parameters:
 			path: src/Handler/CurlHandler.php
 
 		-
-			message: '#^Method GuzzleHttp\\Handler\\CurlMultiHandler\:\:__get\(\) has invalid return type CurlMultiHandle\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
-			message: '#^Method GuzzleHttp\\Handler\\CurlMultiHandler\:\:__get\(\) never returns CurlMultiHandle so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
 			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 5
@@ -151,19 +139,19 @@ parameters:
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: '#^Property GuzzleHttp\\Handler\\CurlMultiHandler\:\:\$_mh \(CurlMultiHandle\|resource\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
+			message: '#^Method GuzzleHttp\\Handler\\CurlMultiHandler\:\:getMultiHandle\(\) has invalid return type CurlMultiHandle\.$#'
+			identifier: class.notFound
 			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: '#^Property GuzzleHttp\\Handler\\CurlMultiHandler\:\:\$_mh \(CurlMultiHandle\|resource\) is never assigned CurlMultiHandle so it can be removed from the property type\.$#'
+			message: '#^Property GuzzleHttp\\Handler\\CurlMultiHandler\:\:\$multiHandle \(CurlMultiHandle\|resource\|null\) is never assigned CurlMultiHandle so it can be removed from the property type\.$#'
 			identifier: property.unusedType
 			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: '#^Property GuzzleHttp\\Handler\\CurlMultiHandler\:\:\$_mh has unknown class CurlMultiHandle as its type\.$#'
+			message: '#^Property GuzzleHttp\\Handler\\CurlMultiHandler\:\:\$multiHandle has unknown class CurlMultiHandle as its type\.$#'
 			identifier: class.notFound
 			count: 1
 			path: src/Handler/CurlMultiHandler.php

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -66,8 +66,10 @@ final class CurlMultiHandler
      */
     private $options = [];
 
-    /** @var resource|\CurlMultiHandle */
-    private $_mh;
+    /**
+     * @var resource|\CurlMultiHandle|null
+     */
+    private $multiHandle;
 
     /**
      * @var bool
@@ -139,46 +141,6 @@ final class CurlMultiHandler
         }
 
         $this->options = $multiOptions;
-
-        // unsetting the property forces the first access to go through
-        // __get().
-        unset($this->_mh);
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return resource|\CurlMultiHandle
-     *
-     * @throws \BadMethodCallException when another field as `_mh` will be gotten
-     * @throws \RuntimeException       when curl can not initialize a multi handle
-     */
-    public function __get($name)
-    {
-        if ($name !== '_mh') {
-            throw new \BadMethodCallException("Can not get other property as '_mh'.");
-        }
-
-        $this->assertOpen();
-
-        $multiHandle = \curl_multi_init();
-
-        if (false === $multiHandle) {
-            throw new \RuntimeException('Can not initialize curl multi handle.');
-        }
-
-        $this->_mh = $multiHandle;
-
-        foreach ($this->options as $option => $value) {
-            if (!\is_int($option)) {
-                throw new \InvalidArgumentException(\sprintf('Invalid cURL multi option "%s".', $option));
-            }
-
-            // A warning is raised in case of a wrong option.
-            curl_multi_setopt($this->_mh, $option, $value);
-        }
-
-        return $this->_mh;
     }
 
     public function __destruct()
@@ -227,7 +189,7 @@ final class CurlMultiHandler
                 if ($currentTime >= $delay) {
                     unset($this->delays[$id]);
                     \curl_multi_add_handle(
-                        $this->_mh,
+                        $this->getMultiHandle(),
                         $this->handles[$id]['easy']->handle
                     );
                 }
@@ -244,7 +206,7 @@ final class CurlMultiHandler
             return;
         }
 
-        if ($this->active && \curl_multi_select($this->_mh, $this->selectTimeout) === -1) {
+        if ($this->active && \curl_multi_select($this->getMultiHandle(), $this->selectTimeout) === -1) {
             // Perform a usleep if a select returns -1.
             // See: https://bugs.php.net/bug.php?id=61141
             \usleep(250);
@@ -259,7 +221,7 @@ final class CurlMultiHandler
 
             // Prevent busy looping for slow HTTP requests.
             if ($exec === \CURLM_CALL_MULTI_PERFORM) {
-                \curl_multi_select($this->_mh, $this->selectTimeout);
+                \curl_multi_select($this->getMultiHandle(), $this->selectTimeout);
             }
         } while ($exec === \CURLM_CALL_MULTI_PERFORM);
 
@@ -282,7 +244,7 @@ final class CurlMultiHandler
         }
 
         if ($exec === \CURLM_CALL_MULTI_PERFORM) {
-            \curl_multi_select($this->_mh, 0);
+            \curl_multi_select($this->getMultiHandle(), 0);
             P\Utils::queue()->add(Closure::fromCallable([$this, 'tickInQueue']));
         }
     }
@@ -436,15 +398,17 @@ final class CurlMultiHandler
 
     private function closeMultiHandle(?\Throwable &$failure): void
     {
-        if (!$this->hasMultiHandle()) {
+        if ($this->multiHandle === null) {
             return;
         }
 
-        $this->captureFailure($failure, function (): void {
+        $multiHandle = $this->multiHandle;
+
+        $this->captureFailure($failure, function () use ($multiHandle): void {
             try {
-                \curl_multi_close($this->_mh);
+                \curl_multi_close($multiHandle);
             } finally {
-                unset($this->_mh);
+                $this->multiHandle = null;
             }
         });
     }
@@ -470,7 +434,7 @@ final class CurlMultiHandler
         $failure = null;
 
         try {
-            return \curl_multi_exec($this->_mh, $this->active);
+            return \curl_multi_exec($this->getMultiHandle(), $this->active);
         } finally {
             $this->executingMulti = false;
             $this->cleanupDeferredCancels($failure);
@@ -546,12 +510,12 @@ final class CurlMultiHandler
      */
     private function removeHandleFromMulti($handle): void
     {
-        \curl_multi_remove_handle($this->_mh, $handle);
+        \curl_multi_remove_handle($this->getMultiHandle(), $handle);
     }
 
     private function hasMultiHandle(): bool
     {
-        return isset($this->_mh);
+        return $this->multiHandle !== null;
     }
 
     private static function hasEasyHandle(EasyHandle $easy): bool
@@ -565,7 +529,7 @@ final class CurlMultiHandler
         $id = (int) $easy->handle;
         $this->handles[$id] = $entry;
         if (empty($easy->options['delay'])) {
-            \curl_multi_add_handle($this->_mh, $easy->handle);
+            \curl_multi_add_handle($this->getMultiHandle(), $easy->handle);
         } else {
             $this->delays[$id] = Utils::currentTime() + ($easy->options['delay'] / 1000);
         }
@@ -630,7 +594,7 @@ final class CurlMultiHandler
 
     private function processMessages(): void
     {
-        while ($done = \curl_multi_info_read($this->_mh)) {
+        while ($done = \curl_multi_info_read($this->getMultiHandle())) {
             if ($done['msg'] !== \CURLMSG_DONE) {
                 // if it's not done, then it would be premature to remove the handle. ref https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216
                 continue;
@@ -676,5 +640,35 @@ final class CurlMultiHandler
         }
 
         return ((int) \max(0, $nextTime - $currentTime)) * 1000000;
+    }
+
+    /**
+     * @return resource|\CurlMultiHandle
+     */
+    private function getMultiHandle()
+    {
+        if ($this->multiHandle !== null) {
+            return $this->multiHandle;
+        }
+
+        $this->assertOpen();
+
+        $multiHandle = \curl_multi_init();
+        if (false === $multiHandle) {
+            throw new \RuntimeException('Can not initialize curl multi handle.');
+        }
+
+        $this->multiHandle = $multiHandle;
+
+        foreach ($this->options as $option => $value) {
+            if (!\is_int($option)) {
+                throw new \InvalidArgumentException(\sprintf('Invalid cURL multi option "%s".', $option));
+            }
+
+            // A warning is raised in case of a wrong option.
+            curl_multi_setopt($multiHandle, $option, $value);
+        }
+
+        return $multiHandle;
     }
 }

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -193,10 +193,10 @@ class CurlMultiHandlerTest extends TestCase
         $handler = new CurlMultiHandler();
 
         $setMultiHandle = \Closure::bind(static function (CurlMultiHandler $handler): void {
-            $handler->_mh = new \stdClass();
+            $handler->multiHandle = new \stdClass();
         }, null, CurlMultiHandler::class);
         $hasMultiHandle = \Closure::bind(static function (CurlMultiHandler $handler): bool {
-            return isset($handler->_mh);
+            return $handler->multiHandle !== null;
         }, null, CurlMultiHandler::class);
 
         $setMultiHandle($handler);
@@ -711,14 +711,6 @@ class CurlMultiHandlerTest extends TestCase
         }
     }
 
-    public function throwsWhenAccessingInvalidProperty(): void
-    {
-        $h = new CurlMultiHandler();
-
-        $this->expectException(\BadMethodCallException::class);
-        $h->foo;
-    }
-
     private static function readSelectTimeout(CurlMultiHandler $handler)
     {
         $readSelectTimeout = \Closure::bind(static function (CurlMultiHandler $handler) {
@@ -731,7 +723,7 @@ class CurlMultiHandlerTest extends TestCase
     private static function hasMultiHandle(CurlMultiHandler $handler): bool
     {
         $hasMultiHandle = \Closure::bind(static function (CurlMultiHandler $handler): bool {
-            return isset($handler->_mh);
+            return $handler->multiHandle !== null;
         }, null, CurlMultiHandler::class);
 
         return $hasMultiHandle($handler);


### PR DESCRIPTION
This replaces CurlMultiHandler's magic property lazy initialization with explicit multi-handle access. The handler keeps lazy initialization, but control flow no longer depends on __get.