### PR TITLE
Make persistent transport sharing best effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Added
 
-- Added persistent cURL share modes for handler-managed cURL sharing
+- Added persistent transport sharing modes
 - Added the `protocols` request option to restrict allowed URI schemes for request transfers
 - Added `cert_type` and `ssl_key_type` request options for TLS certificate and private-key file types
 - Added PHP stream handler support for the `ssl_key` request option

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -382,11 +382,6 @@ handles and does not fall back to handler-lifetime sharing. If persistent
 sharing is unavailable or cannot be created, Guzzle fails while creating the
 handler.
 
-Only `TransportSharing::HANDLER_REQUIRE` and
-`TransportSharing::PERSISTENT_REQUIRE` require a handler that supports transport
-sharing. Prefer modes continue without sharing when the selected handler cannot
-provide it.
-
 Because `TransportSharing::PERSISTENT_REQUIRE` requires connection cache
 sharing, Guzzle rejects request-level cURL options or proxy tunnel cases that
 require a fresh connection for safety.

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -370,16 +370,22 @@ sharing. Guzzle fails when it cannot select a cURL handler with cURL share
 support, when sharing cannot be configured, or when a request is routed to a
 handler that does not support sharing.
 
-`TransportSharing::PERSISTENT_PREFER` uses PHP persistent cURL share handles
-when available. Persistent sharing shares DNS, connection, and SSL session cache
-state. When persistent cURL share handles are unavailable or cannot be created,
-Guzzle falls back to `TransportSharing::HANDLER_REQUIRE`. This fallback still
-requires normal cURL share support.
+`TransportSharing::PERSISTENT_PREFER` asks Guzzle to use the strongest sharing
+available in the current environment. Guzzle first tries persistent cURL share
+handles, which can share DNS, connection, and SSL session cache state across
+handler lifetimes. If persistent sharing is unavailable or cannot be created,
+Guzzle falls back to `TransportSharing::HANDLER_PREFER`. If handler-lifetime
+sharing is also unavailable, Guzzle continues without sharing.
 
 `TransportSharing::PERSISTENT_REQUIRE` requires PHP persistent cURL share
 handles and does not fall back to handler-lifetime sharing. If persistent
 sharing is unavailable or cannot be created, Guzzle fails while creating the
 handler.
+
+Only `TransportSharing::HANDLER_REQUIRE` and
+`TransportSharing::PERSISTENT_REQUIRE` require a handler that supports transport
+sharing. Prefer modes continue without sharing when the selected handler cannot
+provide it.
 
 Because `TransportSharing::PERSISTENT_REQUIRE` requires connection cache
 sharing, Guzzle rejects request-level cURL options or proxy tunnel cases that

