### PR TITLE
Refine built-in handler transfer failure classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Throw `NetworkTimeoutException` for cURL no-response timeout errors
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
 - Classify PSR-7 response sink write timeouts from built-in cURL handlers as `ResponseTimeoutException`
+- Classify PSR-7 request body read timeouts from built-in cURL handlers as `NetworkTimeoutException`
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Throw `ConnectTimeoutException` for connect timeouts
 - Throw `NetworkTimeoutException` for cURL no-response timeout errors
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
+- Classify PSR-7 response sink write timeouts from built-in cURL handlers as `ResponseTimeoutException`
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,12 +52,13 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Classify empty, malformed, or handler-unsupported request protocol versions as request exceptions
 - Classify additional cURL transport failures without a response as `NetworkException`
 - Classify stream connect failures as `ConnectException`, with connect timeouts as `ConnectTimeoutException`
+- Classify stream transport failures without a response as `NetworkException`, with timeouts as `NetworkTimeoutException`
 - Classify generic response-aware request failures as `ResponseException`
 - Throw `ConnectTimeoutException` for connect timeouts
 - Throw `NetworkTimeoutException` for cURL no-response timeout errors
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
-- Classify PSR-7 request body read timeouts from built-in cURL handlers as `NetworkTimeoutException`
-- Classify PSR-7 response sink write timeouts from built-in cURL handlers as `ResponseTimeoutException`
+- Classify cURL PSR-7 request-body upload timeouts by response phase
+- Classify cURL PSR-7 response sink write timeouts by response phase
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Throw `ConnectTimeoutException` for connect timeouts
 - Throw `NetworkTimeoutException` for cURL no-response timeout errors
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
-- Classify PSR-7 response sink write timeouts from built-in cURL handlers as `ResponseTimeoutException`
 - Classify PSR-7 request body read timeouts from built-in cURL handlers as `NetworkTimeoutException`
+- Classify PSR-7 response sink write timeouts from built-in cURL handlers as `ResponseTimeoutException`
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -178,6 +178,12 @@ not `ConnectException`. `ResponseTimeoutException` is thrown for timeouts after
 response headers are received; it extends `ResponseException` and exposes the
 response.
 
+The built-in cURL and stream handlers classify a
+`GuzzleHttp\Psr7\Exception\TimeoutException` raised while writing a response
+body to a configured sink as `ResponseTimeoutException`, because response headers
+have already been received. Inspect `getPrevious()` for the original PSR-7
+timeout exception.
+
 `HandlerClosedException` is new in Guzzle 8.0. It extends `TransferException`
 and is used when an explicitly closed `CurlMultiHandler` rejects transfers that
 are still pending, including delayed transfers. Existing Guzzle 7.x code should

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -178,18 +178,12 @@ not `ConnectException`. `ResponseTimeoutException` is thrown for timeouts after
 response headers are received; it extends `ResponseException` and exposes the
 response.
 
-The built-in cURL and stream handlers classify a
-`GuzzleHttp\Psr7\Exception\TimeoutException` raised while writing a response
-body to a configured sink as `ResponseTimeoutException`, because response headers
-have already been received. Inspect `getPrevious()` for the original PSR-7
-timeout exception.
-
-The built-in cURL handlers classify a
-`GuzzleHttp\Psr7\Exception\TimeoutException` raised while reading the request
-body during upload as `NetworkTimeoutException` when no response has been
-received. If an early response object is available, the failure is classified as
-`ResponseTimeoutException`. Inspect `getPrevious()` for the original PSR-7
-timeout exception.
+These phases apply however the timeout is detected, including timeouts that
+originate from a slow PSR-7 stream. A request body that stalls while it is
+uploaded is a `NetworkTimeoutException` (no response yet); a stall while the
+response body is transferred is a `ResponseTimeoutException` (the response was
+already received). In both cases the original
+`GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
 
 `HandlerClosedException` is new in Guzzle 8.0. It extends `TransferException`
 and is used when an explicitly closed `CurlMultiHandler` rejects transfers that
@@ -230,42 +224,18 @@ try {
 }
 ```
 
-The affected built-in cURL classifications are:
+Beyond timeouts, the built-in handlers reclassify several no-response transport
+failures that Guzzle 7.x reported as `RequestException` or `ConnectException`:
 
-- `CURLE_OPERATION_TIMEOUTED` now throws `ConnectTimeoutException` when the
-  cURL error message identifies a DNS resolution, TCP connection, proxy CONNECT,
-  or TLS connection timeout. Examples include "Resolving timed out",
-  "Connection timed out", "Connection timeout", "Connection time-out",
-  "Failed to resolve ... with timeout", "name lookup timed out",
-  "Proxy CONNECT aborted due to timeout", and "SSL connection timeout". Guzzle
-  7.x threw `ConnectException`.
-- `CURLE_OPERATION_TIMEOUTED` now throws `NetworkTimeoutException` when the
-  timeout occurs before response headers are received and the cURL error message
-  does not identify it as connect-phase. Guzzle 7.x threw `ConnectException`.
-- `CURLE_OPERATION_TIMEOUTED` now throws `ResponseTimeoutException` when a
-  response object was created before the timeout. Guzzle 7.x threw
-  `ConnectException`.
-- `CURLE_COULDNT_RESOLVE_PROXY` now throws `ConnectException`. Guzzle 7.x
-  classified this cURL error as `RequestException`.
-- `CURLE_GOT_NOTHING`, `CURLE_SEND_ERROR`, `CURLE_RECV_ERROR`, and
-  no-response HTTP/2 or HTTP/3 protocol failures now throw `NetworkException`.
-  Guzzle 7.x either threw `ConnectException` or classified some of these as
-  `RequestException`.
-- TLS certificate, proxy connection, DNS, TCP connection, and QUIC connection
-  failures without a response throw `ConnectException`.
-- If a response object was created before the cURL error, the failure is
-  represented by `ResponseException` or `ResponseTimeoutException`.
+- Connection-establishment failures (DNS and proxy resolution, TCP connect, TLS
+  setup, and QUIC connect) are `ConnectException`.
+- Other failures with no response, such as send and receive errors and
+  no-response HTTP/2 and HTTP/3 protocol errors, are `NetworkException`.
+- A failure that occurs after a response was received is a `ResponseException`
+  (or `ResponseTimeoutException`).
 
-The existing cURL DNS, TCP connection, and TLS setup errors, including
-`CURLE_COULDNT_RESOLVE_HOST`, `CURLE_COULDNT_CONNECT`, and
-`CURLE_SSL_CONNECT_ERROR`, still throw `ConnectException`.
-
-The built-in stream handler now classifies DNS, TCP connect, proxy connect, and
-TLS setup failures as `ConnectException`. Stream warnings that identify a
-connection establishment timeout, including platform TCP timeout text such as
-"Connection timed out" or "Operation timed out" and TLS handshake text such as
-"SSL: Handshake timed out", are classified as `ConnectTimeoutException`; other
-malformed or unparseable response failures remain `RequestException`.
+This applies to both the cURL and stream handlers; the exact error codes and
+messages each one maps onto these classes are an implementation detail.
 
 The deprecated `RequestException::wrapException()` method was removed. Create a
 `RequestException` directly for request failures where Guzzle does not expose a

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -176,13 +176,11 @@ connect timeouts. `NetworkTimeoutException` is thrown for other detected
 timeouts before response headers are received; it extends `NetworkException` but
 not `ConnectException`. `ResponseTimeoutException` is thrown for timeouts after
 response headers are received; it extends `ResponseException` and exposes the
