### PR TITLE
Refine network exception classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Avoid stale authenticated proxy tunnels on affected libcurl versions
 - Allow built-in cURL handler `progress` callbacks to abort transfers with truthy return values
 - Normalize built-in handler `progress` callback arguments to integer byte counts
-- Reject cURL `progress` throwables with `ResponseException` when a response exists, otherwise `RequestException`
+- Reject built-in cURL `progress` throwables with `ResponseException` when a response exists, otherwise `RequestException`
 - Release built-in cURL easy handles before invoking `on_stats`
 - Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available
 - Reject cURL multi handler promises when transfer completion callbacks throw during manual event-loop ticks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Apply the stream handler `crypto_method` option through the SSL context so it consistently controls the minimum TLS version
 - Validate built-in handler timeout options before applying them
 - Classify empty, malformed, or handler-unsupported request protocol versions as request exceptions
-- Classify additional cURL transport failures without a response as network exceptions
-- Classify stream handler TLS handshake timeouts as `ConnectException`
+- Classify additional cURL transport failures without a response as `NetworkException`
+- Classify stream connection failures as `ConnectException` and identifiable no-response timeouts as `NetworkTimeoutException`
 - Classify generic response-aware request failures as `ResponseException`
 - Throw `NetworkTimeoutException` for reliably detected no-response transfer timeouts
 - Throw `ResponseTimeoutException` for reliably detected response-aware transfer timeouts
@@ -60,7 +60,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Avoid stale authenticated proxy tunnels on affected libcurl versions
 - Allow built-in cURL handler `progress` callbacks to abort transfers with truthy return values
 - Normalize built-in handler `progress` callback arguments to integer byte counts
-- Reject built-in cURL handler `progress` callback throwables with `RequestException`
+- Reject cURL `progress` throwables with `ResponseException` when a response exists, otherwise `RequestException`
 - Release built-in cURL easy handles before invoking `on_stats`
 - Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available
 - Reject cURL multi handler promises when transfer completion callbacks throw during manual event-loop ticks

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -224,24 +224,24 @@ The affected built-in cURL classifications are:
   `ConnectException`.
 - `CURLE_COULDNT_RESOLVE_PROXY` now throws `ConnectException`. Guzzle 7.x
   classified this cURL error as `RequestException`.
-- `CURLE_SEND_ERROR` and `CURLE_RECV_ERROR` now throw `ConnectException` when
-  no response object was created. If a response object was created before the
-  error, they remain request exceptions and are represented by
-  `ResponseException` when a response is available.
-- When the PHP cURL extension defines them, `CURLE_PROXY`,
-  `CURLE_QUIC_CONNECT_ERROR`, `CURLE_HTTP2`, `CURLE_HTTP2_STREAM`,
-  `CURLE_HTTP3`, `CURLE_PEER_FAILED_VERIFICATION`, `CURLE_SSL_CACERT`,
-  `CURLE_SSL_PEER_CERTIFICATE`, `CURLE_SSL_PINNEDPUBKEYNOTMATCH`,
-  `CURLE_SSL_INVALIDCERTSTATUS`, and `CURLE_SSL_CLIENTCERT` now throw
-  `ConnectException` when no response object was created. If a response object
-  was created before the error, they remain request exceptions and are
-  represented by `ResponseException` when a response is available.
+- `CURLE_GOT_NOTHING`, `CURLE_SEND_ERROR`, `CURLE_RECV_ERROR`, and
+  no-response HTTP/2 or HTTP/3 protocol failures now throw `NetworkException`.
+  Guzzle 7.x either threw `ConnectException` or classified some of these as
+  `RequestException`.
+- TLS certificate, proxy connection, DNS, TCP connection, and QUIC connection
+  failures without a response throw `ConnectException`.
+- If a response object was created before the cURL error, the failure is
+  represented by `ResponseException` or `ResponseTimeoutException`.
 
-The existing always-network cURL errors, including
-`CURLE_COULDNT_RESOLVE_HOST`, `CURLE_COULDNT_CONNECT`,
-`CURLE_SSL_CONNECT_ERROR`, and `CURLE_GOT_NOTHING`, still throw
-`ConnectException`. The built-in stream handler now classifies TLS handshake
-timeouts as `ConnectException`.
+The existing cURL DNS, TCP connection, and TLS setup errors, including
+`CURLE_COULDNT_RESOLVE_HOST`, `CURLE_COULDNT_CONNECT`, and
+`CURLE_SSL_CONNECT_ERROR`, still throw `ConnectException`.
+
+The built-in stream handler now classifies DNS, TCP connect, proxy connect, and
+TLS setup failures as `ConnectException`. No-response stream timeouts that can
+be identified from PHP stream warnings are classified as
+`NetworkTimeoutException`; other malformed or unparseable response failures
+remain `RequestException`.
 
 The deprecated `RequestException::wrapException()` method was removed. Create a
 `RequestException` directly for request failures where Guzzle does not expose a

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -219,7 +219,7 @@ before a response was returned.
 
 ```php
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\NetworkException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use Psr\Http\Message\RequestInterface;
@@ -238,7 +238,7 @@ $stack->push(Middleware::retry(
             return false;
         }
 
-        if ($reason instanceof ConnectException) {
+        if ($reason instanceof NetworkException) {
             return true;
         }
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -470,15 +470,11 @@ When a transfer fails, first ask whether Guzzle has a response object yet. The a
             └── TooManyRedirectsException
 ```
 
