### PR TITLE
Preserve request option compatibility

### DIFF
--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -117,10 +117,12 @@ If TLS client credentials are only trusted for the original origin, disable auto
 ## auth
 
 Summary
-Pass an array of HTTP authentication parameters to use with the request. The array must contain the username in index `[0]`, the password in index `[1]`, and you can optionally provide a built-in authentication type in index `[2]`. Pass `null` to disable authentication for a request.
+Pass HTTP authentication parameters to use with the request. An array must contain the username in index `[0]`, the password in index `[1]`, and can optionally provide a built-in authentication type in index `[2]`. Pass `false` or `null` to disable authentication for a request. String values are passed through for custom handlers.
 
 Types
 - array
+- string
+- false
 - null
 
 Default
@@ -128,8 +130,6 @@ None
 
 Constant
 `GuzzleHttp\RequestOptions::AUTH`
-
-Top-level non-array `auth` values other than `null` are deprecated in 7.11 and will be rejected in 8.0.
 
 The built-in authentication types are as follows:
 
@@ -220,7 +220,7 @@ Values are converted to PSR-7 streams with `GuzzleHttp\Psr7\Utils::streamFor()`.
 ## cert
 
 Summary
-Set to a string to specify the path to a file containing a client side certificate. PEM is the default certificate format. If a password is required, then set to an array containing the path to the certificate file in the first array element followed by the password required for the certificate in the second array element. Use [`cert_type`](#cert_type) to specify another supported certificate format.
+Set to a string to specify the path to a file containing a client side certificate. PEM is the default certificate format. If a password is required, then set to an array containing the path to the certificate file in the first array element followed by the password required for the certificate in the second array element. A `null` password is treated the same as omitting it. Use [`cert_type`](#cert_type) to specify another supported certificate format.
 
 Types
 - string
@@ -523,7 +523,7 @@ array
 Constant
 `GuzzleHttp\RequestOptions::FORM_PARAMS`
 
-Array mapping form field names to values where each value is a string or array of strings. Sets the Content-Type header to application/x-www-form-urlencoded when no Content-Type header is already present.
+Array mapping form field names to scalar, `null`, or nested array values. Values are serialized with PHP's `http_build_query()`. Sets the Content-Type header to application/x-www-form-urlencoded when no Content-Type header is already present.
 
 ```php
 $client->request('POST', '/post', [
@@ -1040,7 +1040,7 @@ $resource = $response->getBody()->detach();
 ## ssl_key
 
 Summary
-Specify the path to a file containing a private SSL key. PEM is the default private key format. If a password is required, then set to an array containing the path to the SSL key in the first array element followed by the password required for the key in the second element. Use [`ssl_key_type`](#ssl_key_type) to specify another supported key format.
+Specify the path to a file containing a private SSL key. PEM is the default private key format. If a password is required, then set to an array containing the path to the SSL key in the first array element followed by the password required for the key in the second element. A `null` password is treated the same as omitting it. Use [`ssl_key_type`](#ssl_key_type) to specify another supported key format.
 
 Types
 - string

--- a/src/Client.php
+++ b/src/Client.php
@@ -361,7 +361,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         self::warnIfPresentAndNotBoolOrInt($options, 'expect');
 
         if (isset($options['form_params'])) {
-            self::warnAboutInvalidStringOrStringArrayOptionTypes('form_params', $options['form_params']);
+            self::warnAboutInvalidFormParamTypes($options['form_params']);
         }
 
         if (isset($options['force_ip_resolve']) && !\is_string($options['force_ip_resolve'])) {
@@ -421,8 +421,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      */
     private static function warnAboutInvalidAuthOptionTypes($auth): void
     {
+        if ($auth === false || \is_string($auth) || $auth === []) {
+            return;
+        }
+
         if (!\is_array($auth)) {
-            self::warnInvalidRequestOptionType('auth', 'array{0: string, 1: string, 2?: string}|null', $auth);
+            self::warnInvalidRequestOptionType('auth', 'array{0: string, 1: string, 2?: string|null}|string|false|null', $auth);
 
             return;
         }
@@ -435,38 +439,45 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             self::warnInvalidRequestOptionType('auth.1', 'string', $auth[1] ?? null);
         }
 
-        if (\array_key_exists(2, $auth) && !\is_string($auth[2])) {
-            self::warnInvalidRequestOptionType('auth.2', 'string', $auth[2]);
+        if (\array_key_exists(2, $auth) && $auth[2] !== null && !\is_string($auth[2])) {
+            self::warnInvalidRequestOptionType('auth.2', 'string|null', $auth[2]);
         }
     }
 
     /**
      * @param mixed $value
      */
-    private static function warnAboutInvalidStringOrStringArrayOptionTypes(string $option, $value): void
+    private static function warnAboutInvalidFormParamTypes($value): void
     {
         if (!\is_array($value)) {
-            self::warnInvalidRequestOptionType($option, 'array<array-key, string|array<array-key, string>>', $value);
+            self::warnInvalidRequestOptionType('form_params', 'array<array-key, string|int|float|bool|null|array<array-key, mixed>>', $value);
 
             return;
         }
 
-        foreach ($value as $key => $item) {
-            $path = $option.'.'.(string) $key;
+        self::warnAboutInvalidFormParamArray($value, 'form_params');
+    }
+
+    private static function warnAboutInvalidFormParamArray(array $values, string $path): bool
+    {
+        foreach ($values as $key => $item) {
+            $itemPath = $path.'.'.(string) $key;
             if (\is_array($item)) {
-                foreach ($item as $index => $nestedItem) {
-                    if (!\is_string($nestedItem)) {
-                        self::warnInvalidRequestOptionType($path.'.'.(string) $index, 'string', $nestedItem);
-
-                        break 2;
-                    }
+                if (!self::warnAboutInvalidFormParamArray($item, $itemPath)) {
+                    return false;
                 }
-            } elseif (!\is_string($item)) {
-                self::warnInvalidRequestOptionType($path, 'string|array<array-key, string>', $item);
 
-                break;
+                continue;
+            }
+
+            if ($item !== null && !\is_scalar($item)) {
+                self::warnInvalidRequestOptionType($itemPath, 'string|int|float|bool|null|array<array-key, mixed>', $item);
+
+                return false;
             }
         }
+
+        return true;
     }
 
     /**
@@ -616,8 +627,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             self::warnInvalidRequestOptionType($option.'.0', 'string', $options[$option][0] ?? null);
         }
 
-        if (\array_key_exists(1, $options[$option]) && !\is_string($options[$option][1])) {
-            self::warnInvalidRequestOptionType($option.'.1', 'string', $options[$option][1]);
+        if (\array_key_exists(1, $options[$option]) && $options[$option][1] !== null && !\is_string($options[$option][1])) {
+            self::warnInvalidRequestOptionType($option.'.1', 'string|null', $options[$option][1]);
         }
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -450,7 +450,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     private static function warnAboutInvalidFormParamTypes($value): void
     {
         if (!\is_array($value)) {
-            self::warnInvalidRequestOptionType('form_params', 'array<array-key, string|int|float|bool|null|array<array-key, mixed>>', $value);
+            self::warnInvalidRequestOptionType('form_params', 'array<array-key, string|int|float|bool|null|array>', $value);
 
             return;
         }
@@ -471,7 +471,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             }
 
             if ($item !== null && !\is_scalar($item)) {
-                self::warnInvalidRequestOptionType($itemPath, 'string|int|float|bool|null|array<array-key, mixed>', $item);
+                self::warnInvalidRequestOptionType($itemPath, 'string|int|float|bool|null|array', $item);
 
                 return false;
             }

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -135,7 +135,7 @@ final class RequestOptions
     public const EXPECT = 'expect';
 
     /**
-     * form_params: (array<array-key, string|int|float|bool|null|array<array-key, mixed>>)
+     * form_params: (array<array-key, string|int|float|bool|null|array>)
      * Associative array of form field names to scalar, null, or nested array
      * values. Sets the Content-Type header to application/x-www-form-urlencoded
      * when no Content-Type header is already present.

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -36,11 +36,12 @@ final class RequestOptions
     public const ALLOW_REDIRECTS = 'allow_redirects';
 
     /**
-     * auth: (array) Pass an array of HTTP authentication parameters to use
-     * with the request. The array must contain the username in index [0],
-     * the password in index [1], and you can optionally provide a built-in
-     * authentication type in index [2]. Pass null to disable authentication
-     * for a request.
+     * auth: (array{0: string, 1: string, 2?: string|null}|string|false|null)
+     * Pass an array of HTTP authentication parameters to use with the request.
+     * The array must contain the username in index [0], the password in index
+     * [1], and you can optionally provide a built-in authentication type in
+     * index [2]. Pass false or null to disable authentication for a request.
+     * String values are passed through for custom handlers.
      */
     public const AUTH = 'auth';
 
@@ -52,12 +53,13 @@ final class RequestOptions
     public const BODY = 'body';
 
     /**
-     * cert: (string|array) Set to a string to specify the path to a client
-     * certificate file. PEM is the default certificate format. If a password
-     * is required, set cert to an array containing the certificate path in
-     * the first array element followed by the certificate password in the
-     * second array element. Use cert_type to specify another supported
-     * certificate format.
+     * cert: (string|array{0: string, 1?: string|null}) Set to a string to
+     * specify the path to a client certificate file. PEM is the default
+     * certificate format. If a password is required, set cert to an array
+     * containing the certificate path in the first array element followed by
+     * the certificate password in the second array element. A null password is
+     * treated the same as omitting it. Use cert_type to specify another
+     * supported certificate format.
      */
     public const CERT = 'cert';
 
@@ -133,9 +135,9 @@ final class RequestOptions
     public const EXPECT = 'expect';
 
     /**
-     * form_params: (array<array-key, string|array<array-key, string>>) Associative
-     * array of form field names to values where each value is a string or array
-     * of strings. Sets the Content-Type header to application/x-www-form-urlencoded
+     * form_params: (array<array-key, string|int|float|bool|null|array<array-key, mixed>>)
+     * Associative array of form field names to scalar, null, or nested array
+     * values. Sets the Content-Type header to application/x-www-form-urlencoded
      * when no Content-Type header is already present.
      */
     public const FORM_PARAMS = 'form_params';
@@ -248,11 +250,12 @@ final class RequestOptions
     public const SYNCHRONOUS = 'synchronous';
 
     /**
-     * ssl_key: (array|string) Specify the path to a private SSL key file. PEM
-     * is the default private key format. If a password is required, set
-     * ssl_key to an array containing the key path in the first array element
-     * followed by the key password in the second element. Use ssl_key_type to
-     * specify another supported key format.
+     * ssl_key: (array{0: string, 1?: string|null}|string) Specify the path to
+     * a private SSL key file. PEM is the default private key format. If a
+     * password is required, set ssl_key to an array containing the key path in
+     * the first array element followed by the key password in the second
+     * element. A null password is treated the same as omitting it. Use
+     * ssl_key_type to specify another supported key format.
      */
     public const SSL_KEY = 'ssl_key';
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -557,11 +557,39 @@ class ClientTest extends TestCase
         self::assertFalse($last->hasHeader('Authorization'));
     }
 
+    public function testAuthCanBeDisabledWithFalse()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->get('http://foo.com', ['auth' => false]);
+
+        $last = $mock->getLastRequest();
+        self::assertFalse($last->hasHeader('Authorization'));
+    }
+
+    public function testAuthCanBeCustomStringForHandlers()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->get('http://foo.com', ['auth' => 'custom']);
+
+        self::assertSame('custom', $mock->getLastOptions()['auth']);
+    }
+
     public function testAuthCanBeArrayForBasicAuth()
     {
         $mock = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b']]);
+        $last = $mock->getLastRequest();
+        self::assertSame('Basic YTpi', $last->getHeaderLine('Authorization'));
+    }
+
+    public function testAuthCanUseNullTypeForDefaultBasicAuth()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->get('http://foo.com', ['auth' => ['a', 'b', null]]);
         $last = $mock->getLastRequest();
         self::assertSame('Basic YTpi', $last->getHeaderLine('Authorization'));
     }
@@ -609,6 +637,41 @@ class ClientTest extends TestCase
             'foo=bar+bam&baz%5Bboo%5D=qux',
             (string) $last->getBody()
         );
+    }
+
+    public function testFormParamsAcceptScalarAndNullValues()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->post('http://foo.com', [
+            'form_params' => [
+                'int' => 1,
+                'float' => 1.5,
+                'true' => true,
+                'false' => false,
+                'null' => null,
+                'nested' => ['value' => 2],
+            ],
+        ]);
+
+        $last = $mock->getLastRequest();
+        self::assertSame(
+            'int=1&float=1.5&true=1&false=0&nested%5Bvalue%5D=2',
+            (string) $last->getBody()
+        );
+    }
+
+    public function testTlsPassphraseOptionsAcceptNullPasswordSlot()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->get('http://foo.com', [
+            'cert' => [__FILE__, null],
+            'ssl_key' => [__FILE__, null],
+        ]);
+
+        self::assertSame([__FILE__, null], $mock->getLastOptions()['cert']);
+        self::assertSame([__FILE__, null], $mock->getLastOptions()['ssl_key']);
     }
 
     public function testFormParamsEncodedProperly()


### PR DESCRIPTION
This preserves historical request option behavior in Guzzle 7.11 by avoiding deprecation warnings for auth values, scalar form parameters, and null TLS passphrase slots that were previously accepted. The change keeps deprecation checks for genuinely invalid values while updating the documented option types and regression coverage.