### PR TITLE
Remove Pool deprecation shim

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -79,6 +79,12 @@ parameters:
 			path: src/Handler/CurlHandler.php
 
 		-
+			message: '#^Method GuzzleHttp\\Handler\\CurlMultiHandler\:\:getMultiHandle\(\) has invalid return type CurlMultiHandle\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
 			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 5
@@ -139,12 +145,6 @@ parameters:
 			path: src/Handler/CurlMultiHandler.php
 
 		-
-			message: '#^Method GuzzleHttp\\Handler\\CurlMultiHandler\:\:getMultiHandle\(\) has invalid return type CurlMultiHandle\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Handler/CurlMultiHandler.php
-
-		-
 			message: '#^Property GuzzleHttp\\Handler\\CurlMultiHandler\:\:\$multiHandle \(CurlMultiHandle\|resource\|null\) is never assigned CurlMultiHandle so it can be removed from the property type\.$#'
 			identifier: property.unusedType
 			count: 1
@@ -191,12 +191,6 @@ parameters:
 			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: src/Middleware.php
-
-		-
-			message: '#^Call to function is_iterable\(\) with array\|Iterator will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Pool.php
 
 		-
 			message: '#^Cannot cast mixed to string\.$#'

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -131,18 +131,6 @@ class Pool implements PromisorInterface
             $opts = [];
         }
 
-        if (!\is_iterable($requests)) {
-            \trigger_deprecation(
-                'guzzlehttp/guzzle',
-                '7.11',
-                'Passing a non-iterable request collection to %s::__construct() or %s::batch() is deprecated; guzzlehttp/guzzle 8.0 will require an iterable.',
-                __CLASS__,
-                __CLASS__
-            );
-
-            $requests = [$requests];
-        }
-
         $requestGenerator = static function () use ($requests, $client, $opts): \Generator {
             foreach ($requests as $key => $rfn) {
                 if ($rfn instanceof RequestInterface) {


### PR DESCRIPTION
This removes the temporary Pool deprecation shim that was carried forward by the 7.11 merge. Guzzle 8 already requires iterable Pool request collections through its native signatures, so the compatibility branch and its PHPStan baseline entry are no longer needed.