### PR TITLE
Tidy transport sharing documentation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -51,9 +51,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * - base_uri: (string|UriInterface) Base URI of the client that is merged
      *   into relative URIs. Can be a string or instance of UriInterface.
      * - transport_sharing: (string|null) Transport sharing mode for the
-     *   default handler. Accepts TransportSharing::NONE,
-     *   TransportSharing::HANDLER_PREFER, or
-     *   TransportSharing::HANDLER_REQUIRE. Defaults to null.
+     *   default handler. Accepts TransportSharing::* or null. Defaults to null.
      * - **: any request option
      *
      * @param array $config Client configuration settings.

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -76,10 +76,7 @@ final class CurlShareHandleState
 
     public static function assertNoRequiredSharingCustomFactoryConflict(array $options, string $handlerName): void
     {
-        if (
-            !\array_key_exists('handle_factory', $options)
-            || $options['handle_factory'] === null
-        ) {
+        if (!\array_key_exists('handle_factory', $options) || $options['handle_factory'] === null) {
             return;
         }
 


### PR DESCRIPTION
This PR applies the small transport sharing cleanups that came up while reviewing the 8.0 follow-up. It shortens the client constructor documentation to say `TransportSharing::* or null`, and it keeps the `handle_factory` guard in `CurlShareHandleState` on one line.