-response.
-
-These phases apply however the timeout is detected, including timeouts that
-originate from a slow PSR-7 stream. A request body that stalls while it is
-uploaded is a `NetworkTimeoutException` (no response yet); a stall while the
-response body is transferred is a `ResponseTimeoutException` (the response was
-already received). In both cases the original
+response. These phases apply however the timeout is detected, including
+timeouts that originate from a slow PSR-7 stream: a request body that stalls
+before any response is received is a `NetworkTimeoutException`, while a stall
+transferring the response body is a `ResponseTimeoutException`. When the
+timeout comes from a PSR-7 stream, the original
 `GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
 
 `HandlerClosedException` is new in Guzzle 8.0. It extends `TransferException`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -184,6 +184,13 @@ body to a configured sink as `ResponseTimeoutException`, because response header
 have already been received. Inspect `getPrevious()` for the original PSR-7
 timeout exception.
 
+The built-in cURL handlers classify a
+`GuzzleHttp\Psr7\Exception\TimeoutException` raised while reading the request
+body during upload as `NetworkTimeoutException` when no response has been
+received. If an early response object is available, the failure is classified as
+`ResponseTimeoutException`. Inspect `getPrevious()` for the original PSR-7
+timeout exception.
+
 `HandlerClosedException` is new in Guzzle 8.0. It extends `TransferException`
 and is used when an explicitly closed `CurlMultiHandler` rejects transfers that
 are still pending, including delayed transfers. Existing Guzzle 7.x code should

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,7 +99,9 @@ $promise = $client->postAsync('http://httpbin.org/post');
 $promise = $client->putAsync('http://httpbin.org/put');
 ```
 
-You can also use the `sendAsync()` and `requestAsync()` methods of a client. Use `requestAsync()` for asynchronous requests that do not have a named shortcut method:
+You can also use the `sendAsync()` and `requestAsync()` methods of a client. Use
+`requestAsync()` for asynchronous requests that do not have a named shortcut
+method:
 
 ```php
 use GuzzleHttp\Psr7\Request;
@@ -115,7 +117,14 @@ $promise = $client->requestAsync('GET', 'http://httpbin.org/get');
 $promise = $client->requestAsync('OPTIONS', 'http://httpbin.org/get');
 ```
 
-The promise returned by these methods is a `GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>` provided by the [Guzzle promises library](https://github.com/guzzle/promises). This means that you can chain `then()` calls off of the promise. These then calls are either fulfilled with a successful `Psr\Http\Message\ResponseInterface` or rejected with a reason. The reason is often an exception from Guzzle's exception hierarchy, but custom handlers can reject with other values.
+The promise returned by these methods is a
+`GuzzleHttp\Promise\PromiseInterface<Psr\Http\Message\ResponseInterface, mixed>`
+provided by the [Guzzle promises library](https://github.com/guzzle/promises).
+This means that you can chain `then()` calls off of the promise. These then
+calls are either fulfilled with a successful
+`Psr\Http\Message\ResponseInterface` or rejected with a reason. The reason is
+often an exception from Guzzle's exception hierarchy, but custom handlers can
+reject with other values.
 
 ```php
 use Psr\Http\Message\ResponseInterface;

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -87,7 +87,8 @@ You can find out more about client middleware in [Handlers and Middleware](handl
 
 ### Async Requests
 
-You can send asynchronous requests using the named async shortcut methods provided by a client:
+You can send asynchronous requests using the named async shortcut methods
+provided by a client:
 
 ```php
 $promise = $client->getAsync('http://httpbin.org/get');
@@ -118,17 +119,16 @@ The promise returned by these methods is a `GuzzleHttp\Promise\PromiseInterface<
 
 ```php
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 
 $promise = $client->requestAsync('GET', 'http://httpbin.org/get');
 $promise->then(
     function (ResponseInterface $res) {
-        echo $res->getStatusCode() . "\n";
+        echo $res->getStatusCode();
     },
     function ($reason) {
-        if ($reason instanceof RequestException) {
-            echo $reason->getMessage() . "\n";
-            echo $reason->getRequest()->getMethod();
+        if ($reason instanceof TransferException) {
+            echo $reason->getMessage();
         }
     }
 );
@@ -486,8 +486,8 @@ If Guzzle has parsed response headers into a response object, later transfer
 failures use `ResponseException`. This is the only branch that exposes
 `getResponse()`, and it includes `ResponseTimeoutException` for response
 timeouts. With Guzzle request methods, middleware can also turn completed
-responses into exceptions: `http_errors` turns 400 level responses into
-`ClientException` and 500 level responses into `ServerException`, and redirect
+responses into exceptions: `http_errors` turns 4xx responses into
+`ClientException` and 5xx responses into `ServerException`, and redirect
 middleware can throw `TooManyRedirectsException`. `Client::sendRequest()`
 follows PSR-18 and returns redirect, 4xx, and 5xx responses normally instead.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -996,6 +996,12 @@ Constant
 
 The timeout applies to individual read operations on a streamed body (when the `stream` option is enabled).
 
+When a read on the streamed PSR-7 body times out, `read()` throws
+`GuzzleHttp\Psr7\Exception\TimeoutException`. This PSR-7 class sits outside the
+`GuzzleHttp\Exception\GuzzleException` hierarchy, so catch it explicitly. If you
+detach the body and read the raw PHP stream resource instead, functions such as
+`fgets()` return `false` on timeout, following PHP's stream semantics.
+
 ```php
 $response = $client->request('GET', '/stream', [
     'stream' => true,
@@ -1004,10 +1010,10 @@ $response = $client->request('GET', '/stream', [
 
 $body = $response->getBody();
 
-// Returns false on timeout
+// Throws GuzzleHttp\Psr7\Exception\TimeoutException on timeout
 $data = $body->read(1024);
 
-// Returns false on timeout
+// Returns false on timeout (raw stream resource)
 $line = fgets($body->detach());
 ```
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1318,6 +1318,11 @@ from the underlying transfer. Connect timeouts throw
 received throw `GuzzleHttp\Exception\ResponseTimeoutException`, which extends
 `GuzzleHttp\Exception\ResponseException`.
 
+This classification also applies to timeouts that originate from a slow PSR-7
+request or response body, which follow the same phase rule above. In that case
+the original `GuzzleHttp\Psr7\Exception\TimeoutException` is available via
+`getPrevious()`.
+
 ## version
 
 Summary

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -68,6 +68,11 @@ final class CurlFactory implements CurlFactoryInterface
     ];
 
     /**
+     * libcurl's CURL_READFUNC_ABORT value. PHP exposes CURL_READFUNC_PAUSE but not CURL_READFUNC_ABORT.
+     */
+    private const CURL_READFUNC_ABORT = 0x10000000;
+
+    /**
      * @var resource[]|\CurlHandle[]
      */
     private array $handles = [];
@@ -581,7 +586,7 @@ final class CurlFactory implements CurlFactoryInterface
         $onStats = $easy->options['on_stats'] ?? null;
         $stats = $onStats !== null ? self::createStats($easy) : null;
 
-        if (!$easy->response || $easy->errno || $easy->sinkWriteTimeoutException) {
+        if (!$easy->response || $easy->errno || $easy->sinkWriteTimeoutException || $easy->bodyReadTimeoutException) {
             return self::finishError($handler, $easy, $factory, $stats, $onStats);
         }
 
@@ -643,7 +648,7 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         // Retry when nothing is present or when curl failed to rewind.
-        if ($easy->sinkWriteTimeoutException === null && empty($easy->options['_err_message']) && (!$easy->errno || $easy->errno == 65)) {
+        if ($easy->sinkWriteTimeoutException === null && $easy->bodyReadTimeoutException === null && empty($easy->options['_err_message']) && (!$easy->errno || $easy->errno == 65)) {
             return self::retryFailedRewind($handler, $easy, $ctx);
         }
 
@@ -762,6 +767,33 @@ final class CurlFactory implements CurlFactoryInterface
                     $easy->request,
                     0,
                     $easy->sinkWriteTimeoutException,
+                    $ctx
+                )
+            );
+        }
+
+        if ($easy->bodyReadTimeoutException) {
+            $ctx['timed_out'] = true;
+
+            if ($easy->response) {
+                /** @var PromiseInterface<ResponseInterface, mixed> */
+                return P\Create::rejectionFor(
+                    new ResponseTimeoutException(
+                        'The cURL handler timed out while transferring the request body',
+                        $easy->request,
+                        $easy->response,
+                        $easy->bodyReadTimeoutException,
+                        $ctx
+                    )
+                );
+            }
+
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(
+                new NetworkTimeoutException(
+                    'The cURL handler timed out while transferring the request body',
+                    $easy->request,
+                    $easy->bodyReadTimeoutException,
                     $ctx
                 )
             );
@@ -1098,7 +1130,7 @@ final class CurlFactory implements CurlFactoryInterface
         $size = $body->getSize();
 
         if ($size === null || $size > 0) {
-            $this->applyBody($easy->request, $easy->options, $conf);
+            $this->applyBody($easy, $conf);
 
             return;
         }
@@ -1120,8 +1152,10 @@ final class CurlFactory implements CurlFactoryInterface
         }
     }
 
