### PR TITLE
Remove response access from RequestException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add explicit `close()` lifecycle methods to the built-in cURL handlers and concrete cURL factory
 - Add `HandlerClosedException` for pending transfers rejected by `CurlMultiHandler::close()`
 - Add `ProxyOptions` for proxy option resolution
-- Add `ResponseException` as the base class for request failures where a response was received
+- Add `ResponseException` for request failures with responses
 
 ### Changed
 
@@ -68,10 +68,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Made `GuzzleHttp\Handler\CurlFactory`, `GuzzleHttp\Handler\CurlHandler`, `GuzzleHttp\Handler\CurlMultiHandler`, `GuzzleHttp\Handler\MockHandler`, and `GuzzleHttp\Handler\StreamHandler` final
 - Made static utility classes non-instantiable and declared `GuzzleHttp\Handler\Proxy` final
 
-### Deprecated
-
-- Deprecated `RequestException::getResponse()` and `RequestException::hasResponse()`; catch `ResponseException` to access a received response
-
 ### Removed
 
 - Dropped support for PHP 7.2 and 7.3
@@ -80,6 +76,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Removed `RedirectMiddleware::$defaultSettings`; use `RedirectMiddleware::DEFAULT_SETTINGS`
 - Removed the deprecated `RetryMiddleware::exponentialDelay()` method
 - Removed the deprecated `RequestException::wrapException()` method
+- Removed response access from `RequestException`; use `ResponseException`
 - Removed `Utils::isHostInNoProxy()`; use `ProxyOptions` helpers for Guzzle 8 no-proxy matching
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -160,9 +160,10 @@ the base class for request failures where response headers were received and a
 response object is available, and `BadResponseException`,
 `ResponseTimeoutException`, and `TooManyRedirectsException` extend it. Use
 `ResponseException::getResponse()` for response-aware exception handling.
-`RequestException::getResponse()` and `RequestException::hasResponse()` are
-deprecated and will be removed in Guzzle 9; catch `ResponseException`, or test
-with `instanceof ResponseException`, before calling `getResponse()`.
+`RequestException` no longer stores or exposes responses: its constructor no
+longer accepts a response argument, and `RequestException::getResponse()` and
+`RequestException::hasResponse()` have been removed. Catch `ResponseException`,
+or test with `instanceof ResponseException`, before calling `getResponse()`.
 
 Timeouts are now split by whether response headers were received.
 `NetworkTimeoutException` is thrown when a built-in handler can reliably
@@ -242,7 +243,10 @@ The existing always-network cURL errors, including
 timeouts as `ConnectException`.
 
 The deprecated `RequestException::wrapException()` method was removed; create a
-`RequestException` directly instead.
+`RequestException` directly instead. When you need to create an exception for a
+failure with a response, create `ResponseException`, `BadResponseException`,
+`ClientException`, `ServerException`, or `TooManyRedirectsException` instead of
+passing the response to `RequestException`.
 `GuzzleHttp\Exception\InvalidArgumentException` remains outside the transfer
 exception hierarchy and is still used for invalid configuration or request
 option values that can be rejected before a transfer starts.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -153,17 +153,18 @@ specifically. Code that must support older Guzzle 7.x releases at the same time
 as Guzzle 8.0 should keep a broader `TransferException` catch at the boundary
 where all Guzzle transfer failures are handled.
 
-Guzzle 8.0 adds the response-aware side of the hierarchy. Guzzle 7.11.0 did not
-add `ResponseException`; response-aware request failures remain under
+Guzzle 8.0 also makes response-aware request failures explicit. Guzzle 7.11.0
+did not add `ResponseException`; response-aware request failures remain under
 `RequestException` throughout Guzzle 7.x. In Guzzle 8.0, `ResponseException` is
 the base class for request failures where response headers were received and a
 response object is available, and `BadResponseException`,
