### PR TITLE
Clarify HTTP version fallback handling

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,6 +6,12 @@
 2.  To use the PHP stream handler, `allow_url_fopen` must be enabled in your system's php.ini.
 3.  To use the cURL handler, you must have cURL >= 7.34.0 compiled with OpenSSL and zlib.
 
+Optional HTTP protocol support depends on the PHP cURL extension and the
+linked runtime libcurl. HTTP/2 requires libcurl built with HTTP/2 support.
+HTTP/3 requires PHP exposing the HTTP/3 cURL constants, libcurl 7.66.0 or
+higher, and a runtime libcurl built with HTTP/3 and QUIC support. HTTP/3
+support usually requires choosing an HTTP/3 backend when libcurl is built.
+
 ## Installation
 
 The recommended way to install Guzzle is with [Composer](https://getcomposer.org). Composer is a dependency management tool for PHP that allows you to declare the dependencies your project needs and installs them into your project.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,11 +6,12 @@
 2.  To use the PHP stream handler, `allow_url_fopen` must be enabled in your system's php.ini.
 3.  To use the cURL handler, you must have cURL >= 7.34.0 compiled with OpenSSL and zlib.
 
-Optional HTTP protocol support depends on the PHP cURL extension and the
+Support for HTTP/2 and HTTP/3 depends on the PHP cURL extension and the
 linked runtime libcurl. HTTP/2 requires libcurl built with HTTP/2 support.
-HTTP/3 requires PHP exposing the HTTP/3 cURL constants, libcurl 7.66.0 or
-higher, and a runtime libcurl built with HTTP/3 and QUIC support. HTTP/3
-support usually requires choosing an HTTP/3 backend when libcurl is built.
+HTTP/3 requires PHP to expose cURL's HTTP/3 constants, libcurl 7.66.0 or
+higher, and runtime libcurl reporting the `CURL_VERSION_HTTP3` feature. Many
+libcurl builds do not enable HTTP/3 unless an HTTP/3 backend is selected at
+build time.
 
 ## Installation
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1329,21 +1329,32 @@ Constant
 // Force HTTP/1.0
 $request = $client->request('GET', '/get', ['version' => 1.0]);
 
+// Attempt HTTP/2 with the cURL handler
+$request = $client->request('GET', 'https://example.com', ['version' => 2.0]);
+
 // Attempt HTTP/3 with the cURL handler
 $request = $client->request('GET', 'https://example.com', ['version' => 3.0]);
 ```
 
-The built-in cURL handler supports HTTP versions `1.0`, `1.1`, `2.0`, and `3.0`, depending on the linked libcurl capabilities. HTTP/3 requires PHP 8.4 or higher, a PHP cURL extension built against libcurl 7.66.0 or higher, a runtime libcurl built with HTTP/3 and QUIC support, and TLS 1.3 support exposed by the PHP cURL extension.
+Guzzle defaults to HTTP/1.1. It does not automatically opt requests into HTTP/2 or HTTP/3 just because the linked libcurl supports them.
+
+The built-in cURL handler supports HTTP versions `1.0`, `1.1`, `2.0`, and `3.0`, depending on the PHP cURL extension and linked runtime libcurl capabilities. Use Guzzle's `version` option instead of raw `CURLOPT_HTTP_VERSION`; built-in cURL handlers reject raw cURL options that conflict with request protocol version handling.
 
 The built-in stream handler supports only HTTP versions `1.0` and `1.1`.
 
-Empty or malformed `version` request option values are rejected before the request is sent. If a request uses a well-formed HTTP version that a built-in handler cannot send, the transfer fails with `GuzzleHttp\Exception\RequestException`.
+Empty or malformed `version` request option values are rejected before the request is sent. If a request uses a well-formed HTTP version that a built-in handler cannot send, the transfer fails with `GuzzleHttp\Exception\RequestException`. For example, the stream handler rejects HTTP/2 and HTTP/3, the cURL handler rejects HTTP/2 when libcurl does not report HTTP/2 support, and the cURL handler rejects HTTP/3 when PHP does not expose the HTTP/3 cURL constants, runtime libcurl is older than 7.66.0, or runtime libcurl was not built with HTTP/3 support.
 
-HTTP/3 requests sent by the built-in cURL handler use Guzzle's normal HTTPS guard rail of TLS 1.2 or newer. HTTP/3 itself is negotiated by libcurl over QUIC and requires TLS 1.3 support in the cURL stack. If `crypto_method` explicitly requests TLS 1.3, Guzzle preserves that stricter minimum. Raw `CURLOPT_SSLVERSION` values passed through the `curl` option are rejected because TLS version handling is managed by Guzzle.
+For HTTP/2, Guzzle uses libcurl's `CURL_HTTP_VERSION_2_0`. This asks libcurl to attempt HTTP/2, but libcurl may use HTTP/1.1 when HTTP/2 cannot be negotiated. The response protocol version may therefore be lower than the requested request protocol version.
 
-When an effective proxy is selected for a request configured with `version => 3.0`, Guzzle does not attempt HTTP/3 through the proxy path. It falls back to HTTP/2 when available, otherwise HTTP/1.1. A matching proxy `no` rule is treated as a direct request and still allows HTTP/3 to be attempted.
+HTTP/3 support is not implied by the libcurl version alone. libcurl is not typically built with HTTP/3 support by default. It must be built with HTTP/3 and QUIC support, using a backend such as ngtcp2 with nghttp3 and a supported QUIC-capable TLS backend, or quiche with BoringSSL.
+
+HTTP/3 requests sent by the built-in cURL handler use Guzzle's normal HTTPS guard rail of TLS 1.2 or newer for fallback-capable transfers. HTTP/3 itself is negotiated by libcurl over QUIC through the HTTP/3 backend. If `crypto_method` explicitly requests TLS 1.3, Guzzle preserves that stricter minimum when the cURL stack exposes TLS 1.3 configuration. Raw `CURLOPT_SSLVERSION` values passed through the `curl` option are rejected because TLS version handling is managed by Guzzle.
+
+When an effective proxy is selected for a request configured with `version => 3.0`, Guzzle does not attempt HTTP/3 through that proxy path. After the request passes HTTP/3 support checks, Guzzle maps the transfer to HTTP/2 when available, otherwise HTTP/1.1. A matching proxy `no` rule is treated as a direct request and still allows HTTP/3 to be attempted.
 
 > [!NOTE]
-> For HTTP/3, Guzzle uses libcurl's `CURL_HTTP_VERSION_3`, which attempts HTTP/3 and allows libcurl to fall back to an earlier HTTP version if needed. The response protocol version may therefore be lower than the requested request protocol version.
+> For HTTP/3, Guzzle uses libcurl's `CURL_HTTP_VERSION_3`, not `CURL_HTTP_VERSION_3ONLY`. This attempts HTTP/3 and allows libcurl to fall back to HTTP/2 or HTTP/1.1 when HTTP/3 cannot be established. The response protocol version may therefore be lower than the requested request protocol version.
 
 Guzzle does not currently expose libcurl's `CURL_HTTP_VERSION_3ONLY` strict HTTP/3 mode.
+
+`CurlMultiHandler` does not force HTTP/2 or HTTP/3 multiplexing for older libcurl versions. Modern libcurl enables HTTP multiplexing by default. Multiplexing is independent from the request `version` option and only matters for concurrent transfers that libcurl can send over a shared HTTP/2 or HTTP/3 connection.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1336,25 +1336,18 @@ $request = $client->request('GET', 'https://example.com', ['version' => 2.0]);
 $request = $client->request('GET', 'https://example.com', ['version' => 3.0]);
 ```
 
-Guzzle defaults to HTTP/1.1. It does not automatically opt requests into HTTP/2 or HTTP/3 just because the linked libcurl supports them.
+Guzzle defaults to HTTP/1.1. Set `version` when you want a request to use or attempt a different HTTP protocol version. Guzzle does not opt requests into HTTP/2 or HTTP/3 automatically just because the installed cURL stack supports them.
 
-The built-in cURL handler supports HTTP versions `1.0`, `1.1`, `2.0`, and `3.0`, depending on the PHP cURL extension and linked runtime libcurl capabilities. Use Guzzle's `version` option instead of raw `CURLOPT_HTTP_VERSION`; built-in cURL handlers reject raw cURL options that conflict with request protocol version handling.
+The built-in stream handler supports only `1.0` and `1.1`. The built-in cURL handler supports `1.0`, `1.1`, `2.0`, and `3.0`, but HTTP/2 and HTTP/3 depend on the PHP cURL extension and the linked runtime libcurl capabilities.
 
-The built-in stream handler supports only HTTP versions `1.0` and `1.1`.
+Empty or malformed `version` values are rejected before the request is sent. If the value is well-formed but the selected handler cannot use it, the transfer fails with `GuzzleHttp\Exception\RequestException`. For example, the stream handler rejects HTTP/2 and HTTP/3, the cURL handler rejects HTTP/2 when libcurl does not report HTTP/2 support, and the cURL handler rejects HTTP/3 when the installed cURL stack does not report HTTP/3 support.
 
-Empty or malformed `version` request option values are rejected before the request is sent. If a request uses a well-formed HTTP version that a built-in handler cannot send, the transfer fails with `GuzzleHttp\Exception\RequestException`. For example, the stream handler rejects HTTP/2 and HTTP/3, the cURL handler rejects HTTP/2 when libcurl does not report HTTP/2 support, and the cURL handler rejects HTTP/3 when PHP does not expose the HTTP/3 cURL constants, runtime libcurl is older than 7.66.0, or runtime libcurl was not built with HTTP/3 support.
+For cURL requests, `version` is converted to Guzzle-managed cURL options. Use this request option instead of passing raw `CURLOPT_HTTP_VERSION`; built-in cURL handlers reject raw cURL options that conflict with Guzzle-managed protocol handling.
 
-For HTTP/2, Guzzle uses libcurl's `CURL_HTTP_VERSION_2_0`. This asks libcurl to attempt HTTP/2, but libcurl may use HTTP/1.1 when HTTP/2 cannot be negotiated. The response protocol version may therefore be lower than the requested request protocol version.
+HTTP/2 uses libcurl's `CURL_HTTP_VERSION_2_0`. HTTP/3 uses libcurl's `CURL_HTTP_VERSION_3`, not `CURL_HTTP_VERSION_3ONLY`. These modes ask libcurl to attempt the requested protocol, but they are not strict modes: libcurl may use a lower HTTP version when negotiation or connection setup falls back. The response protocol version can therefore be lower than the `version` value you requested. Guzzle does not currently expose libcurl's strict HTTP/3-only mode.
 
-HTTP/3 support is not implied by the libcurl version alone. libcurl is not typically built with HTTP/3 support by default. It must be built with HTTP/3 and QUIC support, using a backend such as ngtcp2 with nghttp3 and a supported QUIC-capable TLS backend, or quiche with BoringSSL.
+HTTP/3 support requires PHP to expose cURL's HTTP/3 constants, runtime libcurl 7.66.0 or higher, and runtime libcurl reporting the `CURL_VERSION_HTTP3` feature. A libcurl version number is not enough by itself: libcurl must also be built with HTTP/3 and QUIC support, commonly through an HTTP/3 backend such as ngtcp2 with nghttp3 or quiche.
 
-HTTP/3 requests sent by the built-in cURL handler use Guzzle's normal HTTPS guard rail of TLS 1.2 or newer for fallback-capable transfers. HTTP/3 itself is negotiated by libcurl over QUIC through the HTTP/3 backend. If `crypto_method` explicitly requests TLS 1.3, Guzzle preserves that stricter minimum when the cURL stack exposes TLS 1.3 configuration. Raw `CURLOPT_SSLVERSION` values passed through the `curl` option are rejected because TLS version handling is managed by Guzzle.
+A request configured with `version => 3.0` must pass HTTP/3 support checks even if it uses a proxy. If a proxy is actually selected, Guzzle does not try HTTP/3 through the proxy; it sends the transfer as HTTP/2 when available, otherwise HTTP/1.1. A matching proxy `no` rule makes the request direct, so HTTP/3 can still be attempted.
 
-When an effective proxy is selected for a request configured with `version => 3.0`, Guzzle does not attempt HTTP/3 through that proxy path. After the request passes HTTP/3 support checks, Guzzle maps the transfer to HTTP/2 when available, otherwise HTTP/1.1. A matching proxy `no` rule is treated as a direct request and still allows HTTP/3 to be attempted.
-
-> [!NOTE]
-> For HTTP/3, Guzzle uses libcurl's `CURL_HTTP_VERSION_3`, not `CURL_HTTP_VERSION_3ONLY`. This attempts HTTP/3 and allows libcurl to fall back to HTTP/2 or HTTP/1.1 when HTTP/3 cannot be established. The response protocol version may therefore be lower than the requested request protocol version.
-
-Guzzle does not currently expose libcurl's `CURL_HTTP_VERSION_3ONLY` strict HTTP/3 mode.
-
-`CurlMultiHandler` does not force HTTP/2 or HTTP/3 multiplexing for older libcurl versions. Modern libcurl enables HTTP multiplexing by default. Multiplexing is independent from the request `version` option and only matters for concurrent transfers that libcurl can send over a shared HTTP/2 or HTTP/3 connection.
+For HTTPS cURL requests, Guzzle sets a minimum of TLS 1.2 by default. That minimum also applies when HTTP/2 or HTTP/3 is requested, because cURL may fall back to a TLS-based HTTP/1.1 or HTTP/2 connection. If you set `crypto_method` to TLS 1.3, Guzzle keeps that stricter setting when the cURL stack exposes TLS 1.3 configuration. Raw `CURLOPT_SSLVERSION` values passed through the `curl` option are rejected because TLS version handling is managed by Guzzle.

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -57,18 +57,16 @@ final class CurlVersion
 
     public static function supportsHttp3(): bool
     {
-        if (
-            !self::supportsTls13()
-            || !\defined('CURL_VERSION_HTTP3')
-            || !\defined('CURL_HTTP_VERSION_3')
-        ) {
+        if (!\defined('CURL_VERSION_HTTP3') || !\defined('CURL_HTTP_VERSION_3')) {
             return false;
         }
 
-        $versionInfo = self::getInfo();
+        $version = self::get();
+        if (null === $version || version_compare($version, self::HTTP_3_VERSION, '<')) {
+            return false;
+        }
 
-        return version_compare($versionInfo['version'], self::HTTP_3_VERSION, '>=')
-            && 0 !== ((int) \constant('CURL_VERSION_HTTP3') & $versionInfo['features']);
+        return 0 !== ((int) \constant('CURL_VERSION_HTTP3') & self::getInfo()['features']);
     }
 
     public static function supportsProxyCredentialAwareConnectionReuse(): bool

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -346,12 +346,11 @@ final class RequestOptions
      * version: (string|float, default=1.1) Specifies the HTTP protocol
      * version to attempt to use.
      *
-     * Guzzle defaults to HTTP/1.1. The built-in cURL handler supports
-     * HTTP/1.0, HTTP/1.1, HTTP/2, and HTTP/3 depending on linked libcurl
-     * capabilities. HTTP/3 requires PHP HTTP/3 cURL constants, libcurl
-     * 7.66.0 or higher, and a runtime libcurl built with HTTP/3 and QUIC
-     * support. libcurl may negotiate a lower HTTP version when using
-     * fallback-capable HTTP/2 or HTTP/3 modes.
+     * Guzzle defaults to HTTP/1.1. The built-in stream handler supports
+     * HTTP/1.0 and HTTP/1.1. The built-in cURL handler also supports HTTP/2
+     * and HTTP/3 when the installed cURL stack reports those features. For
+     * HTTP/2 and HTTP/3, libcurl may use a lower HTTP version when
+     * negotiation or connection setup falls back.
      */
     public const VERSION = 'version';
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -343,12 +343,15 @@ final class RequestOptions
     public const URI_FACTORY = 'uri_factory';
 
     /**
-     * version: (string|float) Specifies the HTTP protocol version to attempt
-     * to use.
+     * version: (string|float, default=1.1) Specifies the HTTP protocol
+     * version to attempt to use.
      *
-     * HTTP/3 is supported by the built-in cURL handler on PHP 8.4 or higher
-     * when the PHP cURL extension and linked libcurl support HTTP/3 and
-     * TLS 1.3. HTTP/3 requests use libcurl's fallback-capable HTTP/3 mode.
+     * Guzzle defaults to HTTP/1.1. The built-in cURL handler supports
+     * HTTP/1.0, HTTP/1.1, HTTP/2, and HTTP/3 depending on linked libcurl
+     * capabilities. HTTP/3 requires PHP HTTP/3 cURL constants, libcurl
+     * 7.66.0 or higher, and a runtime libcurl built with HTTP/3 and QUIC
+     * support. libcurl may negotiate a lower HTTP version when using
+     * fallback-capable HTTP/2 or HTTP/3 modes.
      */
     public const VERSION = 'version';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1970,8 +1970,8 @@ class CurlFactoryTest extends TestCase
 
     public function testHttp3PreservesExplicitTls13CryptoMethod(): void
     {
-        if (!CurlVersion::supportsHttp3()) {
-            self::markTestSkipped('HTTP/3 is not supported by this cURL installation.');
+        if (!CurlVersion::supportsHttp3() || !CurlVersion::supportsTls13()) {
+            self::markTestSkipped('HTTP/3 with explicit TLS 1.3 is not supported by this cURL installation.');
         }
 
         $factory = new CurlFactory(3);
@@ -3055,7 +3055,7 @@ class CurlFactoryTest extends TestCase
 
     private static function requireHttp3TestConstants(): void
     {
-        foreach (['CURL_VERSION_HTTP3', 'CURL_HTTP_VERSION_3', 'CURL_SSLVERSION_TLSv1_3'] as $constant) {
+        foreach (['CURL_VERSION_HTTP3', 'CURL_HTTP_VERSION_3'] as $constant) {
             if (!\defined($constant)) {
                 self::markTestSkipped($constant.' is not available.');
             }


### PR DESCRIPTION
This updates Guzzle 8 HTTP version documentation so HTTP/2 and HTTP/3 support, fallback behavior, proxy behavior, and Guzzle-managed cURL options are described in one coherent place. It also aligns HTTP/3 support detection with libcurl's reported HTTP/3 capability instead of requiring PHP cURL to expose TLS 1.3 configuration, while keeping explicit TLS 1.3 crypto handling unchanged.