### PR TITLE
Document BodySummarizer cursor preservation

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -263,6 +263,20 @@ response object. For failures with a response, create `ResponseException`,
 exception hierarchy and is still used for invalid configuration or request
 option values that can be rejected before a transfer starts.
 
+#### Body Summaries In HTTP Error Exceptions
+
+Guzzle's default `http_errors` middleware uses `BodySummarizer` to include a
+short response body summary in response-aware exception messages. In Guzzle 7,
+creating that summary rewound seekable response bodies to the beginning. In
+Guzzle 8, `BodySummarizer` still summarizes from the beginning of the body, but
+then restores the body cursor to its previous position.
+
+Most applications do not need changes. Check only code that catches
+response-aware exceptions from `http_errors` and then reads the response body
+while relying on exception creation to leave that body rewound. If you need to
+read the body from the beginning after catching the exception, call
+`Message::rewindBody()` explicitly.
+
 #### Request Protocol Versions
 
 Invalid request protocol versions are no longer treated as omitted. Passing

--- a/tests/BodySummarizerTest.php
+++ b/tests/BodySummarizerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests;
+
+use GuzzleHttp\BodySummarizer;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+
+class BodySummarizerTest extends TestCase
+{
+    public function testSummarizeReadsFromStartAndRestoresBodyCursor(): void
+    {
+        $body = Utils::streamFor('abcdef');
+        $body->seek(3);
+        $response = new Response(200, [], $body);
+
+        self::assertSame('abcdef', (new BodySummarizer())->summarize($response));
+        self::assertSame(3, $body->tell());
+    }
+
+    public function testSummarizeWithCustomTruncationRestoresBodyCursor(): void
+    {
+        $body = Utils::streamFor('abcdef');
+        $body->seek(3);
+        $response = new Response(200, [], $body);
+
+        self::assertSame('abc (truncated...)', (new BodySummarizer(3))->summarize($response));
+        self::assertSame(3, $body->tell());
+    }
+}


### PR DESCRIPTION
This documents the Guzzle 8 behavior inherited from Guzzle PSR-7 3.x where BodySummarizer still summarizes seekable response bodies from the beginning but restores the body cursor afterward. The upgrade guide now explains which exception-handling code needs review and points users to Message::rewindBody() when they intentionally need to read a summarized response body from the beginning. The new BodySummarizer test covers the inherited cursor-preservation behavior directly.