-    private function applyBody(RequestInterface $request, array $options, array &$conf): void
+    private function applyBody(EasyHandle $easy, array &$conf): void
     {
+        $request = $easy->request;
+        $options = $easy->options;
         $size = $request->hasHeader('Content-Length')
             ? (int) $request->getHeaderLine('Content-Length')
             : null;
@@ -1143,8 +1177,17 @@ final class CurlFactory implements CurlFactoryInterface
             if ($body->isSeekable()) {
                 $body->rewind();
             }
-            $conf[\CURLOPT_READFUNCTION] = static function ($ch, $fd, int $length) use ($body): string {
-                return $body->read($length);
+            /**
+             * @return int|string
+             */
+            $conf[\CURLOPT_READFUNCTION] = static function ($ch, $fd, int $length) use ($easy, $body) {
+                try {
+                    return $body->read($length);
+                } catch (TimeoutException $e) {
+                    $easy->bodyReadTimeoutException = $e;
+
+                    return self::CURL_READFUNC_ABORT;
+                }
             };
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1493,14 +1493,35 @@ final class CurlFactory implements CurlFactoryInterface
             $conf[\CURLOPT_SSLKEY] = $sslKey;
         }
 
-        if (isset($options['progress'])) {
-            $progress = $options['progress'];
-            if (!\is_callable($progress)) {
-                throw new \InvalidArgumentException('progress client option must be callable');
-            }
-            /** @var callable(int, int, int, int): mixed $progress */
+        $progress = $options['progress'] ?? null;
+        if ($progress !== null && !\is_callable($progress)) {
+            throw new \InvalidArgumentException('progress client option must be callable');
+        }
+
+        // The streaming read callback (set by applyBody) aborts the upload on a
+        // body read timeout by returning CURL_READFUNC_ABORT, but PHP ignores
+        // that integer return before 8.1.17/8.2.4. Install a progress callback
+        // so older PHP still has a cross-version abort path; the failure is
+        // classified from `$easy->bodyReadTimeoutException` regardless of errno
+        // (a truncated request may reach the server first on those versions).
+        $abortsOnBodyReadTimeout = isset($conf[\CURLOPT_READFUNCTION]);
+
+        if ($progress !== null || $abortsOnBodyReadTimeout) {
+            /** @var (callable(int, int, int, int): mixed)|null $progress */
             $conf[\CURLOPT_NOPROGRESS] = false;
             $progressCallback = static function ($resource, $downloadSize, $downloaded, $uploadSize, $uploaded) use ($easy, $progress): int {
+                // Abort the transfer when the request body read timed out (the
+                // cross-version abort path, since older PHP ignores the read
+                // callback's return). progressAborted is left unset so the
+                // failure is classified from `$easy->bodyReadTimeoutException`.
+                if ($easy->bodyReadTimeoutException !== null) {
+                    return 1;
+                }
+
+                if ($progress === null) {
+                    return 0;
+                }
+
                 try {
                     if ($progress((int) $downloadSize, (int) $downloaded, (int) $uploadSize, (int) $uploaded)) {
                         $easy->progressAborted = true;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Exception\ResponseTimeoutException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\ProxyOptions;
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\TransferStats;
@@ -580,7 +581,7 @@ final class CurlFactory implements CurlFactoryInterface
         $onStats = $easy->options['on_stats'] ?? null;
         $stats = $onStats !== null ? self::createStats($easy) : null;
 
-        if (!$easy->response || $easy->errno) {
+        if (!$easy->response || $easy->errno || $easy->sinkWriteTimeoutException) {
             return self::finishError($handler, $easy, $factory, $stats, $onStats);
         }
 
@@ -642,7 +643,7 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         // Retry when nothing is present or when curl failed to rewind.
-        if (empty($easy->options['_err_message']) && (!$easy->errno || $easy->errno == 65)) {
+        if ($easy->sinkWriteTimeoutException === null && empty($easy->options['_err_message']) && (!$easy->errno || $easy->errno == 65)) {
             return self::retryFailedRewind($handler, $easy, $ctx);
         }
 
@@ -733,6 +734,34 @@ final class CurlFactory implements CurlFactoryInterface
                     $easy->request,
                     0,
                     $easy->progressException,
+                    $ctx
+                )
+            );
+        }
+
+        if ($easy->sinkWriteTimeoutException) {
+            $ctx['timed_out'] = true;
+
+            if ($easy->response) {
+                /** @var PromiseInterface<ResponseInterface, mixed> */
+                return P\Create::rejectionFor(
+                    new ResponseTimeoutException(
+                        'The cURL handler timed out while transferring the response body',
+                        $easy->request,
+                        $easy->response,
+                        $easy->sinkWriteTimeoutException,
+                        $ctx
+                    )
+                );
+            }
+
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(
+                new RequestException(
+                    'The cURL handler timed out while transferring the response body',
+                    $easy->request,
+                    0,
+                    $easy->sinkWriteTimeoutException,
                     $ctx
                 )
             );
@@ -1254,8 +1283,14 @@ final class CurlFactory implements CurlFactoryInterface
             $sink = new LazyOpenStream($sink, 'w+');
         }
         $easy->sink = $sink;
-        $conf[\CURLOPT_WRITEFUNCTION] = static function ($ch, string $write) use ($sink): int {
-            return $sink->write($write);
+        $conf[\CURLOPT_WRITEFUNCTION] = static function ($ch, string $write) use ($easy, $sink): int {
+            try {
+                return $sink->write($write);
+            } catch (TimeoutException $e) {
+                $easy->sinkWriteTimeoutException = $e;
+
+                return 0;
+            }
         };
 
         $timeoutRequiresNoSignal = false;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -586,7 +586,7 @@ final class CurlFactory implements CurlFactoryInterface
         $onStats = $easy->options['on_stats'] ?? null;
         $stats = $onStats !== null ? self::createStats($easy) : null;
 
-        if (!$easy->response || $easy->errno || $easy->sinkWriteTimeoutException || $easy->bodyReadTimeoutException) {
+        if (!$easy->response || $easy->errno || $easy->bodyReadTimeoutException || $easy->sinkWriteTimeoutException) {
             return self::finishError($handler, $easy, $factory, $stats, $onStats);
         }
 
@@ -648,7 +648,7 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         // Retry when nothing is present or when curl failed to rewind.
-        if ($easy->sinkWriteTimeoutException === null && $easy->bodyReadTimeoutException === null && empty($easy->options['_err_message']) && (!$easy->errno || $easy->errno == 65)) {
+        if ($easy->bodyReadTimeoutException === null && $easy->sinkWriteTimeoutException === null && empty($easy->options['_err_message']) && (!$easy->errno || $easy->errno == 65)) {
             return self::retryFailedRewind($handler, $easy, $ctx);
         }
 
@@ -744,6 +744,33 @@ final class CurlFactory implements CurlFactoryInterface
             );
         }
 
+        if ($easy->bodyReadTimeoutException) {
+            $ctx['timed_out'] = true;
+
+            if ($easy->response) {
+                /** @var PromiseInterface<ResponseInterface, mixed> */
+                return P\Create::rejectionFor(
+                    new ResponseTimeoutException(
+                        'The cURL handler timed out while transferring the request body',
+                        $easy->request,
+                        $easy->response,
+                        $easy->bodyReadTimeoutException,
+                        $ctx
+                    )
+                );
+            }
+
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(
+                new NetworkTimeoutException(
+                    'The cURL handler timed out while transferring the request body',
+                    $easy->request,
+                    $easy->bodyReadTimeoutException,
+                    $ctx
+                )
+            );
+        }
+
         if ($easy->sinkWriteTimeoutException) {
             $ctx['timed_out'] = true;
 
@@ -767,33 +794,6 @@ final class CurlFactory implements CurlFactoryInterface
                     $easy->request,
                     0,
                     $easy->sinkWriteTimeoutException,
-                    $ctx
-                )
-            );
-        }
-
-        if ($easy->bodyReadTimeoutException) {
-            $ctx['timed_out'] = true;
-
-            if ($easy->response) {
-                /** @var PromiseInterface<ResponseInterface, mixed> */
-                return P\Create::rejectionFor(
-                    new ResponseTimeoutException(
-                        'The cURL handler timed out while transferring the request body',
-                        $easy->request,
-                        $easy->response,
-                        $easy->bodyReadTimeoutException,
-                        $ctx
-                    )
-                );
-            }
-
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(
-                new NetworkTimeoutException(
-                    'The cURL handler timed out while transferring the request body',
-                    $easy->request,
-                    $easy->bodyReadTimeoutException,
                     $ctx
                 )
             );

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -68,9 +68,14 @@ final class CurlFactory implements CurlFactoryInterface
     ];
 
     /**
-     * libcurl's CURL_READFUNC_ABORT value. PHP exposes CURL_READFUNC_PAUSE but not CURL_READFUNC_ABORT.
+     * libcurl's CURL_READFUNC_ABORT value.
      */
     private const CURL_READFUNC_ABORT = 0x10000000;
+
+    /**
+     * libcurl's CURLE_SEND_FAIL_REWIND value.
+     */
+    private const CURLE_SEND_FAIL_REWIND = 65;
 
     /**
      * @var resource[]|\CurlHandle[]
@@ -586,7 +591,7 @@ final class CurlFactory implements CurlFactoryInterface
         $onStats = $easy->options['on_stats'] ?? null;
         $stats = $onStats !== null ? self::createStats($easy) : null;
 
-        if (!$easy->response || $easy->errno || $easy->bodyReadTimeoutException || $easy->sinkWriteTimeoutException) {
+        if (self::shouldFinishWithError($easy)) {
             return self::finishError($handler, $easy, $factory, $stats, $onStats);
         }
 
@@ -647,12 +652,32 @@ final class CurlFactory implements CurlFactoryInterface
             $onStats($stats);
         }
 
-        // Retry when nothing is present or when curl failed to rewind.
-        if ($easy->bodyReadTimeoutException === null && $easy->sinkWriteTimeoutException === null && empty($easy->options['_err_message']) && (!$easy->errno || $easy->errno == 65)) {
+        if (self::shouldRetryFailedRewind($easy)) {
             return self::retryFailedRewind($handler, $easy, $ctx);
         }
 
         return self::createRejection($easy, $ctx);
+    }
+
+    private static function shouldFinishWithError(EasyHandle $easy): bool
+    {
+        return !$easy->response
+            || $easy->errno !== 0
+            || $easy->bodyReadTimeoutException !== null
+            || $easy->sinkWriteTimeoutException !== null;
+    }
+
+    private static function shouldRetryFailedRewind(EasyHandle $easy): bool
+    {
+        if ($easy->bodyReadTimeoutException !== null || $easy->sinkWriteTimeoutException !== null) {
+            return false;
+        }
+
+        if (!empty($easy->options['_err_message'])) {
+            return false;
+        }
+
+        return $easy->errno === 0 || $easy->errno === self::CURLE_SEND_FAIL_REWIND;
     }
 
     private static function createErrorContext(EasyHandle $easy): array

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -814,10 +814,9 @@ final class CurlFactory implements CurlFactoryInterface
 
             /** @var PromiseInterface<ResponseInterface, mixed> */
             return P\Create::rejectionFor(
-                new RequestException(
+                new NetworkTimeoutException(
                     'The cURL handler timed out while transferring the response body',
                     $easy->request,
-                    0,
                     $easy->sinkWriteTimeoutException,
                     $ctx
                 )

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Handler;
 
+use GuzzleHttp\Exception\NetworkTimeoutException;
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\TransportSharing;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -70,7 +73,17 @@ final class CurlHandler
             \usleep((int) ($options['delay'] * 1000));
         }
 
-        $easy = $this->factory->create($request, $options);
+        try {
+            $easy = $this->factory->create($request, $options);
+        } catch (TimeoutException $e) {
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(new NetworkTimeoutException(
+                'The cURL handler timed out while transferring the request body',
+                $request,
+                $e
+            ));
+        }
+
         \curl_exec($easy->handle);
         $easy->errno = \curl_errno($easy->handle);
 

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -6,9 +6,11 @@ namespace GuzzleHttp\Handler;
 
 use Closure;
 use GuzzleHttp\Exception\HandlerClosedException;
+use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
@@ -138,7 +140,17 @@ final class CurlMultiHandler
     {
         $this->assertOpen();
 
-        $easy = $this->factory->create($request, $options);
+        try {
+            $easy = $this->factory->create($request, $options);
+        } catch (TimeoutException $e) {
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(new NetworkTimeoutException(
+                'The cURL handler timed out while transferring the request body',
+                $request,
+                $e
+            ));
+        }
+
         $id = (int) $easy->handle;
 
         /** @var Promise<ResponseInterface, mixed> $promise */

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -68,14 +68,14 @@ final class EasyHandle
     public ?\Throwable $createResponseException = null;
 
     /**
-     * @var TimeoutException|null Exception during response sink write timeout.
-     */
-    public ?TimeoutException $sinkWriteTimeoutException = null;
-
-    /**
      * @var TimeoutException|null Exception during request body read timeout.
      */
     public ?TimeoutException $bodyReadTimeoutException = null;
+
+    /**
+     * @var TimeoutException|null Exception during response sink write timeout.
+     */
+    public ?TimeoutException $sinkWriteTimeoutException = null;
 
     /**
      * Attach a response to the easy handle based on the received headers.

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -73,6 +73,11 @@ final class EasyHandle
     public ?TimeoutException $sinkWriteTimeoutException = null;
 
     /**
+     * @var TimeoutException|null Exception during request body read timeout.
+     */
+    public ?TimeoutException $bodyReadTimeoutException = null;
+
+    /**
      * Attach a response to the easy handle based on the received headers.
      *
      * @throws \RuntimeException if no headers have been received or the first

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Handler;
 
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
@@ -65,6 +66,11 @@ final class EasyHandle
      * @var \Throwable|null Exception during createResponse (if any)
      */
     public ?\Throwable $createResponseException = null;
+
+    /**
+     * @var TimeoutException|null Exception during response sink write timeout.
+     */
+    public ?TimeoutException $sinkWriteTimeoutException = null;
 
     /**
      * Attach a response to the easy handle based on the received headers.

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -55,6 +55,7 @@ final class StreamHandler
     private const NETWORK_ERRORS = [
         'SSL: Connection reset by peer',
         'SSL: Broken pipe',
+        'unexpected eof while reading',
     ];
 
     private array $lastHeaders = [];

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -53,8 +53,8 @@ final class StreamHandler
     ];
 
     private const NETWORK_ERRORS = [
-        'Connection reset by peer',
-        'Broken pipe',
+        'SSL: Connection reset by peer',
+        'SSL: Broken pipe',
     ];
 
     private array $lastHeaders = [];

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -7,6 +7,7 @@ namespace GuzzleHttp\Handler;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ConnectTimeoutException;
 use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\ResponseTimeoutException;
@@ -49,6 +50,11 @@ final class StreamHandler
         'Connection timed out',
         'Operation timed out',
         'SSL: Handshake timed out',
+    ];
+
+    private const NETWORK_ERRORS = [
+        'Connection reset by peer',
+        'Broken pipe',
     ];
 
     private array $lastHeaders = [];
@@ -117,14 +123,22 @@ final class StreamHandler
                 throw $e;
             }
 
-            // Determine if the error was a networking error.
-            if (!$e instanceof NetworkException) {
-                if (self::isConnectTimeoutError($e->getMessage())) {
-                    $e = new ConnectTimeoutException($e->getMessage(), $request, $e);
-                } elseif (self::isConnectionError($e->getMessage())) {
-                    $e = new ConnectException($e->getMessage(), $request, $e);
+            if ($e instanceof TimeoutException) {
+                $e = new NetworkTimeoutException('The stream handler timed out while transferring the request body', $request, $e);
+            } elseif (!$e instanceof NetworkException) {
+                $message = $e->getMessage();
+                if (self::isSendError($message)) {
+                    $e = self::isConnectTimeoutError($message)
+                        ? new NetworkTimeoutException($message, $request, $e)
+                        : new NetworkException($message, $request, $e);
+                } elseif (self::isConnectTimeoutError($message)) {
+                    $e = new ConnectTimeoutException($message, $request, $e);
+                } elseif (self::isConnectionError($message)) {
+                    $e = new ConnectException($message, $request, $e);
+                } elseif (self::isNetworkError($message)) {
+                    $e = new NetworkException($message, $request, $e);
                 } elseif (!$e instanceof RequestException) {
-                    $e = new RequestException($e->getMessage(), $request, 0, $e);
+                    $e = new RequestException($message, $request, 0, $e);
                 }
             }
             $this->invokeStats($options, $request, $startTime, null, $e);
@@ -160,6 +174,23 @@ final class StreamHandler
     {
         foreach (self::CONNECTION_ERRORS as $connectionError) {
             if (false !== \stripos($message, $connectionError)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function isSendError(string $message): bool
+    {
+        // A failed write ("Send of N bytes failed ...") implies an established connection.
+        return false !== \stripos($message, 'bytes failed with errno=');
+    }
+
+    private static function isNetworkError(string $message): bool
+    {
+        foreach (self::NETWORK_ERRORS as $networkError) {
+            if (false !== \stripos($message, $networkError)) {
                 return true;
             }
         }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -50,6 +50,7 @@ final class StreamHandler
         'Connection timed out',
         'Operation timed out',
         'SSL: Handshake timed out',
+        'did not properly respond after a period of time',
     ];
 
     private const NETWORK_ERRORS = [

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -14,7 +14,7 @@ use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\ProxyOptions;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\Exception\TimeoutException as Psr7TimeoutException;
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
@@ -363,7 +363,7 @@ final class StreamHandler
                 $sink,
                 (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1
             );
-        } catch (Psr7TimeoutException $e) {
+        } catch (TimeoutException $e) {
             throw new ResponseTimeoutException(
                 'The stream handler timed out while transferring the response body',
                 $request,

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2909,18 +2909,11 @@ class CurlFactoryTest extends TestCase
         self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
     }
 
-    /**
-     * @dataProvider curlHandlerProvider
-     */
-    public function testStreamingRequestBodyReadPsr7TimeoutRejectsAsNetworkTimeoutThroughCurlHandlers(callable $handlerFactory): void
+    public function testStreamingRequestBodyReadPsr7TimeoutAbortsReadCallback(): void
     {
-        Server::flush();
-        Server::enqueue([
-            new Psr7\Response(200, [], 'abc'),
-        ]);
+        $factory = new CurlFactory(3);
         $previous = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
         $readCalled = false;
-        $stats = null;
         $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
             'getSize' => static function (): ?int {
                 return null;
@@ -2932,14 +2925,42 @@ class CurlFactoryTest extends TestCase
             },
         ]);
         $request = new Psr7\Request('PUT', Server::$url, [], $body);
-        $handler = $handlerFactory();
+        $easy = $factory->create($request, []);
 
         try {
-            $handler($request, [
-                'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
-                    $stats = $transferStats;
-                },
-            ])->wait();
+            $callback = $_SERVER['_curl'][\CURLOPT_READFUNCTION];
+
+            self::assertSame(0x10000000, $callback($easy->handle, null, 8192));
+            self::assertTrue($readCalled);
+            self::assertSame($previous, $easy->bodyReadTimeoutException);
+        } finally {
+            if (\array_key_exists('handle', \get_object_vars($easy))) {
+                $factory->release($easy);
+            }
+        }
+    }
+
+    public function testStreamingRequestBodyReadPsr7TimeoutRejectsAsNetworkTimeoutWithoutResponse(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
+        $stats = null;
+        $request = new Psr7\Request('PUT', Server::$url, [], 'payload');
+        $easy = $factory->create($request, [
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
+            },
+        ]);
+        $easy->bodyReadTimeoutException = $previous;
+        $easy->errno = \CURLE_ABORTED_BY_CALLBACK;
+        $handler = static function (RequestInterface $request, array $options) {
+            self::fail('Did not expect timeout failure to be retried');
+
+            return P\Create::promiseFor(new Psr7\Response());
+        };
+
+        try {
+            CurlFactory::finish($handler, $easy, $factory)->wait();
 
             self::fail('Expected NetworkTimeoutException');
         } catch (NetworkTimeoutException $e) {
@@ -2952,18 +2973,55 @@ class CurlFactoryTest extends TestCase
             self::assertInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
-        } finally {
-            Server::flush();
-
-            if (\method_exists($handler, 'close')) {
-                $handler->close();
-            }
         }
 
-        self::assertTrue($readCalled);
         self::assertInstanceOf(TransferStats::class, $stats);
         self::assertFalse($stats->hasResponse());
         self::assertNull($stats->getResponse());
+        self::assertSame($request, $stats->getRequest());
+        self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $stats->getHandlerErrorData());
+    }
+
+    public function testStreamingRequestBodyReadPsr7TimeoutRejectsAsResponseTimeoutWithResponse(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
+        $stats = null;
+        $request = new Psr7\Request('PUT', Server::$url, [], 'payload');
+        $response = new Psr7\Response(200, [], 'early');
+        $easy = $factory->create($request, [
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
+            },
+        ]);
+        $easy->response = $response;
+        $easy->bodyReadTimeoutException = $previous;
+        $easy->errno = \CURLE_ABORTED_BY_CALLBACK;
+        $handler = static function (RequestInterface $request, array $options) {
+            self::fail('Did not expect timeout failure to be retried');
+
+            return P\Create::promiseFor(new Psr7\Response());
+        };
+
+        try {
+            CurlFactory::finish($handler, $easy, $factory)->wait();
+
+            self::fail('Expected ResponseTimeoutException');
+        } catch (ResponseTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($response, $e->getResponse());
+            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
+            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
+            self::assertInstanceOf(ResponseException::class, $e);
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame($response, $stats->getResponse());
         self::assertSame($request, $stats->getRequest());
         self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $stats->getHandlerErrorData());
     }

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2853,62 +2853,6 @@ class CurlFactoryTest extends TestCase
         self::assertSame('abc 123', (string) $response->getBody());
     }
 
