### PR TITLE
Document Guzzle 7 exception hierarchy changes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,19 +83,19 @@ async variants continue to use uppercase standard methods.
 
 #### Exception hierarchy and classification
 
-Some Guzzle 8 exception changes add intermediate classes, while others
+Some Guzzle 8.0 exception changes add intermediate classes, while others
 intentionally reclassify specific failures. Broad `TransferException` and
 `GuzzleException` catch blocks still catch all Guzzle transfer failures, and
 `RequestException` still catches response-aware and other non-network request
-failures. More specific catch blocks need auditing: Guzzle 8 splits timeout
+failures. More specific catch blocks need auditing: Guzzle 8.0 splits timeout
 failures by whether a response was received, and the built-in cURL and stream
 handlers classify more no-response transport failures as network failures. This
-section covers the Guzzle 7 to Guzzle 8 path. Guzzle 7.0 already moved
-`ConnectException` out from under `RequestException`; see the 6.0 to 7.0 notes
-for that migration. The hierarchy changes are easiest to compare in the three
-trees below.
+section covers upgrading from Guzzle 7.x to Guzzle 8.0. The `ConnectException`
+inheritance change happened earlier, in Guzzle 7.0.0, when it moved out from
+under `RequestException`; see the 6.0 to 7.0 notes for that migration. The
+hierarchy changes are easiest to compare in the three trees below.
 
-Guzzle 7 before 7.11.0 uses this hierarchy:
+Guzzle 7 releases before 7.11.0 use this hierarchy:
 
 ```text
 . \RuntimeException
@@ -108,7 +108,7 @@ Guzzle 7 before 7.11.0 uses this hierarchy:
         └── TooManyRedirectsException
 ```
 
-Guzzle 7 starting with 7.11.0 uses this hierarchy:
+Guzzle 7 releases starting with 7.11.0 use this hierarchy:
 
 ```text
 . \RuntimeException
@@ -122,7 +122,7 @@ Guzzle 7 starting with 7.11.0 uses this hierarchy:
         └── TooManyRedirectsException
 ```
 
-Guzzle 8 uses this hierarchy:
+Guzzle 8.0 uses this hierarchy:
 
 ```text
 . \RuntimeException
@@ -143,39 +143,40 @@ Guzzle 8 uses this hierarchy:
 `NetworkException` was added in Guzzle 7.11.0 as the base class for no-response
 network failures. Before 7.11.0, `ConnectException` implemented
 `Psr\Http\Client\NetworkExceptionInterface` directly and there was no
-Guzzle-specific network base class. Code that must support Guzzle 7 versions
+Guzzle-specific network base class. Code that must support Guzzle 7.x releases
 before 7.11.0 should catch `Psr\Http\Client\NetworkExceptionInterface`,
 `TransferException`, or `GuzzleException`, depending on intent. Code that can
 require Guzzle 7.11.0 or newer may catch `NetworkException`. `ConnectException`
-still extends `NetworkException` in Guzzle 8, so existing 7.11
-`NetworkException`, `TransferException`, and `GuzzleException` catch blocks still
-catch connection failures.
+still extends `NetworkException` in Guzzle 8.0, so catch blocks that target
+`NetworkException`, `TransferException`, or `GuzzleException` in Guzzle 7.11.0
+and newer still catch connection failures.
 
-Guzzle 8 adds the response-aware side of the hierarchy. Guzzle 7.11.0 did not
+Guzzle 8.0 adds the response-aware side of the hierarchy. Guzzle 7.11.0 did not
 add `ResponseException`; response-aware request failures remain under
-`RequestException` throughout Guzzle 7. In Guzzle 8, `ResponseException` is the
-base class for request failures where a response was received, and
+`RequestException` throughout Guzzle 7.x. In Guzzle 8.0, `ResponseException` is
+the base class for request failures where a response was received, and
 `BadResponseException`, `ResponseTimeoutException`, and
 `TooManyRedirectsException` extend it. Use `ResponseException::getResponse()` for
 response-aware exception handling. `RequestException::getResponse()` and
 `RequestException::hasResponse()` are deprecated and will be removed in Guzzle 9;
 check for `ResponseException` before reading a response from an exception.
 
-Timeouts are now split by whether a response was received. `NetworkTimeoutException`
-is thrown when a built-in handler can reliably identify a transfer timeout before
-a response is received. It extends `NetworkException`, but not
-`ConnectException`, so code that caught `ConnectException` for cURL timeouts
-should catch `NetworkException`, `Psr\Http\Client\NetworkExceptionInterface`,
-`TransferException`, or `GuzzleException`, depending on intent.
+Timeouts are now split by whether a response was received.
+`NetworkTimeoutException` is thrown when a built-in handler can reliably identify
+a transfer timeout before a response is received. It extends `NetworkException`,
+but not `ConnectException`, so code that caught `ConnectException` for cURL
+timeouts should catch `NetworkException`,
+`Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
+`GuzzleException`, depending on intent.
 `ResponseTimeoutException` is thrown when a built-in handler can reliably
 identify a transfer timeout after a response is received. It extends
 `ResponseException` and exposes the response, which avoids reporting
 response-aware failures as PSR-18 network exceptions.
 