-If the request cannot be completed because of a network problem and no response has been received, Guzzle throws `NetworkException`. This is the branch for transport failures that happen while opening the connection or moving bytes over the network. Connection establishment failures use the more specific `ConnectException`. Timeouts before a response is available use `NetworkTimeoutException`. Other no-response transport failures, such as send or receive errors, use `NetworkException` itself.
+If a network problem prevents Guzzle from receiving a response, it throws `NetworkException`. This covers transport failures while opening the connection or moving bytes over the network. Connection establishment failures use the more specific `ConnectException`, timeouts before a response is available use `NetworkTimeoutException`, and other no-response transport failures, such as send or receive errors, use `NetworkException` itself.
 
-If response headers have been parsed into a response object, later transfer failures use `ResponseException`. This is the only branch that exposes `getResponse()`. It includes `ResponseTimeoutException` when a timeout is identified after a response is available. When using Guzzle request methods, middleware may also turn completed responses into exceptions: `http_errors` turns 400 level responses into `ClientException` and 500 level responses into `ServerException`, and redirect middleware can throw `TooManyRedirectsException`.
+If Guzzle has parsed response headers into a response object, later transfer failures use `ResponseException`. This is the only branch that exposes `getResponse()`, and it includes `ResponseTimeoutException` when a timeout is identified after a response is available. With Guzzle request methods, middleware can also turn completed responses into exceptions: `http_errors` turns 400 level responses into `ClientException` and 500 level responses into `ServerException`, and redirect middleware can throw `TooManyRedirectsException`. `Client::sendRequest()` follows PSR-18 and returns redirect, 4xx, and 5xx responses normally instead.
 
-`Client::sendRequest()` follows PSR-18 and returns redirect, 4xx, and 5xx responses as normal responses. Those response-status exceptions are used by Guzzle request methods when the corresponding middleware options are enabled.
-
-If the failure belongs to the request but is not a network failure, and Guzzle does not have a response object, Guzzle throws `RequestException`. This includes invalid or handler-unsupported HTTP protocol versions, malformed response data that cannot be parsed into a PSR-7 response, and no-response transfers aborted by application code. `RequestException` exposes `getRequest()`, but it does not expose `getResponse()`.
-
-When handling these failures separately, put the catch blocks in the order shown below. The first catch handles transport failures with no response. The second handles failures where a response is available. The final catch handles other request failures without a response.
+If a non-network request failure occurs before Guzzle has a response object, it throws `RequestException`. This includes invalid or handler-unsupported HTTP protocol versions, malformed response data that cannot be parsed into a PSR-7 response, and no-response transfers aborted by application code. `RequestException` exposes `getRequest()`, but not `getResponse()`. When handling these cases separately, catch no-response transport failures first, response-aware failures second, and other request failures last.
 
 ```php
 use GuzzleHttp\Exception\NetworkException;

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -462,7 +462,7 @@ If response headers have been parsed into a response object, later transfer fail
 
 If the failure belongs to the request but is not a network failure, and Guzzle does not have a response object, Guzzle throws `RequestException`. This includes invalid or handler-unsupported HTTP protocol versions, malformed response data that cannot be parsed into a PSR-7 response, and no-response transfers aborted by application code. `RequestException` exposes `getRequest()`, but it does not expose `getResponse()`.
 
-`NetworkException` and `RequestException` are sibling branches under `TransferException`, so catching `RequestException` does not catch network failures. `ResponseException` extends `RequestException`, so catch `ResponseException` first when you need to call `getResponse()`.
+When handling these failures separately, put the catch blocks in the order shown below. The first catch handles transport failures with no response. The second handles failures where a response is available. The final catch handles other request failures without a response.
 
 ```php
 use GuzzleHttp\Exception\NetworkException;

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -452,9 +452,37 @@ echo $response->getStatusCode();
 
 ## Exceptions
 
-**Tree View**
+Transfer failures are reported by exceptions that implement `GuzzleException`, which extends PSR-18's `ClientExceptionInterface`. The short class names below are in the `GuzzleHttp\Exception` namespace.
 
-The following tree view describes how the Guzzle Exceptions depend on each other.
+The most useful distinction is where the failure happens in the request/response lifecycle. Before response headers have been parsed into a response object, network transport failures are reported as `NetworkException`. This matches PSR-18's network exception rule: there is no response object, but `getRequest()` returns the request. `ConnectException` is the more specific case for connection establishment failures, and `NetworkTimeoutException` is used when a timeout is identified before a response is available.
+
+After response headers have been parsed into a response object, later transfer failures are reported as `ResponseException`. Response exceptions expose the request with `getRequest()` and the response with `getResponse()`. This includes `ResponseTimeoutException` when a timeout is identified after a response is available. When using Guzzle request methods with the `http_errors` option enabled, this branch also includes `ClientException` for 400 level responses and `ServerException` for 500 level responses. When redirects are enabled, it includes `TooManyRedirectsException` when too many redirects are followed.
+
+Other request-related transfer failures are reported as `RequestException`. This branch is for non-network failures where Guzzle does not expose a response, such as invalid or handler-unsupported HTTP protocol versions, malformed response data that prevents Guzzle from creating a PSR-7 response, or a no-response transfer aborted by application code. It exposes the request with `getRequest()`, but it does not expose a response.
+
+`NetworkException` does not extend `RequestException`, so catch it separately when you need to handle transport failures. Catch `ResponseException` before `RequestException` when you need to call `getResponse()`.
+
+```php
+use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Psr7\Message;
+
+try {
+    $client->request('GET', 'https://github.com/_abc_123_404');
+} catch (NetworkException $e) {
+    echo Message::toString($e->getRequest());
+} catch (ResponseException $e) {
+    echo Message::toString($e->getRequest());
+    echo Message::toString($e->getResponse());
+} catch (RequestException $e) {
+    echo Message::toString($e->getRequest());
+}
+```
+
+`HandlerClosedException` is used when a built-in handler rejects a transfer because the handler was explicitly closed before the transfer completed. For example, pending `CurlMultiHandler` transfers are rejected with this exception when `CurlMultiHandler::close()` is called.
+
+For reference, the exception hierarchy is:
 
 ```
 . \RuntimeException
@@ -472,45 +500,9 @@ The following tree view describes how the Guzzle Exceptions depend on each other
             └── TooManyRedirectsException
 ```
 