-    /**
-     * @dataProvider curlHandlerProvider
-     */
-    public function testSinkWritePsr7TimeoutRejectsAsResponseTimeoutThroughCurlHandlers(callable $handlerFactory): void
-    {
-        Server::flush();
-        Server::enqueue([
-            new Psr7\Response(200, [], 'abc'),
-        ]);
-        $request = new Psr7\Request('GET', Server::$url);
-        $handler = $handlerFactory();
-        $previous = new Psr7\Exception\TimeoutException('Unable to write to stream: timed out');
-        $stats = null;
-        $writeCalled = false;
-        $sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor(), [
-            'write' => static function (string $data) use (&$writeCalled, $previous): int {
-                $writeCalled = true;
-
-                throw $previous;
-            },
-        ]);
-
-        try {
-            $handler($request, [
-                'sink' => $sink,
-                'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
-                    $stats = $transferStats;
-                },
-            ])->wait();
-
-            self::fail('Expected ResponseTimeoutException');
-        } catch (ResponseTimeoutException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertSame(200, $e->getResponse()->getStatusCode());
-            self::assertSame('The cURL handler timed out while transferring the response body', $e->getMessage());
-            self::assertSame($previous, $e->getPrevious());
-            self::assertSame(\CURLE_WRITE_ERROR, $e->getHandlerContext()['errno']);
-            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
-            self::assertInstanceOf(ResponseException::class, $e);
-            self::assertInstanceOf(RequestExceptionInterface::class, $e);
-            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
-        } finally {
-            Server::flush();
-
-            if (\method_exists($handler, 'close')) {
-                $handler->close();
-            }
-        }
-
-        self::assertTrue($writeCalled);
-        self::assertInstanceOf(TransferStats::class, $stats);
-        self::assertTrue($stats->hasResponse());
-        self::assertSame(200, $stats->getResponse()->getStatusCode());
-        self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
-    }
-
     public function testStreamingRequestBodyReadPsr7TimeoutAbortsReadCallback(): void
     {
         $factory = new CurlFactory(3);
@@ -3154,6 +3098,62 @@ class CurlFactoryTest extends TestCase
         }
 
         self::assertTrue($castCalled);
