### PR TITLE
Add response exception base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added PHP stream handler support for the `ssl_key` request option
 - Added handler-lifetime cURL sharing through `curl_share` and cURL handler `share` options
 - Added `GuzzleHttp\Exception\NetworkException` as the base class for network-related transfer failures
+- Added `GuzzleHttp\Exception\ResponseException` as the base class for request failures where a response was received
 
 ### Changed
 
@@ -19,6 +20,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Allowed domainless `SetCookie` instances to be stored without wildcard request matching
 - Changed no-proxy matching to respect request ports for host-and-port rules
 - Made `GuzzleHttp\Exception\ConnectException` extend `GuzzleHttp\Exception\NetworkException`
+- Made `GuzzleHttp\Exception\BadResponseException` extend `GuzzleHttp\Exception\ResponseException`
+- Changed `GuzzleHttp\Exception\RequestException::create()` to return `GuzzleHttp\Exception\ResponseException` for generic response-present failures
 - Prevented `CurlMultiHandler` destructors from throwing during cleanup
 - Improved invalid response handling across handlers
 
@@ -29,6 +32,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated scalar-coerced `idn_conversion` request option values, which will be rejected in 8.0
 - Deprecated invalid documented request option value types, which will be rejected in 8.0
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
+- Deprecated response probing through `GuzzleHttp\Exception\RequestException::getResponse()` and `GuzzleHttp\Exception\RequestException::hasResponse()`; use `GuzzleHttp\Exception\ResponseException` for response-aware request failures
+- Deprecated `GuzzleHttp\Exception\RequestException::wrapException()`
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,32 @@
 Guzzle Upgrade Guide
 ====================
 
+7.11 to 8.0
+-----------
+
+Guzzle 7.11 introduces `GuzzleHttp\Exception\ResponseException` as the base
+class for request failures where a response was received. Code that needs to
+inspect an exception response should check for `ResponseException` and call
+`ResponseException::getResponse()`.
+
+```php
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
+
+try {
+    $client->request('GET', $uri);
+} catch (ResponseException $e) {
+    $response = $e->getResponse();
+} catch (RequestException $e) {
+    // Request-related failure without supported response access.
+}
+```
+
+`GuzzleHttp\Exception\RequestException::getResponse()` and
+`GuzzleHttp\Exception\RequestException::hasResponse()` are deprecated in 7.11
+and will be removed in 8.0. `GuzzleHttp\Exception\RequestException::wrapException()`
+is also deprecated and should not be used in new code.
+
 6.0 to 7.0
 ----------
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,32 +1,6 @@
 Guzzle Upgrade Guide
 ====================
 
-7.11 to 8.0
------------
-
-Guzzle 7.11 introduces `GuzzleHttp\Exception\ResponseException` as the base
-class for request failures where a response was received. Code that needs to
-inspect an exception response should check for `ResponseException` and call
-`ResponseException::getResponse()`.
-
-```php
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ResponseException;
-
-try {
-    $client->request('GET', $uri);
-} catch (ResponseException $e) {
-    $response = $e->getResponse();
-} catch (RequestException $e) {
-    // Request-related failure without supported response access.
-}
-```
-
-`GuzzleHttp\Exception\RequestException::getResponse()` and
-`GuzzleHttp\Exception\RequestException::hasResponse()` are deprecated in 7.11
-and will be removed in 8.0. `GuzzleHttp\Exception\RequestException::wrapException()`
-is also deprecated and should not be used in new code.
-
 6.0 to 7.0
 ----------
 

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -334,7 +334,7 @@ Custom handlers do not need to support every handler-owned option, but they shou
 
 ### Callback Semantics
 
-The `on_headers` option is invoked after the response headers have been received and before response body bytes are written to the configured `sink`. In Guzzle 7, the callback receives the response object. If it throws, the request promise is rejected with a `GuzzleHttp\Exception\RequestException` that wraps the thrown exception.
+The `on_headers` option is invoked after the response headers have been received and before response body bytes are written to the configured `sink`. In Guzzle 7, the callback receives the response object. If it throws, the request promise is rejected with a `GuzzleHttp\Exception\ResponseException` that wraps the thrown exception and exposes the response.
 
 The `on_stats` option is invoked when the handler has finished sending a request, with a `GuzzleHttp\TransferStats` object that describes the response received or the error encountered. Built-in cURL handlers may invoke `on_stats` per low-level transfer attempt.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -481,9 +481,12 @@ Guzzle throws exceptions for errors that occur during a transfer.
 
 - A `GuzzleHttp\Exception\ConnectException` exception is thrown in the event of a connection or networking error. This exception extends from `GuzzleHttp\Exception\NetworkException`. Catch `NetworkException` or `Psr\Http\Client\NetworkExceptionInterface` when you want to handle all no-response network failures.
 
-- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `Psr\Http\Client\RequestExceptionInterface`. Accessing responses through `RequestException::getResponse()` and checking `RequestException::hasResponse()` are deprecated; use `GuzzleHttp\Exception\ResponseException` for response-aware request failures.
+- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `Psr\Http\Client\RequestExceptionInterface`.
 
 - `GuzzleHttp\Exception\ResponseException` is the base class for request-related transfer failures where a response was received. It exposes the response with `getResponse()`.