-Guzzle throws exceptions for errors that occur during a transfer.
-
-- `GuzzleHttp\Exception\NetworkException` is the base class for networking errors where no response has been received. It implements PSR-18's `Psr\Http\Client\NetworkExceptionInterface`.
-
-- `GuzzleHttp\Exception\HandlerClosedException` is used when a built-in handler rejects a transfer because the handler was explicitly closed before the transfer completed. For example, pending `CurlMultiHandler` transfers are rejected with this exception when `CurlMultiHandler::close()` is called.
-
-- `GuzzleHttp\Exception\RequestException` is the base class for request-related transfer failures that are not network failures. It implements PSR-18's `Psr\Http\Client\RequestExceptionInterface` and exposes the request with `getRequest()`.
-
-- `GuzzleHttp\Exception\ResponseException` is the base class for request-related transfer failures where a response was received. It exposes the response with `getResponse()`.
-
-  Because `ResponseException` extends `RequestException`, catch `ResponseException` before `RequestException` when you need to call `getResponse()`.
-
-- A `GuzzleHttp\Exception\ConnectException` exception is thrown when a connection cannot be established. This exception extends from `GuzzleHttp\Exception\NetworkException`. Invalid or handler-unsupported HTTP request protocol versions are reported as `RequestException`, not `ConnectException`.
-
-- A `GuzzleHttp\Exception\NetworkTimeoutException` exception is thrown when a transfer timeout can be reliably identified before a response is received. This exception extends from `GuzzleHttp\Exception\NetworkException`.
-
-- A `GuzzleHttp\Exception\ResponseTimeoutException` exception is thrown when a transfer timeout can be reliably identified after a response is received. This exception extends from `GuzzleHttp\Exception\ResponseException`.
-
-- A `GuzzleHttp\Exception\ClientException` is thrown for 400 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException` and `GuzzleHttp\Exception\BadResponseException` extends from `GuzzleHttp\Exception\ResponseException`.
-
-  ```php
-  use GuzzleHttp\Psr7;
-  use GuzzleHttp\Exception\ClientException;
-
-  try {
-      $client->request('GET', 'https://github.com/_abc_123_404');
-  } catch (ClientException $e) {
-      echo Psr7\Message::toString($e->getRequest());
-      echo Psr7\Message::toString($e->getResponse());
-  }
-  ```
-
-- A `GuzzleHttp\Exception\ServerException` is thrown for 500 level errors if the `http_errors` request option is set to true. This exception extends from `GuzzleHttp\Exception\BadResponseException`.
-
-- A `GuzzleHttp\Exception\TooManyRedirectsException` is thrown when too many redirects are followed. This exception extends from `GuzzleHttp\Exception\ResponseException`.
-
 `Client::sendRequest()` returns redirect, 4xx, and 5xx responses as normal PSR-18 responses. These response-status exceptions are used by Guzzle request methods when the corresponding middleware options are enabled.
 
-All of the above exceptions extend from `GuzzleHttp\Exception\TransferException`. `TransferException` implements `GuzzleHttp\Exception\GuzzleException`, which extends PSR-18's `ClientExceptionInterface`.
+All transfer exceptions listed above extend from `TransferException`. `TransferException` implements `GuzzleException`, which extends PSR-18's `ClientExceptionInterface`.
 
 ## Environment Variables
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -496,8 +496,6 @@ try {
 
 `HandlerClosedException` sits outside the request/response lifecycle. It is used when a built-in handler rejects a transfer because the handler was explicitly closed before the transfer completed. For example, pending `CurlMultiHandler` transfers are rejected with this exception when `CurlMultiHandler::close()` is called.
 
-All transfer exceptions listed above extend from `TransferException` and implement `GuzzleException`.
-
 ## Environment Variables
 
 Guzzle exposes a few environment variables that can be used to customize the behavior of the library.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -452,9 +452,9 @@ echo $response->getStatusCode();
 
 ## Exceptions
 
-When a transfer fails, first ask whether Guzzle has a response object yet. That answer determines which part of the exception hierarchy you should catch. Transfer failures are reported by exceptions that implement `GuzzleException`, which extends PSR-18's `ClientExceptionInterface`.
+When a transfer fails, first ask whether Guzzle has a response object yet. That answer determines which part of the exception hierarchy you should catch. Use `TransferException` or `GuzzleException` only when one catch block should handle every Guzzle transfer failure.
 
-If the request cannot be completed because of a network problem and no response has been received, Guzzle throws `NetworkException`. This matches PSR-18's network exception rule: `getRequest()` is available, but there is no response object. Connection establishment failures use the more specific `ConnectException`. Timeouts before a response is available use `NetworkTimeoutException`. Other no-response transport failures, such as send or receive errors, use `NetworkException` itself.
+If the request cannot be completed because of a network problem and no response has been received, Guzzle throws `NetworkException`. This is the branch for transport failures that happen while opening the connection or moving bytes over the network. Connection establishment failures use the more specific `ConnectException`. Timeouts before a response is available use `NetworkTimeoutException`. Other no-response transport failures, such as send or receive errors, use `NetworkException` itself.
 
 If response headers have been parsed into a response object, later transfer failures use `ResponseException`. This is the only branch that exposes `getResponse()`. It includes `ResponseTimeoutException` when a timeout is identified after a response is available. When using Guzzle request methods, middleware may also turn completed responses into exceptions: `http_errors` turns 400 level responses into `ClientException` and 500 level responses into `ServerException`, and redirect middleware can throw `TooManyRedirectsException`.
 
@@ -502,7 +502,7 @@ For reference, the exception hierarchy is:
             └── TooManyRedirectsException
 ```
 
