### PR TITLE
Add safe handler parameter types

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -597,7 +597,7 @@ final class CurlFactory implements CurlFactoryInterface
      *
      * @return PromiseInterface<ResponseInterface, mixed>
      */
-    private static function finishError(callable $handler, EasyHandle $easy, CurlFactoryInterface $factory, ?TransferStats $stats, $onStats): PromiseInterface
+    private static function finishError(callable $handler, EasyHandle $easy, CurlFactoryInterface $factory, ?TransferStats $stats, ?callable $onStats): PromiseInterface
     {
         // Get error information and release the handle to the factory.
         $ctx = self::createErrorContext($easy);
@@ -1041,7 +1041,7 @@ final class CurlFactory implements CurlFactoryInterface
             if ($body->isSeekable()) {
                 $body->rewind();
             }
-            $conf[\CURLOPT_READFUNCTION] = static function ($ch, $fd, $length) use ($body): string {
+            $conf[\CURLOPT_READFUNCTION] = static function ($ch, $fd, int $length) use ($body): string {
                 return $body->read($length);
             };
         }
@@ -1181,7 +1181,7 @@ final class CurlFactory implements CurlFactoryInterface
             $sink = new LazyOpenStream($sink, 'w+');
         }
         $easy->sink = $sink;
-        $conf[\CURLOPT_WRITEFUNCTION] = static function ($ch, $write) use ($sink): int {
+        $conf[\CURLOPT_WRITEFUNCTION] = static function ($ch, string $write) use ($sink): int {
             return $sink->write($write);
         };
 
@@ -1439,7 +1439,9 @@ final class CurlFactory implements CurlFactoryInterface
             $onHeaders = null;
         }
 
-        return static function ($ch, $h) use (
+        $startingResponse = false;
+
+        return static function ($ch, string $h) use (
             $onHeaders,
             $easy,
             &$startingResponse

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -112,11 +112,9 @@ final class EasyHandle
     }
 
     /**
-     * @param string $name
-     *
      * @throws \BadMethodCallException
      */
-    public function __get($name): void
+    public function __get(string $name): void
     {
         $msg = $name === 'handle' ? 'The EasyHandle has been released' : 'Invalid property: '.$name;
         throw new \BadMethodCallException($msg);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -343,7 +343,7 @@ final class StreamHandler
     private function createResource(callable $callback)
     {
         $errors = [];
-        \set_error_handler(static function ($_, $msg, $file, $line) use (&$errors): bool {
+        \set_error_handler(static function (int $_, string $msg, string $file, int $line) use (&$errors): bool {
             $errors[] = [
                 'message' => $msg,
                 'file' => $file,

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -194,7 +194,7 @@ class HandlerStack
             $count = \count($this->stack);
             $this->stack = \array_values(\array_filter(
                 $this->stack,
-                static function ($tuple) use ($remove): bool {
+                static function (array $tuple) use ($remove): bool {
                     return $tuple[1] !== $remove;
                 }
             ));
@@ -206,7 +206,7 @@ class HandlerStack
 
         $this->stack = \array_values(\array_filter(
             $this->stack,
-            static function ($tuple) use ($remove): bool {
+            static function (array $tuple) use ($remove): bool {
                 return $tuple[0] !== $remove;
             }
         ));


### PR DESCRIPTION
This adds native parameter types to internal handler callbacks and helpers where the existing contracts can be expressed precisely while retaining PHP 7.4 support. It also initializes the cURL header callback state before the closure captures it.