### PR TITLE
Classify stream TLS connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Validate built-in handler timeout options before applying them
 - Classify empty, malformed, or handler-unsupported request protocol versions as request exceptions
 - Classify additional cURL transport failures without a response as network exceptions
+- Classify additional stream handler transport failures as `ConnectException`
 - Classify generic response-aware request failures as `ResponseException`
 - Throw `NetworkTimeoutException` for reliably detected no-response transfer timeouts
 - Throw `ResponseTimeoutException` for reliably detected response-aware transfer timeouts

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -192,8 +192,14 @@ The existing always-network cURL errors, including
 `CURLE_SSL_CONNECT_ERROR`, and `CURLE_GOT_NOTHING`, still throw
 `ConnectException`.
 
-For example, code that previously treated `RequestException` as the only cURL
-transport failure type should add network-specific handling:
+The built-in stream handler now classifies additional connection setup, early
+connection close, and TLS handshake or protocol failures as `ConnectException`.
+If you previously caught only `RequestException` for these stream handler
+failures, catch `NetworkException`, `NetworkExceptionInterface`,
+`TransferException`, or `GuzzleException` instead.
+
+For example, code that previously treated `RequestException` as the only built-in
+handler transport failure type should add network-specific handling:
 
 ```php
 use GuzzleHttp\Exception\NetworkException;
@@ -206,7 +212,7 @@ try {
     $errno = $e->getHandlerContext()['errno'] ?? null;
 
     // Network failures without an HTTP response, including the reclassified
-    // built-in cURL transport errors.
+    // built-in handler transport errors.
 } catch (ResponseException $e) {
     $response = $e->getResponse();
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -31,7 +31,6 @@ final class StreamHandler
         'gethostbyname failed',
         'Connection refused',
         'No connection could be made because the target machine actively refused it',
-        "couldn't connect to host", // error on HHVM
         'connection attempt failed',
         'connect() failed',
         'Connection timed out',
@@ -40,7 +39,11 @@ final class StreamHandler
         'No route to host',
         'Host is unreachable',
         'Host is down',
+        'Connection reset by peer',
         'Cannot connect to HTTPS server through proxy',
+        'SSL: Handshake timed out',
+        'SSL operation failed',
+        'SSL: fatal protocol error',
     ];
 
     private array $lastHeaders = [];


### PR DESCRIPTION
This classifies additional PHP stream early-close and TLS connection failures as ConnectException. It also removes the legacy HHVM-specific stream error match.