-All transfer exceptions listed above extend from `TransferException`. `TransferException` implements `GuzzleException`, which extends PSR-18's `ClientExceptionInterface`.
+All transfer exceptions listed above extend from `TransferException` and implement `GuzzleException`.
 
 ## Environment Variables
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -482,6 +482,8 @@ Guzzle throws exceptions for errors that occur during a transfer.
 
 - `GuzzleHttp\Exception\ResponseException` is the base class for request-related transfer failures where a response was received. It exposes the response with `getResponse()`.
 
+  Because `ResponseException` extends `RequestException`, catch `ResponseException` before `RequestException` when you need to call `getResponse()`.
+
 - A `GuzzleHttp\Exception\ConnectException` exception is thrown when a connection cannot be established. This exception extends from `GuzzleHttp\Exception\NetworkException`. Invalid or handler-unsupported HTTP request protocol versions are reported as `RequestException`, not `ConnectException`.
 
 - A `GuzzleHttp\Exception\NetworkTimeoutException` exception is thrown when a transfer timeout can be reliably identified before a response is received. This exception extends from `GuzzleHttp\Exception\NetworkException`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -452,15 +452,17 @@ echo $response->getStatusCode();
 
 ## Exceptions
 
-Transfer failures are reported by exceptions that implement `GuzzleException`, which extends PSR-18's `ClientExceptionInterface`. The short class names below are in the `GuzzleHttp\Exception` namespace.
+When a transfer fails, first ask whether Guzzle has a response object yet. That answer determines which part of the exception hierarchy you should catch. Transfer failures are reported by exceptions that implement `GuzzleException`, which extends PSR-18's `ClientExceptionInterface`.
 
-The most useful distinction is where the failure happens in the request/response lifecycle. Before response headers have been parsed into a response object, network transport failures are reported as `NetworkException`. This matches PSR-18's network exception rule: there is no response object, but `getRequest()` returns the request. `ConnectException` is the more specific case for connection establishment failures, and `NetworkTimeoutException` is used when a timeout is identified before a response is available.
+If the request cannot be completed because of a network problem and no response has been received, Guzzle throws `NetworkException`. This matches PSR-18's network exception rule: `getRequest()` is available, but there is no response object. Connection establishment failures use the more specific `ConnectException`. Timeouts before a response is available use `NetworkTimeoutException`. Other no-response transport failures, such as send or receive errors, use `NetworkException` itself.
 
-After response headers have been parsed into a response object, later transfer failures are reported as `ResponseException`. Response exceptions expose the request with `getRequest()` and the response with `getResponse()`. This includes `ResponseTimeoutException` when a timeout is identified after a response is available. When using Guzzle request methods with the `http_errors` option enabled, this branch also includes `ClientException` for 400 level responses and `ServerException` for 500 level responses. When redirects are enabled, it includes `TooManyRedirectsException` when too many redirects are followed.
+If response headers have been parsed into a response object, later transfer failures use `ResponseException`. This is the only branch that exposes `getResponse()`. It includes `ResponseTimeoutException` when a timeout is identified after a response is available. When using Guzzle request methods, middleware may also turn completed responses into exceptions: `http_errors` turns 400 level responses into `ClientException` and 500 level responses into `ServerException`, and redirect middleware can throw `TooManyRedirectsException`.
 
-Other request-related transfer failures are reported as `RequestException`. This branch is for non-network failures where Guzzle does not expose a response, such as invalid or handler-unsupported HTTP protocol versions, malformed response data that prevents Guzzle from creating a PSR-7 response, or a no-response transfer aborted by application code. It exposes the request with `getRequest()`, but it does not expose a response.
+`Client::sendRequest()` follows PSR-18 and returns redirect, 4xx, and 5xx responses as normal responses. Those response-status exceptions are used by Guzzle request methods when the corresponding middleware options are enabled.
 
