### PR TITLE
Require test server 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "ext-curl": "*",
         "bamarni/composer-bin-plugin": "^1.8.2",
         "guzzle/client-integration-tests": "3.0.2",
-        "guzzlehttp/test-server": "^0.3.2",
+        "guzzlehttp/test-server": "^0.4",
         "php-http/message-factory": "^1.1",
         "phpunit/phpunit": "^8.5.52 || ^9.6.34",
         "psr/log": "^1.1 || ^2.0 || ^3.0"

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -47,6 +47,8 @@ class StreamHandlerTest extends TestCase
         self::assertSame('hi there', (string) $response->getBody());
         $sent = Server::received()[0];
         self::assertSame('GET', $sent->getMethod());
+        self::assertSame('127.0.0.1', $sent->getUri()->getHost());
+        self::assertSame(8126, $sent->getUri()->getPort());
         self::assertSame('/', $sent->getUri()->getPath());
         self::assertSame('127.0.0.1:8126', $sent->getHeaderLine('Host'));
         self::assertSame('Bar', $sent->getHeaderLine('foo'));


### PR DESCRIPTION
This upgrades the test server dependency on the 7.10 line.