### PR TITLE
Cover exception classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated scalar-coerced `idn_conversion` request option values, which will be rejected in 8.0
 - Deprecated invalid documented request option value types, which will be rejected in 8.0
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
+- Deprecated `RequestException::wrapException()`, which will be removed in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 
 

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -45,9 +45,13 @@ class RequestException extends TransferException implements RequestExceptionInte
 
     /**
      * Wrap non-RequestExceptions with a RequestException
+     *
+     * @deprecated since 7.11. Create a RequestException directly instead.
      */
     public static function wrapException(RequestInterface $request, \Throwable $e): RequestException
     {
+        \trigger_deprecation('guzzlehttp/guzzle', '7.11', '%s::wrapException() is deprecated and will be removed in 8.0. Create a %s directly instead.', self::class, self::class);
+
         return $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, null, $e);
     }
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -92,7 +92,7 @@ class StreamHandler
             ) {
                 $e = new ConnectException($e->getMessage(), $request, $e);
             } else {
-                $e = RequestException::wrapException($request, $e);
+                $e = $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, null, $e);
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
 

--- a/tests/Exception/ClientExceptionTest.php
+++ b/tests/Exception/ClientExceptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\ClientException
+ */
+class ClientExceptionTest extends TestCase
+{
+    public function testHasRequestAndResponse()
+    {
+        $req = new Request('GET', '/');
+        $res = new Response(404);
+        $prev = new \Exception();
+        $e = new ClientException('foo', $req, $res, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(BadResponseException::class, $e);
+        self::assertInstanceOf(RequestException::class, $e);
+        self::assertInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
+        self::assertSame($res, $e->getResponse());
+        self::assertTrue($e->hasResponse());
+        self::assertSame(404, $e->getCode());
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\InvalidArgumentException
+ */
+class InvalidArgumentExceptionTest extends TestCase
+{
+    public function testIsGuzzleException()
+    {
+        $prev = new \Exception();
+        $e = new InvalidArgumentException('foo', 123, $prev);
+
+        self::assertInstanceOf(\InvalidArgumentException::class, $e);
+        self::assertInstanceOf(GuzzleException::class, $e);
+        self::assertInstanceOf(ClientExceptionInterface::class, $e);
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame(123, $e->getCode());
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/NetworkExceptionTest.php
+++ b/tests/Exception/NetworkExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\NetworkException
+ */
+class NetworkExceptionTest extends TestCase
+{
+    public function testHasRequest()
+    {
+        $req = new Request('GET', '/');
+        $prev = new \Exception();
+        $e = new NetworkException('foo', $req, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(TransferException::class, $e);
+        self::assertInstanceOf(GuzzleException::class, $e);
+        self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+        self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -138,23 +138,6 @@ class RequestExceptionTest extends TestCase
         self::assertSame(442, $e->getCode());
     }
 
-    public function testWrapsRequestExceptions()
-    {
-        $e = new \Exception('foo');
-        $r = new Request('GET', 'http://www.oo.com');
-        $ex = RequestException::wrapException($r, $e);
-        self::assertInstanceOf(RequestException::class, $ex);
-        self::assertSame($e, $ex->getPrevious());
-    }
-
-    public function testDoesNotWrapExistingRequestExceptions()
-    {
-        $r = new Request('GET', 'http://www.oo.com');
-        $e = new RequestException('foo', $r);
-        $e2 = RequestException::wrapException($r, $e);
-        self::assertSame($e, $e2);
-    }
-
     public function testCanProvideHandlerContext()
     {
         $r = new Request('GET', 'http://www.oo.com');

--- a/tests/Exception/ServerExceptionTest.php
+++ b/tests/Exception/ServerExceptionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\ServerException
+ */
+class ServerExceptionTest extends TestCase
+{
+    public function testHasRequestAndResponse()
+    {
+        $req = new Request('GET', '/');
+        $res = new Response(500);
+        $prev = new \Exception();
+        $e = new ServerException('foo', $req, $res, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(BadResponseException::class, $e);
+        self::assertInstanceOf(RequestException::class, $e);
+        self::assertInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
+        self::assertSame($res, $e->getResponse());
+        self::assertTrue($e->hasResponse());
+        self::assertSame(500, $e->getCode());
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/TooManyRedirectsExceptionTest.php
+++ b/tests/Exception/TooManyRedirectsExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\TooManyRedirectsException
+ */
+class TooManyRedirectsExceptionTest extends TestCase
+{
+    public function testHasRequestAndResponse()
+    {
+        $req = new Request('GET', '/');
+        $res = new Response(302);
+        $prev = new \Exception();
+        $e = new TooManyRedirectsException('foo', $req, $res, $prev, ['foo' => 'bar']);
+
+        self::assertInstanceOf(RequestException::class, $e);
+        self::assertInstanceOf(RequestExceptionInterface::class, $e);
+        self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
+        self::assertSame($res, $e->getResponse());
+        self::assertTrue($e->hasResponse());
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame('bar', $e->getHandlerContext()['foo']);
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/tests/Exception/TransferExceptionTest.php
+++ b/tests/Exception/TransferExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GuzzleHttp\Tests\Exception;
+
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\TransferException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * @covers \GuzzleHttp\Exception\TransferException
+ */
+class TransferExceptionTest extends TestCase
+{
+    public function testIsGuzzleException()
+    {
+        $prev = new \Exception();
+        $e = new TransferException('foo', 123, $prev);
+
+        self::assertInstanceOf(\RuntimeException::class, $e);
+        self::assertInstanceOf(GuzzleException::class, $e);
+        self::assertInstanceOf(ClientExceptionInterface::class, $e);
+        self::assertSame('foo', $e->getMessage());
+        self::assertSame(123, $e->getCode());
+        self::assertSame($prev, $e->getPrevious());
+    }
+}


### PR DESCRIPTION
This adds direct coverage for the remaining concrete exception classes so the hierarchy and shared request, response, network, and handler context behavior are documented by tests. It also deprecates RequestException::wrapException() ahead of 8.0 and stops the stream handler from calling it internally, keeping the deprecation focused on userland usage.