+    }
+
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testSinkWritePsr7TimeoutRejectsAsResponseTimeoutThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, [], 'abc'),
+        ]);
+        $request = new Psr7\Request('GET', Server::$url);
+        $handler = $handlerFactory();
+        $previous = new Psr7\Exception\TimeoutException('Unable to write to stream: timed out');
+        $stats = null;
+        $writeCalled = false;
+        $sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor(), [
+            'write' => static function (string $data) use (&$writeCalled, $previous): int {
+                $writeCalled = true;
+
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $handler($request, [
+                'sink' => $sink,
+                'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                    $stats = $transferStats;
+                },
+            ])->wait();
+
+            self::fail('Expected ResponseTimeoutException');
+        } catch (ResponseTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+            self::assertSame('The cURL handler timed out while transferring the response body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(\CURLE_WRITE_ERROR, $e->getHandlerContext()['errno']);
+            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
+            self::assertInstanceOf(ResponseException::class, $e);
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+
+        self::assertTrue($writeCalled);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame(200, $stats->getResponse()->getStatusCode());
+        self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
     }
 
     public function testInvokesOnStatsOnSuccess(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2940,6 +2940,95 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public function testStreamingUploadInstallsProgressAbortForBodyReadTimeout(): void
+    {
+        $factory = new CurlFactory(3);
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+        $easy = $factory->create($request, []);
+
+        try {
+            // A progress callback is installed for streaming uploads even when
+            // the "progress" option is absent, so the upload can be aborted on a
+            // body read timeout on PHP versions where the read callback's abort
+            // return value is ignored (< 8.1.17 / < 8.2.4).
+            self::assertArrayHasKey(self::progressCallbackOption(), $_SERVER['_curl']);
+            $progress = $_SERVER['_curl'][self::progressCallbackOption()];
+
+            self::assertSame(0, $progress($easy->handle, 0, 0, 0, 0));
+
+            $easy->bodyReadTimeoutException = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
+            self::assertSame(1, $progress($easy->handle, 0, 0, 0, 0));
+            self::assertFalse($easy->progressAborted);
+        } finally {
+            if (\array_key_exists('handle', \get_object_vars($easy))) {
+                $factory->release($easy);
+            }
+        }
+    }
+
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testStreamingRequestBodyReadTimeoutAbortsTransferThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, [], 'hi'),
+        ]);
+        $handler = $handlerFactory();
+        $previous = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
+        $readCalled = false;
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+            'read' => static function (int $length) use (&$readCalled, $previous): string {
+                $readCalled = true;
+
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected the upload read timeout to reject the transfer');
+        } catch (NetworkTimeoutException $e) {
+            // On PHP >= 8.1.17 / 8.2.4 the read callback aborts synchronously
+            // (and on older PHP the progress callback may abort before a
+            // response arrives), so no usable response is received.
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+        } catch (ResponseTimeoutException $e) {
+            // PHP versions without read-callback abort support (< 8.1.17, and
+            // 8.2.0-8.2.3 since the fix shipped in 8.1.17 and 8.2.4) ignore the
+            // read callback's abort return, so the transfer is aborted by the
+            // progress callback, possibly after an early response is observed.
+            // It is still a timeout, never a silent success.
+            self::assertTrue(\PHP_VERSION_ID < 80117 || (\PHP_VERSION_ID >= 80200 && \PHP_VERSION_ID < 80204));
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+
+        self::assertTrue($readCalled);
+    }
+
     public function testStreamingRequestBodyReadPsr7TimeoutRejectsAsNetworkTimeoutWithoutResponse(): void
     {
         $factory = new CurlFactory(3);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2909,6 +2909,106 @@ class CurlFactoryTest extends TestCase
         self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
     }
 
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testStreamingRequestBodyReadPsr7TimeoutRejectsAsNetworkTimeoutThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, [], 'abc'),
+        ]);
+        $previous = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
+        $readCalled = false;
+        $stats = null;
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+            'read' => static function (int $length) use (&$readCalled, $previous): string {
+                $readCalled = true;
+
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+        $handler = $handlerFactory();
+
+        try {
+            $handler($request, [
+                'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                    $stats = $transferStats;
+                },
+            ])->wait();
+
+            self::fail('Expected NetworkTimeoutException');
+        } catch (NetworkTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
+            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
+            self::assertInstanceOf(NetworkException::class, $e);
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+
+        self::assertTrue($readCalled);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertFalse($stats->hasResponse());
+        self::assertNull($stats->getResponse());
+        self::assertSame($request, $stats->getRequest());
+        self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $stats->getHandlerErrorData());
+    }
+
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testStringRequestBodyReadPsr7TimeoutRejectsAsNetworkTimeoutThroughCurlHandlers(callable $handlerFactory): void
+    {
+        $previous = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
+        $castCalled = false;
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+            '__toString' => static function () use (&$castCalled, $previous): string {
+                $castCalled = true;
+
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+        $handler = $handlerFactory();
+
+        try {
+            $handler($request, [
+                'curl' => ['body_as_string' => true],
+            ])->wait();
+
+            self::fail('Expected NetworkTimeoutException');
+        } catch (NetworkTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame([], $e->getHandlerContext());
+            self::assertInstanceOf(NetworkException::class, $e);
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+        } finally {
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+
+        self::assertTrue($castCalled);
+    }
+
     public function testInvokesOnStatsOnSuccess(): void
     {
         Server::flush();

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3156,6 +3156,48 @@ class CurlFactoryTest extends TestCase
         self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
     }
 
+    public function testSinkWritePsr7TimeoutRejectsAsNetworkTimeoutWithoutResponse(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new Psr7\Exception\TimeoutException('Unable to write to stream: timed out');
+        $stats = null;
+        $request = new Psr7\Request('GET', Server::$url);
+        $easy = $factory->create($request, [
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
+            },
+        ]);
+        $easy->sinkWriteTimeoutException = $previous;
+        $easy->errno = \CURLE_WRITE_ERROR;
+        $handler = static function (RequestInterface $request, array $options) {
+            self::fail('Did not expect timeout failure to be retried');
+
+            return P\Create::promiseFor(new Psr7\Response());
+        };
+
+        try {
+            CurlFactory::finish($handler, $easy, $factory)->wait();
+
+            self::fail('Expected NetworkTimeoutException');
+        } catch (NetworkTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('The cURL handler timed out while transferring the response body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(\CURLE_WRITE_ERROR, $e->getHandlerContext()['errno']);
+            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
+            self::assertInstanceOf(NetworkException::class, $e);
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+        }
+
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertFalse($stats->hasResponse());
+        self::assertNull($stats->getResponse());
+        self::assertSame($request, $stats->getRequest());
+        self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
+    }
+
     public function testInvokesOnStatsOnSuccess(): void
     {
         Server::flush();

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2853,6 +2853,62 @@ class CurlFactoryTest extends TestCase
         self::assertSame('abc 123', (string) $response->getBody());
     }
 
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testSinkWritePsr7TimeoutRejectsAsResponseTimeoutThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, [], 'abc'),
+        ]);
+        $request = new Psr7\Request('GET', Server::$url);
+        $handler = $handlerFactory();
+        $previous = new Psr7\Exception\TimeoutException('Unable to write to stream: timed out');
+        $stats = null;
+        $writeCalled = false;
+        $sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor(), [
+            'write' => static function (string $data) use (&$writeCalled, $previous): int {
+                $writeCalled = true;
+
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $handler($request, [
+                'sink' => $sink,
+                'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                    $stats = $transferStats;
+                },
+            ])->wait();
+
+            self::fail('Expected ResponseTimeoutException');
+        } catch (ResponseTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+            self::assertSame('The cURL handler timed out while transferring the response body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(\CURLE_WRITE_ERROR, $e->getHandlerContext()['errno']);
+            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
+            self::assertInstanceOf(ResponseException::class, $e);
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+
+        self::assertTrue($writeCalled);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame(200, $stats->getResponse()->getStatusCode());
+        self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
+    }
+
     public function testInvokesOnStatsOnSuccess(): void
     {
         Server::flush();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1166,6 +1166,51 @@ class StreamHandlerTest extends TestCase
         self::assertSame('abc 123', (string) $response->getBody());
     }
 
+    public function testThrowsResponseTimeoutExceptionWhenSinkWriteTimesOut(): void
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $stats = null;
+        $exception = null;
+        $writeCalled = false;
+        $previous = new Psr7\Exception\TimeoutException('Unable to write to stream: timed out');
+        $sink = FnStream::decorate(Psr7\Utils::streamFor(), [
+            'write' => static function (string $data) use (&$writeCalled, $previous): int {
+                $writeCalled = true;
+
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $handler(
+                $request,
+                [
+                    'sink' => $sink,
+                    'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                        $stats = $transferStats;
+                    },
+                ]
+            )->wait();
+
+            self::fail('Expected ResponseTimeoutException');
+        } catch (ResponseTimeoutException $e) {
+            $exception = $e;
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+            self::assertSame('The stream handler timed out while transferring the response body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertSame(['timed_out' => true], $e->getHandlerContext());
+        }
+
+        self::assertTrue($writeCalled);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame($exception->getResponse(), $stats->getResponse());
+        self::assertSame($exception, $stats->getHandlerErrorData());
+    }
+
     public function testInvokesOnStatsOnSuccess(): void
     {
         Server::flush();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace GuzzleHttp\Test\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ConnectTimeoutException;
+use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\ResponseTimeoutException;
@@ -19,6 +22,8 @@ use GuzzleHttp\TransferStats;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -121,6 +126,152 @@ class StreamHandlerTest extends TestCase
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Cannot connect to HTTPS server through proxy'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Failed to enable crypto'));
         self::assertFalse($this->matchesStreamHandlerError('isConnectionError', 'HTTP request failed!'));
+    }
+
+    public function testClassifiesStreamSendErrors(): void
+    {
+        self::assertTrue($this->matchesStreamHandlerError('isSendError', 'Send of 65536 bytes failed with errno=110 Connection timed out'));
+        self::assertTrue($this->matchesStreamHandlerError('isSendError', 'Send of 8192 bytes failed with errno=60 Operation timed out'));
+        self::assertFalse($this->matchesStreamHandlerError('isSendError', 'fopen(): Failed to open stream: Connection timed out'));
+        self::assertFalse($this->matchesStreamHandlerError('isSendError', 'HTTP request failed!'));
+    }
+
+    public function testClassifiesStreamNetworkErrors(): void
+    {
+        self::assertTrue($this->matchesStreamHandlerError('isNetworkError', 'SSL: Connection reset by peer'));
+        self::assertTrue($this->matchesStreamHandlerError('isNetworkError', 'Send of 64 bytes failed with errno=32 Broken pipe'));
+        self::assertFalse($this->matchesStreamHandlerError('isNetworkError', 'fopen(): Failed to open stream: Connection refused'));
+        self::assertFalse($this->matchesStreamHandlerError('isNetworkError', 'HTTP request failed!'));
+    }
+
+    public function testThrowsNetworkTimeoutExceptionWhenRequestBodyReadTimesOut(): void
+    {
+        $handler = new StreamHandler();
+        $previous = new Psr7\Exception\TimeoutException('Unable to read stream contents: timed out');
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function () use ($previous): string {
+                throw $previous;
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+        $stats = null;
+        $exception = null;
+
+        try {
+            $handler($request, [
+                'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                    $stats = $transferStats;
+                },
+            ])->wait();
+
+            self::fail('Expected NetworkTimeoutException');
+        } catch (NetworkTimeoutException $e) {
+            $exception = $e;
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('The stream handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(NetworkException::class, $e);
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+        }
+
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertFalse($stats->hasResponse());
+        self::assertSame($request, $stats->getRequest());
+        self::assertSame($exception, $stats->getHandlerErrorData());
+    }
+
+    public function testClassifiesPostConnectSendTimeoutAsNetworkTimeout(): void
+    {
+        // A real send() ETIMEDOUT can't be triggered, so the request-body read
+        // is only a seam to feed a representative send-failure message in.
+        $handler = new StreamHandler();
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function (): string {
+                throw new \RuntimeException('Send of 65536 bytes failed with errno=110 Connection timed out');
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected NetworkTimeoutException');
+        } catch (NetworkTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ConnectException::class, $e);
+        }
+    }
+
+    public function testClassifiesConnectTimeoutMessageAsConnectTimeout(): void
+    {
+        // Without the "Send of ..." marker, a connect-timeout message stays a connect timeout.
+        $handler = new StreamHandler();
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function (): string {
+                throw new \RuntimeException('fopen(): Failed to open stream: Connection timed out');
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected ConnectTimeoutException');
+        } catch (ConnectTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(ConnectException::class, $e);
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+    }
+
+    public function testClassifiesPostConnectSendFailureAsNetwork(): void
+    {
+        // A non-timeout send failure (e.g. peer reset) is a network error, not a timeout.
+        $handler = new StreamHandler();
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function (): string {
+                throw new \RuntimeException('Send of 65536 bytes failed with errno=104 Connection reset by peer');
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected NetworkException');
+        } catch (NetworkException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
+            self::assertNotInstanceOf(ConnectException::class, $e);
+            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+        }
+    }
+
+    public function testClassifiesConnectionResetAsNetwork(): void
+    {
+        // A post-connect reset (e.g. TLS "SSL: Connection reset by peer") is a network error.
+        $handler = new StreamHandler();
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function (): string {
+                throw new \RuntimeException('SSL: Connection reset by peer');
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected NetworkException');
+        } catch (NetworkException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ConnectException::class, $e);
+            self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
+        }
     }
 
     public function testRejectsHttp3(): void

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -139,7 +139,9 @@ class StreamHandlerTest extends TestCase
     public function testClassifiesStreamNetworkErrors(): void
     {
         self::assertTrue($this->matchesStreamHandlerError('isNetworkError', 'SSL: Connection reset by peer'));
-        self::assertTrue($this->matchesStreamHandlerError('isNetworkError', 'Send of 64 bytes failed with errno=32 Broken pipe'));
+        self::assertTrue($this->matchesStreamHandlerError('isNetworkError', 'SSL: Broken pipe'));
+        // A bare connect-phase reset (no "SSL:" prefix) is not a network error.
+        self::assertFalse($this->matchesStreamHandlerError('isNetworkError', 'fopen(): Failed to open stream: Connection reset by peer'));
         self::assertFalse($this->matchesStreamHandlerError('isNetworkError', 'fopen(): Failed to open stream: Connection refused'));
         self::assertFalse($this->matchesStreamHandlerError('isNetworkError', 'HTTP request failed!'));
     }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -112,7 +112,7 @@ class StreamHandlerTest extends TestCase
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'fopen(): SSL: Handshake timed out'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'fopen(): Failed to open stream: Connection timed out'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'fopen(): Failed to open stream: Operation timed out'));
-        self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'stream_socket_client(): connect() failed: Operation timed out'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'stream_socket_client(): Unable to connect to example.test:443 (Operation timed out)'));
         self::assertFalse($this->matchesStreamHandlerError('isConnectTimeoutError', 'HTTP request failed!'));
         self::assertFalse($this->matchesStreamHandlerError('isConnectionError', 'fopen(): SSL: Handshake timed out'));
     }