--- a/src/Client.php
+++ b/src/Client.php
@@ -149,7 +149,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                 : HandlerStack::create(Utils::chooseHandler(['transport_sharing' => $transportSharingMode]));
         } elseif (!\is_callable($config['handler'])) {
             throw new InvalidArgumentException('handler must be a callable');
-        } elseif (!\in_array($transportSharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER], true)) {
+        } elseif (!\in_array($transportSharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER, TransportSharing::PERSISTENT_PREFER], true)) {
             throw new InvalidArgumentException('The "transport_sharing" client option can only require sharing when Guzzle creates the default handler. Configure the "transport_sharing" option on CurlHandler or CurlMultiHandler when providing a custom cURL handler.');
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -149,7 +149,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                 : HandlerStack::create(Utils::chooseHandler(['transport_sharing' => $transportSharingMode]));
         } elseif (!\is_callable($config['handler'])) {
             throw new InvalidArgumentException('handler must be a callable');
-        } elseif (!\in_array($transportSharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER, TransportSharing::PERSISTENT_PREFER], true)) {
+        } elseif (\in_array($transportSharingMode, [TransportSharing::HANDLER_REQUIRE, TransportSharing::PERSISTENT_REQUIRE], true)) {
             throw new InvalidArgumentException('The "transport_sharing" client option can only require sharing when Guzzle creates the default handler. Configure the "transport_sharing" option on CurlHandler or CurlMultiHandler when providing a custom cURL handler.');
         }
 

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -88,15 +88,12 @@ final class CurlShareHandleState
 
     public static function assertNoRequiredSharingCustomFactoryConflict(array $options, string $handlerName): void
     {
-        if (
-            !\array_key_exists('handle_factory', $options)
-            || $options['handle_factory'] === null
-        ) {
+        if (!\array_key_exists('handle_factory', $options) || $options['handle_factory'] === null) {
             return;
         }
 
         $mode = self::normalizeMode($options['transport_sharing'] ?? null, 'transport_sharing');
-        if (\in_array($mode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER, TransportSharing::PERSISTENT_PREFER], true)) {
+        if (!\in_array($mode, [TransportSharing::HANDLER_REQUIRE, TransportSharing::PERSISTENT_REQUIRE], true)) {
             return;
         }
 

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -96,7 +96,7 @@ final class CurlShareHandleState
         }
 
         $mode = self::normalizeMode($options['transport_sharing'] ?? null, 'transport_sharing');
-        if ($mode === TransportSharing::NONE || $mode === TransportSharing::HANDLER_PREFER) {
+        if (\in_array($mode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER, TransportSharing::PERSISTENT_PREFER], true)) {
             return;
         }
 
@@ -147,17 +147,17 @@ final class CurlShareHandleState
         return new self($mode, $handle);
     }
 
-    private static function createPersistentShareOrFallback(): self
+    private static function createPersistentShareOrFallback(): ?self
     {
-        if (!self::supportsPersistentShare()) {
-            return self::createHandlerShare(TransportSharing::HANDLER_REQUIRE);
+        if (self::supportsPersistentShare()) {
+            try {
+                return self::createPersistentShare(TransportSharing::PERSISTENT_PREFER);
+            } catch (\Throwable $e) {
+                // Fall back to handler-lifetime best effort below.
+            }
         }
 
-        try {
-            return self::createPersistentShare(TransportSharing::PERSISTENT_PREFER);
-        } catch (\Throwable $e) {
-            return self::createHandlerShare(TransportSharing::HANDLER_REQUIRE);
-        }
+        return self::createHandlerShareOrNull(TransportSharing::HANDLER_PREFER);
     }
 
     private static function createPersistentShare(string $mode): self

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -624,7 +624,7 @@ final class StreamHandler
         if (\array_key_exists('transport_sharing', $options)) {
             $transportSharingMode = CurlShareHandleState::normalizeMode($options['transport_sharing'], 'transport_sharing');
 
-            if (!\in_array($transportSharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER], true)) {
+            if (!\in_array($transportSharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER, TransportSharing::PERSISTENT_PREFER], true)) {
                 throw new \InvalidArgumentException('The "transport_sharing" option requires transport sharing, but the stream handler does not support it.');
             }
         }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -624,7 +624,7 @@ final class StreamHandler
         if (\array_key_exists('transport_sharing', $options)) {
             $transportSharingMode = CurlShareHandleState::normalizeMode($options['transport_sharing'], 'transport_sharing');
 
-            if (!\in_array($transportSharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER, TransportSharing::PERSISTENT_PREFER], true)) {
+            if (\in_array($transportSharingMode, [TransportSharing::HANDLER_REQUIRE, TransportSharing::PERSISTENT_REQUIRE], true)) {
                 throw new \InvalidArgumentException('The "transport_sharing" option requires transport sharing, but the stream handler does not support it.');
             }
         }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -101,7 +101,7 @@ final class Utils
         $handler = null;
         $sharingMode = CurlShareHandleState::normalizeMode($handlerOptions['transport_sharing'] ?? null, 'transport_sharing');
         $sharingRequested = $sharingMode !== TransportSharing::NONE;