-`NetworkException` does not extend `RequestException`, so catch it separately when you need to handle transport failures. Catch `ResponseException` before `RequestException` when you need to call `getResponse()`.
+If the failure belongs to the request but is not a network failure, and Guzzle does not have a response object, Guzzle throws `RequestException`. This includes invalid or handler-unsupported HTTP protocol versions, malformed response data that cannot be parsed into a PSR-7 response, and no-response transfers aborted by application code. `RequestException` exposes `getRequest()`, but it does not expose `getResponse()`.
+
+`NetworkException` and `RequestException` are sibling branches under `TransferException`, so catching `RequestException` does not catch network failures. `ResponseException` extends `RequestException`, so catch `ResponseException` first when you need to call `getResponse()`.
 
 ```php
 use GuzzleHttp\Exception\NetworkException;
@@ -480,7 +482,7 @@ try {
 }
 ```
 
-`HandlerClosedException` is used when a built-in handler rejects a transfer because the handler was explicitly closed before the transfer completed. For example, pending `CurlMultiHandler` transfers are rejected with this exception when `CurlMultiHandler::close()` is called.
+`HandlerClosedException` sits outside the request/response lifecycle. It is used when a built-in handler rejects a transfer because the handler was explicitly closed before the transfer completed. For example, pending `CurlMultiHandler` transfers are rejected with this exception when `CurlMultiHandler::close()` is called.
 
 For reference, the exception hierarchy is:
 
@@ -499,8 +501,6 @@ For reference, the exception hierarchy is:
             ├── ResponseTimeoutException
             └── TooManyRedirectsException
 ```
-
-`Client::sendRequest()` returns redirect, 4xx, and 5xx responses as normal PSR-18 responses. These response-status exceptions are used by Guzzle request methods when the corresponding middleware options are enabled.
 
 All transfer exceptions listed above extend from `TransferException`. `TransferException` implements `GuzzleException`, which extends PSR-18's `ClientExceptionInterface`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -452,7 +452,23 @@ echo $response->getStatusCode();
 
 ## Exceptions
 
-When a transfer fails, first ask whether Guzzle has a response object yet. That answer determines which part of the exception hierarchy you should catch. Use `TransferException` or `GuzzleException` only when one catch block should handle every Guzzle transfer failure.
+When a transfer fails, first ask whether Guzzle has a response object yet. The answer determines which branch below to catch: `NetworkException` for no-response network failures, `ResponseException` for failures with a response, and `RequestException` for other request failures. Use `TransferException` or `GuzzleException` only when one catch block should handle every Guzzle transfer failure.
+
+```
+. \RuntimeException
+└── TransferException (implements GuzzleException)
+    ├── HandlerClosedException
+    ├── NetworkException (implements NetworkExceptionInterface)
+    │   ├── ConnectException
+    │   └── NetworkTimeoutException
+    └── RequestException (implements RequestExceptionInterface)
+        └── ResponseException
+            ├── BadResponseException
+            │   ├── ServerException
+            │   └── ClientException
+            ├── ResponseTimeoutException
+            └── TooManyRedirectsException
+```
 
 If the request cannot be completed because of a network problem and no response has been received, Guzzle throws `NetworkException`. This is the branch for transport failures that happen while opening the connection or moving bytes over the network. Connection establishment failures use the more specific `ConnectException`. Timeouts before a response is available use `NetworkTimeoutException`. Other no-response transport failures, such as send or receive errors, use `NetworkException` itself.
 
@@ -483,24 +499,6 @@ try {
 ```
 
 `HandlerClosedException` sits outside the request/response lifecycle. It is used when a built-in handler rejects a transfer because the handler was explicitly closed before the transfer completed. For example, pending `CurlMultiHandler` transfers are rejected with this exception when `CurlMultiHandler::close()` is called.
-
-For reference, the exception hierarchy is:
-
-```
-. \RuntimeException
-└── TransferException (implements GuzzleException)
-    ├── HandlerClosedException
-    ├── NetworkException (implements NetworkExceptionInterface)
-    │   ├── ConnectException
-    │   └── NetworkTimeoutException
-    └── RequestException (implements RequestExceptionInterface)
-        └── ResponseException
-            ├── BadResponseException
-            │   ├── ServerException
-            │   └── ClientException
-            ├── ResponseTimeoutException
-            └── TooManyRedirectsException
-```
 
 All transfer exceptions listed above extend from `TransferException` and implement `GuzzleException`.
 

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -35,7 +35,7 @@ class RequestException extends TransferException implements RequestExceptionInte
      * Factory method to create a new exception with a normalized error message
      *
      * @param RequestInterface             $request        Request sent
-     * @param ResponseInterface            $response       Response received
+     * @param ResponseInterface|null       $response       Response received, if any
      * @param \Throwable|null              $previous       Previous exception
      * @param array                        $handlerContext Optional handler context
      * @param BodySummarizerInterface|null $bodySummarizer Optional body summarizer

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\NetworkException;
 use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