@@ -125,6 +125,10 @@ class StreamHandlerTest extends TestCase
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'fopen(): Failed to open stream: No connection could be made because the target machine actively refused it'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Cannot connect to HTTPS server through proxy'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'Failed to enable crypto'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'fopen(): Failed to open stream: Network is unreachable'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'fopen(): Failed to open stream: No route to host'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'fopen(): Failed to open stream: Host is down'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectionError', 'A connection attempt failed because the connected party did not properly respond after a period of time'));
         self::assertFalse($this->matchesStreamHandlerError('isConnectionError', 'HTTP request failed!'));
     }
 
@@ -140,6 +144,8 @@ class StreamHandlerTest extends TestCase
     {
         self::assertTrue($this->matchesStreamHandlerError('isNetworkError', 'SSL: Connection reset by peer'));
         self::assertTrue($this->matchesStreamHandlerError('isNetworkError', 'SSL: Broken pipe'));
+        // OpenSSL 3.0+ reports a peer closing the connection without close_notify this way.
+        self::assertTrue($this->matchesStreamHandlerError('isNetworkError', 'SSL operation failed with code 1. OpenSSL Error messages: error:0A000126:SSL routines::unexpected eof while reading'));
         // A bare connect-phase reset (no "SSL:" prefix) is not a network error.
         self::assertFalse($this->matchesStreamHandlerError('isNetworkError', 'fopen(): Failed to open stream: Connection reset by peer'));
         self::assertFalse($this->matchesStreamHandlerError('isNetworkError', 'fopen(): Failed to open stream: Connection refused'));
@@ -272,6 +278,56 @@ class StreamHandlerTest extends TestCase
             self::assertSame($request, $e->getRequest());
             self::assertInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(ConnectException::class, $e);
+            self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
+        }
+    }
+
+    public function testClassifiesUnexpectedEofAsNetwork(): void
+    {
+        // OpenSSL 3.0+ surfaces a peer closing the connection without a TLS
+        // close_notify (an empty reply, like cURL's CURLE_GOT_NOTHING) as
+        // "unexpected eof while reading". The handshake already completed, so
+        // there is no "Failed to enable crypto", and it is a network error.
+        $handler = new StreamHandler();
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function (): string {
+                throw new \RuntimeException('SSL operation failed with code 1. OpenSSL Error messages: error:0A000126:SSL routines::unexpected eof while reading');
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected NetworkException');
+        } catch (NetworkException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ConnectException::class, $e);
+            self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
+        }
+    }
+
+    public function testClassifiesHandshakeUnexpectedEofAsConnect(): void
+    {
+        // The same OpenSSL EOF during the handshake co-emits "Failed to enable
+        // crypto", which is matched as a connection error first, so it stays a
+        // connect error instead of being reclassified as a network error.
+        $handler = new StreamHandler();
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function (): string {
+                throw new \RuntimeException('SSL operation failed with code 1. OpenSSL Error messages: error:0A000126:SSL routines::unexpected eof while reading. Failed to enable crypto');
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected ConnectException');
+        } catch (ConnectException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
         }
     }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -113,6 +113,10 @@ class StreamHandlerTest extends TestCase
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'fopen(): Failed to open stream: Connection timed out'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'fopen(): Failed to open stream: Operation timed out'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'stream_socket_client(): Unable to connect to example.test:443 (Operation timed out)'));
+        // Windows WSAETIMEDOUT (errno 10060) wording matches for both connect-phase
+        // and post-connect send timeouts; the end-to-end tests prove which classifier wins.
+        self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond'));
+        self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'Send of 65536 bytes failed with errno=10060 A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond'));
         self::assertFalse($this->matchesStreamHandlerError('isConnectTimeoutError', 'HTTP request failed!'));
         self::assertFalse($this->matchesStreamHandlerError('isConnectionError', 'fopen(): SSL: Handshake timed out'));
     }
