### PR TITLE
Add cURL handler property types

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -29,27 +29,21 @@ final class CurlFactory implements CurlFactoryInterface
     /**
      * @var resource[]|\CurlHandle[]
      */
-    private $handles = [];
+    private array $handles = [];
 
     /**
      * @var int Total number of idle handles to keep in cache
      */
-    private $maxHandles;
+    private int $maxHandles;
 
-    /**
-     * @var bool
-     */
-    private $closed = false;
+    private bool $closed = false;
 
     /**
      * @var resource|\CurlShareHandle|\CurlSharePersistentHandle|null
      */
     private $shareHandle;
 
-    /**
-     * @var string
-     */
-    private $shareMode;
+    private string $shareMode;
 
     /**
      * @param int                                                       $maxHandles  Maximum number of idle handles.

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -17,25 +17,13 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class CurlHandler
 {
-    /**
-     * @var CurlFactoryInterface
-     */
-    private $factory;
+    private CurlFactoryInterface $factory;
 
-    /**
-     * @var bool
-     */
-    private $ownsFactory;
+    private bool $ownsFactory;
 
-    /**
-     * @var bool
-     */
-    private $closed = false;
+    private bool $closed = false;
 
-    /**
-     * @var CurlShareHandleState|null
-     */
-    private $shareHandleState;
+    private ?CurlShareHandleState $shareHandleState;
 
     /**
      * Accepts an associative array of options:

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -22,84 +22,57 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class CurlMultiHandler
 {
-    /**
-     * @var CurlFactoryInterface
-     */
-    private $factory;
+    private CurlFactoryInterface $factory;
 
-    /**
-     * @var bool
-     */
-    private $ownsFactory;
+    private bool $ownsFactory;
 
-    /**
-     * @var CurlShareHandleState|null
-     */
-    private $shareHandleState;
+    private ?CurlShareHandleState $shareHandleState;
 
-    /**
-     * @var float
-     */
-    private $selectTimeout;
+    private float $selectTimeout;
 
     /**
      * @var int Will be higher than 0 when `curl_multi_exec` is still running.
      */
-    private $active = 0;
+    private int $active = 0;
 
     /**
      * @var array Request entry handles, indexed by handle id in `addRequest`.
      *
      * @see CurlMultiHandler::addRequest
      */
-    private $handles = [];
+    private array $handles = [];
 
     /**
      * @var array<int, float> An array of delay times, indexed by handle id in `addRequest`.
      *
      * @see CurlMultiHandler::addRequest
      */
-    private $delays = [];
+    private array $delays = [];
 
     /**
      * @var array<mixed> An associative array of CURLMOPT_* options and corresponding values for curl_multi_setopt()
      */
-    private $options = [];
+    private array $options = [];
 
     /**
      * @var resource|\CurlMultiHandle|null
      */
     private $multiHandle;
 
-    /**
-     * @var bool
-     */
-    private $closed = false;
+    private bool $closed = false;
 
-    /**
-     * @var bool
-     */
-    private $closing = false;
+    private bool $closing = false;
 
-    /**
-     * @var bool
-     */
-    private $executingMulti = false;
+    private bool $executingMulti = false;
 
     /**
      * @var array<int, array{easy: EasyHandle, attached: bool}>
      */
-    private $deferredCancels = [];
+    private array $deferredCancels = [];
 
-    /**
-     * @var bool
-     */
-    private $deferredClose = false;
+    private bool $deferredClose = false;
 
-    /**
-     * @var bool
-     */
-    private $deferredCloseExplicit = false;
+    private bool $deferredCloseExplicit = false;
 
     /**
      * This handler accepts the following options:


### PR DESCRIPTION
Adds native property types to private cURL handler properties while leaving cURL resource and handle properties untyped for PHP 7.4 and PHP 8 compatibility.