### PR TITLE
Add closure return types

### DIFF
--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -139,7 +139,7 @@ final class MockHandler implements \Countable
         }
 
         $promise = $response->then(
-            function ($value) use ($request, $options) {
+            function ($value) use ($request, $options): ?ResponseInterface {
                 /** @var ResponseInterface|null $value */
                 $this->invokeStats($request, $options, $value);
                 if ($this->onFulfilled) {

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -270,7 +270,7 @@ class CurlHandlerTest extends TestCase
 
     private static function readFactory(CurlHandler $handler): CurlFactory
     {
-        $readFactory = \Closure::bind(static function (CurlHandler $handler) {
+        $readFactory = \Closure::bind(static function (CurlHandler $handler): CurlFactory {
             return $handler->factory;
         }, null, CurlHandler::class);
 

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -731,7 +731,7 @@ class CurlMultiHandlerTest extends TestCase
 
     private static function readFactory(CurlMultiHandler $handler): CurlFactory
     {
-        $readFactory = \Closure::bind(static function (CurlMultiHandler $handler) {
+        $readFactory = \Closure::bind(static function (CurlMultiHandler $handler): CurlFactory {
             return $handler->factory;
         }, null, CurlMultiHandler::class);
 

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -143,7 +143,7 @@ class MockHandlerTest extends TestCase
     {
         $response = new Response(201);
         $mock = new MockHandler([
-            static function () use ($response) {
+            static function () use ($response): PromiseInterface {
                 return Create::promiseFor($response);
             },
         ]);


### PR DESCRIPTION
This adds native return types to the remaining safe source and test closures. The remaining untyped returns require PHP 8-only union or mixed types, resource types, or intentionally broader callback contracts.