### PR TITLE
Classify stream connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Defer cURL multi cancellation cleanup until after progress callbacks return.
+- Classify additional stream handler connection failures as `ConnectException`.
 
 
 ## 7.10.4 - 2025-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Fixed
 
-- Defer cURL multi cancellation cleanup until after progress callbacks return.
-- Classify additional stream handler connection failures as `ConnectException`.
+- Defer cURL multi cancellation cleanup until after progress callbacks return
+- Classify additional stream handler connection failures as `ConnectException`
 
 
 ## 7.10.4 - 2025-05-22

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -80,12 +80,33 @@ class StreamHandler
         } catch (\Exception $e) {
             // Determine if the error was a networking error.
             $message = $e->getMessage();
-            // This list can probably get more comprehensive.
-            if (false !== \strpos($message, 'getaddrinfo') // DNS lookup failed
-                || false !== \strpos($message, 'Connection refused')
-                || false !== \strpos($message, "couldn't connect to host") // error on HHVM
-                || false !== \strpos($message, 'connection attempt failed')
-            ) {
+            static $connectionErrors = [
+                'php_network_getaddresses:',
+                'getaddrinfo',
+                'gethostbyname failed',
+                'Connection refused',
+                'No connection could be made because the target machine actively refused it',
+                "couldn't connect to host", // error on HHVM
+                'connection attempt failed',
+                'connect() failed',
+                'Connection timed out',
+                'Operation timed out',
+                'Network is unreachable',
+                'No route to host',
+                'Host is unreachable',
+                'Host is down',
+                'Cannot connect to HTTPS server through proxy',
+            ];
+
+            $isConnectionError = false;
+            foreach ($connectionErrors as $connectionError) {
+                if (false !== \strpos($message, $connectionError)) {
+                    $isConnectionError = true;
+                    break;
+                }
+            }
+
+            if ($isConnectionError) {
                 $e = new ConnectException($e->getMessage(), $request, $e);
             } else {
                 $e = RequestException::wrapException($request, $e);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -79,34 +79,7 @@ class StreamHandler
             throw $e;
         } catch (\Exception $e) {
             // Determine if the error was a networking error.
-            $message = $e->getMessage();
-            static $connectionErrors = [
-                'php_network_getaddresses:',
-                'getaddrinfo',
-                'gethostbyname failed',
-                'Connection refused',
-                'No connection could be made because the target machine actively refused it',
-                "couldn't connect to host", // error on HHVM
-                'connection attempt failed',
-                'connect() failed',
-                'Connection timed out',
-                'Operation timed out',
-                'Network is unreachable',
-                'No route to host',
-                'Host is unreachable',
-                'Host is down',
-                'Cannot connect to HTTPS server through proxy',
-            ];
-
-            $isConnectionError = false;
-            foreach ($connectionErrors as $connectionError) {
-                if (false !== \strpos($message, $connectionError)) {
-                    $isConnectionError = true;
-                    break;
-                }
-            }
-
-            if ($isConnectionError) {
+            if (self::isConnectionError($e->getMessage())) {
                 $e = new ConnectException($e->getMessage(), $request, $e);
             } else {
                 $e = RequestException::wrapException($request, $e);
@@ -115,6 +88,35 @@ class StreamHandler
 
             return P\Create::rejectionFor($e);
         }
+    }
+
+    private static function isConnectionError(string $message): bool
+    {
+        static $connectionErrors = [
+            'php_network_getaddresses:',
+            'getaddrinfo',
+            'gethostbyname failed',
+            'Connection refused',
+            'No connection could be made because the target machine actively refused it',
+            "couldn't connect to host", // error on HHVM
+            'connection attempt failed',
+            'connect() failed',
+            'Connection timed out',
+            'Operation timed out',
+            'Network is unreachable',
+            'No route to host',
+            'Host is unreachable',
+            'Host is down',
+            'Cannot connect to HTTPS server through proxy',
+        ];
+
+        foreach ($connectionErrors as $connectionError) {
+            if (false !== \strpos($message, $connectionError)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function invokeStats(

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -22,6 +22,24 @@ use Psr\Http\Message\UriInterface;
  */
 class StreamHandler
 {
+    private const CONNECTION_ERRORS = [
+        'php_network_getaddresses:',
+        'getaddrinfo',
+        'gethostbyname failed',
+        'Connection refused',
+        'No connection could be made because the target machine actively refused it',
+        "couldn't connect to host", // error on HHVM
+        'connection attempt failed',
+        'connect() failed',
+        'Connection timed out',
+        'Operation timed out',
+        'Network is unreachable',
+        'No route to host',
+        'Host is unreachable',
+        'Host is down',
+        'Cannot connect to HTTPS server through proxy',
+    ];
+
     /**
      * @var array
      */
@@ -92,25 +110,7 @@ class StreamHandler
 
     private static function isConnectionError(string $message): bool
     {
-        static $connectionErrors = [
-            'php_network_getaddresses:',
-            'getaddrinfo',
-            'gethostbyname failed',
-            'Connection refused',
-            'No connection could be made because the target machine actively refused it',
-            "couldn't connect to host", // error on HHVM
-            'connection attempt failed',
-            'connect() failed',
-            'Connection timed out',
-            'Operation timed out',
-            'Network is unreachable',
-            'No route to host',
-            'Host is unreachable',
-            'Host is down',
-            'Cannot connect to HTTPS server through proxy',
-        ];
-
-        foreach ($connectionErrors as $connectionError) {
+        foreach (self::CONNECTION_ERRORS as $connectionError) {
             if (false !== \strpos($message, $connectionError)) {
                 return true;
             }


### PR DESCRIPTION
This classifies additional PHP stream connection setup failures as ConnectException. The added messages cover DNS, socket, timeout, unreachable host, Windows refusal, and HTTPS proxy failures observed in php-src.