### PR TITLE
Deprecate invalid request option value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
 - Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE`, which will be rejected in 8.0
 - Deprecated scalar-coerced `idn_conversion` request option values, which will be rejected in 8.0
+- Deprecated invalid documented request option value types, which will be rejected in 8.0
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "guzzlehttp/promises": "^2.3",
         "guzzlehttp/psr7": "^2.10.1",
         "psr/http-client": "^1.0",
-        "symfony/deprecation-contracts": "^2.2 || ^3.0"
+        "symfony/deprecation-contracts": "^2.2 || ^3.0",
+        "symfony/polyfill-php80": "^1.24"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -56,7 +56,7 @@ You can also pass an associative array containing the following key value pairs:
 
 - referer: (bool, default=false) Set to true to enable adding the Referer header when redirecting.
 
-- protocols: (array, default=`['http', 'https']`) Specified which protocols are allowed for redirect requests.
+- protocols: (non-empty array of strings, default=`['http', 'https']`) Specifies which protocols are allowed for redirect requests. Redirect matching is case-sensitive; use `http` and `https`.
 
 - on_redirect: (callable) PHP callable that is invoked when a redirect is encountered. The callable is invoked with the original request, the redirect response that was received, and the effective URI. Any return value from the on_redirect function is ignored.
 
@@ -121,7 +121,6 @@ Pass an array of HTTP authentication parameters to use with the request. The arr
 
 Types
 - array
-- string
 - null
 
 Default
@@ -129,6 +128,8 @@ None
 
 Constant
 `GuzzleHttp\RequestOptions::AUTH`
+
+Top-level non-array `auth` values other than `null` are deprecated in 7.11 and will be rejected in 8.0.
 
 The built-in authentication types are as follows:
 
@@ -295,10 +296,11 @@ $client->request('GET', '/get', ['cookies' => $jar]);
 ## connect_timeout
 
 Summary
-Float describing the number of seconds to wait while trying to connect to a server. Use `0` to wait 300 seconds (the default behavior).
+Number of seconds to wait while trying to connect to a server. Use `0` to wait 300 seconds (the default behavior).
 
 Types
-float
+- int
+- float
 
 Default
 `0`
@@ -338,6 +340,30 @@ $client->request('GET', '/foo', ['crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2
 
 > [!NOTE]
 > This setting must be set to one of the `STREAM_CRYPTO_METHOD_TLS*_CLIENT` constants. PHP 7.4 or higher is required in order to use TLS 1.3, and cURL 7.34.0 or higher is required in order to specify a crypto method, with cURL 7.52.0 or higher being required to use TLS 1.3.
+
+## curl
+
+Summary
+Raw cURL options to apply when using a built-in cURL handler.
+
+Types
+- array
+
+Default
+None
+
+Constant
+No `RequestOptions` constant is defined for this handler-specific option.
+
+The array is keyed by integer or string cURL option names and values are passed to cURL after Guzzle applies request options. Raw cURL options that conflict with Guzzle-managed request handling are deprecated and will be rejected by the built-in cURL handlers in 8.0.
+
+```php
+$client->request('GET', '/', [
+    'curl' => [
+        CURLOPT_FRESH_CONNECT => true,
+    ],
+]);
+```
 
 ## debug
 
@@ -516,10 +542,11 @@ $client->request('POST', '/post', [
 ## headers
 
 Summary
-Array keyed by header names to add to the request. List-style header arrays are rejected. PHP stores numeric-string header names as integer keys; when such keys are accepted, Guzzle casts header keys back to strings while applying them. Each value is a string or array of strings representing the header field values.
+Array keyed by header names to add to the request. List-style header arrays are rejected. PHP stores numeric-string header names as integer keys; when such keys are accepted, Guzzle casts header keys back to strings while applying them. Each value is a string or non-empty array of strings representing the header field values.
 
 Types
-array
+- array
+- null
 
 Defaults
 None
@@ -599,6 +626,7 @@ Internationalized Domain Name (IDN) support.
 Types
 - bool
 - int
+- null
 
 Default
 `false`
@@ -614,7 +642,7 @@ $res = $client->request('GET', 'https://яндекс.рф', ['idn_conversion' =>
 // The domain part (яндекс.рф) stays unmodified
 ```
 