+
+> [!NOTE]
+> Accessing responses through `RequestException::getResponse()` and checking `RequestException::hasResponse()` are deprecated. Use `GuzzleHttp\Exception\ResponseException` for response-aware request failures. `GuzzleHttp\Exception\RequestException::wrapException()` is also deprecated and should not be used in new code.
 
 - A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\ResponseException`.
 
@@ -502,8 +505,6 @@ Guzzle throws exceptions for errors that occur during a transfer.
 - A `GuzzleHttp\Exception\ServerException` is thrown for 500 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException`.
 
 - A `GuzzleHttp\Exception\TooManyRedirectsException` is thrown when too many redirects are followed. This exception extends from `GuzzleHttp\Exception\RequestException`.
-
-- `GuzzleHttp\Exception\RequestException::wrapException()` is deprecated and should not be used in new code.
 
 All of the above exceptions extend from `GuzzleHttp\Exception\TransferException`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -468,9 +468,10 @@ The following tree view describes how the Guzzle Exceptions depend on each other
     ├── NetworkException (implements NetworkExceptionInterface)
     │   └── ConnectException
     └── RequestException (implements RequestExceptionInterface)
-        ├── BadResponseException
-        │   ├── ServerException
-        │   └── ClientException
+        ├── ResponseException
+        │   └── BadResponseException
+        │       ├── ServerException
+        │       └── ClientException
         └── TooManyRedirectsException
 ```
 
@@ -480,9 +481,11 @@ Guzzle throws exceptions for errors that occur during a transfer.
 
 - A `GuzzleHttp\Exception\ConnectException` exception is thrown in the event of a connection or networking error. This exception extends from `GuzzleHttp\Exception\NetworkException`. Catch `NetworkException` or `Psr\Http\Client\NetworkExceptionInterface` when you want to handle all no-response network failures.
 
-- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `Psr\Http\Client\RequestExceptionInterface`.
+- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `Psr\Http\Client\RequestExceptionInterface`. Accessing responses through `RequestException::getResponse()` and checking `RequestException::hasResponse()` are deprecated; use `GuzzleHttp\Exception\ResponseException` for response-aware request failures.
 
-- A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\RequestException`.
+- `GuzzleHttp\Exception\ResponseException` is the base class for request-related transfer failures where a response was received. It exposes the response with `getResponse()`.
+
+- A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\ResponseException`.
 
   ```php
   use GuzzleHttp\Psr7;
