### PR TITLE
Allow null proxy values

### DIFF
--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -895,7 +895,7 @@ Pass a string to specify a proxy for all protocols.
 $client->request('GET', '/', ['proxy' => 'http://localhost:8125']);
 ```
 
-Pass an associative array to specify HTTP proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair to provide a list of host names that should not be proxied to. No-proxy entries may include ports, for example `example.com:8080` or `[::1]:8080`.
+Pass an associative array to specify HTTP proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair to provide a list of host names that should not be proxied to. No-proxy entries may include ports, for example `example.com:8080` or `[::1]:8080`. The `http`, `https`, and `no` entries may be set to `null` to leave that entry unconfigured.
 
 > [!NOTE]
 > Guzzle will automatically populate this value with your environment's `NO_PROXY` environment variable. However, when providing a `proxy` request option, it is up to you to provide the `no` value parsed from the `NO_PROXY` environment variable (e.g., `explode(',', getenv('NO_PROXY'))`).

--- a/src/Client.php
+++ b/src/Client.php
@@ -569,7 +569,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         if (!\is_string($options['proxy']) && !\is_array($options['proxy'])) {
-            self::warnInvalidRequestOptionType('proxy', 'string|array{http?: string, https?: string, no?: string|array<array-key, string>}', $options['proxy']);
+            self::warnInvalidRequestOptionType('proxy', 'string|array{http?: string|null, https?: string|null, no?: string|array<array-key, string>|null}', $options['proxy']);
 
             return;
         }
@@ -579,12 +579,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         foreach (['http', 'https'] as $scheme) {
-            if (\array_key_exists($scheme, $options['proxy']) && !\is_string($options['proxy'][$scheme])) {
-                self::warnInvalidRequestOptionType('proxy.'.$scheme, 'string', $options['proxy'][$scheme]);
+            if (\array_key_exists($scheme, $options['proxy']) && $options['proxy'][$scheme] !== null && !\is_string($options['proxy'][$scheme])) {
+                self::warnInvalidRequestOptionType('proxy.'.$scheme, 'string|null', $options['proxy'][$scheme]);
             }
         }
 
-        if (!\array_key_exists('no', $options['proxy'])) {
+        if (!\array_key_exists('no', $options['proxy']) || $options['proxy']['no'] === null) {
             return;
         }
 
@@ -593,7 +593,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         if (!\is_array($options['proxy']['no'])) {
-            self::warnInvalidRequestOptionType('proxy.no', 'string|array<array-key, string>', $options['proxy']['no']);
+            self::warnInvalidRequestOptionType('proxy.no', 'string|array<array-key, string>|null', $options['proxy']['no']);
 
             return;
         }

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -220,9 +220,9 @@ final class RequestOptions
     /**
      * proxy: (string|array) Pass a string to specify an HTTP proxy, or an
      * array to specify different proxies for different protocols (where the
-     * key is the protocol and the value is a proxy string). Provide a "no"
-     * key as a string or array of strings to specify hosts or host-and-port
-     * pairs that should not be proxied.
+     * key is the protocol and the value is a proxy string or null). Provide a
+     * "no" key as a string, array of strings, or null to specify hosts or
+     * host-and-port pairs that should not be proxied.
      */
     public const PROXY = 'proxy';
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -826,6 +826,25 @@ class ClientTest extends TestCase
         }
     }
 
+    public function testNullProxyValuesAreAccepted()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $client->get('http://foo.com', [
+            'proxy' => [
+                'http' => null,
+                'https' => null,
+                'no' => null,
+            ],
+        ]);
+
+        self::assertSame(
+            ['http' => null, 'https' => null, 'no' => null],
+            $mock->getLastOptions()['proxy']
+        );
+    }
+
     public function testRequestSendsWithSync()
     {
         $mock = new MockHandler([new Response()]);


### PR DESCRIPTION
This preserves the historical handling of null proxy map entries by treating null http, https, and no proxy values as omitted instead of deprecated request option shapes.