-`ResponseTimeoutException`, and `TooManyRedirectsException` extend it. Use
-`ResponseException::getResponse()` for response-aware exception handling.
-`RequestException` no longer stores or exposes responses: its constructor no
-longer accepts a response argument, and `RequestException::getResponse()` and
-`RequestException::hasResponse()` have been removed. Catch `ResponseException`,
-or test with `instanceof ResponseException`, before calling `getResponse()`.
+`ResponseTimeoutException`, and `TooManyRedirectsException` extend it. Response
+access now belongs to this branch only: `RequestException` no longer stores
+responses, no longer accepts a response constructor argument, and no longer has
+`getResponse()` or `hasResponse()` methods. Catch `ResponseException`, or test
+with `instanceof ResponseException`, before calling `getResponse()`. If you
+instantiate `RequestException` directly, its third constructor argument is now
+the exception code, followed by the previous exception and handler context.
 
 Timeouts are now split by whether response headers were received.
 `NetworkTimeoutException` is thrown when a built-in handler can reliably
@@ -242,11 +243,11 @@ The existing always-network cURL errors, including
 `ConnectException`. The built-in stream handler now classifies TLS handshake
 timeouts as `ConnectException`.
 
-The deprecated `RequestException::wrapException()` method was removed; create a
-`RequestException` directly instead. When you need to create an exception for a
-failure with a response, create `ResponseException`, `BadResponseException`,
-`ClientException`, `ServerException`, or `TooManyRedirectsException` instead of
-passing the response to `RequestException`.
+The deprecated `RequestException::wrapException()` method was removed. Create a
+`RequestException` directly for request failures where Guzzle does not expose a
+response object. For failures with a response, create `ResponseException`,
+`BadResponseException`, `ClientException`, `ServerException`, or
+`TooManyRedirectsException` instead.
 `GuzzleHttp\Exception\InvalidArgumentException` remains outside the transfer
 exception hierarchy and is still used for invalid configuration or request
 option values that can be rejected before a transfer starts.

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
         "guzzlehttp/psr7": "^3.0@dev",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "symfony/deprecation-contracts": "^2.2 || ^3.0",
         "symfony/polyfill-php80": "^1.24"
     },
     "require-dev": {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -482,9 +482,6 @@ Guzzle throws exceptions for errors that occur during a transfer.
 
 - `GuzzleHttp\Exception\ResponseException` is the base class for request-related transfer failures where a response was received. It exposes the response with `getResponse()`.
 
-> [!NOTE]
-> Legacy response probing on `GuzzleHttp\Exception\RequestException` is deprecated. Catch `GuzzleHttp\Exception\ResponseException` to access a received response.
-
 - A `GuzzleHttp\Exception\ConnectException` exception is thrown when a connection cannot be established. This exception extends from `GuzzleHttp\Exception\NetworkException`. Invalid or handler-unsupported HTTP request protocol versions are reported as `RequestException`, not `ConnectException`.
 
 - A `GuzzleHttp\Exception\NetworkTimeoutException` exception is thrown when a transfer timeout can be reliably identified before a response is received. This exception extends from `GuzzleHttp\Exception\NetworkException`.

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -17,22 +17,17 @@ class RequestException extends TransferException implements RequestExceptionInte
 {
     private RequestInterface $request;
 
-    private ?ResponseInterface $response;
-
     private array $handlerContext;
 
     public function __construct(
         string $message,
         RequestInterface $request,
-        ?ResponseInterface $response = null,
         ?\Throwable $previous = null,
-        array $handlerContext = []
+        array $handlerContext = [],
+        int $code = 0
     ) {
-        // Set the code of the exception if the response is set and not future.
-        $code = $response ? $response->getStatusCode() : 0;
         parent::__construct($message, $code, $previous);
         $this->request = $request;
-        $this->response = $response;
         $this->handlerContext = $handlerContext;
     }
 
@@ -56,7 +51,6 @@ class RequestException extends TransferException implements RequestExceptionInte
             return new self(
                 'Error completing request',
                 $request,
-                null,
                 $previous,
                 $handlerContext
             );
@@ -107,31 +101,6 @@ class RequestException extends TransferException implements RequestExceptionInte
     public function getRequest(): RequestInterface
     {
         return $this->request;
-    }
-
-    /**
-     * Get the associated response
-     *
-     * Calling this method is deprecated since 8.0. Use instanceof
-     * ResponseException and ResponseException::getResponse() instead.
-     */
-    public function getResponse(): ?ResponseInterface
-    {
-        \trigger_deprecation('guzzlehttp/guzzle', '8.0', '%s::getResponse() is deprecated and will be removed in 9.0. Use instanceof %s and %s::getResponse() instead.', static::class, ResponseException::class, ResponseException::class);
-
-        return $this->response;
-    }
-
-    /**
-     * Check if a response was received
-     *
-     * @deprecated since 8.0. Use instanceof ResponseException instead.
-     */
-    public function hasResponse(): bool
-    {
-        \trigger_deprecation('guzzlehttp/guzzle', '8.0', '%s::hasResponse() is deprecated and will be removed in 9.0. Use instanceof %s instead.', static::class, ResponseException::class);
-
-        return $this->response !== null;
     }
 
     /**

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -22,9 +22,9 @@ class RequestException extends TransferException implements RequestExceptionInte
     public function __construct(
         string $message,
         RequestInterface $request,
+        int $code = 0,
         ?\Throwable $previous = null,
-        array $handlerContext = [],
-        int $code = 0
+        array $handlerContext = []
     ) {
         parent::__construct($message, $code, $previous);
         $this->request = $request;
@@ -51,6 +51,7 @@ class RequestException extends TransferException implements RequestExceptionInte
             return new self(
                 'Error completing request',
                 $request,
+                0,
                 $previous,
                 $handlerContext
             );

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -21,7 +21,7 @@ class ResponseException extends RequestException
         ?\Throwable $previous = null,
         array $handlerContext = []
     ) {
-        parent::__construct($message, $request, $previous, $handlerContext, $response->getStatusCode());
+        parent::__construct($message, $request, $response->getStatusCode(), $previous, $handlerContext);
         $this->response = $response;
     }
 

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -21,7 +21,7 @@ class ResponseException extends RequestException
         ?\Throwable $previous = null,
         array $handlerContext = []
     ) {
-        parent::__construct($message, $request, $response, $previous, $handlerContext);
+        parent::__construct($message, $request, $previous, $handlerContext, $response->getStatusCode());
         $this->response = $response;
     }
 
@@ -31,15 +31,5 @@ class ResponseException extends RequestException
     public function getResponse(): ResponseInterface
     {
         return $this->response;
-    }
-
-    /**
-     * @deprecated since 8.0. Response exceptions always have a response. Use instanceof ResponseException instead.
-     */
-    public function hasResponse(): bool
-    {
-        \trigger_deprecation('guzzlehttp/guzzle', '8.0', '%s::hasResponse() is deprecated and will be removed in 9.0. Use instanceof %s instead.', static::class, self::class);
-
-        return true;
     }
 }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -673,7 +673,6 @@ final class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'An error was encountered while creating the response',
                     $easy->request,
-                    null,
                     $easy->createResponseException,
                     $ctx
                 )