-`HandlerClosedException` is new in Guzzle 8. It extends `TransferException` and
+`HandlerClosedException` is new in Guzzle 8.0. It extends `TransferException` and
 is used when an explicitly closed `CurlMultiHandler` rejects transfers that are
-still pending, including delayed transfers. Existing Guzzle 7 code should not
-normally see this exception just by upgrading. Guzzle 7 did not have this
+still pending, including delayed transfers. Existing Guzzle 7.x code should not
+normally see this exception just by upgrading. Guzzle 7.x did not have this
 exception or a public cURL handler `close()` method, and destructor cleanup did
 not reject pending promises. If you add deterministic cleanup with
 `CurlMultiHandler::close()`, wait for or cancel outstanding transfers first, or
@@ -184,8 +185,8 @@ may still observe.
 
 The main code to audit is code that used `catch (RequestException $e)` as its
 only catch block for built-in handler transport failures where no response was
-received. Guzzle 8 classifies more response-less cURL and stream handler failures
-as network failures. Catch `NetworkException`,
+received. Guzzle 8.0 classifies more response-less cURL and stream handler
+failures as network failures. Catch `NetworkException`,
 `Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
 `GuzzleException` for those failures. Keep catching `RequestException` for
 response-aware handling, HTTP error responses, redirects, callback failures, and
@@ -194,10 +195,10 @@ request-related failures that are not network failures.
 For the built-in cURL handlers, the affected cURL error classifications are:
 
 - `CURLE_OPERATION_TIMEOUTED` now throws `NetworkTimeoutException` when no
-  response was received. Guzzle 7 threw `ConnectException`.
+  response was received. Guzzle 7.x threw `ConnectException`.
 - `CURLE_OPERATION_TIMEOUTED` now throws `ResponseTimeoutException` when a
-  response was received before the timeout. Guzzle 7 threw `ConnectException`.
-- `CURLE_COULDNT_RESOLVE_PROXY` now throws `ConnectException`. Guzzle 7
+  response was received before the timeout. Guzzle 7.x threw `ConnectException`.
+- `CURLE_COULDNT_RESOLVE_PROXY` now throws `ConnectException`. Guzzle 7.x
   classified this cURL error as `RequestException`.
 - `CURLE_SEND_ERROR` and `CURLE_RECV_ERROR` now throw `ConnectException` when
   no response was created. If a response was created before the error, they

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,14 +83,31 @@ async variants continue to use uppercase standard methods.
 
 #### Exception hierarchy and classification
 
-Except for the cURL transport reclassifications described below, the exception
-hierarchy changes are additive and are almost never breaking. Existing catch
-blocks that target the same failure category still work: `NetworkException` still
-catches no-response network failures, `RequestException` still catches
-response-aware and request-related transfer failures, and `TransferException` or
-`GuzzleException` still catch all Guzzle transfer failures.
+Except for the built-in handler transport reclassifications described below, the
+exception hierarchy changes are additive and are almost never breaking. Existing
+catch blocks that target the same failure category still work: `RequestException`
+still catches response-aware and request-related transfer failures, and
+`TransferException` or `GuzzleException` still catch all Guzzle transfer
+failures.
 
-Guzzle 7.11 transfer exceptions use this hierarchy:
+This section describes the Guzzle 7 to Guzzle 8 path. Guzzle 7.0 already moved
+`ConnectException` out from under `RequestException`; see the 6.0 to 7.0 notes
+for that migration.
+
+Guzzle 7 before 7.11.0 uses this hierarchy:
+
+```text
+. \RuntimeException
+└── TransferException (implements GuzzleException)
+    ├── ConnectException (implements NetworkExceptionInterface)
+    └── RequestException (implements RequestExceptionInterface)
+        ├── BadResponseException
+        │   ├── ServerException
+        │   └── ClientException
+        └── TooManyRedirectsException
+```
+
+Guzzle 7 starting with 7.11.0 uses this hierarchy:
 
 ```text
 . \RuntimeException
