### PR TITLE
Remove redundant transport sharing docs sentence

### DIFF
--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -278,9 +278,6 @@ $handler = new CurlHandler([
 ]);
 ```
 
-Do not pass `CURLOPT_SHARE` in the `curl` request option when transport sharing
-is configured.
-
 ## Creating a Handler
 
 As stated earlier, a handler is a function that accepts a `Psr\Http\Message\RequestInterface` and an array of request options. A handler used with Guzzle middleware returns a `GuzzleHttp\Promise\PromiseInterface` that is fulfilled with a `Psr\Http\Message\ResponseInterface` or rejected with a reason.


### PR DESCRIPTION
This removes a redundant sentence from the transport sharing documentation. The sentence was easy to read as implying that request-level CURLOPT_SHARE is acceptable when transport sharing is not configured, which is not the guidance we want to give.