@@ -701,7 +700,6 @@ final class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'An error was encountered during the on_headers event',
                     $easy->request,
-                    null,
                     $easy->onHeadersException,
                     $ctx
                 )
@@ -727,7 +725,6 @@ final class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'An error was encountered during the progress event',
                     $easy->request,
-                    null,
                     $easy->progressException,
                     $ctx
                 )
@@ -753,7 +750,6 @@ final class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'The transfer was aborted by the progress callback',
                     $easy->request,
-                    null,
                     null,
                     $ctx
                 )
@@ -790,7 +786,7 @@ final class CurlFactory implements CurlFactoryInterface
         } elseif ($easy->response) {
             $error = new ResponseException($message, $easy->request, $easy->response, null, $ctx);
         } else {
-            $error = new RequestException($message, $easy->request, null, null, $ctx);
+            $error = new RequestException($message, $easy->request, null, $ctx);
         }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -673,6 +673,7 @@ final class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'An error was encountered while creating the response',
                     $easy->request,
+                    0,
                     $easy->createResponseException,
                     $ctx
                 )
@@ -700,6 +701,7 @@ final class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'An error was encountered during the on_headers event',
                     $easy->request,
+                    0,
                     $easy->onHeadersException,
                     $ctx
                 )
@@ -725,6 +727,7 @@ final class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'An error was encountered during the progress event',
                     $easy->request,