-Enables/disables IDN support, can also be used for precise control by combining `IDNA_*` constants (except `IDNA_ERROR_*`), see the `$options` parameter in the [idn_to_ascii()](https://www.php.net/manual/en/function.idn-to-ascii.php) documentation for more details.
+Enables/disables IDN support, can also be used for precise control by combining `IDNA_*` constants (except `IDNA_ERROR_*`), see the `$options` parameter in the [idn_to_ascii()](https://www.php.net/manual/en/function.idn-to-ascii.php) documentation for more details. Pass `false` or `null` to disable IDN conversion.
 
 ## json
 
@@ -818,7 +846,7 @@ Summary
 Allowed URI schemes for request transfers.
 
 Types
-- array
+- non-empty array
 
 Default
 `['http', 'https']`
@@ -826,9 +854,10 @@ Default
 Constant
 `GuzzleHttp\RequestOptions::PROTOCOLS`
 
-This option accepts a non-empty array containing `http`, `https`, or both. It
-applies to each request transfer Guzzle sends, including redirect requests that
-reuse the same request options.
+This option accepts a non-empty array of strings. Built-in handlers accept only
+the case-sensitive values `http` and `https`. It applies to each request
+transfer Guzzle sends, including redirect requests that reuse the same request
+options.
 
 ```php
 $client->request('GET', 'https://example.com', [
@@ -914,10 +943,11 @@ $client->request('GET', '/get?abc=123', ['query' => ['foo' => 'bar']]);
 ## read_timeout
 
 Summary
-Float describing the timeout to use when reading a streamed body
+Number of seconds to use when reading a streamed body
 
 Types
-float
+- int
+- float
 
 Default
 Defaults to the value of the `default_socket_timeout` PHP ini setting
@@ -941,6 +971,22 @@ $data = $body->read(1024);
 // Returns false on timeout
 $line = fgets($body->detach());
 ```
+
+## retries
+
+Summary
+Current retry count used by `GuzzleHttp\Middleware::retry()`.
+
+Types
+- int
+
+Default
+`0` when retry middleware is used
+
+Constant
+No `RequestOptions` constant is defined for this middleware-specific option.
+
+The retry middleware initializes this option to `0` before the first attempt and increments it before each retry. Applications may seed it on a per-request basis when using the retry middleware.
 
 ## sink
 
@@ -1064,6 +1110,22 @@ while (!$body->eof()) {
 > [!NOTE]
 > Streaming response support must be implemented by the HTTP handler used by a client. This option might not be supported by every HTTP handler, but the interface of the response object remains the same regardless of whether or not it is supported by the handler.
 
+## stream_context
+
+Summary
+PHP stream context options to merge into the context used by the built-in stream handler.
+
+Types
+- array
+
+Default
+None
+
+Constant
+No `RequestOptions` constant is defined for this handler-specific option.
+
+This option is only supported by the built-in stream handler. Built-in cURL handlers deprecate and will reject this option in 8.0 because cURL does not use PHP stream contexts.
+
 ## synchronous
 
 Summary
@@ -1113,10 +1175,11 @@ If you do not need a specific certificate bundle, then Mozilla provides a common
 ## timeout
 
 Summary
-Float describing the total timeout of the request in seconds. Use `0` to wait indefinitely (the default behavior).
+Number of seconds to use as the total timeout of the request. Use `0` to wait indefinitely (the default behavior).
 
 Types
-float
+- int
+- float
 
 Default
 `0`

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -327,7 +328,406 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             }
         }
 
+        self::warnAboutInvalidRequestOptionTypes($result);
+
         return $result;
+    }
+
+    private static function warnAboutInvalidRequestOptionTypes(array $options): void
+    {
+        if (isset($options['handler']) && !\is_callable($options['handler'])) {
+            self::warnInvalidRequestOptionType('handler', 'callable', $options['handler']);
+        }
+
+        if (isset($options['allow_redirects']) && \is_array($options['allow_redirects'])) {
+            self::warnAboutInvalidAllowRedirectsOptionTypes($options['allow_redirects']);
+        }
+
+        if (isset($options['auth'])) {
+            self::warnAboutInvalidAuthOptionTypes($options['auth']);
+        }
+
+        if (isset($options['body']) && \is_array($options['body'])) {
+            self::warnInvalidRequestOptionType('body', 'resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable', $options['body']);
+        }
+
+        self::warnAboutInvalidTlsFileOptionTypes($options, 'cert');
+        self::warnIfPresentAndNotString($options, 'cert_type');
+        self::warnIfPresentAndNotNumber($options, 'connect_timeout');
+        self::warnIfPresentAndNotInt($options, 'crypto_method');
+        self::warnIfPresentAndNotBoolOrResource($options, 'debug');
+        self::warnIfPresentAndNotBoolOrString($options, 'decode_content');
+        self::warnIfPresentAndNotNumber($options, 'delay');
+        self::warnIfPresentAndNotBoolOrInt($options, 'expect');
+
+        if (isset($options['form_params'])) {
+            self::warnAboutInvalidStringOrStringArrayOptionTypes('form_params', $options['form_params']);
+        }
+
+        if (isset($options['force_ip_resolve']) && !\is_string($options['force_ip_resolve'])) {
+            self::warnInvalidRequestOptionType('force_ip_resolve', 'string', $options['force_ip_resolve']);
+        }
+
+        if (isset($options['headers'])) {
+            self::warnAboutInvalidHeaderOptionTypes($options['headers']);
+        }
+
+        self::warnIfPresentAndNotBool($options, 'http_errors');
+
+        if (isset($options['multipart'])) {
+            self::warnAboutInvalidMultipartOptionTypes($options['multipart']);
+        }
+
+        self::warnIfPresentAndNotCallable($options, 'on_headers');
+        self::warnIfPresentAndNotCallable($options, 'on_stats');
+        self::warnIfPresentAndNotCallable($options, 'progress');
+        self::warnIfPresentAndNotStringArray($options, 'protocols', true);
+        self::warnAboutInvalidProxyOptionTypes($options);
+
+        self::warnIfPresentAndNotNumber($options, 'read_timeout');
+        self::warnIfPresentAndNotInt($options, 'retries');
+
+        if (isset($options['sink']) && !\is_bool($options['sink']) && !\is_resource($options['sink']) && !\is_string($options['sink']) && !$options['sink'] instanceof StreamInterface) {
+            self::warnInvalidRequestOptionType('sink', 'resource|string|StreamInterface', $options['sink']);
+        }
+
+        self::warnAboutInvalidTlsFileOptionTypes($options, 'ssl_key');
+        self::warnIfPresentAndNotString($options, 'ssl_key_type');
+        self::warnIfPresentAndNotBool($options, 'stream');
+        self::warnIfPresentAndNotArray($options, 'stream_context', 'array<array-key, mixed>');
+        self::warnIfPresentAndNotBool($options, 'synchronous');
+        self::warnIfPresentAndNotNumber($options, 'timeout');
+        self::warnIfPresentAndNotBoolOrString($options, 'verify');
+        self::warnIfPresentAndNotStringOrFloat($options, 'version');
+        self::warnIfPresentAndNotArray($options, 'curl', 'array<int|string, mixed>');
+
+        if (isset($options['cookies']) && $options['cookies'] === true) {
+            self::warnInvalidRequestOptionType('cookies', 'false|CookieJarInterface', $options['cookies']);
+        }
+    }
+
+    private static function warnAboutInvalidAllowRedirectsOptionTypes(array $allowRedirects): void
+    {
+        self::warnIfPresentAndNotInt($allowRedirects, 'max', 'allow_redirects.max');
+        self::warnIfPresentAndNotBool($allowRedirects, 'strict', 'allow_redirects.strict');
+        self::warnIfPresentAndNotBool($allowRedirects, 'referer', 'allow_redirects.referer');
+        self::warnIfPresentAndNotStringArray($allowRedirects, 'protocols', true, 'allow_redirects.protocols');
+        self::warnIfPresentAndNotCallable($allowRedirects, 'on_redirect', 'allow_redirects.on_redirect');
+        self::warnIfPresentAndNotBool($allowRedirects, 'track_redirects', 'allow_redirects.track_redirects');
+    }
+
+    /**
+     * @param mixed $auth
+     */
+    private static function warnAboutInvalidAuthOptionTypes($auth): void
+    {
+        if (!\is_array($auth)) {
+            self::warnInvalidRequestOptionType('auth', 'array{0: string, 1: string, 2?: string}|null', $auth);
+
+            return;
+        }
+
+        if (!\array_key_exists(0, $auth) || !\is_string($auth[0])) {
+            self::warnInvalidRequestOptionType('auth.0', 'string', $auth[0] ?? null);
+        }
+
+        if (!\array_key_exists(1, $auth) || !\is_string($auth[1])) {
+            self::warnInvalidRequestOptionType('auth.1', 'string', $auth[1] ?? null);
+        }
+
+        if (\array_key_exists(2, $auth) && !\is_string($auth[2])) {
+            self::warnInvalidRequestOptionType('auth.2', 'string', $auth[2]);
+        }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function warnAboutInvalidStringOrStringArrayOptionTypes(string $option, $value): void
+    {
+        if (!\is_array($value)) {
+            self::warnInvalidRequestOptionType($option, 'array<array-key, string|array<array-key, string>>', $value);
+
+            return;
+        }
+
+        foreach ($value as $key => $item) {
+            $path = $option.'.'.(string) $key;
+            if (\is_array($item)) {
+                foreach ($item as $index => $nestedItem) {
+                    if (!\is_string($nestedItem)) {
+                        self::warnInvalidRequestOptionType($path.'.'.(string) $index, 'string', $nestedItem);
+
+                        break 2;
+                    }
+                }
+            } elseif (!\is_string($item)) {
+                self::warnInvalidRequestOptionType($path, 'string|array<array-key, string>', $item);
+
+                break;
+            }
+        }
+    }
+
+    /**
+     * @param mixed $headers
+     */
+    private static function warnAboutInvalidHeaderOptionTypes($headers): void
+    {
+        if (!\is_array($headers)) {
+            self::warnInvalidRequestOptionType('headers', 'array<array-key, string|non-empty-array<array-key, string>>|null', $headers);
+
+            return;
+        }
+
+        foreach ($headers as $name => $value) {
+            $path = 'headers.'.(string) $name;
+            if (\is_array($value)) {
+                if ($value === []) {
+                    self::warnInvalidRequestOptionType($path, 'string|non-empty-array<array-key, string>', $value);
+
+                    break;
+                }
+
+                foreach ($value as $index => $item) {
+                    if (!\is_string($item)) {
+                        self::warnInvalidRequestOptionType($path.'.'.(string) $index, 'string', $item);
+
+                        break 2;
+                    }
+                }
+            } elseif (!\is_string($value)) {
+                self::warnInvalidRequestOptionType($path, 'string|non-empty-array<array-key, string>', $value);
+
+                break;
+            }
+        }
+    }
+
+    /**
+     * @param mixed $multipart
+     */
+    private static function warnAboutInvalidMultipartOptionTypes($multipart): void
+    {
+        if (!\is_array($multipart)) {
+            self::warnInvalidRequestOptionType('multipart', 'array<array-key, array{name: string|int, contents: mixed, headers?: array<array-key, string>, filename?: string}>', $multipart);
+
+            return;
+        }
+
+        foreach ($multipart as $index => $part) {
+            $path = 'multipart.'.(string) $index;
+            if (!\is_array($part)) {
+                self::warnInvalidRequestOptionType($path, 'array{name: string|int, contents: mixed, headers?: array<array-key, string>, filename?: string}', $part);
+
+                return;
+            }
+
+            if (!\array_key_exists('name', $part) || (!\is_string($part['name']) && !\is_int($part['name']))) {
+                self::warnInvalidRequestOptionType($path.'.name', 'string|int', $part['name'] ?? null);
+            }
+
+            if (!\array_key_exists('contents', $part)) {
+                self::warnInvalidRequestOptionType($path, 'array{name: string|int, contents: mixed, headers?: array<array-key, string>, filename?: string}', $part);
+            }
+
+            if (\array_key_exists('headers', $part)) {
+                if (!\is_array($part['headers'])) {
+                    self::warnInvalidRequestOptionType($path.'.headers', 'array<array-key, string>', $part['headers']);
+                } else {
+                    foreach ($part['headers'] as $name => $value) {
+                        if (!\is_string($value)) {
+                            self::warnInvalidRequestOptionType($path.'.headers.'.(string) $name, 'string', $value);
+
+                            break 2;
+                        }
+                    }
+                }
+            }
+
+            if (\array_key_exists('filename', $part) && !\is_string($part['filename'])) {
+                self::warnInvalidRequestOptionType($path.'.filename', 'string', $part['filename']);
+            }
+        }
+    }
+
+    private static function warnAboutInvalidProxyOptionTypes(array $options): void
+    {
+        if (!isset($options['proxy'])) {
+            return;
+        }
+
+        if (!\is_string($options['proxy']) && !\is_array($options['proxy'])) {
+            self::warnInvalidRequestOptionType('proxy', 'string|array{http?: string, https?: string, no?: string|array<array-key, string>}', $options['proxy']);
+
+            return;
+        }
+
+        if (!\is_array($options['proxy'])) {
+            return;
+        }
+
+        foreach (['http', 'https'] as $scheme) {
+            if (\array_key_exists($scheme, $options['proxy']) && !\is_string($options['proxy'][$scheme])) {
+                self::warnInvalidRequestOptionType('proxy.'.$scheme, 'string', $options['proxy'][$scheme]);
+            }
+        }
+
+        if (!\array_key_exists('no', $options['proxy'])) {
+            return;
+        }
+
+        if (\is_string($options['proxy']['no'])) {
+            return;
+        }
+
+        if (!\is_array($options['proxy']['no'])) {
+            self::warnInvalidRequestOptionType('proxy.no', 'string|array<array-key, string>', $options['proxy']['no']);
+
+            return;
+        }
+
+        foreach ($options['proxy']['no'] as $index => $noProxy) {
+            if (!\is_string($noProxy)) {
+                self::warnInvalidRequestOptionType('proxy.no.'.(string) $index, 'string', $noProxy);
+
+                return;
+            }
+        }
+    }
+
+    private static function warnAboutInvalidTlsFileOptionTypes(array $options, string $option): void
+    {
+        if (!isset($options[$option])) {
+            return;
+        }
+
+        if (\is_string($options[$option])) {
+            return;
+        }
+
+        if (!\is_array($options[$option])) {
+            self::warnInvalidRequestOptionType($option, 'string|array{0: string, 1?: string}', $options[$option]);
+
+            return;
+        }
+
+        if (!\array_key_exists(0, $options[$option]) || !\is_string($options[$option][0])) {
+            self::warnInvalidRequestOptionType($option.'.0', 'string', $options[$option][0] ?? null);
+        }
+
+        if (\array_key_exists(1, $options[$option]) && !\is_string($options[$option][1])) {
+            self::warnInvalidRequestOptionType($option.'.1', 'string', $options[$option][1]);
+        }
+    }
+
+    private static function warnIfPresentAndNotArray(array $options, string $option, string $expected): void
+    {
+        if (\array_key_exists($option, $options) && !\is_array($options[$option])) {
+            self::warnInvalidRequestOptionType($option, $expected, $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotBool(array $options, string $option, ?string $path = null): void
+    {
+        if (\array_key_exists($option, $options) && !\is_bool($options[$option])) {
+            self::warnInvalidRequestOptionType($path ?? $option, 'bool', $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotBoolOrInt(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_bool($options[$option]) && !\is_int($options[$option])) {
+            self::warnInvalidRequestOptionType($option, 'bool|int', $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotBoolOrResource(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_bool($options[$option]) && !\is_resource($options[$option])) {
+            self::warnInvalidRequestOptionType($option, 'bool|resource', $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotBoolOrString(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_bool($options[$option]) && !\is_string($options[$option])) {
+            self::warnInvalidRequestOptionType($option, 'bool|string', $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotCallable(array $options, string $option, ?string $path = null): void
+    {
+        if (\array_key_exists($option, $options) && !\is_callable($options[$option])) {
+            self::warnInvalidRequestOptionType($path ?? $option, 'callable', $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotInt(array $options, string $option, ?string $path = null): void
+    {
+        if (\array_key_exists($option, $options) && !\is_int($options[$option])) {
+            self::warnInvalidRequestOptionType($path ?? $option, 'int', $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotNumber(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_int($options[$option]) && !\is_float($options[$option])) {
+            self::warnInvalidRequestOptionType($option, 'int|float', $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotString(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_string($options[$option])) {
+            self::warnInvalidRequestOptionType($option, 'string', $options[$option]);
+        }
+    }
+
+    private static function warnIfPresentAndNotStringArray(array $options, string $option, bool $nonEmpty, ?string $path = null): void
+    {
+        if (!\array_key_exists($option, $options)) {
+            return;
+        }
+
+        $path = $path ?? $option;
+        $expected = ($nonEmpty ? 'non-empty-' : '').'array<array-key, string>';
+
+        if (!\is_array($options[$option]) || ($nonEmpty && $options[$option] === [])) {
+            self::warnInvalidRequestOptionType($path, $expected, $options[$option]);
+
+            return;
+        }
+
+        foreach ($options[$option] as $index => $item) {
+            if (!\is_string($item)) {
+                self::warnInvalidRequestOptionType($path.'.'.(string) $index, 'string', $item);
+
+                return;
+            }
+        }
+    }
+
+    private static function warnIfPresentAndNotStringOrFloat(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_string($options[$option]) && !\is_float($options[$option])) {
+            self::warnInvalidRequestOptionType($option, 'string|float', $options[$option]);
+        }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function warnInvalidRequestOptionType(string $option, string $expected, $value): void
+    {
+        \trigger_deprecation(
+            'guzzlehttp/guzzle',
+            '7.11',
+            'Passing %s to request option "%s" is deprecated; guzzlehttp/guzzle 8.0 requires %s.',
+            \get_debug_type($value),
+            $option,
+            $expected
+        );
     }
 
     /**

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -23,12 +23,15 @@ final class RequestOptions
      *   browsers do which is redirect POST requests with GET requests
      * - referer: (bool, default=false) Set to true to enable the Referer
      *   header.
-     * - protocols: (array, default=['http', 'https']) Allowed redirect
-     *   protocols.
+     * - protocols: (non-empty-array<array-key, string>, default=['http', 'https'])
+     *   Allowed redirect protocols. Redirect matching is case-sensitive; use
+     *   "http" and "https".
      * - on_redirect: (callable) PHP callable that is invoked when a redirect
      *   is encountered. The callable is invoked with the request, the redirect
      *   response that was received, and the effective URI. Any return value
      *   from the on_redirect function is ignored.
+     * - track_redirects: (bool, default=false) Track redirected URI and status
+     *   history in response headers.
      */
     public const ALLOW_REDIRECTS = 'allow_redirects';
 
@@ -42,8 +45,9 @@ final class RequestOptions
     public const AUTH = 'auth';
 
     /**
-     * body: (resource|string|null|int|float|StreamInterface|callable|\Iterator)
-     * Body to send in the request.
+     * body: (resource|string|null|int|float|bool|\Psr\Http\Message\StreamInterface|(callable&object)|\Iterator|\Stringable)
+     * Body to send in the request. Callable arrays are arrays, and arrays are
+     * not valid body values in Guzzle.
      */
     public const BODY = 'body';
 
@@ -63,7 +67,7 @@ final class RequestOptions
     public const CERT_TYPE = 'cert_type';
 
     /**
-     * cookies: (bool|GuzzleHttp\Cookie\CookieJarInterface, default=false)
+     * cookies: (false|GuzzleHttp\Cookie\CookieJarInterface, default=false)
      * Specifies whether or not cookies are used in a request or what cookie
      * jar to use or what cookies to send. This option only works if your
      * handler has the `cookie` middleware. Valid values are `false` and
@@ -72,9 +76,9 @@ final class RequestOptions
     public const COOKIES = 'cookies';
 
     /**
-     * connect_timeout: (float, default=0) Float describing the number of
-     * seconds to wait while trying to connect to a server. Use 0 to wait
-     * 300 seconds (the default behavior).
+     * connect_timeout: (int|float, default=0) Number of seconds to wait while
+     * trying to connect to a server. Use 0 to wait 300 seconds (the default
+     * behavior).
      */
     public const CONNECT_TIMEOUT = 'connect_timeout';
 
@@ -98,14 +102,15 @@ final class RequestOptions
     public const DEBUG = 'debug';
 
     /**
-     * decode_content: (bool, default=true) Specify whether or not
+     * decode_content: (bool|string, default=true) Specify whether or not
      * Content-Encoding responses (gzip, deflate, etc.) are automatically
      * decoded.
      */
     public const DECODE_CONTENT = 'decode_content';
 
     /**
-     * delay: (int) The amount of time to delay before sending in milliseconds.
+     * delay: (int|float) The amount of time to delay before sending in
+     * milliseconds.
      */
     public const DELAY = 'delay';
 
@@ -128,16 +133,17 @@ final class RequestOptions
     public const EXPECT = 'expect';
 
     /**
-     * form_params: (array) Associative array of form field names to values
-     * where each value is a string or array of strings. Sets the Content-Type
-     * header to application/x-www-form-urlencoded when no Content-Type header
-     * is already present.
+     * form_params: (array<array-key, string|array<array-key, string>>) Associative
+     * array of form field names to values where each value is a string or array
+     * of strings. Sets the Content-Type header to application/x-www-form-urlencoded
+     * when no Content-Type header is already present.
      */
     public const FORM_PARAMS = 'form_params';
 
     /**
-     * headers: (array) Associative array of HTTP headers. Each value MUST be
-     * a string or array of strings.
+     * headers: (array<array-key, string|non-empty-array<array-key, string>>|null)
+     * Associative array of HTTP headers. Each value MUST be a string or non-empty
+     * array of strings.
      */
     public const HEADERS = 'headers';
 
@@ -150,10 +156,10 @@ final class RequestOptions
     public const HTTP_ERRORS = 'http_errors';
 
     /**
-     * idn: (bool|int, default=true) A combination of IDNA_* constants for
-     * idn_to_ascii() PHP's function (see "options" parameter). Set to false to
-     * disable IDN support completely, or to true to use the default
-     * configuration (IDNA_DEFAULT constant).
+     * idn_conversion: (bool|int|null, default=false) A combination of IDNA_*
+     * constants for PHP's idn_to_ascii() function. Set to false or null to
+     * disable IDN support, or to true to use the default configuration
+     * (IDNA_DEFAULT constant).
      */
     public const IDN_CONVERSION = 'idn_conversion';
 
@@ -165,13 +171,13 @@ final class RequestOptions
     public const JSON = 'json';
 
     /**
-     * multipart: (array) Array of associative arrays, each containing a
-     * required "name" key mapping to the form field, name, a required
-     * "contents" key mapping to a StreamInterface|resource|string, an
-     * optional "headers" associative array of custom headers, and an
-     * optional "filename" key mapping to a string to send as the filename in
-     * the part. If no "filename" key is present, then no "filename" attribute
-     * will be added to the part.
+     * multipart: (array) Array of part arrays, each containing a required
+     * "name" key mapping to the string or integer form field name, a required
+     * "contents" key mapping to any non-array value accepted by PSR-7
+     * Utils::streamFor() or a nested array of field values, an optional
+     * "headers" array of string custom header values, and an optional
+     * "filename" key mapping to a string to send as the filename in the part.
+     * "headers" and "filename" cannot be used when "contents" is an array.
      */
     public const MULTIPART = 'multipart';
 
@@ -203,7 +209,9 @@ final class RequestOptions
     public const PROGRESS = 'progress';
 
     /**
-     * protocols: (array, default=['http', 'https']) Allowed URI schemes.
+     * protocols: (non-empty-array<array-key, string>, default=['http', 'https'])
+     * Allowed URI schemes. Built-in handlers accept only the case-sensitive
+     * values "http" and "https".
      */
     public const PROTOCOLS = 'protocols';
 
@@ -211,23 +219,23 @@ final class RequestOptions
      * proxy: (string|array) Pass a string to specify an HTTP proxy, or an
      * array to specify different proxies for different protocols (where the
      * key is the protocol and the value is a proxy string). Provide a "no"
-     * key as an array of hosts or host-and-port pairs that should not be
-     * proxied.
+     * key as a string or array of strings to specify hosts or host-and-port
+     * pairs that should not be proxied.
      */
     public const PROXY = 'proxy';
 
     /**
-     * query: (array|string) Associative array of query string values to add
-     * to the request. This option uses PHP's http_build_query() to create
-     * the string representation. Pass a string value if you need more
-     * control than what this method provides
+     * query: (array<array-key, mixed>|string) Associative array of query string
+     * values to add to the request. This option uses PHP's http_build_query()
+     * to create the string representation. Pass a string value if you need
+     * more control than what this method provides
      */
     public const QUERY = 'query';
 
     /**
-     * sink: (resource|string|StreamInterface) Where the data of the
-     * response is written to. Defaults to a PHP temp stream. Providing a
-     * string will write data to a file by the given name.
+     * sink: (resource|string|\Psr\Http\Message\StreamInterface) Where the data
+     * of the response is written to. Defaults to a PHP temp stream. Providing
+     * a string will write data to a file by the given name.
      */
     public const SINK = 'sink';
 
@@ -254,7 +262,7 @@ final class RequestOptions
     public const SSL_KEY_TYPE = 'ssl_key_type';
 
     /**
-     * stream: Set to true to attempt to stream a response rather than
+     * stream: (bool) Set to true to attempt to stream a response rather than
      * download it all up-front.
      */
     public const STREAM = 'stream';
@@ -270,24 +278,26 @@ final class RequestOptions
     public const VERIFY = 'verify';
 
     /**
-     * timeout: (float, default=0) Float describing the timeout of the
+     * timeout: (int|float, default=0) Number describing the timeout of the
      * request in seconds. Use 0 to wait indefinitely (the default behavior).
      */
     public const TIMEOUT = 'timeout';
 
     /**
-     * read_timeout: (float, default=default_socket_timeout ini setting) Float describing
-     * the body read timeout, for stream requests.
+     * read_timeout: (int|float, default=default_socket_timeout ini setting)
+     * Number describing the body read timeout, for stream requests.
      */
     public const READ_TIMEOUT = 'read_timeout';
 
     /**
-     * version: (string|float) Specifies the HTTP protocol version to attempt to use.
+     * version: (string|float) Specifies the HTTP protocol version to attempt
+     * to use.
      */
     public const VERSION = 'version';
 
     /**
-     * force_ip_resolve: (bool) Force client to use only ipv4 or ipv6 protocol
+     * force_ip_resolve: (string) Set to "v4" to force IPv4 resolution or "v6"
+     * for IPv6 resolution when supported by the handler.
      */
     public const FORCE_IP_RESOLVE = 'force_ip_resolve';
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -262,7 +262,6 @@ EOT
                 throw new InvalidArgumentException('protocols must contain only strings');
             }
 
-            $protocol = \strtolower($protocol);
             if ($protocol !== 'http' && $protocol !== 'https') {
                 throw new InvalidArgumentException('protocols may only contain "http" and "https"');
             }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -547,11 +547,12 @@ class ClientTest extends TestCase
         self::assertSame('application/json', $last->getHeaderLine('Content-Type'));
     }
 
-    public function testAuthCanBeTrue()
+    public function testAuthCanBeDisabledWithNull()
     {
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
-        $client->get('http://foo.com', ['auth' => false]);
+        $client->get('http://foo.com', ['auth' => null]);
+
         $last = $mock->getLastRequest();
         self::assertFalse($last->hasHeader('Authorization'));
     }
@@ -587,15 +588,6 @@ class ClientTest extends TestCase
             \CURLOPT_HTTPAUTH => 8,
             \CURLOPT_USERPWD => 'a:b',
         ], $last['curl']);
-    }
-
-    public function testAuthCanBeCustomType()
-    {
-        $mock = new MockHandler([new Response()]);
-        $client = new Client(['handler' => $mock]);
-        $client->get('http://foo.com', ['auth' => 'foo']);
-        $last = $mock->getLastOptions();
-        self::assertSame('foo', $last['auth']);
     }
 
     public function testCanAddFormParams()

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -156,6 +156,19 @@ class UtilsTest extends TestCase
         self::assertSame($expected, Utils::normalizeHeaderKeys($input));
     }
 
+    public function testNormalizeProtocolsAcceptsLowercaseProtocols()
+    {
+        self::assertSame(['http', 'https'], Utils::normalizeProtocols(['http', 'https', 'http']));
+    }
+
+    public function testNormalizeProtocolsRejectsUppercaseProtocols()
+    {
+        $this->expectException(GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('protocols may only contain "http" and "https"');
+
+        Utils::normalizeProtocols(['HTTPS']);
+    }
+
     public static function noProxyProvider()
     {
         return [


### PR DESCRIPTION
This change adds Guzzle 7.11 deprecation warnings when documented request option values use shapes or scalar types that Guzzle 8.0 will reject, while preserving 7.x runtime behavior where invalid values already fail later in request handling. It also corrects the request option documentation and in-code option reference to describe the 8.0 target shapes, uses the PHP 8 polyfill for get_debug_type(), and makes the new top-level protocols handler normalization case-sensitive without moving enum validation into the client.