### PR TITLE
Add no-proxy string changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Added
 
+- Added support for providing the `proxy` request option's `no` value as a comma-delimited string
 - Added the `protocols` request option to restrict allowed URI schemes for request transfers
 - Added `cert_type` and `ssl_key_type` request options for TLS certificate and private-key file types
 - Added PHP stream handler support for the `ssl_key` request option


### PR DESCRIPTION
This adds a changelog entry for the recently merged support for providing the proxy request option's no value as a comma-delimited string.