@@ -634,39 +635,6 @@ final class CurlFactory implements CurlFactoryInterface
      */
     private static function createRejection(EasyHandle $easy, array $ctx): PromiseInterface
     {
-        static $connectionErrors = [
-            \CURLE_COULDNT_RESOLVE_HOST => true,
-            \CURLE_COULDNT_RESOLVE_PROXY => true,
-            \CURLE_COULDNT_CONNECT => true,
-            \CURLE_SSL_CONNECT_ERROR => true,
-            \CURLE_GOT_NOTHING => true,
-        ];
-        static $networkErrorsWithoutResponse;
-        if ($networkErrorsWithoutResponse === null) {
-            $networkErrorsWithoutResponse = [
-                \CURLE_SEND_ERROR => true,
-                \CURLE_RECV_ERROR => true,
-            ];
-
-            foreach ([
-                'CURLE_PROXY',
-                'CURLE_QUIC_CONNECT_ERROR',
-                'CURLE_HTTP2',
-                'CURLE_HTTP2_STREAM',
-                'CURLE_HTTP3',
-                'CURLE_PEER_FAILED_VERIFICATION',
-                'CURLE_SSL_CACERT',
-                'CURLE_SSL_PEER_CERTIFICATE',
-                'CURLE_SSL_PINNEDPUBKEYNOTMATCH',
-                'CURLE_SSL_INVALIDCERTSTATUS',
-                'CURLE_SSL_CLIENTCERT',
-            ] as $constant) {
-                if (\defined($constant)) {
-                    $networkErrorsWithoutResponse[(int) \constant($constant)] = true;
-                }
-            }
-        }
-
         if ($easy->createResponseException) {
             /** @var PromiseInterface<ResponseInterface, mixed> */
             return P\Create::rejectionFor(
@@ -778,23 +746,76 @@ final class CurlFactory implements CurlFactoryInterface
             }
         }
 
-        $isNetworkError = isset($connectionErrors[$easy->errno])
-            || (!$easy->response && isset($networkErrorsWithoutResponse[$easy->errno]));
-
         if ($easy->errno === \CURLE_OPERATION_TIMEOUTED) {
             $error = $easy->response !== null
                 ? new ResponseTimeoutException($message, $easy->request, $easy->response, null, $ctx)
                 : new NetworkTimeoutException($message, $easy->request, null, $ctx);
-        } elseif ($isNetworkError) {
-            $error = new ConnectException($message, $easy->request, null, $ctx);
         } elseif ($easy->response) {
             $error = new ResponseException($message, $easy->request, $easy->response, null, $ctx);
+        } elseif (self::isConnectionError($easy->errno)) {
+            $error = new ConnectException($message, $easy->request, null, $ctx);
+        } elseif (self::isNetworkError($easy->errno)) {
+            $error = new NetworkException($message, $easy->request, null, $ctx);
         } else {
             $error = new RequestException($message, $easy->request, 0, null, $ctx);
         }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */
         return P\Create::rejectionFor($error);
+    }
+
+    private static function isConnectionError(int $errno): bool
+    {
+        static $connectionErrors;
+        if ($connectionErrors === null) {
+            $connectionErrors = [
+                \CURLE_COULDNT_RESOLVE_HOST => true,
+                \CURLE_COULDNT_RESOLVE_PROXY => true,
+                \CURLE_COULDNT_CONNECT => true,
+                \CURLE_SSL_CONNECT_ERROR => true,
+            ];
+
+            foreach ([
+                'CURLE_PROXY',
+                'CURLE_QUIC_CONNECT_ERROR',
+                'CURLE_PEER_FAILED_VERIFICATION',
+                'CURLE_SSL_CACERT',
+                'CURLE_SSL_PEER_CERTIFICATE',
+                'CURLE_SSL_PINNEDPUBKEYNOTMATCH',
+                'CURLE_SSL_INVALIDCERTSTATUS',
+                'CURLE_SSL_CLIENTCERT',
+            ] as $constant) {
+                if (\defined($constant)) {
+                    $connectionErrors[(int) \constant($constant)] = true;
+                }
+            }
+        }
+
+        return isset($connectionErrors[$errno]);
+    }
+
+    private static function isNetworkError(int $errno): bool
+    {
+        static $networkErrors;
+        if ($networkErrors === null) {
+            $networkErrors = [
+                \CURLE_GOT_NOTHING => true,
+                \CURLE_SEND_ERROR => true,
+                \CURLE_RECV_ERROR => true,
+            ];
+
+            foreach ([
+                'CURLE_HTTP2',
+                'CURLE_HTTP2_STREAM',
+                'CURLE_HTTP3',
+            ] as $constant) {
+                if (\defined($constant)) {
+                    $networkErrors[(int) \constant($constant)] = true;
+                }
+            }
+        }
+
+        return isset($networkErrors[$errno]);
     }
 
     private static function sanitizeCurlError(string $error, UriInterface $uri): string

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\ResponseTimeoutException;
@@ -30,17 +32,22 @@ final class StreamHandler
         'php_network_getaddresses:',
         'getaddrinfo',
         'gethostbyname failed',
+        'Unable to connect to',
         'Connection refused',
         'No connection could be made because the target machine actively refused it',
         'connection attempt failed',
         'connect() failed',
-        'Connection timed out',
-        'Operation timed out',
         'Network is unreachable',
         'No route to host',
         'Host is unreachable',
         'Host is down',
         'Cannot connect to HTTPS server through proxy',
+        'Failed to enable crypto',
+    ];
+
+    private const TIMEOUT_ERRORS = [
+        'Connection timed out',
+        'Operation timed out',
         'SSL: Handshake timed out',
     ];
 
