### PR TITLE
Type public handler state properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Adjusted `guzzlehttp/psr7` version constraint to `^3.0`
 - Quote multipart `Content-Type` boundary parameters when required
 - Added parameter and return types to `SetCookie` methods
+- Added native property types to supported public cURL handler state properties
 - Added `string` return types to `__toString()` methods
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Normalize no-proxy domain and IP literal matching consistently

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -573,6 +573,19 @@ Applications that extended `CurlFactory` should implement
 composition instead: wrap a handler instance in a custom callable or provide a
 custom handler rather than subclassing the built-in handler.
 
+#### Custom cURL handle factories
+
+Custom `GuzzleHttp\Handler\CurlFactoryInterface` implementations that create or
+mutate `GuzzleHttp\Handler\EasyHandle` instances must assign values compatible
+with EasyHandle's documented public property types. Several EasyHandle
+bookkeeping properties now use native property types, so assigning incompatible
+values to those properties raises `TypeError`.
+
+The native cURL handle properties intentionally remain untyped because PHP 7.4
+represents cURL handles as resources while PHP 8 represents them as cURL handle
+objects. Custom factories must still unset `$easy->handle` when releasing an easy
+handle, as required by `CurlFactoryInterface::release()`.
+
 #### Progress callback parameter types
 
 The built-in handlers now pass integer byte counts to `progress` callbacks.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -581,6 +581,10 @@ with EasyHandle's documented public property types. Several EasyHandle
 bookkeeping properties now use native property types, so assigning incompatible
 values to those properties raises `TypeError`.
 
+Custom factories must assign the request and sink state before returning an
+EasyHandle to Guzzle because those properties are required typed invariants.
+Reading them before assignment raises PHP's uninitialized typed-property `Error`.
+
 The native cURL handle properties intentionally remain untyped because PHP 7.4
 represents cURL handles as resources while PHP 8 represents them as cURL handle
 objects. Custom factories must still unset `$easy->handle` when releasing an easy

--- a/src/Handler/CurlFactoryInterface.php
+++ b/src/Handler/CurlFactoryInterface.php
@@ -11,8 +11,9 @@ interface CurlFactoryInterface
     /**
      * Creates a cURL handle resource.
      *
-     * Implementations must return an EasyHandle whose public state properties
-     * contain values compatible with Guzzle's cURL handlers.
+     * Implementations must return an EasyHandle whose public state properties,
+     * including the request and sink, contain values compatible with Guzzle's
+     * cURL handlers.
      *
      * @param RequestInterface $request Request
      * @param array            $options Transfer options

--- a/src/Handler/CurlFactoryInterface.php
+++ b/src/Handler/CurlFactoryInterface.php
@@ -11,6 +11,9 @@ interface CurlFactoryInterface
     /**
      * Creates a cURL handle resource.
      *
+     * Implementations must return an EasyHandle whose public state properties
+     * contain values compatible with Guzzle's cURL handlers.
+     *
      * @param RequestInterface $request Request
      * @param array            $options Transfer options
      *

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -16,10 +16,7 @@ final class CurlShareHandleState
      */
     public $handle;
 
-    /**
-     * @var string
-     */
-    public $mode;
+    public string $mode;
 
     /**
      * @param resource|\CurlShareHandle|\CurlSharePersistentHandle|null $handle

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -22,10 +22,7 @@ final class EasyHandle
      */
     public $handle;
 
-    /**
-     * @var StreamInterface Where data is being written
-     */
-    public $sink;
+    public StreamInterface $sink;
 
     /**
      * @var list<string> Received HTTP headers so far
@@ -37,10 +34,7 @@ final class EasyHandle
      */
     public ?ResponseInterface $response = null;
 
-    /**
-     * @var RequestInterface Request being sent
-     */
-    public $request;
+    public RequestInterface $request;
 
     /**
      * @var array Request options

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -28,14 +28,14 @@ final class EasyHandle
     public $sink;
 
     /**
-     * @var array Received HTTP headers so far
+     * @var list<string> Received HTTP headers so far
      */
-    public $headers = [];
+    public array $headers = [];
 
     /**
      * @var ResponseInterface|null Received response (if any)
      */
-    public $response;
+    public ?ResponseInterface $response = null;
 
     /**
      * @var RequestInterface Request being sent
@@ -50,27 +50,27 @@ final class EasyHandle
     /**
      * @var int cURL error number (if any)
      */
-    public $errno = 0;
+    public int $errno = 0;
 
     /**
      * @var \Throwable|null Exception during on_headers (if any)
      */
-    public $onHeadersException;
+    public ?\Throwable $onHeadersException = null;
 
     /**
      * @var \Throwable|null Exception during progress callback (if any)
      */
-    public $progressException;
+    public ?\Throwable $progressException = null;
 
     /**
      * @var bool Whether the progress callback requested abort
      */
-    public $progressAborted = false;
+    public bool $progressAborted = false;
 
     /**
      * @var \Throwable|null Exception during createResponse (if any)
      */
-    public $createResponseException;
+    public ?\Throwable $createResponseException = null;
 
     /**
      * Attach a response to the easy handle based on the received headers.

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -24,6 +24,8 @@ final class EasyHandle
 
     public StreamInterface $sink;
 
+    public RequestInterface $request;
+
     /**
      * @var list<string> Received HTTP headers so far
      */
@@ -33,8 +35,6 @@ final class EasyHandle
      * @var ResponseInterface|null Received response (if any)
      */
     public ?ResponseInterface $response = null;
-
-    public RequestInterface $request;
 
     /**
      * @var array Request options


### PR DESCRIPTION
Adds native property types to PHP 7.4-compatible public handler state properties and documents the impact for custom cURL handle factories.