@@ -122,17 +139,29 @@ Guzzle 8 uses this hierarchy:
             └── TooManyRedirectsException
 ```
 
-`NetworkException` was added in 7.11 and remains the base class for
-no-response network failures. `ConnectException` still extends
-`NetworkException`, so existing `NetworkException`, `TransferException`, and
-`GuzzleException` catch blocks still catch connection failures.
+`NetworkException` was added in Guzzle 7.11.0 as the base class for
+no-response network failures. Before 7.11.0, `ConnectException` implemented
+`Psr\Http\Client\NetworkExceptionInterface` directly and there was no
+Guzzle-specific network base class.
+
+Code that must support Guzzle 7 versions before 7.11.0 should catch
+`Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
+`GuzzleException`, depending on intent. Code that can require Guzzle 7.11.0 or
+newer may catch `NetworkException`.
+
+`ConnectException` still extends `NetworkException` in Guzzle 8, so existing
+7.11 `NetworkException`, `TransferException`, and `GuzzleException` catch blocks
+still catch connection failures.
+
+Guzzle 7.11.0 did not add `ResponseException`; response-aware request failures
+remain under `RequestException` throughout Guzzle 7.
 
 `NetworkTimeoutException` is new and is thrown when a built-in handler can
 reliably identify a transfer timeout before a response is received. It extends
 `NetworkException`, but not `ConnectException`. Code that caught
 `ConnectException` for cURL timeouts should catch `NetworkException`,
-`NetworkExceptionInterface`, `TransferException`, or `GuzzleException`, depending
-on intent.
+`Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
+`GuzzleException`, depending on intent.
 
 `ResponseException` is new and is the base class for request failures where a
 response was received. Use `ResponseException::getResponse()` for response-aware
@@ -160,11 +189,11 @@ may still observe.
 The main code to audit is code that used `catch (RequestException $e)` as its
 only catch block for cURL transport failures where no response was received.
 Guzzle 8 classifies more response-less built-in cURL failures as network
-failures. Catch `NetworkException`, `NetworkExceptionInterface`,
-`TransferException`, or `GuzzleException` for those failures. Keep catching
-`RequestException` for response-aware handling, HTTP error responses,
-redirects, callback failures, and request-related failures that are not network
-failures.
+failures. Catch `NetworkException`,
+`Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
+`GuzzleException` for those failures. Keep catching `RequestException` for
+response-aware handling, HTTP error responses, redirects, callback failures, and
+request-related failures that are not network failures.
 
 For the built-in cURL handlers, the affected cURL error classifications are:
 
@@ -195,8 +224,9 @@ The existing always-network cURL errors, including
 The built-in stream handler now classifies additional connection setup, early
 connection close, and TLS handshake or protocol failures as `ConnectException`.
 If you previously caught only `RequestException` for these stream handler
