### PR TITLE
Honor string no-proxy options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Prevented `CurlMultiHandler` destructors from throwing during cleanup
 - Improved invalid response handling across handlers
 
+### Fixed
+
+- Fixed string `proxy.no` request option values being accepted but ignored by built-in handlers
+
 ### Deprecated
 
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Prevented `CurlMultiHandler` destructors from throwing during cleanup
 - Improved invalid response handling across handlers
 
-### Fixed
-
-- Fixed string `proxy.no` request option values being accepted but ignored by built-in handlers
-
 ### Deprecated
 
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -895,10 +895,10 @@ Pass a string to specify a proxy for all protocols.
 $client->request('GET', '/', ['proxy' => 'http://localhost:8125']);
 ```
 
-Pass an associative array to specify HTTP proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair to provide a list of host names that should not be proxied to. No-proxy entries may include ports, for example `example.com:8080` or `[::1]:8080`. The `http`, `https`, and `no` entries may be set to `null` to leave that entry unconfigured.
+Pass an associative array to specify HTTP proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair as a comma-delimited string or an array to provide a list of host names that should not be proxied to. No-proxy entries may include ports, for example `example.com:8080` or `[::1]:8080`. The `http`, `https`, and `no` entries may be set to `null` to leave that entry unconfigured.
 
 > [!NOTE]
-> Guzzle will automatically populate this value with your environment's `NO_PROXY` environment variable. However, when providing a `proxy` request option, it is up to you to provide the `no` value parsed from the `NO_PROXY` environment variable (e.g., `explode(',', getenv('NO_PROXY'))`).
+> Guzzle will automatically populate this value with your environment's `NO_PROXY` environment variable. However, when providing a `proxy` request option, it is up to you to provide the `no` value from the `NO_PROXY` environment variable.
 
 ```php
 $client->request('GET', '/', [

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -877,7 +877,6 @@ class CurlFactory implements CurlFactoryInterface
                 if (isset($options['proxy'][$scheme])) {
                     if (
                         isset($options['proxy']['no'])
-                        && \is_array($options['proxy']['no'])
                         && Utils::isUriInNoProxy($easy->request->getUri(), $options['proxy']['no'])
                     ) {
                         unset($conf[\CURLOPT_PROXY]);

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -605,7 +605,6 @@ class StreamHandler
             if (isset($value[$scheme])) {
                 if (
                     !isset($value['no'])
-                    || !\is_array($value['no'])
                     || !Utils::isUriInNoProxy($request->getUri(), $value['no'])
                 ) {
                     $uri = $value[$scheme];

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -221,8 +221,8 @@ final class RequestOptions
      * proxy: (string|array) Pass a string to specify an HTTP proxy, or an
      * array to specify different proxies for different protocols (where the
      * key is the protocol and the value is a proxy string or null). Provide a
-     * "no" key as a string, array of strings, or null to specify hosts or
-     * host-and-port pairs that should not be proxied.
+     * "no" key as a comma-delimited string, array of strings, or null to
+     * specify hosts or host-and-port pairs that should not be proxied.
      */
     public const PROXY = 'proxy';
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -333,12 +333,20 @@ EOT
     /**
      * Returns true if the provided URI matches any of the no proxy areas.
      *
-     * @param array<array-key, mixed> $noProxyArray An array of host patterns.
+     * @param mixed $noProxy No-proxy host patterns.
      *
      * @internal
      */
-    public static function isUriInNoProxy(UriInterface $uri, array $noProxyArray): bool
+    public static function isUriInNoProxy(UriInterface $uri, $noProxy): bool
     {
+        if (\is_string($noProxy)) {
+            $noProxy = \explode(',', $noProxy);
+        }
+
+        if (!\is_array($noProxy)) {
+            return false;
+        }
+
         $host = $uri->getHost();
         if ($host === '') {
             return false;
@@ -349,10 +357,12 @@ EOT
             $port = self::getDefaultPort($uri->getScheme());
         }
 
-        foreach ($noProxyArray as $area) {
+        foreach ($noProxy as $area) {
             if (!\is_string($area)) {
                 continue;
             }
+
+            $area = \trim($area);
 
             // Always match on wildcards.
             if ($area === '*') {

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -345,6 +345,14 @@ class CurlFactoryTest extends TestCase
             'proxy' => ['http' => 'http://bar.com', 'https' => 'https://t'],
         ]);
         self::assertEquals('http://bar.com', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        $this->checkNoProxyForHost('http://test.test.com', 'test.test.com', false);
+        $this->checkNoProxyForHost('http://test.test.com', 'other.test.com, test.test.com', false);
+        $this->checkNoProxyForHost('http://test.test.com', ' other.test.com , test.test.com ', false);
+        $this->checkNoProxyForHost('http://test.test.com', 'test.test.com:80', false);
+        $this->checkNoProxyForHost('http://test.test.com', '*', false);
+        $this->checkNoProxyForHost('http://test.test.com', '', true);
+        $this->checkNoProxyForHost('http://test.test.com', null, true);
+        $this->checkNoProxyForHost('http://test.test.com', [' test.test.com ', new \stdClass()], false);
         $this->checkNoProxyForHost('http://test.test.com', ['test.test.com'], false);
         $this->checkNoProxyForHost('http://test.test.com', ['.test.com'], false);
         $this->checkNoProxyForHost('http://test.test.com', ['test.test.com:80'], false);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -364,6 +364,29 @@ class StreamHandlerTest extends TestCase
         self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://[::1]:8081')['http']['proxy']);
     }
 
+    public function testAddsProxyButHonorsStringNoProxy()
+    {
+        $proxy = [
+            'http' => 'http://proxy.example.com:8125',
+            'https' => 'http://proxy.example.com:8125',
+            'no' => 'example.com, foo.example.com',
+        ];
+
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://example.com')['http']);
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://foo.example.com')['http']);
+
+        $proxy['no'] = ' example.com:80 , [::1]:8080 ';
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://example.com')['http']);
+        self::assertArrayNotHasKey('proxy', $this->getProxyContext($proxy, 'http://[::1]:8080')['http']);
+        self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'https://example.com')['http']['proxy']);
+
+        $proxy['no'] = '';
+        self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://example.com')['http']['proxy']);
+
+        $proxy['no'] = null;
+        self::assertSame('tcp://proxy.example.com:8125', $this->getProxyContext($proxy, 'http://example.com')['http']['proxy']);
+    }
+
     public function testUsesProxy()
     {
         $this->queueRes();

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -229,6 +229,13 @@ class UtilsTest extends TestCase
     public static function uriNoProxyProvider()
     {
         return [
+            ['http://example.com', 'example.com', true],
+            ['http://foo.com', 'example.com, foo.com', true],
+            ['http://foo.com', ' example.com , foo.com ', true],
+            ['http://foo.com', '', false],
+            ['http://foo.com', null, false],
+            ['http://foo.com', false, false],
+            ['http://example.com', [' example.com ', new \stdClass()], true],
             ['http://example.com', ['example.com:80'], true],
             ['https://example.com', ['example.com:443'], true],
             ['http://example.com:8080', ['example.com:8080'], true],


### PR DESCRIPTION
String values for `proxy['no']` were accepted by the request option compatibility layer, but the cURL and stream handlers only honored arrays, so a caller could think an internal host was excluded while the request still went through the proxy. This normalizes string values the same way `NO_PROXY` and 8.0 do, keeps null and invalid compatibility behavior non-fatal in 7.x, and adds focused coverage for cURL, stream, and the shared URI matcher.