+                    0,
                     $easy->progressException,
                     $ctx
                 )
@@ -750,6 +753,7 @@ final class CurlFactory implements CurlFactoryInterface
                 new RequestException(
                     'The transfer was aborted by the progress callback',
                     $easy->request,
+                    0,
                     null,
                     $ctx
                 )
@@ -786,7 +790,7 @@ final class CurlFactory implements CurlFactoryInterface
         } elseif ($easy->response) {
             $error = new ResponseException($message, $easy->request, $easy->response, null, $ctx);
         } else {
-            $error = new RequestException($message, $easy->request, null, $ctx);
+            $error = new RequestException($message, $easy->request, 0, null, $ctx);
         }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -115,7 +115,7 @@ final class StreamHandler
                 if (self::isConnectionError($e->getMessage())) {
                     $e = new ConnectException($e->getMessage(), $request, $e);
                 } else {
-                    $e = $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, $e);
+                    $e = $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, 0, $e);
                 }
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
@@ -239,6 +239,7 @@ final class StreamHandler
         $reason = new RequestException(
             'An error was encountered while creating the response',
             $request,
+            0,
             $previous
         );
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -115,7 +115,7 @@ final class StreamHandler
                 if (self::isConnectionError($e->getMessage())) {
                     $e = new ConnectException($e->getMessage(), $request, $e);
                 } else {
-                    $e = $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, null, $e);
+                    $e = $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, $e);
                 }
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
@@ -239,7 +239,6 @@ final class StreamHandler
         $reason = new RequestException(
             'An error was encountered while creating the response',
             $request,
-            null,
             $previous
         );
 

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -149,7 +149,7 @@ class RequestExceptionTest extends TestCase
     public function testCanProvideHandlerContext(): void
     {
         $r = new Request('GET', 'http://www.oo.com');
-        $e = new RequestException('foo', $r, null, ['bar' => 'baz']);
+        $e = new RequestException('foo', $r, 0, null, ['bar' => 'baz']);
         self::assertSame(['bar' => 'baz'], $e->getHandlerContext());
     }
 

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -28,14 +28,7 @@ class RequestExceptionTest extends TestCase
         self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         self::assertSame($req, $e->getRequest());
         self::assertSame('foo', $e->getMessage());
-    }
-
-    public function testDoesNotExposeResponseAccessors(): void
-    {
-        $e = new RequestException('foo', new Request('GET', '/'));
-
-        self::assertFalse(\method_exists($e, 'getResponse'));
-        self::assertFalse(\method_exists($e, 'hasResponse'));
+        self::assertSame(0, $e->getCode());
     }
 
     public function testCreatesGenerateException(): void
@@ -149,8 +142,9 @@ class RequestExceptionTest extends TestCase
     public function testCanProvideHandlerContext(): void
     {
         $r = new Request('GET', 'http://www.oo.com');
-        $e = new RequestException('foo', $r, 0, null, ['bar' => 'baz']);
+        $e = new RequestException('foo', $r, 123, null, ['bar' => 'baz']);
         self::assertSame(['bar' => 'baz'], $e->getHandlerContext());
+        self::assertSame(123, $e->getCode());
     }
 
     public function testObfuscateUrlWithToken(): void