@@ -256,6 +260,52 @@ class StreamHandlerTest extends TestCase
             self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
             self::assertNotInstanceOf(ConnectException::class, $e);
             self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+        }
+    }
+
+    public function testClassifiesWindowsSendTimeoutAsNetworkTimeout(): void
+    {
+        // Windows WSAETIMEDOUT (errno 10060) write timeout on an established
+        // connection. The body-read seam only feeds a representative message in.
+        $handler = new StreamHandler();
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function (): string {
+                throw new \RuntimeException('Send of 65536 bytes failed with errno=10060 A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond');
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected NetworkTimeoutException');
+        } catch (NetworkTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ConnectException::class, $e);
+        }
+    }
+
+    public function testClassifiesWindowsConnectTimeoutAsConnectTimeout(): void
+    {
+        // The same WSAETIMEDOUT wording without the "Send of ..." marker is a
+        // connect-phase timeout and must be a ConnectTimeoutException.
+        $handler = new StreamHandler();
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function (): string {
+                throw new \RuntimeException('A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond');
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected ConnectTimeoutException');
+        } catch (ConnectTimeoutException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(ConnectException::class, $e);
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
         }
     }
 


### PR DESCRIPTION
This refines how the built-in handlers classify timeout and transport failures that happen while request and response bodies are being transferred.

PSR-7 stream timeouts are now mapped into Guzzle phase-based exception taxonomy. A timeout while reading a request body is reported as `NetworkTimeoutException` before any response is available, or as `ResponseTimeoutException` if an early response object already exists. A timeout while writing a response body to a sink follows the same response-phase rule. The original `GuzzleHttp\Psr7\Exception\TimeoutException` remains available through `getPrevious()`.

The cURL handlers now capture PSR-7 body read and sink write timeouts inside their callbacks so the transfer is rejected consistently instead of leaking the raw PSR-7 exception or succeeding after a truncated upload. Streaming uploads also install a progress callback fallback so older supported PHP versions still abort when libcurl read-abort handling is not available.

The stream handler also classifies more no-response transport failures as `NetworkException` or `NetworkTimeoutException` instead of `RequestException` or connect-phase exceptions when the failure clearly happens after a connection has been established. Documentation and tests were updated to describe the phase-based behavior without exposing handler-specific error-code details.