-        $sharingRequired = !\in_array($sharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER, TransportSharing::PERSISTENT_PREFER], true);
+        $sharingRequired = \in_array($sharingMode, [TransportSharing::HANDLER_REQUIRE, TransportSharing::PERSISTENT_REQUIRE], true);
         $curlHandlerOptions = [];
         $curlSupported = CurlVersion::supportsTls12()
             && (\function_exists('curl_multi_exec') || \function_exists('curl_exec'));

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -101,7 +101,7 @@ final class Utils
         $handler = null;
         $sharingMode = CurlShareHandleState::normalizeMode($handlerOptions['transport_sharing'] ?? null, 'transport_sharing');
         $sharingRequested = $sharingMode !== TransportSharing::NONE;
-        $sharingRequired = !\in_array($sharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER], true);
+        $sharingRequired = !\in_array($sharingMode, [TransportSharing::NONE, TransportSharing::HANDLER_PREFER, TransportSharing::PERSISTENT_PREFER], true);
         $curlHandlerOptions = [];
         $curlSupported = CurlVersion::supportsTls12()
             && (\function_exists('curl_multi_exec') || \function_exists('curl_exec'));

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -251,6 +251,16 @@ class ClientTest extends TestCase
         self::assertNull($client->getConfig('transport_sharing'));
     }
 
+    public function testPersistentPreferTransportSharingCanBeUsedWithCustomHandler(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler(),
+            'transport_sharing' => TransportSharing::PERSISTENT_PREFER,
+        ]);
+
+        self::assertNull($client->getConfig('transport_sharing'));
+    }
+
     /**
      * @dataProvider strictTransportSharingModeProvider
      */
@@ -268,7 +278,6 @@ class ClientTest extends TestCase
     public static function strictTransportSharingModeProvider(): iterable
     {
         yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
-        yield 'persistent prefer' => [TransportSharing::PERSISTENT_PREFER];
         yield 'persistent require' => [TransportSharing::PERSISTENT_REQUIRE];
     }
 

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -204,14 +204,23 @@ class CurlHandlerTest extends TestCase
         }
     }
 