--- a/tests/Exception/RequestExceptionTest.php
+++ b/tests/Exception/RequestExceptionTest.php
@@ -30,6 +30,14 @@ class RequestExceptionTest extends TestCase
         self::assertSame('foo', $e->getMessage());
     }
 
+    public function testDoesNotExposeResponseAccessors(): void
+    {
+        $e = new RequestException('foo', new Request('GET', '/'));
+
+        self::assertFalse(\method_exists($e, 'getResponse'));
+        self::assertFalse(\method_exists($e, 'hasResponse'));
+    }
+
     public function testCreatesGenerateException(): void
     {
         $e = RequestException::create(new Request('GET', '/'));
@@ -141,7 +149,7 @@ class RequestExceptionTest extends TestCase
     public function testCanProvideHandlerContext(): void
     {
         $r = new Request('GET', 'http://www.oo.com');
-        $e = new RequestException('foo', $r, null, null, ['bar' => 'baz']);
+        $e = new RequestException('foo', $r, null, ['bar' => 'baz']);
         self::assertSame(['bar' => 'baz'], $e->getHandlerContext());
     }
 

--- a/tests/Exception/ResponseExceptionTest.php
+++ b/tests/Exception/ResponseExceptionTest.php
@@ -30,7 +30,9 @@ class ResponseExceptionTest extends TestCase
         self::assertSame($req, $e->getRequest());
         self::assertSame($res, $e->getResponse());
         self::assertSame('foo', $e->getMessage());
+        self::assertSame(200, $e->getCode());
         self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
+        self::assertFalse(\method_exists($e, 'hasResponse'));
     }
 }

--- a/tests/Exception/ResponseExceptionTest.php
+++ b/tests/Exception/ResponseExceptionTest.php
@@ -17,10 +17,10 @@ use Psr\Http\Client\RequestExceptionInterface;
  */
 class ResponseExceptionTest extends TestCase
 {
-    public function testHasRequestAndResponse(): void
+    public function testCarriesRequestResponseAndContext(): void
     {
         $req = new Request('GET', '/');
-        $res = new Response(200);
+        $res = new Response(418);
         $prev = new \Exception();
         $e = new ResponseException('foo', $req, $res, $prev, ['foo' => 'bar']);
 
@@ -30,9 +30,8 @@ class ResponseExceptionTest extends TestCase
         self::assertSame($req, $e->getRequest());
         self::assertSame($res, $e->getResponse());
         self::assertSame('foo', $e->getMessage());
-        self::assertSame(200, $e->getCode());
+        self::assertSame(418, $e->getCode());
         self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
-        self::assertFalse(\method_exists($e, 'hasResponse'));
     }
 }

--- a/tests/MessageFormatterTest.php
+++ b/tests/MessageFormatterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Tests;
 
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -54,7 +54,7 @@ class MessageFormatterTest extends TestCase
     {
         $request = new Request('PUT', '/', ['x-test' => 'abc'], Psr7\Utils::streamFor('foo'));
         $response = new Response(200, ['X-Baz' => 'Bar'], Psr7\Utils::streamFor('baz'));
-        $err = new RequestException('Test', $request, $response);
+        $err = new ResponseException('Test', $request, $response);
 
         return [
             ['{request}', [$request], Psr7\Message::toString($request)],


### PR DESCRIPTION
This removes the transitional response API from RequestException in Guzzle 8. Response-bearing failures now expose their response through ResponseException only, while plain RequestException remains for request failures where Guzzle does not expose a response object.

The upgrade guide now presents this as a hard Guzzle 8 migration step instead of a deprecation bridge, and the changelog entries were folded into the existing ResponseException and removed API notes.