### PR TITLE
Add network exception base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Adjusted `guzzlehttp/psr7` version constraint to `^2.10`
 - Allowed domainless `SetCookie` instances to be stored without wildcard request matching
 - Changed no-proxy matching to respect request ports for host-and-port rules
-- Made `ConnectException` extend `NetworkException`; thrown classes unchanged
+- Made `GuzzleHttp\Exception\ConnectException` extend `GuzzleHttp\Exception\NetworkException`
 - Prevented `CurlMultiHandler` destructors from throwing during cleanup
 - Improved invalid response handling across handlers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Adjusted `guzzlehttp/psr7` version constraint to `^2.10`
 - Allowed domainless `SetCookie` instances to be stored without wildcard request matching
 - Changed no-proxy matching to respect request ports for host-and-port rules
-- Made `GuzzleHttp\Exception\ConnectException` extend `GuzzleHttp\Exception\NetworkException`; thrown classes are unchanged
+- Made `ConnectException` extend `NetworkException`; thrown classes unchanged
 - Prevented `CurlMultiHandler` destructors from throwing during cleanup
 - Improved invalid response handling across handlers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added `cert_type` and `ssl_key_type` request options for TLS certificate and private-key file types
 - Added PHP stream handler support for the `ssl_key` request option
 - Added handler-lifetime cURL sharing through `curl_share` and cURL handler `share` options
+- Added `GuzzleHttp\Exception\NetworkException` as the base class for network-related transfer failures
 
 ### Changed
 
 - Adjusted `guzzlehttp/psr7` version constraint to `^2.10`
 - Allowed domainless `SetCookie` instances to be stored without wildcard request matching
 - Changed no-proxy matching to respect request ports for host-and-port rules
+- Made `GuzzleHttp\Exception\ConnectException` extend `GuzzleHttp\Exception\NetworkException`; thrown classes are unchanged
 - Prevented `CurlMultiHandler` destructors from throwing during cleanup
 - Improved invalid response handling across handlers
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -465,9 +465,9 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 ```
 . \RuntimeException
 └── TransferException (implements GuzzleException)
-    ├── NetworkException (implements NetworkExceptionInterface)
+    ├── NetworkException (implements Psr\Http\Client\NetworkExceptionInterface)
     │   └── ConnectException
-    └── RequestException (implements RequestExceptionInterface)
+    └── RequestException (implements Psr\Http\Client\RequestExceptionInterface)
         ├── BadResponseException
         │   ├── ServerException
         │   └── ClientException
@@ -476,11 +476,11 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 
 Guzzle throws exceptions for errors that occur during a transfer.
 
-- `GuzzleHttp\Exception\NetworkException` is the base class for networking errors where no response has been received. It implements PSR-18's `NetworkExceptionInterface`.
+- `GuzzleHttp\Exception\NetworkException` is the base class for networking errors where no response has been received. It implements PSR-18's `Psr\Http\Client\NetworkExceptionInterface`.
 
-- A `GuzzleHttp\Exception\ConnectException` exception is thrown in the event of a connection or networking error. This exception extends from `GuzzleHttp\Exception\NetworkException`. Catch `NetworkException` or `NetworkExceptionInterface` when you want to handle all no-response network failures.
+- A `GuzzleHttp\Exception\ConnectException` exception is thrown in the event of a connection or networking error. This exception extends from `GuzzleHttp\Exception\NetworkException`. Catch `NetworkException` or `Psr\Http\Client\NetworkExceptionInterface` when you want to handle all no-response network failures.
 
-- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `RequestExceptionInterface`.
+- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `Psr\Http\Client\RequestExceptionInterface`.
 
 - A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\RequestException`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -467,7 +467,7 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 └── TransferException (implements GuzzleException)
     ├── NetworkException (implements NetworkExceptionInterface)
     │   └── ConnectException
-    └── RequestException
+    └── RequestException (implements RequestExceptionInterface)
         ├── BadResponseException
         │   ├── ServerException
         │   └── ClientException