-    public function testPreferredTransportSharingCanBeUsedWithCustomFactory(): void
+    /**
+     * @dataProvider preferredTransportSharingModeProvider
+     */
+    public function testPreferredTransportSharingCanBeUsedWithCustomFactory(string $transportSharing): void
     {
         $handler = new CurlHandler([
             'handle_factory' => new CurlFactory(0),
-            'transport_sharing' => TransportSharing::HANDLER_PREFER,
+            'transport_sharing' => $transportSharing,
         ]);
 
         self::assertInstanceOf(CurlHandler::class, $handler);
+    }
+
+    public static function preferredTransportSharingModeProvider(): iterable
+    {
+        yield 'handler prefer' => [TransportSharing::HANDLER_PREFER];
+        yield 'persistent prefer' => [TransportSharing::PERSISTENT_PREFER];
     }
 
     /**
@@ -231,7 +240,6 @@ class CurlHandlerTest extends TestCase
     public static function strictTransportSharingModeProvider(): iterable
     {
         yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
-        yield 'persistent prefer' => [TransportSharing::PERSISTENT_PREFER];
         yield 'persistent require' => [TransportSharing::PERSISTENT_REQUIRE];
     }
 

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -142,14 +142,23 @@ class CurlMultiHandlerTest extends TestCase
         self::assertPersistentPreferShareWasCreated();
     }
 
-    public function testPreferredTransportSharingCanBeUsedWithCustomFactory(): void
+    /**
+     * @dataProvider preferredTransportSharingModeProvider
+     */
+    public function testPreferredTransportSharingCanBeUsedWithCustomFactory(string $transportSharing): void
     {
         $handler = new CurlMultiHandler([
             'handle_factory' => new CurlFactory(0),
-            'transport_sharing' => TransportSharing::HANDLER_PREFER,
+            'transport_sharing' => $transportSharing,
         ]);
 
         self::assertInstanceOf(CurlMultiHandler::class, $handler);
+    }
+
+    public static function preferredTransportSharingModeProvider(): iterable
+    {
+        yield 'handler prefer' => [TransportSharing::HANDLER_PREFER];
+        yield 'persistent prefer' => [TransportSharing::PERSISTENT_PREFER];
     }
 
     /**
@@ -169,7 +178,6 @@ class CurlMultiHandlerTest extends TestCase
     public static function strictTransportSharingModeProvider(): iterable
     {
         yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
-        yield 'persistent prefer' => [TransportSharing::PERSISTENT_PREFER];
         yield 'persistent require' => [TransportSharing::PERSISTENT_REQUIRE];
     }
 

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -94,11 +94,11 @@ class CurlShareHandleStateTest extends TestCase
         $state = CurlShareHandleState::fromOption(TransportSharing::PERSISTENT_PREFER);
 
         self::assertInstanceOf(CurlShareHandleState::class, $state);
-        self::assertSame(TransportSharing::HANDLER_REQUIRE, $state->mode);
+        self::assertSame(TransportSharing::HANDLER_PREFER, $state->mode);
         self::assertHandlerShareWasCreated();
     }
 
-    public function testPersistentPreferStillFailsWhenHandlerSharingFallbackFails(): void
+    public function testPersistentPreferFallsBackToNoSharingWhenHandlerSharingFallbackFails(): void
     {
         self::skipIfCurlShareIsUnavailable();
 
@@ -107,10 +107,7 @@ class CurlShareHandleStateTest extends TestCase
         }
         $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to configure cURL share handle');
-
-        CurlShareHandleState::fromOption(TransportSharing::PERSISTENT_PREFER);
+        self::assertNull(CurlShareHandleState::fromOption(TransportSharing::PERSISTENT_PREFER));
     }
 
     public function testPersistentPreferUsesPersistentSharingWhenAvailable(): void
@@ -207,7 +204,6 @@ class CurlShareHandleStateTest extends TestCase
     public static function strictTransportSharingModes(): iterable
     {
         yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
-        yield 'persistent prefer' => [TransportSharing::PERSISTENT_PREFER];
         yield 'persistent require' => [TransportSharing::PERSISTENT_REQUIRE];
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1286,7 +1286,7 @@ class StreamHandlerTest extends TestCase
     public function testStreamAcceptsPreferredTransportSharingOption(): void
     {
         Server::flush();
-        Server::enqueue([new Response(200)]);
+        Server::enqueue([new Response(200), new Response(200)]);
 
         $handler = new StreamHandler();
         $response = $handler(new Request('GET', Server::$url), [
@@ -1294,9 +1294,18 @@ class StreamHandlerTest extends TestCase
         ])->wait();
 
         self::assertSame(200, $response->getStatusCode());
+
+        $response = $handler(new Request('GET', Server::$url), [
+            'transport_sharing' => TransportSharing::PERSISTENT_PREFER,
+        ])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testStreamRejectsRequiredTransportSharingOption(): void
+    /**
+     * @dataProvider requiredTransportSharingModeProvider
+     */
+    public function testStreamRejectsRequiredTransportSharingOption(string $transportSharing): void
     {
         $handler = new StreamHandler();
 
@@ -1304,8 +1313,14 @@ class StreamHandlerTest extends TestCase
         $this->expectExceptionMessage('transport_sharing');
 
         $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => TransportSharing::HANDLER_REQUIRE,
+            'transport_sharing' => $transportSharing,
         ]);
+    }
+
+    public static function requiredTransportSharingModeProvider(): iterable
+    {
+        yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
+        yield 'persistent require' => [TransportSharing::PERSISTENT_REQUIRE];
     }
 
     public function testStreamRejectsCurlOption(): void


### PR DESCRIPTION
This PR updates the 8.0 transport sharing behavior so `TransportSharing::PERSISTENT_PREFER` really means to use the strongest sharing available in the current environment. Guzzle now tries persistent sharing first, then falls back to `TransportSharing::HANDLER_PREFER`, and finally continues without sharing if handler-lifetime sharing cannot be configured. The strict behavior remains limited to `TransportSharing::HANDLER_REQUIRE` and `TransportSharing::PERSISTENT_REQUIRE`, so preferred modes do not fail just because the selected handler or custom factory cannot provide sharing.