### PR TITLE
Tighten stream connection error classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Validate built-in handler timeout options before applying them
 - Classify empty, malformed, or handler-unsupported request protocol versions as request exceptions
 - Classify additional cURL transport failures without a response as network exceptions
-- Classify additional stream handler transport failures as `ConnectException`
+- Classify stream handler TLS handshake timeouts as `ConnectException`
 - Classify generic response-aware request failures as `ResponseException`
 - Throw `NetworkTimeoutException` for reliably detected no-response transfer timeouts
 - Throw `ResponseTimeoutException` for reliably detected response-aware transfer timeouts

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -238,9 +238,8 @@ The affected built-in cURL classifications are:
 The existing always-network cURL errors, including
 `CURLE_COULDNT_RESOLVE_HOST`, `CURLE_COULDNT_CONNECT`,
 `CURLE_SSL_CONNECT_ERROR`, and `CURLE_GOT_NOTHING`, still throw
-`ConnectException`. The built-in stream handler now classifies additional
-connection setup, early connection close, and TLS handshake or protocol failures
-as `ConnectException`.
+`ConnectException`. The built-in stream handler now classifies TLS handshake
+timeouts as `ConnectException`.
 
 The deprecated `RequestException::wrapException()` method was removed; create a
 `RequestException` directly instead.

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -39,11 +39,8 @@ final class StreamHandler
         'No route to host',
         'Host is unreachable',
         'Host is down',
-        'Connection reset by peer',
         'Cannot connect to HTTPS server through proxy',
         'SSL: Handshake timed out',
-        'SSL operation failed',
-        'SSL: fatal protocol error',
     ];
 
     private array $lastHeaders = [];


### PR DESCRIPTION
This removes generic socket and SSL I/O messages from the stream handler connection error list. The 8.0 stream handler change is limited to TLS handshake timeouts.