-failures, catch `NetworkException`, `NetworkExceptionInterface`,
-`TransferException`, or `GuzzleException` instead.
+failures, catch `NetworkException`,
+`Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
+`GuzzleException` instead.
 
 For example, code that previously treated `RequestException` as the only built-in
 handler transport failure type should add network-specific handling:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,16 +83,17 @@ async variants continue to use uppercase standard methods.
 
 #### Exception hierarchy and classification
 
-Except for the built-in handler transport reclassifications described below, the
-exception hierarchy changes are additive and are almost never breaking. Existing
-catch blocks that target the same failure category still work: `RequestException`
-still catches response-aware and request-related transfer failures, and
-`TransferException` or `GuzzleException` still catch all Guzzle transfer
-failures.
-
-This section describes the Guzzle 7 to Guzzle 8 path. Guzzle 7.0 already moved
+Some Guzzle 8 exception changes add intermediate classes, while others
+intentionally reclassify specific failures. Broad `TransferException` and
+`GuzzleException` catch blocks still catch all Guzzle transfer failures, and
+`RequestException` still catches response-aware and other non-network request
+failures. More specific catch blocks need auditing: Guzzle 8 splits timeout
+failures by whether a response was received, and the built-in cURL and stream
+handlers classify more no-response transport failures as network failures. This
+section covers the Guzzle 7 to Guzzle 8 path. Guzzle 7.0 already moved
 `ConnectException` out from under `RequestException`; see the 6.0 to 7.0 notes
-for that migration.
+for that migration. The hierarchy changes are easiest to compare in the three
+trees below.
 
 Guzzle 7 before 7.11.0 uses this hierarchy:
 
@@ -139,42 +140,37 @@ Guzzle 8 uses this hierarchy:
             └── TooManyRedirectsException
 ```
 
-`NetworkException` was added in Guzzle 7.11.0 as the base class for
-no-response network failures. Before 7.11.0, `ConnectException` implemented
+`NetworkException` was added in Guzzle 7.11.0 as the base class for no-response
+network failures. Before 7.11.0, `ConnectException` implemented
 `Psr\Http\Client\NetworkExceptionInterface` directly and there was no
-Guzzle-specific network base class.
+Guzzle-specific network base class. Code that must support Guzzle 7 versions
+before 7.11.0 should catch `Psr\Http\Client\NetworkExceptionInterface`,
+`TransferException`, or `GuzzleException`, depending on intent. Code that can
+require Guzzle 7.11.0 or newer may catch `NetworkException`. `ConnectException`
+still extends `NetworkException` in Guzzle 8, so existing 7.11
+`NetworkException`, `TransferException`, and `GuzzleException` catch blocks still
+catch connection failures.
 
-Code that must support Guzzle 7 versions before 7.11.0 should catch
-`Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
-`GuzzleException`, depending on intent. Code that can require Guzzle 7.11.0 or
-newer may catch `NetworkException`.
+Guzzle 8 adds the response-aware side of the hierarchy. Guzzle 7.11.0 did not
+add `ResponseException`; response-aware request failures remain under
+`RequestException` throughout Guzzle 7. In Guzzle 8, `ResponseException` is the
+base class for request failures where a response was received, and
+`BadResponseException`, `ResponseTimeoutException`, and
+`TooManyRedirectsException` extend it. Use `ResponseException::getResponse()` for
+response-aware exception handling. `RequestException::getResponse()` and
+`RequestException::hasResponse()` are deprecated and will be removed in Guzzle 9;
+check for `ResponseException` before reading a response from an exception.
 
-`ConnectException` still extends `NetworkException` in Guzzle 8, so existing
-7.11 `NetworkException`, `TransferException`, and `GuzzleException` catch blocks
-still catch connection failures.
-
-Guzzle 7.11.0 did not add `ResponseException`; response-aware request failures
-remain under `RequestException` throughout Guzzle 7.
-
-`NetworkTimeoutException` is new and is thrown when a built-in handler can
-reliably identify a transfer timeout before a response is received. It extends
-`NetworkException`, but not `ConnectException`. Code that caught
-`ConnectException` for cURL timeouts should catch `NetworkException`,
-`Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
-`GuzzleException`, depending on intent.
-
-`ResponseException` is new and is the base class for request failures where a
-response was received. Use `ResponseException::getResponse()` for response-aware
-exception handling.
-
-`ResponseTimeoutException` is new and is thrown when a built-in handler can
-reliably identify a transfer timeout after a response is received. It extends
-`ResponseException` and exposes the response. This avoids reporting
+Timeouts are now split by whether a response was received. `NetworkTimeoutException`
+is thrown when a built-in handler can reliably identify a transfer timeout before
+a response is received. It extends `NetworkException`, but not
+`ConnectException`, so code that caught `ConnectException` for cURL timeouts
+should catch `NetworkException`, `Psr\Http\Client\NetworkExceptionInterface`,
+`TransferException`, or `GuzzleException`, depending on intent.
+`ResponseTimeoutException` is thrown when a built-in handler can reliably
+identify a transfer timeout after a response is received. It extends
+`ResponseException` and exposes the response, which avoids reporting
 response-aware failures as PSR-18 network exceptions.
