### PR TITLE
Cover empty auth array handling

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1587,6 +1587,16 @@ class ClientTest extends TestCase
         self::assertFalse($last->hasHeader('Authorization'));
     }
 
+    public function testEmptyAuthArrayIsIgnored(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+        $client->get('http://foo.com', ['auth' => []]);
+
+        $last = $mock->getLastRequest();
+        self::assertFalse($last->hasHeader('Authorization'));
+    }
+
     public function testAuthCanBeCustomStringForHandlers(): void
     {
         $mock = new MockHandler([new Response()]);


### PR DESCRIPTION
This adds regression coverage for empty auth arrays after preserving historical auth option compatibility in Guzzle 8. Empty auth arrays are ignored rather than treated as malformed credentials.