@@ -499,6 +502,8 @@ Guzzle throws exceptions for errors that occur during a transfer.
 - A `GuzzleHttp\Exception\ServerException` is thrown for 500 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException`.
 
 - A `GuzzleHttp\Exception\TooManyRedirectsException` is thrown when too many redirects are followed. This exception extends from `GuzzleHttp\Exception\RequestException`.
+
+- `GuzzleHttp\Exception\RequestException::wrapException()` is deprecated and should not be used in new code.
 
 All of the above exceptions extend from `GuzzleHttp\Exception\TransferException`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -485,9 +485,6 @@ Guzzle throws exceptions for errors that occur during a transfer.
 
 - `GuzzleHttp\Exception\ResponseException` is the base class for request-related transfer failures where a response was received. It exposes the response with `getResponse()`.
 
-> [!NOTE]
-> Accessing responses through `RequestException::getResponse()` and checking `RequestException::hasResponse()` are deprecated. Use `GuzzleHttp\Exception\ResponseException` for response-aware request failures. `GuzzleHttp\Exception\RequestException::wrapException()` is also deprecated and should not be used in new code.
-
 - A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\ResponseException`.
 
   ```php
@@ -532,3 +529,6 @@ Guzzle can utilize PHP ini settings when configuring clients.
 
 `openssl.cafile`
 Specifies the path on disk to a CA file in PEM format to use when sending requests over "https". See: <https://wiki.php.net/rfc/tls-peer-verification#phpini_defaults>
+
+> [!NOTE]
+> Legacy response probing on `GuzzleHttp\Exception\RequestException` is deprecated. Use `GuzzleHttp\Exception\ResponseException` for response-aware request failures. `GuzzleHttp\Exception\RequestException::wrapException()` is also deprecated and should not be used in new code.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -745,7 +745,7 @@ Types
 Constant
 `GuzzleHttp\RequestOptions::ON_HEADERS`
 
-The callable accepts a `Psr\Http\Message\ResponseInterface` object. If an exception is thrown by the callable, then the promise associated with the response will be rejected with a `GuzzleHttp\Exception\RequestException` that wraps the exception that was thrown.
+The callable accepts a `Psr\Http\Message\ResponseInterface` object. If an exception is thrown by the callable, then the promise associated with the response will be rejected with a `GuzzleHttp\Exception\ResponseException` that wraps the exception that was thrown and exposes the response.
 
 You may need to know what headers and status codes were received before data can be written to the sink.
 

--- a/src/Exception/BadResponseException.php
+++ b/src/Exception/BadResponseException.php
@@ -2,38 +2,9 @@
 
 namespace GuzzleHttp\Exception;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-
 /**
  * Exception when an HTTP error occurs (4xx or 5xx error)
  */
-class BadResponseException extends RequestException
+class BadResponseException extends ResponseException
 {
-    public function __construct(
-        string $message,
-        RequestInterface $request,
-        ResponseInterface $response,
-        ?\Throwable $previous = null,
-        array $handlerContext = []
-    ) {
-        parent::__construct($message, $request, $response, $previous, $handlerContext);
-    }
-
-    /**
-     * Current exception and the ones that extend it will always have a response.
-     */
-    public function hasResponse(): bool
-    {
-        return true;
-    }
-
-    /**
-     * This function narrows the return type from the parent class and does not allow it to be nullable.
-     */
-    public function getResponse(): ResponseInterface
-    {
-        /** @var ResponseInterface */
-        return parent::getResponse();
-    }
 }

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -45,9 +45,13 @@ class RequestException extends TransferException implements RequestExceptionInte
 
     /**
      * Wrap non-RequestExceptions with a RequestException
+     *
+     * @deprecated since 7.11. Create a RequestException or ResponseException directly instead.
      */
     public static function wrapException(RequestInterface $request, \Throwable $e): RequestException
     {
+        \trigger_deprecation('guzzlehttp/guzzle', '7.11', '%s::wrapException() is deprecated and will be removed in 8.0. Create a %s or %s directly instead.', self::class, self::class, ResponseException::class);
+
         return $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, null, $e);
     }
 
@@ -86,7 +90,7 @@ class RequestException extends TransferException implements RequestExceptionInte
             $className = ServerException::class;
         } else {
             $label = 'Unsuccessful request';
-            $className = __CLASS__;
+            $className = ResponseException::class;
         }
 
         $uri = \GuzzleHttp\Psr7\Utils::redactUserInfo($request->getUri());
@@ -121,17 +125,26 @@ class RequestException extends TransferException implements RequestExceptionInte
 
     /**
      * Get the associated response
+     *
+     * Calling this method is deprecated since 7.11. Use instanceof
+     * ResponseException and ResponseException::getResponse() instead.
      */
     public function getResponse(): ?ResponseInterface
     {
+        \trigger_deprecation('guzzlehttp/guzzle', '7.11', '%s::getResponse() is deprecated and will be removed in 8.0. Use instanceof %s and %s::getResponse() instead.', static::class, ResponseException::class, ResponseException::class);
+
         return $this->response;
     }
 
     /**
      * Check if a response was received
+     *
+     * @deprecated since 7.11. Use instanceof ResponseException instead.
      */
     public function hasResponse(): bool
     {
+        \trigger_deprecation('guzzlehttp/guzzle', '7.11', '%s::hasResponse() is deprecated and will be removed in 8.0. Use instanceof %s instead.', static::class, ResponseException::class);
+
         return $this->response !== null;
     }
 

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -5,17 +5,20 @@ namespace GuzzleHttp\Exception;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-class TooManyRedirectsException extends RequestException
+/**
+ * Exception thrown when a request fails after a response is received.
+ */
+class ResponseException extends RequestException
 {
     /**
-     * @var ResponseInterface|null
+     * @var ResponseInterface
      */
     private $response;
 
     public function __construct(
         string $message,
         RequestInterface $request,
-        ?ResponseInterface $response = null,
+        ResponseInterface $response,
         ?\Throwable $previous = null,
         array $handlerContext = []
     ) {
@@ -24,9 +27,9 @@ class TooManyRedirectsException extends RequestException
     }
 
     /**
-     * Get the associated response
+     * Get the associated response.
      */
-    public function getResponse(): ?ResponseInterface
+    public function getResponse(): ResponseInterface
     {
         return $this->response;
     }
@@ -36,8 +39,8 @@ class TooManyRedirectsException extends RequestException
      */
     public function hasResponse(): bool
     {
-        \trigger_deprecation('guzzlehttp/guzzle', '7.11', '%s::hasResponse() is deprecated and will be removed in 8.0. Use instanceof %s instead.', static::class, ResponseException::class);
+        \trigger_deprecation('guzzlehttp/guzzle', '7.11', '%s::hasResponse() is deprecated and will be removed in 8.0. Use instanceof %s instead.', static::class, self::class);
 
-        return $this->response !== null;
+        return true;
     }
 }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -545,13 +546,21 @@ class CurlFactory implements CurlFactoryInterface
         // return a rejected promise that wraps that exception.
         if ($easy->onHeadersException) {
             return P\Create::rejectionFor(
-                new RequestException(
-                    'An error was encountered during the on_headers event',
-                    $easy->request,
-                    $easy->response,
-                    $easy->onHeadersException,
-                    $ctx
-                )
+                $easy->response
+                    ? new ResponseException(
+                        'An error was encountered during the on_headers event',
+                        $easy->request,
+                        $easy->response,
+                        $easy->onHeadersException,
+                        $ctx
+                    )
+                    : new RequestException(
+                        'An error was encountered during the on_headers event',
+                        $easy->request,
+                        null,
+                        $easy->onHeadersException,
+                        $ctx
+                    )
             );
         }
 
@@ -574,9 +583,13 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         // Create a connection exception if it was a specific error code.
-        $error = isset($connectionErrors[$easy->errno])
-            ? new ConnectException($message, $easy->request, null, $ctx)
-            : new RequestException($message, $easy->request, $easy->response, null, $ctx);
+        if (isset($connectionErrors[$easy->errno])) {
+            $error = new ConnectException($message, $easy->request, null, $ctx);
+        } elseif ($easy->response) {
+            $error = new ResponseException($message, $easy->request, $easy->response, null, $ctx);
+        } else {
+            $error = new RequestException($message, $easy->request, null, null, $ctx);
+        }
 
         return P\Create::rejectionFor($error);
     }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -545,22 +545,26 @@ class CurlFactory implements CurlFactoryInterface
         // If an exception was encountered during the onHeaders event, then
         // return a rejected promise that wraps that exception.
         if ($easy->onHeadersException) {
-            return P\Create::rejectionFor(
-                $easy->response
-                    ? new ResponseException(
+            if ($easy->response) {
+                return P\Create::rejectionFor(
+                    new ResponseException(
                         'An error was encountered during the on_headers event',
                         $easy->request,
                         $easy->response,
                         $easy->onHeadersException,
                         $ctx
                     )
-                    : new RequestException(
-                        'An error was encountered during the on_headers event',
-                        $easy->request,
-                        null,
-                        $easy->onHeadersException,
-                        $ctx
-                    )
+                );
+            }
+
+            return P\Create::rejectionFor(
+                new RequestException(
+                    'An error was encountered during the on_headers event',
+                    $easy->request,
+                    null,
+                    $easy->onHeadersException,
+                    $ctx
+                )
             );
         }
 
@@ -584,14 +588,20 @@ class CurlFactory implements CurlFactoryInterface
 
         // Create a connection exception if it was a specific error code.
         if (isset($connectionErrors[$easy->errno])) {
-            $error = new ConnectException($message, $easy->request, null, $ctx);
-        } elseif ($easy->response) {
-            $error = new ResponseException($message, $easy->request, $easy->response, null, $ctx);
-        } else {
-            $error = new RequestException($message, $easy->request, null, null, $ctx);
+            return P\Create::rejectionFor(
+                new ConnectException($message, $easy->request, null, $ctx)
+            );
         }
 
-        return P\Create::rejectionFor($error);
+        if ($easy->response) {
+            return P\Create::rejectionFor(
+                new ResponseException($message, $easy->request, $easy->response, null, $ctx)
+            );
+        }
+
+        return P\Create::rejectionFor(
+            new RequestException($message, $easy->request, null, null, $ctx)
+        );
     }
 
     private static function sanitizeCurlError(string $error, UriInterface $uri): string

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -99,7 +100,9 @@ class MockHandler implements \Countable
                 $options['on_headers']($response);
             } catch (\Exception $e) {
                 $msg = 'An error was encountered during the on_headers event';
-                $response = new RequestException($msg, $request, $response, $e);
+                $response = $response instanceof ResponseInterface
+                    ? new ResponseException($msg, $request, $response, $e)
+                    : new RequestException($msg, $request, null, $e);
             }
         }
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -92,7 +93,7 @@ class StreamHandler
             ) {
                 $e = new ConnectException($e->getMessage(), $request, $e);
             } else {
-                $e = RequestException::wrapException($request, $e);
+                $e = $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, null, $e);
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
 
@@ -146,7 +147,7 @@ class StreamHandler
                 $options['on_headers']($response);
             } catch (\Throwable $e) {
                 return P\Create::rejectionFor(
-                    new RequestException('An error was encountered during the on_headers event', $request, $response, $e)
+                    new ResponseException('An error was encountered during the on_headers event', $request, $response, $e)
                 );
             }
         }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -4,6 +4,8 @@ namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -212,7 +214,7 @@ final class Middleware
                         return $response;
                     },
                     static function ($reason) use ($logger, $request, $formatter): PromiseInterface {
-                        $response = $reason instanceof RequestException ? $reason->getResponse() : null;
+                        $response = ($reason instanceof ResponseException || $reason instanceof TooManyRedirectsException) ? $reason->getResponse() : null;
                         $message = $formatter->format($request, $response, P\Create::exceptionFor($reason));
                         $logger->error($message);
 

--- a/tests/Exception/BadResponseExceptionTest.php
+++ b/tests/Exception/BadResponseExceptionTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BadResponseExceptionTest extends TestCase
 {
-    public function testHasResponse()
+    public function testHasRequestAndResponse()
     {
         $req = new Request('GET', '/');
         $prev = new \Exception();
@@ -24,41 +24,5 @@ class BadResponseExceptionTest extends TestCase
         self::assertSame($response, $e->getResponse());
         self::assertSame('foo', $e->getMessage());
         self::assertSame($prev, $e->getPrevious());
-    }
-
-    public function testHasResponseIsDeprecated()
-    {
-        $e = new BadResponseException('foo', new Request('GET', '/'), new Response());
-
-        $deprecations = self::captureDeprecations(static function () use ($e): void {
-            self::assertTrue($e->hasResponse());
-        });
-
-        self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\BadResponseException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
-        ], $deprecations);
-    }
-
-    private static function captureDeprecations(callable $callback): array
-    {
-        $deprecations = [];
-
-        set_error_handler(static function (int $severity, string $message) use (&$deprecations): bool {
-            if ($severity !== \E_USER_DEPRECATED) {
-                return false;
-            }
-
-            $deprecations[] = $message;
-
-            return true;
-        });
-
-        try {
-            $callback();
-        } finally {
-            restore_error_handler();
-        }
-
-        return $deprecations;
     }
 }

--- a/tests/Exception/ClientExceptionTest.php
+++ b/tests/Exception/ClientExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\ClientException
+ */
+class ClientExceptionTest extends TestCase
+{
+    public function testHasRequestAndResponse()
+    {
+        $req = new Request('GET', '/');
+        $res = new Response(404);
+        $prev = new \Exception();
+        $e = new ClientException('foo', $req, $res, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(BadResponseException::class, $e);
+        self::assertInstanceOf(ResponseException::class, $e);
+        self::assertInstanceOf(RequestException::class, $e);
+        self::assertInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
+        self::assertSame($res, $e->getResponse());
+        self::assertSame(404, $e->getCode());
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\InvalidArgumentException
+ */
+class InvalidArgumentExceptionTest extends TestCase
+{
+    public function testIsGuzzleException()
+    {
+        $prev = new \Exception();
+        $e = new InvalidArgumentException('foo', 123, $prev);
+
+        self::assertInstanceOf(\InvalidArgumentException::class, $e);
+        self::assertInstanceOf(GuzzleException::class, $e);
+        self::assertInstanceOf(ClientExceptionInterface::class, $e);
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame(123, $e->getCode());
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/NetworkExceptionTest.php
+++ b/tests/Exception/NetworkExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\NetworkException
+ */
+class NetworkExceptionTest extends TestCase
+{
+    public function testHasRequest()
+    {
+        $req = new Request('GET', '/');
+        $prev = new \Exception();
+        $e = new NetworkException('foo', $req, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(TransferException::class, $e);
+        self::assertInstanceOf(GuzzleException::class, $e);
+        self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+        self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -28,35 +28,7 @@ class RequestExceptionTest extends TestCase
         self::assertSame('foo', $e->getMessage());
     }
 
-    public function testGetResponseIsDeprecated()
-    {
-        $req = new Request('GET', '/');
-        $res = new Response(200);
-        $e = new RequestException('foo', $req, $res);
-
-        $deprecations = self::captureDeprecations(static function () use ($e, $res): void {
-            self::assertSame($res, $e->getResponse());
-        });
-
-        self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\RequestException::getResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException and GuzzleHttp\\Exception\\ResponseException::getResponse() instead.',
-        ], $deprecations);
-    }
-
-    public function testHasResponseIsDeprecated()
-    {
-        $e = new RequestException('foo', new Request('GET', '/'), new Response(200));
-
-        $deprecations = self::captureDeprecations(static function () use ($e): void {
-            self::assertTrue($e->hasResponse());
-        });
-
-        self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\RequestException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
-        ], $deprecations);
-    }
-
-    public function testCreatesGenerateException()
+    public function testCreatesGenericException()
     {
         $e = RequestException::create(new Request('GET', '/'));
         self::assertSame('Error completing request', $e->getMessage());
@@ -164,39 +136,6 @@ class RequestExceptionTest extends TestCase
         self::assertSame(442, $e->getCode());
     }
 
-    public function testWrapsRequestExceptions()
-    {
-        $e = new \Exception('foo');
-        $r = new Request('GET', 'http://www.oo.com');
-        $ex = null;
-
-        $deprecations = self::captureDeprecations(static function () use ($r, $e, &$ex): void {
-            $ex = RequestException::wrapException($r, $e);
-        });
-
-        self::assertInstanceOf(RequestException::class, $ex);
-        self::assertSame($e, $ex->getPrevious());
-        self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\RequestException::wrapException() is deprecated and will be removed in 8.0. Create a GuzzleHttp\\Exception\\RequestException or GuzzleHttp\\Exception\\ResponseException directly instead.',
-        ], $deprecations);
-    }
-
-    public function testDoesNotWrapExistingRequestExceptions()
-    {
-        $r = new Request('GET', 'http://www.oo.com');
-        $e = new RequestException('foo', $r);
-        $e2 = null;
-
-        $deprecations = self::captureDeprecations(static function () use ($r, $e, &$e2): void {
-            $e2 = RequestException::wrapException($r, $e);
-        });
-
-        self::assertSame($e, $e2);
-        self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\RequestException::wrapException() is deprecated and will be removed in 8.0. Create a GuzzleHttp\\Exception\\RequestException or GuzzleHttp\\Exception\\ResponseException directly instead.',
-        ], $deprecations);
-    }
-
     public function testCanProvideHandlerContext()
     {
         $r = new Request('GET', 'http://www.oo.com');
@@ -216,29 +155,6 @@ class RequestExceptionTest extends TestCase
         $r = new Request('GET', 'http://user:password@www.oo.com');
         $e = RequestException::create($r, new Response(500));
         self::assertStringContainsString('http://user:***@www.oo.com', $e->getMessage());
-    }
-
-    private static function captureDeprecations(callable $callback): array
-    {
-        $deprecations = [];
-
-        set_error_handler(static function (int $severity, string $message) use (&$deprecations): bool {
-            if ($severity !== \E_USER_DEPRECATED) {
-                return false;
-            }
-
-            $deprecations[] = $message;
-
-            return true;
-        });
-
-        try {
-            $callback();
-        } finally {
-            restore_error_handler();
-        }
-
-        return $deprecations;
     }
 }
 

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests\Exception;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -17,17 +18,42 @@ use Psr\Http\Client\RequestExceptionInterface;
  */
 class RequestExceptionTest extends TestCase
 {
-    public function testHasRequestAndResponse()
+    public function testHasRequest()
+    {
+        $req = new Request('GET', '/');
+        $e = new RequestException('foo', $req);
+        self::assertInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
+        self::assertSame('foo', $e->getMessage());
+    }
+
+    public function testGetResponseIsDeprecated()
     {
         $req = new Request('GET', '/');
         $res = new Response(200);
         $e = new RequestException('foo', $req, $res);
-        self::assertInstanceOf(RequestExceptionInterface::class, $e);
-        self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
-        self::assertSame($req, $e->getRequest());
-        self::assertSame($res, $e->getResponse());
-        self::assertTrue($e->hasResponse());
-        self::assertSame('foo', $e->getMessage());
+
+        $deprecations = self::captureDeprecations(static function () use ($e, $res): void {
+            self::assertSame($res, $e->getResponse());
+        });
+
+        self::assertSame([
+            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\RequestException::getResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException and GuzzleHttp\\Exception\\ResponseException::getResponse() instead.',
+        ], $deprecations);
+    }
+
+    public function testHasResponseIsDeprecated()
+    {
+        $e = new RequestException('foo', new Request('GET', '/'), new Response(200));
+
+        $deprecations = self::captureDeprecations(static function () use ($e): void {
+            self::assertTrue($e->hasResponse());
+        });
+
+        self::assertSame([
+            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\RequestException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
+        ], $deprecations);
     }
 
     public function testCreatesGenerateException()
@@ -76,7 +102,7 @@ class RequestExceptionTest extends TestCase
             '300 ',
             $e->getMessage()
         );
-        self::assertInstanceOf(RequestException::class, $e);
+        self::assertInstanceOf(ResponseException::class, $e);
     }
 
     public function testThrowsInvalidArgumentExceptionOnOutOfBoundsResponseCode()
@@ -142,17 +168,33 @@ class RequestExceptionTest extends TestCase
     {
         $e = new \Exception('foo');
         $r = new Request('GET', 'http://www.oo.com');
-        $ex = RequestException::wrapException($r, $e);
+        $ex = null;
+
+        $deprecations = self::captureDeprecations(static function () use ($r, $e, &$ex): void {
+            $ex = RequestException::wrapException($r, $e);
+        });
+
         self::assertInstanceOf(RequestException::class, $ex);
         self::assertSame($e, $ex->getPrevious());
+        self::assertSame([
+            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\RequestException::wrapException() is deprecated and will be removed in 8.0. Create a GuzzleHttp\\Exception\\RequestException or GuzzleHttp\\Exception\\ResponseException directly instead.',
+        ], $deprecations);
     }
 
     public function testDoesNotWrapExistingRequestExceptions()
     {
         $r = new Request('GET', 'http://www.oo.com');
         $e = new RequestException('foo', $r);
-        $e2 = RequestException::wrapException($r, $e);
+        $e2 = null;
+
+        $deprecations = self::captureDeprecations(static function () use ($r, $e, &$e2): void {
+            $e2 = RequestException::wrapException($r, $e);
+        });
+
         self::assertSame($e, $e2);
+        self::assertSame([
+            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\RequestException::wrapException() is deprecated and will be removed in 8.0. Create a GuzzleHttp\\Exception\\RequestException or GuzzleHttp\\Exception\\ResponseException directly instead.',
+        ], $deprecations);
     }
 
     public function testCanProvideHandlerContext()
@@ -174,6 +216,29 @@ class RequestExceptionTest extends TestCase
         $r = new Request('GET', 'http://user:password@www.oo.com');
         $e = RequestException::create($r, new Response(500));
         self::assertStringContainsString('http://user:***@www.oo.com', $e->getMessage());
+    }
+
+    private static function captureDeprecations(callable $callback): array
+    {
+        $deprecations = [];
+
+        set_error_handler(static function (int $severity, string $message) use (&$deprecations): bool {
+            if ($severity !== \E_USER_DEPRECATED) {
+                return false;
+            }
+
+            $deprecations[] = $message;
+
+            return true;
+        });
+
+        try {
+            $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $deprecations;
     }
 }
 

--- a/tests/Exception/ResponseExceptionTest.php
+++ b/tests/Exception/ResponseExceptionTest.php
@@ -2,40 +2,46 @@
 
 namespace GuzzleHttp\Tests\Exception;
 
-use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
 
 /**
- * @covers \GuzzleHttp\Exception\BadResponseException
+ * @covers \GuzzleHttp\Exception\ResponseException
  */
-class BadResponseExceptionTest extends TestCase
+class ResponseExceptionTest extends TestCase
 {
-    public function testHasResponse()
+    public function testHasRequestAndResponse()
     {
         $req = new Request('GET', '/');
+        $res = new Response(200);
         $prev = new \Exception();
-        $response = new Response();
-        $e = new BadResponseException('foo', $req, $response, $prev);
-        self::assertInstanceOf(ResponseException::class, $e);
+        $e = new ResponseException('foo', $req, $res, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(RequestException::class, $e);
+        self::assertInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         self::assertSame($req, $e->getRequest());
-        self::assertSame($response, $e->getResponse());
+        self::assertSame($res, $e->getResponse());
         self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
     }
 
     public function testHasResponseIsDeprecated()
     {
-        $e = new BadResponseException('foo', new Request('GET', '/'), new Response());
+        $e = new ResponseException('foo', new Request('GET', '/'), new Response(200));
 
         $deprecations = self::captureDeprecations(static function () use ($e): void {
             self::assertTrue($e->hasResponse());
         });
 
         self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\BadResponseException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
+            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\ResponseException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
         ], $deprecations);
     }
 

--- a/tests/Exception/ResponseExceptionTest.php
+++ b/tests/Exception/ResponseExceptionTest.php
@@ -31,40 +31,4 @@ class ResponseExceptionTest extends TestCase
         self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
     }
-
-    public function testHasResponseIsDeprecated()
-    {
-        $e = new ResponseException('foo', new Request('GET', '/'), new Response(200));
-
-        $deprecations = self::captureDeprecations(static function () use ($e): void {
-            self::assertTrue($e->hasResponse());
-        });
-
-        self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\ResponseException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
-        ], $deprecations);
-    }
-
-    private static function captureDeprecations(callable $callback): array
-    {
-        $deprecations = [];
-
-        set_error_handler(static function (int $severity, string $message) use (&$deprecations): bool {
-            if ($severity !== \E_USER_DEPRECATED) {
-                return false;
-            }
-
-            $deprecations[] = $message;
-
-            return true;
-        });
-
-        try {
-            $callback();
-        } finally {
-            restore_error_handler();
-        }
-
-        return $deprecations;
-    }
 }

--- a/tests/Exception/ServerExceptionTest.php
+++ b/tests/Exception/ServerExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\ServerException
+ */
+class ServerExceptionTest extends TestCase
+{
+    public function testHasRequestAndResponse()
+    {
+        $req = new Request('GET', '/');
+        $res = new Response(500);
+        $prev = new \Exception();
+        $e = new ServerException('foo', $req, $res, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(BadResponseException::class, $e);
+        self::assertInstanceOf(ResponseException::class, $e);
+        self::assertInstanceOf(RequestException::class, $e);
+        self::assertInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
+        self::assertSame($res, $e->getResponse());
+        self::assertSame(500, $e->getCode());
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/TooManyRedirectsExceptionTest.php
+++ b/tests/Exception/TooManyRedirectsExceptionTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class TooManyRedirectsExceptionTest extends TestCase
 {
-    public function testHasResponse()
+    public function testHasRequestAndResponse()
     {
         $req = new Request('GET', '/');
         $res = new Response(302);
@@ -28,41 +28,5 @@ class TooManyRedirectsExceptionTest extends TestCase
         self::assertSame('foo', $e->getMessage());
         self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
-    }
-
-    public function testHasResponseIsDeprecated()
-    {
-        $e = new TooManyRedirectsException('foo', new Request('GET', '/'), new Response(302));
-
-        $deprecations = self::captureDeprecations(static function () use ($e): void {
-            self::assertTrue($e->hasResponse());
-        });
-
-        self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\TooManyRedirectsException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
-        ], $deprecations);
-    }
-
-    private static function captureDeprecations(callable $callback): array
-    {
-        $deprecations = [];
-
-        set_error_handler(static function (int $severity, string $message) use (&$deprecations): bool {
-            if ($severity !== \E_USER_DEPRECATED) {
-                return false;
-            }
-
-            $deprecations[] = $message;
-
-            return true;
-        });
-
-        try {
-            $callback();
-        } finally {
-            restore_error_handler();
-        }
-
-        return $deprecations;
     }
 }

--- a/tests/Exception/TooManyRedirectsExceptionTest.php
+++ b/tests/Exception/TooManyRedirectsExceptionTest.php
@@ -2,40 +2,44 @@
 
 namespace GuzzleHttp\Tests\Exception;
 
-use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \GuzzleHttp\Exception\BadResponseException
+ * @covers \GuzzleHttp\Exception\TooManyRedirectsException
  */
-class BadResponseExceptionTest extends TestCase
+class TooManyRedirectsExceptionTest extends TestCase
 {
     public function testHasResponse()
     {
         $req = new Request('GET', '/');
+        $res = new Response(302);
         $prev = new \Exception();
-        $response = new Response();
-        $e = new BadResponseException('foo', $req, $response, $prev);
-        self::assertInstanceOf(ResponseException::class, $e);
+        $e = new TooManyRedirectsException('foo', $req, $res, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(RequestException::class, $e);
+        self::assertNotInstanceOf(ResponseException::class, $e);
         self::assertSame($req, $e->getRequest());
-        self::assertSame($response, $e->getResponse());
+        self::assertSame($res, $e->getResponse());
         self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
     }
 
     public function testHasResponseIsDeprecated()
     {
-        $e = new BadResponseException('foo', new Request('GET', '/'), new Response());
+        $e = new TooManyRedirectsException('foo', new Request('GET', '/'), new Response(302));
 
         $deprecations = self::captureDeprecations(static function () use ($e): void {
             self::assertTrue($e->hasResponse());
         });
 
         self::assertSame([
-            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\BadResponseException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
+            'Since guzzlehttp/guzzle 7.11: GuzzleHttp\\Exception\\TooManyRedirectsException::hasResponse() is deprecated and will be removed in 8.0. Use instanceof GuzzleHttp\\Exception\\ResponseException instead.',
         ], $deprecations);
     }
 

--- a/tests/Exception/TransferExceptionTest.php
+++ b/tests/Exception/TransferExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\TransferException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\TransferException
+ */
+class TransferExceptionTest extends TestCase
+{
+    public function testIsGuzzleException()
+    {
+        $prev = new \Exception();
+        $e = new TransferException('foo', 123, $prev);
+
+        self::assertInstanceOf(\RuntimeException::class, $e);
+        self::assertInstanceOf(GuzzleException::class, $e);
+        self::assertInstanceOf(ClientExceptionInterface::class, $e);
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame(123, $e->getCode());
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Handler;
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlShare;
@@ -1025,6 +1026,31 @@ class CurlFactoryTest extends TestCase
         $response->wait();
     }
 
+    public function testCreatesResponseExceptionForCurlErrorWithResponse()
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $response = new Psr7\Response(200);
+        $easy = $factory->create($request, []);
+        $easy->errno = \CURLE_WRITE_ERROR;
+        $easy->response = $response;
+        $promise = CurlFactory::finish(
+            static function () {
+            },
+            $easy,
+            $factory
+        );
+
+        try {
+            $promise->wait();
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($response, $e->getResponse());
+            self::assertSame(\CURLE_WRITE_ERROR, $e->getHandlerContext()['errno']);
+        }
+    }
+
     public function testAddsTimeouts()
     {
         $f = new CurlFactory(3);
@@ -1107,8 +1133,7 @@ class CurlFactoryTest extends TestCase
                 $e->getMessage()
             );
             self::assertFalse($called);
-            self::assertFalse($e->hasResponse());
-            self::assertNull($e->getResponse());
+            self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
         }
     }
@@ -1138,8 +1163,7 @@ class CurlFactoryTest extends TestCase
                 'An error was encountered while creating the response',
                 $e->getMessage()
             );
-            self::assertFalse($e->hasResponse());
-            self::assertNull($e->getResponse());
+            self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertSame($easy->createResponseException, $e->getPrevious());
         }
     }
@@ -1167,7 +1191,7 @@ class CurlFactoryTest extends TestCase
             },
         ]);
 
-        $this->expectException(RequestException::class);
+        $this->expectException(ResponseException::class);
         $this->expectExceptionMessage('An error was encountered during the on_headers event');
         $promise->wait();
     }
@@ -1188,12 +1212,13 @@ class CurlFactoryTest extends TestCase
 
         try {
             $promise->wait();
-            self::fail('Expected RequestException');
-        } catch (RequestException $e) {
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
             self::assertStringContainsString(
                 'An error was encountered during the on_headers event',
                 $e->getMessage()
             );
+            self::assertSame(200, $e->getResponse()->getStatusCode());
             self::assertInstanceOf(\Error::class, $e->getPrevious());
         }
     }
@@ -1375,8 +1400,7 @@ class CurlFactoryTest extends TestCase
                 'An error was encountered while creating the response',
                 $e->getMessage()
             );
-            self::assertFalse($e->hasResponse());
-            self::assertNull($e->getResponse());
+            self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
         }
     }

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -3,7 +3,7 @@
 namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -154,7 +154,7 @@ class MockHandlerTest extends TestCase
             },
         ]);
 
-        $this->expectException(RequestException::class);
+        $this->expectException(ResponseException::class);
         $this->expectExceptionMessage('An error was encountered during the on_headers event');
         $promise->wait();
     }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Handler\CurlShare;
 use GuzzleHttp\Handler\StreamHandler;
 use GuzzleHttp\Psr7;
@@ -859,7 +860,7 @@ class StreamHandlerTest extends TestCase
             },
         ]);
 
-        $this->expectException(RequestException::class);
+        $this->expectException(ResponseException::class);
         $this->expectExceptionMessage('An error was encountered during the on_headers event');
         $promise->wait();
     }
@@ -880,12 +881,13 @@ class StreamHandlerTest extends TestCase
 
         try {
             $promise->wait();
-            self::fail('Expected RequestException');
-        } catch (RequestException $e) {
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
             self::assertStringContainsString(
                 'An error was encountered during the on_headers event',
                 $e->getMessage()
             );
+            self::assertSame(200, $e->getResponse()->getStatusCode());
             self::assertInstanceOf(\Error::class, $e->getPrevious());
         }
     }
@@ -1103,8 +1105,7 @@ class StreamHandlerTest extends TestCase
                 $e->getMessage()
             );
             self::assertFalse($called);
-            self::assertFalse($e->hasResponse());
-            self::assertNull($e->getResponse());
+            self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertInstanceOf(\InvalidArgumentException::class, $e->getPrevious());
             self::assertInstanceOf(TransferStats::class, $stats);
             self::assertFalse($stats->hasResponse());

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -2,7 +2,7 @@
 
 namespace GuzzleHttp\Tests;
 
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -52,7 +52,7 @@ class MessageFormatterTest extends TestCase
     {
         $request = new Request('PUT', '/', ['x-test' => 'abc'], Psr7\Utils::streamFor('foo'));
         $response = new Response(200, ['X-Baz' => 'Bar'], Psr7\Utils::streamFor('baz'));
-        $err = new RequestException('Test', $request, $response);
+        $err = new ResponseException('Test', $request, $response);
 
         return [
             ['{request}', [$request], Psr7\Message::toString($request)],

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -5,6 +5,7 @@ namespace GuzzleHttp\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -215,8 +216,7 @@ class PoolTest extends TestCase
 
         foreach ($rejected as $reason) {
             self::assertInstanceOf(RequestException::class, $reason);
-            self::assertFalse($reason->hasResponse());
-            self::assertNull($reason->getResponse());
+            self::assertNotInstanceOf(ResponseException::class, $reason);
         }
     }
 


### PR DESCRIPTION
This adds ResponseException as the response-aware request exception base. BadResponseException now extends it, generic response-present request failures use it, and legacy response probing on RequestException is deprecated ahead of Guzzle 8. The existing TooManyRedirectsException response behavior is preserved on 7.11 without moving it under ResponseException yet, so userland construction remains compatible for this release line.