@@ -111,11 +118,13 @@ final class StreamHandler
             }
 
             // Determine if the error was a networking error.
-            if (!$e instanceof ConnectException) {
-                if (self::isConnectionError($e->getMessage())) {
+            if (!$e instanceof NetworkException) {
+                if (self::isTimeoutError($e->getMessage())) {
+                    $e = new NetworkTimeoutException($e->getMessage(), $request, $e);
+                } elseif (self::isConnectionError($e->getMessage())) {
                     $e = new ConnectException($e->getMessage(), $request, $e);
-                } else {
-                    $e = $e instanceof RequestException ? $e : new RequestException($e->getMessage(), $request, 0, $e);
+                } elseif (!$e instanceof RequestException) {
+                    $e = new RequestException($e->getMessage(), $request, 0, $e);
                 }
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
@@ -136,10 +145,21 @@ final class StreamHandler
         return true;
     }
 
+    private static function isTimeoutError(string $message): bool
+    {
+        foreach (self::TIMEOUT_ERRORS as $timeoutError) {
+            if (false !== \stripos($message, $timeoutError)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static function isConnectionError(string $message): bool
     {
         foreach (self::CONNECTION_ERRORS as $connectionError) {
-            if (false !== \strpos($message, $connectionError)) {
+            if (false !== \stripos($message, $connectionError)) {
                 return true;
             }
         }
@@ -471,7 +491,7 @@ final class StreamHandler
         );
 
         return $this->createResource(
-            function () use ($uri, $contextResource, $context, $request, $readTimeout) {
+            function () use ($uri, $contextResource, $readTimeout) {
                 $resource = @\fopen((string) $uri, 'r', false, $contextResource);
 
                 // See https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable
@@ -482,7 +502,7 @@ final class StreamHandler
                 $this->lastHeaders = $http_response_header ?? [];
 
                 if (false === $resource) {
-                    throw new ConnectException(sprintf('Connection refused for URI %s', $uri), $request, null, $context);
+                    return false;
                 }
 
                 if ($readTimeout !== null) {

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\NetworkException;
 use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
@@ -2268,7 +2269,21 @@ class CurlFactoryTest extends TestCase
         yield 'resolve proxy' => [\CURLE_COULDNT_RESOLVE_PROXY];
         yield 'connect' => [\CURLE_COULDNT_CONNECT];
         yield 'ssl connect' => [\CURLE_SSL_CONNECT_ERROR];
-        yield 'got nothing' => [\CURLE_GOT_NOTHING];
+
+        foreach ([
+            'CURLE_PROXY',
+            'CURLE_QUIC_CONNECT_ERROR',
+            'CURLE_PEER_FAILED_VERIFICATION',
+            'CURLE_SSL_CACERT',
+            'CURLE_SSL_PEER_CERTIFICATE',
+            'CURLE_SSL_PINNEDPUBKEYNOTMATCH',
+            'CURLE_SSL_INVALIDCERTSTATUS',
+            'CURLE_SSL_CLIENTCERT',
+        ] as $constant) {
+            if (\defined($constant)) {
+                yield $constant => [(int) \constant($constant)];
+            }
+        }
     }
 
     /**
@@ -2296,23 +2311,16 @@ class CurlFactoryTest extends TestCase
         }
     }
 
-    public static function curlResponseSensitiveNetworkErrorProvider(): iterable
+    public static function curlNetworkErrorWithoutResponseProvider(): iterable
     {
+        yield 'got nothing' => [\CURLE_GOT_NOTHING];
         yield 'send' => [\CURLE_SEND_ERROR];
         yield 'receive' => [\CURLE_RECV_ERROR];
 
         foreach ([
-            'CURLE_PROXY',
-            'CURLE_QUIC_CONNECT_ERROR',
             'CURLE_HTTP2',
             'CURLE_HTTP2_STREAM',
             'CURLE_HTTP3',
-            'CURLE_PEER_FAILED_VERIFICATION',
-            'CURLE_SSL_CACERT',
-            'CURLE_SSL_PEER_CERTIFICATE',
-            'CURLE_SSL_PINNEDPUBKEYNOTMATCH',
-            'CURLE_SSL_INVALIDCERTSTATUS',
-            'CURLE_SSL_CLIENTCERT',
         ] as $constant) {
             if (\defined($constant)) {
                 yield $constant => [(int) \constant($constant)];
@@ -2321,9 +2329,9 @@ class CurlFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider curlResponseSensitiveNetworkErrorProvider
+     * @dataProvider curlNetworkErrorWithoutResponseProvider
      */
-    public function testCreatesConnectExceptionForNetworkErrorsWithoutResponse(int $errno): void
+    public function testCreatesNetworkExceptionForNetworkErrorsWithoutResponse(int $errno): void
     {
         $factory = new CurlFactory(1);
         $request = new Psr7\Request('GET', Server::$url);
@@ -2340,19 +2348,33 @@ class CurlFactoryTest extends TestCase
 
         try {
             $promise->wait();
-            self::fail('Expected ConnectException');
+            self::fail('Expected NetworkException');
         } catch (NetworkTimeoutException $e) {
-            self::fail('Expected non-timeout ConnectException');
-        } catch (ConnectException $e) {
+            self::fail('Expected non-timeout NetworkException');
+        } catch (NetworkException $e) {
+            self::assertNotInstanceOf(ConnectException::class, $e);
             self::assertSame($request, $e->getRequest());
             self::assertSame($errno, $e->getHandlerContext()['errno']);
         }
     }
 
     /**
-     * @dataProvider curlResponseSensitiveNetworkErrorProvider
+     * @dataProvider curlNetworkErrorWithoutResponseProvider
      */
-    public function testNetworkErrorsWithResponseStayRequestExceptions(int $errno): void
+    public function testNetworkErrorsWithResponseStayResponseExceptions(int $errno): void
+    {
+        $this->assertCurlErrorWithResponseCreatesResponseException($errno);
+    }
+
+    /**
+     * @dataProvider curlConnectionErrorProvider
+     */
+    public function testConnectionErrorsWithResponseStayResponseExceptions(int $errno): void
+    {
+        $this->assertCurlErrorWithResponseCreatesResponseException($errno);
+    }
+
+    private function assertCurlErrorWithResponseCreatesResponseException(int $errno): void
     {
         $factory = new CurlFactory(1);
         $request = new Psr7\Request('GET', Server::$url);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -116,6 +116,7 @@ class StreamHandlerTest extends TestCase
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'php_network_getaddresses: getaddrinfo for example.test failed'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Unable to connect to example.test:80'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'fopen(): Failed to open stream: Connection refused'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'fopen(): Failed to open stream: No connection could be made because the target machine actively refused it'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Cannot connect to HTTPS server through proxy'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Failed to enable crypto'));
         self::assertFalse($this->matchesStreamHandlerError('isConnectionError', 'HTTP request failed!'));
@@ -458,10 +459,12 @@ class StreamHandlerTest extends TestCase
 
     public function testAddsProxy(): void
     {
-        $this->expectException(ConnectException::class);
-        $this->expectExceptionMessage('Connection refused');
-
-        $this->getSendResult(['proxy' => '127.0.0.1:8125']);
+        try {
+            $this->getSendResult(['proxy' => '127.0.0.1:8125']);
+            self::fail('Expected ConnectException');
+        } catch (ConnectException $e) {
+            self::assertMatchesRegularExpression('/refused/i', $e->getMessage());
+        }
     }
 
     public function testAddsProxyByProtocol(): void
@@ -1476,9 +1479,12 @@ class StreamHandlerTest extends TestCase
             )->wait();
             self::fail('Expected an exception');
         } catch (ConnectException $e) {
-            self::assertStringContainsString('Connection refused', $e->getMessage());
+            self::assertMatchesRegularExpression('/refused/i', $e->getMessage());
         } catch (RequestException $e) {
-            self::assertStringContainsString('HTTP invalid response format', $e->getMessage());
+            self::assertMatchesRegularExpression(
+                '/HTTP invalid response format|An error was encountered while creating the response/',
+                $e->getMessage()
+            );
         }
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -102,6 +102,25 @@ class StreamHandlerTest extends TestCase
         )->wait();
     }
 
+    public function testClassifiesStreamTimeoutErrors(): void
+    {
+        self::assertTrue($this->matchesStreamHandlerError('isTimeoutError', 'fopen(): SSL: Handshake timed out'));
+        self::assertTrue($this->matchesStreamHandlerError('isTimeoutError', 'fopen(): Failed to open stream: Connection timed out'));
+        self::assertTrue($this->matchesStreamHandlerError('isTimeoutError', 'fopen(): Failed to open stream: Operation timed out'));
+        self::assertFalse($this->matchesStreamHandlerError('isTimeoutError', 'HTTP request failed!'));
+        self::assertFalse($this->matchesStreamHandlerError('isConnectionError', 'fopen(): SSL: Handshake timed out'));
+    }
+
+    public function testClassifiesStreamConnectionErrors(): void
+    {
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'php_network_getaddresses: getaddrinfo for example.test failed'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Unable to connect to example.test:80'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'fopen(): Failed to open stream: Connection refused'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Cannot connect to HTTPS server through proxy'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Failed to enable crypto'));
+        self::assertFalse($this->matchesStreamHandlerError('isConnectionError', 'HTTP request failed!'));
+    }
+
     public function testRejectsHttp3(): void
     {
         $handler = new StreamHandler();
@@ -425,6 +444,16 @@ class StreamHandlerTest extends TestCase
         $method->invokeArgs($handler, [$request, &$context]);
 
         return $context;
+    }
+
+    private function matchesStreamHandlerError(string $method, string $message): bool
+    {
+        $reflection = new \ReflectionMethod(StreamHandler::class, $method);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
+
+        return $reflection->invoke(null, $message) === true;
     }
 
     public function testAddsProxy(): void
@@ -1449,7 +1478,7 @@ class StreamHandlerTest extends TestCase
         } catch (ConnectException $e) {
             self::assertStringContainsString('Connection refused', $e->getMessage());
         } catch (RequestException $e) {
-            self::assertStringContainsString('An error was encountered while creating the response', $e->getMessage());
+            self::assertStringContainsString('HTTP invalid response format', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
This tightens the Guzzle 8 exception hierarchy by keeping ConnectException for connection establishment failures, using NetworkException for other no-response network transport failures, and preserving ResponseException for failures that already have a response. It also updates the stream handler timeout classification and the docs so applications moving from Guzzle 7.10 know to catch NetworkException when they previously used ConnectException as the broad network-failure type.