-
-`RequestException::getResponse()` and `RequestException::hasResponse()` are
-deprecated. Check for `ResponseException` before reading a response from an
-exception. These legacy response probing methods will be removed in Guzzle 9.
 
 `HandlerClosedException` is new in Guzzle 8. It extends `TransferException` and
 is used when an explicitly closed `CurlMultiHandler` rejects transfers that are
@@ -187,9 +183,9 @@ handle `HandlerClosedException` or `TransferException` for pending promises you
 may still observe.
 
 The main code to audit is code that used `catch (RequestException $e)` as its
-only catch block for cURL transport failures where no response was received.
-Guzzle 8 classifies more response-less built-in cURL failures as network
-failures. Catch `NetworkException`,
+only catch block for built-in handler transport failures where no response was
+received. Guzzle 8 classifies more response-less cURL and stream handler failures
+as network failures. Catch `NetworkException`,
 `Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
 `GuzzleException` for those failures. Keep catching `RequestException` for
 response-aware handling, HTTP error responses, redirects, callback failures, and
@@ -219,12 +215,10 @@ For the built-in cURL handlers, the affected cURL error classifications are:
 The existing always-network cURL errors, including
 `CURLE_COULDNT_RESOLVE_HOST`, `CURLE_COULDNT_CONNECT`,
 `CURLE_SSL_CONNECT_ERROR`, and `CURLE_GOT_NOTHING`, still throw
-`ConnectException`.
-
-The built-in stream handler now classifies additional connection setup, early
-connection close, and TLS handshake or protocol failures as `ConnectException`.
-If you previously caught only `RequestException` for these stream handler
-failures, catch `NetworkException`,
+`ConnectException`. The built-in stream handler now classifies additional
+connection setup, early connection close, and TLS handshake or protocol failures
+as `ConnectException`. If you previously caught only `RequestException` for
+these stream handler failures, catch `NetworkException`,
 `Psr\Http\Client\NetworkExceptionInterface`, `TransferException`, or
 `GuzzleException` instead.
 
@@ -253,12 +247,11 @@ try {
 }
 ```
 
-The deprecated `RequestException::wrapException()` method was removed. Create a
-`RequestException` directly instead.
-
-`GuzzleHttp\Exception\InvalidArgumentException` remains outside the transfer
-exception hierarchy and is still used for invalid configuration or request option
-values that can be rejected before a transfer starts.
+The deprecated `RequestException::wrapException()` method was removed; create a
+`RequestException` directly instead. `GuzzleHttp\Exception\InvalidArgumentException`
+remains outside the transfer exception hierarchy and is still used for invalid
+configuration or request option values that can be rejected before a transfer
+starts.
 
 #### Request Protocol Versions
 


### PR DESCRIPTION
This expands the Guzzle 8 upgrade guide's exception hierarchy section to distinguish Guzzle 7 before 7.11.0 from Guzzle 7 starting with 7.11.0. It makes the NetworkException transition explicit, keeps the response-aware hierarchy change scoped to Guzzle 8, and points users who support older Guzzle 7 releases at the PSR-18 network interface or broader Guzzle exception types.