### PR TITLE
Normalize null no-proxy values

### DIFF
--- a/src/ProxyOptions.php
+++ b/src/ProxyOptions.php
@@ -62,16 +62,20 @@ final class ProxyOptions
      */
     public static function normalizeNoProxy($noProxy): array
     {
+        if ($noProxy === null) {
+            return [];
+        }
+
         if (\is_string($noProxy)) {
             $noProxy = \explode(',', $noProxy);
         } elseif (!\is_array($noProxy)) {
-            throw new InvalidArgumentException('proxy no list must be a string or array of strings');
+            throw new InvalidArgumentException('proxy no list must be null, a string, or an array of strings');
         }
 
         $result = [];
         foreach ($noProxy as $area) {
             if (!\is_string($area)) {
-                throw new InvalidArgumentException('proxy no list must be a string or array of strings');
+                throw new InvalidArgumentException('proxy no list must be null, a string, or an array of strings');
             }
 
             $area = \trim($area);
@@ -175,7 +179,7 @@ final class ProxyOptions
     {
         foreach ($noProxy as $area) {
             if (!\is_string($area)) {
-                throw new InvalidArgumentException('proxy no list must be a string or array of strings');
+                throw new InvalidArgumentException('proxy no list must be null, a string, or an array of strings');
             }
         }
     }

--- a/tests/ProxyOptionsTest.php
+++ b/tests/ProxyOptionsTest.php
@@ -18,6 +18,8 @@ class ProxyOptionsTest extends TestCase
             ['http://example.com', '', null, false, true],
             ['http://example.com', ['https' => 'http://proxy.example.com:8080'], null, false, false],
             ['http://example.com', ['http' => 'http://proxy.example.com:8080'], 'http://proxy.example.com:8080', false, false],
+            ['http://example.com', ['http' => 'http://proxy.example.com:8080', 'no' => null], 'http://proxy.example.com:8080', false, false],
+            ['http://example.com', ['http' => null], null, false, false],
             ['http://example.com', ['http' => ''], null, false, true],
             ['http://example.com', ['http' => 'http://proxy.example.com:8080', 'no' => ['example.com']], null, true, false],
             ['http://example.com', ['http' => 'http://proxy.example.com:8080', 'no' => 'example.com,localhost'], null, true, false],
@@ -125,10 +127,15 @@ class ProxyOptionsTest extends TestCase
         self::assertSame(['foo.com', 'bar.com'], ProxyOptions::normalizeNoProxy([' foo.com ', '', ' bar.com ']));
     }
 
+    public function testNormalizesNullNoProxyValue(): void
+    {
+        self::assertSame([], ProxyOptions::normalizeNoProxy(null));
+    }
+
     public function testValidatesNoProxyValue(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('proxy no list must be a string or array of strings');
+        $this->expectExceptionMessage('proxy no list must be null, a string, or an array of strings');
 
         ProxyOptions::normalizeNoProxy(new \stdClass());
     }
@@ -136,7 +143,7 @@ class ProxyOptionsTest extends TestCase
     public function testValidatesNoProxyArrayValues(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('proxy no list must be a string or array of strings');
+        $this->expectExceptionMessage('proxy no list must be null, a string, or an array of strings');
 
         ProxyOptions::normalizeNoProxy(['foo.com', new \stdClass()]);
     }
@@ -144,7 +151,7 @@ class ProxyOptionsTest extends TestCase
     public function testValidatesNoProxyValueWhenResolvingProxy(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('proxy no list must be a string or array of strings');
+        $this->expectExceptionMessage('proxy no list must be null, a string, or an array of strings');
 
         ProxyOptions::resolve(Psr7\Utils::uriFor('http://example.com'), [
             'http' => 'http://proxy.example.com:8080',
@@ -155,7 +162,7 @@ class ProxyOptionsTest extends TestCase
     public function testValidatesNoProxyArrayValueWhenResolvingProxy(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('proxy no list must be a string or array of strings');
+        $this->expectExceptionMessage('proxy no list must be null, a string, or an array of strings');
 
         ProxyOptions::resolve(Psr7\Utils::uriFor('http://example.com'), [
             'http' => 'http://proxy.example.com:8080',


### PR DESCRIPTION
This makes the public no-proxy normalization helper treat null the same way the documented proxy.no request option does, preserving the compatibility behavior that null means the no-proxy list is omitted.