@@ -479,6 +479,8 @@ Guzzle throws exceptions for errors that occur during a transfer.
 - `GuzzleHttp\Exception\NetworkException` is the base class for networking errors where no response has been received. It implements PSR-18's `NetworkExceptionInterface`.
 
 - A `GuzzleHttp\Exception\ConnectException` exception is thrown in the event of a connection or networking error. This exception extends from `GuzzleHttp\Exception\NetworkException`. Catch `NetworkException` or `NetworkExceptionInterface` when you want to handle all no-response network failures.
+
+- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `RequestExceptionInterface`.
 
 - A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\RequestException`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -465,9 +465,9 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 ```
 . \RuntimeException
 └── TransferException (implements GuzzleException)
-    ├── NetworkException (implements Psr\Http\Client\NetworkExceptionInterface)
+    ├── NetworkException (implements NetworkExceptionInterface)
     │   └── ConnectException
-    └── RequestException (implements Psr\Http\Client\RequestExceptionInterface)
+    └── RequestException (implements RequestExceptionInterface)
         ├── BadResponseException
         │   ├── ServerException
         │   └── ClientException

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -465,7 +465,8 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 ```
 . \RuntimeException
 └── TransferException (implements GuzzleException)
-    ├── ConnectException (implements NetworkExceptionInterface)
+    ├── NetworkException (implements NetworkExceptionInterface)
+    │   └── ConnectException
     └── RequestException
         ├── BadResponseException
         │   ├── ServerException
@@ -475,7 +476,9 @@ The following tree view describes how the Guzzle Exceptions depend on each other
 
 Guzzle throws exceptions for errors that occur during a transfer.
 
-- A `GuzzleHttp\Exception\ConnectException` exception is thrown in the event of a networking error. This exception extends from `GuzzleHttp\Exception\TransferException`.
+- `GuzzleHttp\Exception\NetworkException` is the base class for networking errors where no response has been received. It implements PSR-18's `NetworkExceptionInterface`.
+
+- A `GuzzleHttp\Exception\ConnectException` exception is thrown in the event of a connection or networking error. This exception extends from `GuzzleHttp\Exception\NetworkException`. Catch `NetworkException` or `NetworkExceptionInterface` when you want to handle all no-response network failures.
 
 - A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\RequestException`.
 

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -6,8 +6,6 @@ use Psr\Http\Message\RequestInterface;
 
 /**
  * Exception thrown when a connection cannot be established.
- *
- * Note that no response is present for a ConnectException
  */
 class ConnectException extends NetworkException
 {

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -2,7 +2,6 @@
 
 namespace GuzzleHttp\Exception;
 
-use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -10,7 +9,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * Note that no response is present for a ConnectException
  */
-class ConnectException extends TransferException implements NetworkExceptionInterface
+class ConnectException extends NetworkException
 {
     /**
      * @var RequestInterface

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace GuzzleHttp\Exception;
+
+use Psr\Http\Client\NetworkExceptionInterface;
+
+/**
+ * Base exception for network-related transfer failures.
+ */
+abstract class NetworkException extends TransferException implements NetworkExceptionInterface
+{
+}

--- a/tests/Exception/ConnectExceptionTest.php
+++ b/tests/Exception/ConnectExceptionTest.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Tests\Exception;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\NetworkException;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\NetworkExceptionInterface;
@@ -18,6 +19,7 @@ class ConnectExceptionTest extends TestCase
         $req = new Request('GET', '/');
         $prev = new \Exception();
         $e = new ConnectException('foo', $req, $prev, ['foo' => 'bar']);
+        self::assertInstanceOf(NetworkException::class, $e);
         self::assertInstanceOf(NetworkExceptionInterface::class, $e);
         self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
         self::assertSame($req, $e->getRequest());


### PR DESCRIPTION
This adds a Guzzle-specific NetworkException base class for no-response network failures and makes ConnectException extend it without changing which exception classes are thrown. The quickstart and changelog now point users at NetworkException or the PSR NetworkExceptionInterface when they want to handle the broader network failure category.