### PR TITLE
Remove redundant network exception method check

### DIFF
--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -135,7 +135,6 @@ class CurlHandlerTest extends TestCase
         $p = $handler($request, ['timeout' => 0.001, 'connect_timeout' => 0.001])
             ->otherwise(static function (NetworkException $e) use (&$called): void {
                 $called = true;
-                self::assertTrue(\method_exists($e, 'getHandlerContext'));
                 self::assertArrayHasKey('errno', $e->getHandlerContext());
             });
         $p->wait();


### PR DESCRIPTION
This removes an unnecessary method_exists assertion from the curl handler error context test. NetworkException now defines getHandlerContext directly, so the remaining assertion can call it without checking for the method first.