### PR TITLE
Deprecate non-iterable Pool inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Prevented `CurlMultiHandler` destructors from throwing during cleanup
 - Improved invalid response handling across handlers
 
+### Fixed
+
+- Prevented single `Pool` inputs from triggering `guzzlehttp/promises` non-iterable deprecations
+
 ### Deprecated
 
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,9 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Prevented `CurlMultiHandler` destructors from throwing during cleanup
 - Improved invalid response handling across handlers
 
-### Fixed
-
-- Prevented single `Pool` inputs from triggering `guzzlehttp/promises` non-iterable deprecations
-
 ### Deprecated
 
+- Deprecated non-iterable `Pool` request collections, which will be rejected in 8.0
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
 - Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE`, which will be rejected in 8.0
 - Deprecated scalar-coerced `idn_conversion` request option values, which will be rejected in 8.0

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -277,6 +277,12 @@ parameters:
 			path: src/Middleware.php
 
 		-
+			message: '#^Call to function is_iterable\(\) with array\|Iterator will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Pool.php
+
+		-
 			message: '#^PHPDoc tag @var has invalid value \(callable\(int\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 24 on line 2$#'
 			identifier: phpDoc.parseError
 			count: 1

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -2,6 +2,7 @@
 
 namespace GuzzleHttp;
 
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
@@ -29,7 +30,7 @@ class Pool implements PromisorInterface
 
     /**
      * @param ClientInterface $client   Client used to send the requests.
-     * @param iterable        $requests Requests or functions that return
+     * @param array|\Iterator $requests Requests or functions that return
      *                                  requests to send concurrently.
      * @param array           $config   Associative array of options
      *                                  - concurrency: (int) Maximum number of requests to send concurrently
@@ -62,8 +63,9 @@ class Pool implements PromisorInterface
             $requests = [$requests];
         }
 
-        $requests = static function () use ($requests, $client, $opts) {
-            foreach ($requests as $key => $rfn) {
+        $iterable = P\Create::iterFor($requests);
+        $requests = static function () use ($iterable, $client, $opts) {
+            foreach ($iterable as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {
                     yield $key => $client->sendAsync($rfn, $opts);
                 } elseif (\is_callable($rfn)) {
@@ -94,7 +96,7 @@ class Pool implements PromisorInterface
      * indeterminate number of requests concurrently.
      *
      * @param ClientInterface $client   Client used to send the requests
-     * @param iterable        $requests Requests to send concurrently.
+     * @param array|\Iterator $requests Requests to send concurrently.
      * @param array           $options  Passes through the options available in
      *                                  {@see Pool::__construct}
      *

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -2,7 +2,6 @@
 
 namespace GuzzleHttp;
 
-use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\EachPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
@@ -30,7 +29,7 @@ class Pool implements PromisorInterface
 
     /**
      * @param ClientInterface $client   Client used to send the requests.
-     * @param array|\Iterator $requests Requests or functions that return
+     * @param iterable        $requests Requests or functions that return
      *                                  requests to send concurrently.
      * @param array           $config   Associative array of options
      *                                  - concurrency: (int) Maximum number of requests to send concurrently
@@ -52,12 +51,19 @@ class Pool implements PromisorInterface
         }
 
         if (!\is_iterable($requests)) {
+            \trigger_deprecation(
+                'guzzlehttp/guzzle',
+                '7.11',
+                'Passing a non-iterable request collection to %s::__construct() or %s::batch() is deprecated; guzzlehttp/guzzle 8.0 will require an iterable.',
+                __CLASS__,
+                __CLASS__
+            );
+
             $requests = [$requests];
         }
 
-        $iterable = P\Create::iterFor($requests);
-        $requests = static function () use ($iterable, $client, $opts) {
-            foreach ($iterable as $key => $rfn) {
+        $requests = static function () use ($requests, $client, $opts) {
+            foreach ($requests as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {
                     yield $key => $client->sendAsync($rfn, $opts);
                 } elseif (\is_callable($rfn)) {
@@ -88,7 +94,7 @@ class Pool implements PromisorInterface
      * indeterminate number of requests concurrently.
      *
      * @param ClientInterface $client   Client used to send the requests
-     * @param array|\Iterator $requests Requests to send concurrently.
+     * @param iterable        $requests Requests to send concurrently.
      * @param array           $options  Passes through the options available in
      *                                  {@see Pool::__construct}
      *

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -51,6 +51,10 @@ class Pool implements PromisorInterface
             $opts = [];
         }
 
+        if (!\is_iterable($requests)) {
+            $requests = [$requests];
+        }
+
         $iterable = P\Create::iterFor($requests);
         $requests = static function () use ($iterable, $client, $opts) {
             foreach ($iterable as $key => $rfn) {

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -18,7 +18,7 @@ use Psr\Http\Message\RequestInterface;
 
 class PoolTest extends TestCase
 {
-    public function testValidatesIterable()
+    public function testValidatesSingleInvalidElement()
     {
         $p = new Pool(new Client(), 'foo');
 
@@ -44,6 +44,31 @@ class PoolTest extends TestCase
         $c = $this->getClient();
         $p = new Pool($c, [new Request('GET', 'http://example.com')]);
         $p->promise()->wait();
+    }
+
+    public function testAcceptsSingleRequest()
+    {
+        $h = [];
+        $handler = new MockHandler([
+            static function (RequestInterface $request) use (&$h) {
+                $h[] = $request;
+
+                return new Response();
+            },
+        ]);
+        $c = new Client(['handler' => $handler]);
+        $keys = [];
+        $p = new Pool($c, new Request('GET', 'http://example.com'), [
+            'fulfilled' => static function ($res, $index) use (&$keys) {
+                $keys[] = $index;
+            },
+        ]);
+
+        $p->promise()->wait();
+
+        self::assertCount(1, $h);
+        self::assertSame('http://example.com', (string) $h[0]->getUri());
+        self::assertSame([0], $keys);
     }
 
     /**
@@ -110,6 +135,40 @@ class PoolTest extends TestCase
         $p->promise()->wait();
         self::assertCount(1, $h);
         self::assertTrue($h[0]->hasHeader('x-foo'));
+    }
+
+    public function testAcceptsSingleCallable()
+    {
+        $h = [];
+        $handler = new MockHandler([
+            static function (RequestInterface $request) use (&$h) {
+                $h[] = $request;
+
+                return new Response();
+            },
+        ]);
+        $c = new Client(['handler' => $handler]);
+        $optHistory = [];
+        $fn = static function (array $opts) use (&$optHistory, $c) {
+            $optHistory = $opts;
+
+            return $c->requestAsync('GET', 'http://example.com', $opts);
+        };
+        $keys = [];
+        $opts = [
+            'options' => ['headers' => ['x-foo' => 'bar']],
+            'fulfilled' => static function ($res, $index) use (&$keys) {
+                $keys[] = $index;
+            },
+        ];
+        $p = new Pool($c, $fn, $opts);
+
+        $p->promise()->wait();
+
+        self::assertSame($opts['options'], $optHistory);
+        self::assertCount(1, $h);
+        self::assertTrue($h[0]->hasHeader('x-foo'));
+        self::assertSame([0], $keys);
     }
 
     public function testBatchesResults()

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -18,14 +18,6 @@ use Psr\Http\Message\RequestInterface;
 
 class PoolTest extends TestCase
 {
-    public function testValidatesSingleInvalidElement()
-    {
-        $p = new Pool(new Client(), 'foo');
-
-        $this->expectException(\InvalidArgumentException::class);
-        $p->promise()->wait();
-    }
-
     public function testValidatesEachElement()
     {
         $c = new Client();
@@ -44,31 +36,6 @@ class PoolTest extends TestCase
         $c = $this->getClient();
         $p = new Pool($c, [new Request('GET', 'http://example.com')]);
         $p->promise()->wait();
-    }
-
-    public function testAcceptsSingleRequest()
-    {
-        $h = [];
-        $handler = new MockHandler([
-            static function (RequestInterface $request) use (&$h) {
-                $h[] = $request;
-
-                return new Response();
-            },
-        ]);
-        $c = new Client(['handler' => $handler]);
-        $keys = [];
-        $p = new Pool($c, new Request('GET', 'http://example.com'), [
-            'fulfilled' => static function ($res, $index) use (&$keys) {
-                $keys[] = $index;
-            },
-        ]);
-
-        $p->promise()->wait();
-
-        self::assertCount(1, $h);
-        self::assertSame('http://example.com', (string) $h[0]->getUri());
-        self::assertSame([0], $keys);
     }
 
     /**
@@ -135,40 +102,6 @@ class PoolTest extends TestCase
         $p->promise()->wait();
         self::assertCount(1, $h);
         self::assertTrue($h[0]->hasHeader('x-foo'));
-    }
-
-    public function testAcceptsSingleCallable()
-    {
-        $h = [];
-        $handler = new MockHandler([
-            static function (RequestInterface $request) use (&$h) {
-                $h[] = $request;
-
-                return new Response();
-            },
-        ]);
-        $c = new Client(['handler' => $handler]);
-        $optHistory = [];
-        $fn = static function (array $opts) use (&$optHistory, $c) {
-            $optHistory = $opts;
-
-            return $c->requestAsync('GET', 'http://example.com', $opts);
-        };
-        $keys = [];
-        $opts = [
-            'options' => ['headers' => ['x-foo' => 'bar']],
-            'fulfilled' => static function ($res, $index) use (&$keys) {
-                $keys[] = $index;
-            },
-        ];
-        $p = new Pool($c, $fn, $opts);
-
-        $p->promise()->wait();
-
-        self::assertSame($opts['options'], $optHistory);
-        self::assertCount(1, $h);
-        self::assertTrue($h[0]->hasHeader('x-foo'));
-        self::assertSame([0], $keys);
     }
 
     public function testBatchesResults()


### PR DESCRIPTION
This makes Guzzle own the transition away from non-iterable Pool request collections before Guzzle 8 requires iterables. Pool now emits a Guzzle deprecation before preserving the legacy one-item wrapping behavior, while the 7.11 PHPDoc remains compatible with the current documented array and iterator input shape.