### PR TITLE
Add remaining test return types

### DIFF
--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -711,9 +711,9 @@ class CurlMultiHandlerTest extends TestCase
         }
     }
 
-    private static function readSelectTimeout(CurlMultiHandler $handler)
+    private static function readSelectTimeout(CurlMultiHandler $handler): float
     {
-        $readSelectTimeout = \Closure::bind(static function (CurlMultiHandler $handler) {
+        $readSelectTimeout = \Closure::bind(static function (CurlMultiHandler $handler): float {
             return $handler->selectTimeout;
         }, null, CurlMultiHandler::class);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -73,7 +73,7 @@ namespace GuzzleHttp\Handler {
         return \curl_share_init();
     }
 
-    function curl_share_setopt($handle, int $option, $value)
+    function curl_share_setopt($handle, int $option, $value): bool
     {
         if (!empty($_SERVER['curl_test'])) {
             $_SERVER['_curl_share'][$option][] = $value;


### PR DESCRIPTION
This adds the remaining PHP 7.4-compatible native return types in the test suite. The production return type audit found no further source methods that can be typed precisely while retaining PHP 7.4 support.