### PR TITLE
Allow integer HTTP version options

### DIFF
--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1199,7 +1199,7 @@ Summary
 Protocol version to use with the request.
 
 Types
-string, float
+string, int, float
 
 Default
 `1.1`

--- a/src/Client.php
+++ b/src/Client.php
@@ -398,7 +398,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         self::warnIfPresentAndNotBool($options, 'synchronous');
         self::warnIfPresentAndNotNumber($options, 'timeout');
         self::warnIfPresentAndNotBoolOrString($options, 'verify');
-        self::warnIfPresentAndNotStringOrFloat($options, 'version');
+        self::warnIfPresentAndNotStringOrNumber($options, 'version');
         self::warnIfPresentAndNotArray($options, 'curl', 'array<int|string, mixed>');
 
         if (isset($options['cookies']) && $options['cookies'] === true) {
@@ -708,10 +708,15 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
     }
 
-    private static function warnIfPresentAndNotStringOrFloat(array $options, string $option): void
+    private static function warnIfPresentAndNotStringOrNumber(array $options, string $option): void
     {
-        if (\array_key_exists($option, $options) && !\is_string($options[$option]) && !\is_float($options[$option])) {
-            self::warnInvalidRequestOptionType($option, 'string|float', $options[$option]);
+        if (
+            \array_key_exists($option, $options)
+            && !\is_string($options[$option])
+            && !\is_int($options[$option])
+            && !\is_float($options[$option])
+        ) {
+            self::warnInvalidRequestOptionType($option, 'string|int|float', $options[$option]);
         }
     }
 
@@ -897,7 +902,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     }
 
     /**
-     * @param string|float $version
+     * @param string|int|float $version
      */
     private static function normalizeProtocolVersion($version): string
     {

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -290,7 +290,7 @@ final class RequestOptions
     public const READ_TIMEOUT = 'read_timeout';
 
     /**
-     * version: (string|float) Specifies the HTTP protocol version to attempt
+     * version: (string|int|float) Specifies the HTTP protocol version to attempt
      * to use.
      */
     public const VERSION = 'version';

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -932,6 +932,7 @@ class ClientTest extends TestCase
         yield ['1.1', '1.1'];
         yield [1.1, '1.1'];
         yield ['2', '2'];
+        yield [2, '2'];
         yield [2.0, '2.0'];
     }
 


### PR DESCRIPTION
This preserves historical version request option behavior in Guzzle 7.11 by allowing integer values to pass the request option type deprecation check. It also updates the documented type and adds normalization coverage for integer HTTP versions.