### PR TITLE
Type client config return value

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -583,7 +583,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *
      * @param string|null $option The config option to retrieve.
      *
-     * @return mixed
+     * @return ($option is null ? array<string, mixed> : mixed)
      */
     public function getConfig(?string $option = null)
     {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -144,7 +144,7 @@ class ClientTest extends TestCase
             'headers' => ['bar' => 'baz'],
             'handler' => new MockHandler(),
         ]);
-        $config = self::readClientConfig($client);
+        $config = $client->getConfig();
         self::assertArrayHasKey('base_uri', $config);
         self::assertInstanceOf(Uri::class, $config['base_uri']);
         self::assertSame('http://foo.com', (string) $config['base_uri']);
@@ -345,7 +345,7 @@ class ClientTest extends TestCase
             'handler' => $mock,
             'base_uri' => 'http://bar.com',
         ]);
-        $config = self::readClientConfig($client);
+        $config = $client->getConfig();
         self::assertSame('http://bar.com', (string) $config['base_uri']);
         $request = new Request('GET', '/baz');
         $client->send($request);
@@ -358,7 +358,7 @@ class ClientTest extends TestCase
     public function testClientHasDefaultPsr17Factories(): void
     {
         $client = new Client(['handler' => new MockHandler()]);
-        $config = self::readClientConfig($client);
+        $config = $client->getConfig();
 
         self::assertArrayHasKey(RequestOptions::REQUEST_FACTORY, $config);
         self::assertInstanceOf(RequestFactoryInterface::class, $config[RequestOptions::REQUEST_FACTORY]);
@@ -651,7 +651,7 @@ class ClientTest extends TestCase
             RequestOptions::URI_FACTORY => $factory,
         ]);
 
-        $config = self::readClientConfig($client);
+        $config = $client->getConfig();
         self::assertInstanceOf(ClientTestUri::class, $config['base_uri']);
 
         $client->request('GET', 'relative');
@@ -1043,7 +1043,7 @@ class ClientTest extends TestCase
     public function testMergesDefaultOptionsAndDoesNotOverwriteUa(): void
     {
         $client = new Client(['headers' => ['User-agent' => 'foo']]);
-        $config = self::readClientConfig($client);
+        $config = $client->getConfig();
         self::assertSame(['User-agent' => 'foo'], $config['headers']);
         self::assertIsArray($config['allow_redirects']);
         self::assertTrue($config['http_errors']);
@@ -1677,19 +1677,19 @@ class ClientTest extends TestCase
 
         try {
             $client = new Client();
-            $config = self::readClientConfig($client);
+            $config = $client->getConfig();
             self::assertArrayNotHasKey('proxy', $config);
 
             \putenv('HTTP_PROXY=127.0.0.1');
             $client = new Client();
-            $config = self::readClientConfig($client);
+            $config = $client->getConfig();
             self::assertArrayHasKey('proxy', $config);
             self::assertSame(['http' => '127.0.0.1'], $config['proxy']);
 
             \putenv('HTTPS_PROXY=127.0.0.2');
             \putenv('NO_PROXY= 127.0.0.3 , 127.0.0.4 , [::1]:8080 ');
             $client = new Client();
-            $config = self::readClientConfig($client);
+            $config = $client->getConfig();
             self::assertArrayHasKey('proxy', $config);
             self::assertSame(
                 ['http' => '127.0.0.1', 'https' => '127.0.0.2', 'no' => ['127.0.0.3', '127.0.0.4', '[::1]:8080']],
@@ -1700,18 +1700,18 @@ class ClientTest extends TestCase
             \putenv('HTTPS_PROXY=');
             \putenv('NO_PROXY=0');
             $client = new Client();
-            $config = self::readClientConfig($client);
+            $config = $client->getConfig();
             self::assertArrayHasKey('proxy', $config);
             self::assertSame(['no' => ['0']], $config['proxy']);
 
             \putenv('NO_PROXY= , , ');
             $client = new Client();
-            $config = self::readClientConfig($client);
+            $config = $client->getConfig();
             self::assertArrayNotHasKey('proxy', $config);
 
             \putenv('HTTP_PROXY=127.0.0.1');
             $client = new Client();
-            $config = self::readClientConfig($client);
+            $config = $client->getConfig();
             self::assertArrayHasKey('proxy', $config);
             self::assertSame(['http' => '127.0.0.1'], $config['proxy']);
 
@@ -1719,7 +1719,7 @@ class ClientTest extends TestCase
 
             \putenv('NO_PROXY=exa mple.com, foo.com');
             $client = new Client();
-            $config = self::readClientConfig($client);
+            $config = $client->getConfig();
             self::assertArrayHasKey('proxy', $config);
             self::assertSame(['no' => ['exa mple.com', 'foo.com']], $config['proxy']);
         } finally {
@@ -1978,7 +1978,7 @@ class ClientTest extends TestCase
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $config = self::readClientConfig($client);
+        $config = $client->getConfig();
 
         self::assertFalse($config['idn_conversion']);
     }
@@ -2049,7 +2049,7 @@ class ClientTest extends TestCase
             'base_uri' => 'http://яндекс.рф',
             'idn_conversion' => true,
         ]);
-        $config = self::readClientConfig($client);
+        $config = $client->getConfig();
         self::assertSame('http://яндекс.рф', (string) $config['base_uri']);
         $request = new Request('GET', '/baz');
         $client->send($request);
@@ -2087,15 +2087,6 @@ class ClientTest extends TestCase
         $request = $requests[0]['request'];
         self::assertSame('https://xn--d1acpjx3f.xn--p1ai/images', (string) $request->getUri());
         self::assertSame('xn--d1acpjx3f.xn--p1ai', (string) $request->getHeaderLine('Host'));
-    }
-
-    private static function readClientConfig(Client $client): array
-    {
-        $config = $client->getConfig();
-
-        self::assertIsArray($config);
-
-        return $config;
     }
 
     private static function requestWithProtocolVersion(string $protocolVersion): RequestInterface


### PR DESCRIPTION
This adds a conditional return type for Client::getConfig so zero-argument calls are known to return the full configuration array. It then removes the ClientTest helper that only existed to assert and narrow that return value.