### PR TITLE
Reject invalid request option value types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "guzzlehttp/promises": "^3.0@dev",
         "guzzlehttp/psr7": "^3.0@dev",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0"
+        "psr/http-factory": "^1.0",
+        "symfony/polyfill-php80": "^1.24"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/src/Client.php
+++ b/src/Client.php
@@ -800,7 +800,366 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             }
         }
 
+        self::assertRequestOptionTypes($result);
+
         return $result;
+    }
+
+    private static function assertRequestOptionTypes(array $options): void
+    {
+        if (isset($options['handler']) && !\is_callable($options['handler'])) {
+            self::invalidRequestOptionType('handler', 'callable', $options['handler']);
+        }
+
+        if (isset($options['allow_redirects'])) {
+            if (!\is_bool($options['allow_redirects']) && !\is_array($options['allow_redirects'])) {
+                self::invalidRequestOptionType('allow_redirects', 'bool|array', $options['allow_redirects']);
+            }
+
+            if (\is_array($options['allow_redirects'])) {
+                self::assertAllowRedirectsOptionTypes($options['allow_redirects']);
+            }
+        }
+
+        if (isset($options['auth']) && !\is_array($options['auth'])) {
+            self::invalidRequestOptionType('auth', 'array{0: string, 1: string, 2?: string}|null', $options['auth']);
+        }
+
+        self::assertTlsFileOptionTypes($options, 'cert');
+        self::assertIfPresentAndNotString($options, 'cert_type');
+        self::assertIfPresentAndNotNumber($options, 'connect_timeout');
+        self::assertIfPresentAndNotInt($options, 'crypto_method');
+        self::assertIfPresentAndNotBoolOrResource($options, 'debug');
+        self::assertIfPresentAndNotBoolOrString($options, 'decode_content');
+        self::assertIfPresentAndNotNumber($options, 'delay');
+        self::assertIfPresentAndNotBoolOrInt($options, 'expect');
+
+        if (isset($options['form_params'])) {
+            self::assertStringOrStringArrayOptionTypes('form_params', $options['form_params']);
+        }
+
+        if (isset($options['force_ip_resolve']) && !\is_string($options['force_ip_resolve'])) {
+            self::invalidRequestOptionType('force_ip_resolve', 'string', $options['force_ip_resolve']);
+        }
+
+        if (isset($options['headers'])) {
+            self::assertHeaderOptionTypes($options['headers']);
+        }
+
+        self::assertIfPresentAndNotBool($options, 'http_errors');
+
+        if (isset($options['multipart'])) {
+            self::assertMultipartOptionTypes($options['multipart']);
+        }
+
+        self::assertIfPresentAndNotCallable($options, 'on_headers');
+        self::assertIfPresentAndNotCallable($options, 'on_stats');
+        self::assertIfPresentAndNotCallable($options, 'progress');
+        self::assertIfPresentAndNotStringArray($options, 'protocols', true);
+        self::assertProxyOptionTypes($options);
+        self::assertIfPresentAndNotNumber($options, 'read_timeout');
+        self::assertIfPresentAndNotInt($options, 'retries');
+
+        if (isset($options['sink']) && !\is_resource($options['sink']) && !\is_string($options['sink']) && !$options['sink'] instanceof StreamInterface) {
+            self::invalidRequestOptionType('sink', 'resource|string|StreamInterface', $options['sink']);
+        }
+
+        self::assertTlsFileOptionTypes($options, 'ssl_key');
+        self::assertIfPresentAndNotString($options, 'ssl_key_type');
+        self::assertIfPresentAndNotBool($options, 'stream');
+        self::assertIfPresentAndNotArray($options, 'stream_context', 'array<array-key, mixed>');
+        self::assertIfPresentAndNotBool($options, 'synchronous');
+        self::assertIfPresentAndNotNumber($options, 'timeout');
+        self::assertIfPresentAndNotBoolOrString($options, 'verify');
+        self::assertIfPresentAndNotStringOrFloat($options, 'version');
+        self::assertIfPresentAndNotArray($options, 'curl', 'array<int|string, mixed>');
+
+        if (isset($options['cookies']) && $options['cookies'] !== false && !$options['cookies'] instanceof CookieJarInterface) {
+            self::invalidRequestOptionType('cookies', 'false|CookieJarInterface', $options['cookies']);
+        }
+    }
+
+    private static function assertAllowRedirectsOptionTypes(array $allowRedirects): void
+    {
+        self::assertIfPresentAndNotInt($allowRedirects, 'max', 'allow_redirects.max');
+        self::assertIfPresentAndNotBool($allowRedirects, 'strict', 'allow_redirects.strict');
+        self::assertIfPresentAndNotBool($allowRedirects, 'referer', 'allow_redirects.referer');
+        self::assertIfPresentAndNotStringArray($allowRedirects, 'protocols', true, 'allow_redirects.protocols');
+        self::assertIfPresentAndNotCallable($allowRedirects, 'on_redirect', 'allow_redirects.on_redirect');
+        self::assertIfPresentAndNotBool($allowRedirects, 'track_redirects', 'allow_redirects.track_redirects');
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function assertStringOrStringArrayOptionTypes(string $option, $value): void
+    {
+        if (!\is_array($value)) {
+            self::invalidRequestOptionType($option, 'array<array-key, string|array<array-key, string>>', $value);
+
+            return;
+        }
+
+        foreach ($value as $key => $item) {
+            $path = $option.'.'.(string) $key;
+            if (\is_array($item)) {
+                foreach ($item as $index => $nestedItem) {
+                    if (!\is_string($nestedItem)) {
+                        self::invalidRequestOptionType($path.'.'.(string) $index, 'string', $nestedItem);
+                    }
+                }
+            } elseif (!\is_string($item)) {
+                self::invalidRequestOptionType($path, 'string|array<array-key, string>', $item);
+            }
+        }
+    }
+
+    /**
+     * @param mixed $headers
+     */
+    private static function assertHeaderOptionTypes($headers): void
+    {
+        if (!\is_array($headers)) {
+            self::invalidRequestOptionType('headers', 'array<array-key, string|non-empty-array<array-key, string>>|null', $headers);
+
+            return;
+        }
+
+        foreach ($headers as $name => $value) {
+            $path = 'headers.'.(string) $name;
+            if (\is_array($value)) {
+                if ($value === []) {
+                    self::invalidRequestOptionType($path, 'string|non-empty-array<array-key, string>', $value);
+                }
+
+                foreach ($value as $index => $item) {
+                    if (!\is_string($item)) {
+                        self::invalidRequestOptionType($path.'.'.(string) $index, 'string', $item);
+                    }
+                }
+            } elseif (!\is_string($value)) {
+                self::invalidRequestOptionType($path, 'string|non-empty-array<array-key, string>', $value);
+            }
+        }
+    }
+
+    /**
+     * @param mixed $multipart
+     */
+    private static function assertMultipartOptionTypes($multipart): void
+    {
+        if (!\is_array($multipart)) {
+            self::invalidRequestOptionType('multipart', 'array<array-key, array{name: string|int, contents: mixed, headers?: array<array-key, string>, filename?: string}>', $multipart);
+
+            return;
+        }
+
+        foreach ($multipart as $index => $part) {
+            $path = 'multipart.'.(string) $index;
+            if (!\is_array($part)) {
+                self::invalidRequestOptionType($path, 'array{name: string|int, contents: mixed, headers?: array<array-key, string>, filename?: string}', $part);
+
+                return;
+            }
+
+            if (!\array_key_exists('name', $part) || (!\is_string($part['name']) && !\is_int($part['name']))) {
+                self::invalidRequestOptionType($path.'.name', 'string|int', $part['name'] ?? null);
+            }
+
+            if (!\array_key_exists('contents', $part)) {
+                self::invalidRequestOptionType($path, 'array{name: string|int, contents: mixed, headers?: array<array-key, string>, filename?: string}', $part);
+            }
+
+            if (\array_key_exists('headers', $part)) {
+                if (!\is_array($part['headers'])) {
+                    self::invalidRequestOptionType($path.'.headers', 'array<array-key, string>', $part['headers']);
+
+                    return;
+                }
+
+                foreach ($part['headers'] as $name => $value) {
+                    if (!\is_string($value)) {
+                        self::invalidRequestOptionType($path.'.headers.'.(string) $name, 'string', $value);
+                    }
+                }
+            }
+
+            if (\array_key_exists('filename', $part) && !\is_string($part['filename'])) {
+                self::invalidRequestOptionType($path.'.filename', 'string', $part['filename']);
+            }
+        }
+    }
+
+    private static function assertProxyOptionTypes(array $options): void
+    {
+        if (!isset($options['proxy'])) {
+            return;
+        }
+
+        if (!\is_string($options['proxy']) && !\is_array($options['proxy'])) {
+            self::invalidRequestOptionType('proxy', 'string|array{http?: string, https?: string, no?: string|array<array-key, string>}', $options['proxy']);
+
+            return;
+        }
+
+        if (!\is_array($options['proxy'])) {
+            return;
+        }
+
+        foreach (['http', 'https'] as $scheme) {
+            if (\array_key_exists($scheme, $options['proxy']) && !\is_string($options['proxy'][$scheme])) {
+                self::invalidRequestOptionType('proxy.'.$scheme, 'string', $options['proxy'][$scheme]);
+            }
+        }
+
+        if (!\array_key_exists('no', $options['proxy'])) {
+            return;
+        }
+
+        if (\is_string($options['proxy']['no'])) {
+            return;
+        }
+
+        if (!\is_array($options['proxy']['no'])) {
+            self::invalidRequestOptionType('proxy.no', 'string|array<array-key, string>', $options['proxy']['no']);
+
+            return;
+        }
+
+        foreach ($options['proxy']['no'] as $index => $noProxy) {
+            if (!\is_string($noProxy)) {
+                self::invalidRequestOptionType('proxy.no.'.(string) $index, 'string', $noProxy);
+            }
+        }
+    }
+
+    private static function assertTlsFileOptionTypes(array $options, string $option): void
+    {
+        if (!isset($options[$option])) {
+            return;
+        }
+
+        if (\is_string($options[$option])) {
+            return;
+        }
+
+        if (!\is_array($options[$option])) {
+            self::invalidRequestOptionType($option, 'string|array{0: string, 1?: string}', $options[$option]);
+
+            return;
+        }
+
+        if (!\array_key_exists(0, $options[$option]) || !\is_string($options[$option][0])) {
+            self::invalidRequestOptionType($option.'.0', 'string', $options[$option][0] ?? null);
+        }
+
+        if (\array_key_exists(1, $options[$option]) && !\is_string($options[$option][1])) {
+            self::invalidRequestOptionType($option.'.1', 'string', $options[$option][1]);
+        }
+    }
+
+    private static function assertIfPresentAndNotArray(array $options, string $option, string $expected): void
+    {
+        if (\array_key_exists($option, $options) && !\is_array($options[$option])) {
+            self::invalidRequestOptionType($option, $expected, $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotBool(array $options, string $option, ?string $path = null): void
+    {
+        if (\array_key_exists($option, $options) && !\is_bool($options[$option])) {
+            self::invalidRequestOptionType($path ?? $option, 'bool', $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotBoolOrInt(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_bool($options[$option]) && !\is_int($options[$option])) {
+            self::invalidRequestOptionType($option, 'bool|int', $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotBoolOrResource(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_bool($options[$option]) && !\is_resource($options[$option])) {
+            self::invalidRequestOptionType($option, 'bool|resource', $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotBoolOrString(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_bool($options[$option]) && !\is_string($options[$option])) {
+            self::invalidRequestOptionType($option, 'bool|string', $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotCallable(array $options, string $option, ?string $path = null): void
+    {
+        if (\array_key_exists($option, $options) && !\is_callable($options[$option])) {
+            self::invalidRequestOptionType($path ?? $option, 'callable', $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotInt(array $options, string $option, ?string $path = null): void
+    {
+        if (\array_key_exists($option, $options) && !\is_int($options[$option])) {
+            self::invalidRequestOptionType($path ?? $option, 'int', $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotNumber(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_int($options[$option]) && !\is_float($options[$option])) {
+            self::invalidRequestOptionType($option, 'int|float', $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotString(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_string($options[$option])) {
+            self::invalidRequestOptionType($option, 'string', $options[$option]);
+        }
+    }
+
+    private static function assertIfPresentAndNotStringArray(array $options, string $option, bool $nonEmpty, ?string $path = null): void
+    {
+        if (!\array_key_exists($option, $options)) {
+            return;
+        }
+
+        $path = $path ?? $option;
+
+        if (!\is_array($options[$option]) || ($nonEmpty && $options[$option] === [])) {
+            self::invalidRequestOptionType($path, ($nonEmpty ? 'non-empty-' : '').'array<array-key, string>', $options[$option]);
+
+            return;
+        }
+
+        foreach ($options[$option] as $index => $item) {
+            if (!\is_string($item)) {
+                self::invalidRequestOptionType($path.'.'.(string) $index, 'string', $item);
+            }
+        }
+    }
+
+    private static function assertIfPresentAndNotStringOrFloat(array $options, string $option): void
+    {
+        if (\array_key_exists($option, $options) && !\is_string($options[$option]) && !\is_float($options[$option])) {
+            self::invalidRequestOptionType($option, 'string|float', $options[$option]);
+        }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function invalidRequestOptionType(string $option, string $expected, $value): void
+    {
+        throw new InvalidArgumentException(\sprintf(
+            'Passing %s to request option "%s" is invalid; expected %s.',
+            \get_debug_type($value),
+            $option,
+            $expected
+        ));
     }
 
     /**

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -267,7 +267,7 @@ class RedirectMiddleware
         }
 
         // Ensure that the redirect URI is allowed based on the protocols.
-        if (!\in_array($resolvedUri->getScheme(), $protocols)) {
+        if (!\in_array($resolvedUri->getScheme(), $protocols, true)) {
             throw new BadResponseException(\sprintf('Redirect URI, %s, does not use one of the allowed redirect protocols: %s', $resolvedUri, \implode(', ', $protocols)), $request, $response);
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\CurlShare;
 use GuzzleHttp\Handler\CurlVersion;
@@ -1151,7 +1152,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $handler]);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('allow_redirects must be true, false, or array');
+        $this->expectExceptionMessage('Passing string to request option "allow_redirects" is invalid; expected bool|array.');
         $client->get('http://foo.com', ['allow_redirects' => 'foo']);
     }
 
@@ -1172,7 +1173,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $handler]);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('cookies must be an instance of GuzzleHttp\\Cookie\\CookieJarInterface');
+        $this->expectExceptionMessage('Passing string to request option "cookies" is invalid; expected false|CookieJarInterface.');
         $client->get('http://foo.com', ['cookies' => 'foo']);
     }
 
@@ -1245,6 +1246,209 @@ class ClientTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $client->get('http://foo.com', ['headers' => 'foo']);
+    }
+
+    /**
+     * @dataProvider invalidRequestOptionTypeProvider
+     */
+    public function testRejectsInvalidRequestOptionTypes(array $options, string $expectedMessage): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $client->request('POST', 'http://foo.com', $options);
+    }
+
+    public static function invalidRequestOptionTypeProvider(): iterable
+    {
+        yield 'handler' => [
+            ['handler' => false],
+            'Passing bool to request option "handler" is invalid; expected callable.',
+        ];
+
+        yield 'allow_redirects' => [
+            ['allow_redirects' => 'true'],
+            'Passing string to request option "allow_redirects" is invalid; expected bool|array.',
+        ];
+
+        yield 'allow_redirects.protocols' => [
+            ['allow_redirects' => ['protocols' => []]],
+            'Passing array to request option "allow_redirects.protocols" is invalid; expected non-empty-array<array-key, string>.',
+        ];
+
+        yield 'allow_redirects.protocols value' => [
+            ['allow_redirects' => ['protocols' => [false]]],
+            'Passing bool to request option "allow_redirects.protocols.0" is invalid; expected string.',
+        ];
+
+        yield 'auth' => [
+            ['auth' => false],
+            'Passing bool to request option "auth" is invalid; expected array{0: string, 1: string, 2?: string}|null.',
+        ];
+
+        yield 'cert password' => [
+            ['cert' => ['cert.pem', null]],
+            'Passing null to request option "cert.1" is invalid; expected string.',
+        ];
+
+        yield 'cert_type' => [
+            ['cert_type' => false],
+            'Passing bool to request option "cert_type" is invalid; expected string.',
+        ];
+
+        yield 'connect_timeout' => [
+            ['connect_timeout' => '1'],
+            'Passing string to request option "connect_timeout" is invalid; expected int|float.',
+        ];
+
+        yield 'crypto_method' => [
+            ['crypto_method' => '1'],
+            'Passing string to request option "crypto_method" is invalid; expected int.',
+        ];
+
+        yield 'debug' => [
+            ['debug' => 'debug'],
+            'Passing string to request option "debug" is invalid; expected bool|resource.',
+        ];
+
+        yield 'decode_content' => [
+            ['decode_content' => 1],
+            'Passing int to request option "decode_content" is invalid; expected bool|string.',
+        ];
+
+        yield 'delay' => [
+            ['delay' => '1'],
+            'Passing string to request option "delay" is invalid; expected int|float.',
+        ];
+
+        yield 'expect' => [
+            ['expect' => 1.5],
+            'Passing float to request option "expect" is invalid; expected bool|int.',
+        ];
+
+        yield 'form param value' => [
+            ['form_params' => ['foo' => 1]],
+            'Passing int to request option "form_params.foo" is invalid; expected string|array<array-key, string>.',
+        ];
+
+        yield 'force_ip_resolve' => [
+            ['force_ip_resolve' => false],
+            'Passing bool to request option "force_ip_resolve" is invalid; expected string.',
+        ];
+
+        yield 'header value' => [
+            ['headers' => ['X-Test' => []]],
+            'Passing array to request option "headers.X-Test" is invalid; expected string|non-empty-array<array-key, string>.',
+        ];
+
+        yield 'multipart contents' => [
+            ['multipart' => [['name' => 'foo']]],
+            'Passing array to request option "multipart.0" is invalid; expected array{name: string|int, contents: mixed, headers?: array<array-key, string>, filename?: string}.',
+        ];
+
+        yield 'multipart header value' => [
+            ['multipart' => [['name' => 'foo', 'contents' => 'bar', 'headers' => ['X-Test' => false]]]],
+            'Passing bool to request option "multipart.0.headers.X-Test" is invalid; expected string.',
+        ];
+
+        yield 'http_errors' => [
+            ['http_errors' => 'false'],
+            'Passing string to request option "http_errors" is invalid; expected bool.',
+        ];
+
+        yield 'on_headers' => [
+            ['on_headers' => 'not a callable'],
+            'Passing string to request option "on_headers" is invalid; expected callable.',
+        ];
+
+        yield 'on_stats' => [
+            ['on_stats' => 'not a callable'],
+            'Passing string to request option "on_stats" is invalid; expected callable.',
+        ];
+
+        yield 'progress' => [
+            ['progress' => 'not a callable'],
+            'Passing string to request option "progress" is invalid; expected callable.',
+        ];
+
+        yield 'protocols' => [
+            ['protocols' => []],
+            'Passing array to request option "protocols" is invalid; expected non-empty-array<array-key, string>.',
+        ];
+
+        yield 'protocol value' => [
+            ['protocols' => [false]],
+            'Passing bool to request option "protocols.0" is invalid; expected string.',
+        ];
+
+        yield 'proxy no value' => [
+            ['proxy' => ['no' => [false]]],
+            'Passing bool to request option "proxy.no.0" is invalid; expected string.',
+        ];
+
+        yield 'retries' => [
+            ['retries' => '1'],
+            'Passing string to request option "retries" is invalid; expected int.',
+        ];
+
+        yield 'sink' => [
+            ['sink' => 123],
+            'Passing int to request option "sink" is invalid; expected resource|string|StreamInterface.',
+        ];
+
+        yield 'ssl_key password' => [
+            ['ssl_key' => ['key.pem', null]],
+            'Passing null to request option "ssl_key.1" is invalid; expected string.',
+        ];
+
+        yield 'ssl_key_type' => [
+            ['ssl_key_type' => false],
+            'Passing bool to request option "ssl_key_type" is invalid; expected string.',
+        ];
+
+        yield 'stream' => [
+            ['stream' => '1'],
+            'Passing string to request option "stream" is invalid; expected bool.',
+        ];
+
+        yield 'stream_context' => [
+            ['stream_context' => 'context'],
+            'Passing string to request option "stream_context" is invalid; expected array<array-key, mixed>.',
+        ];
+
+        yield 'timeout' => [
+            ['timeout' => '1'],
+            'Passing string to request option "timeout" is invalid; expected int|float.',
+        ];
+
+        yield 'verify' => [
+            ['verify' => 1],
+            'Passing int to request option "verify" is invalid; expected bool|string.',
+        ];
+
+        yield 'version' => [
+            ['version' => 1],
+            'Passing int to request option "version" is invalid; expected string|float.',
+        ];
+
+        yield 'curl' => [
+            ['curl' => 'curl'],
+            'Passing string to request option "curl" is invalid; expected array<int|string, mixed>.',
+        ];
+    }
+
+    public function testRejectsInvalidSynchronousRequestOption(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Passing string to request option "synchronous" is invalid; expected bool.');
+
+        $client->sendAsync(new Request('GET', 'http://foo.com'), ['synchronous' => '1']);
     }
 
     public function testAddsBody(): void
@@ -1423,7 +1627,7 @@ class ClientTest extends TestCase
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
 
-        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $client->get('http://foo.com', ['auth' => $auth]);
     }
 
@@ -1743,7 +1947,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $request = new Request('GET', 'http://foo.com');
 
-        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $client->send($request, ['headers' => ['X-Foo: Bar']]);
     }
 
@@ -1753,7 +1957,7 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $request = new Request('GET', 'http://foo.com');
 
-        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $client->send($request, ['headers' => ['X-Foo: Bar', 'X-Test: Fail']]);
     }
 
@@ -2009,7 +2213,7 @@ class ClientTest extends TestCase
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('idn_conversion must be true, false, null, or an integer IDNA_* bitmask');
 
         $client->request('GET', 'https://example.com', ['idn_conversion' => '0']);
@@ -2023,7 +2227,7 @@ class ClientTest extends TestCase
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('IDN conversion failed');
         $client->request('GET', 'https://-яндекс.рф/images', ['idn_conversion' => true]);
     }

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -283,6 +283,24 @@ class RedirectMiddlewareTest extends TestCase
         ], new Response(302, ['Location' => 'http://example.com/redirected']));
     }
 
+    public function testRedirectProtocolMatchingIsStrict(): void
+    {
+        $redirectMiddleware = new RedirectMiddleware(static function (): void {
+        });
+        $request = new Request('GET', 'http://example.com/');
+
+        $this->expectException(BadResponseException::class);
+        $this->expectExceptionMessage('does not use one of the allowed redirect protocols');
+
+        $redirectMiddleware->modifyRequest($request, [
+            'allow_redirects' => [
+                'protocols' => [true],
+                'strict' => false,
+                'referer' => false,
+            ],
+        ], new Response(302, ['Location' => 'http://example.com/redirected']));
+    }
+
     public function testRelativeRedirectPreservesCustomRequestAndUriImplementations(): void
     {
         $mock = new MockHandler([

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -124,7 +124,7 @@ class RetryMiddlewareTest extends TestCase
         $c = new Client(['handler' => $m($h)]);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('retries must be an integer');
+        $this->expectExceptionMessage('Passing string to request option "retries" is invalid; expected int.');
 
         $c->send(new Request('GET', 'http://test.com'), ['retries' => '0']);
     }


### PR DESCRIPTION
This follows the 7.11 deprecation work by rejecting invalid documented request option value types and shapes in 8.0. It keeps client validation focused on documented types and shapes, leaves supported protocol values to the handlers and redirect middleware, adds the PHP 8.0 polyfill for consistent debug-type exception messages on PHP 7.4, and makes redirect protocol matching strict.