### PR TITLE
Add handler property types

### DIFF
--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -22,17 +22,14 @@ final class MockHandler implements \Countable
     /**
      * @var list<ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>|callable(RequestInterface, array<array-key, mixed>): (ResponseInterface|\Throwable|PromiseInterface<ResponseInterface, mixed>)>
      */
-    private $queue = [];
+    private array $queue = [];
 
-    /**
-     * @var RequestInterface|null
-     */
-    private $lastRequest;
+    private ?RequestInterface $lastRequest = null;
 
     /**
      * @var array<array-key, mixed>
      */
-    private $lastOptions = [];
+    private array $lastOptions = [];
 
     /**
      * @var (callable(ResponseInterface|null): mixed)|null

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -24,15 +24,9 @@ use Psr\Http\Message\UriInterface;
  */
 final class StreamHandler
 {
-    /**
-     * @var array
-     */
-    private $lastHeaders = [];
+    private array $lastHeaders = [];
 
-    /**
-     * @var \Throwable|null
-     */
-    private $onStatsException;
+    private ?\Throwable $onStatsException = null;
 
     /**
      * Sends an HTTP request.

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -26,7 +26,7 @@ class HandlerStack
     /**
      * @var array<int, array{0: callable(callable&THandler): (callable&THandler), 1: string|null}>
      */
-    private $stack = [];
+    private array $stack = [];
 
     /**
      * @var (callable&THandler)|null


### PR DESCRIPTION
Adds native property types to private non-cURL handler properties while preserving callable properties and PHP 7.4 compatibility.