### PR TITLE
Normalize easy request inputs before PSR-7

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,6 +25,12 @@ parameters:
 			path: src/Client.php
 
 		-
+			message: '#^Parameter \#3 \$headers of class GuzzleHttp\\Psr7\\Request constructor expects array\<array\<string\>\|string\>, array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Client.php
+
+		-
 			message: '#^Part \$value\[0\] \(mixed\) of encapsed string cannot be cast to string\.$#'
 			identifier: encapsedStringPart.nonString
 			count: 3

--- a/src/Client.php
+++ b/src/Client.php
@@ -168,9 +168,20 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      */
     public function requestAsync(string $method, $uri = '', array $options = []): PromiseInterface
     {
+        $normalizedMethod = \strtoupper($method);
+        if ($method !== $normalizedMethod) {
+            \trigger_deprecation(
+                'guzzlehttp/guzzle',
+                '7.11',
+                'Passing a non-uppercase HTTP method to Client::requestAsync() is deprecated; guzzlehttp/guzzle 8.0 will preserve HTTP method casing. Pass an uppercase method explicitly if uppercase is required.'
+            );
+            $method = $normalizedMethod;
+        }
+
         $options = $this->prepareDefaults($options);
         // Remove request modifying parameter because it can be done up-front.
         $headers = $options['headers'] ?? [];
+        self::castDeprecatedHeaderOptionValues($headers);
         $body = $options['body'] ?? null;
         $version = self::normalizeProtocolVersion($options['version'] ?? '1.1');
         // Merge the URI into the base URI.
@@ -200,6 +211,16 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      */
     public function request(string $method, $uri = '', array $options = []): ResponseInterface
     {
+        $normalizedMethod = \strtoupper($method);
+        if ($method !== $normalizedMethod) {
+            \trigger_deprecation(
+                'guzzlehttp/guzzle',
+                '7.11',
+                'Passing a non-uppercase HTTP method to Client::request() is deprecated; guzzlehttp/guzzle 8.0 will preserve HTTP method casing. Pass an uppercase method explicitly if uppercase is required.'
+            );
+            $method = $normalizedMethod;
+        }
+
         $options[RequestOptions::SYNCHRONOUS] = true;
 
         return $this->requestAsync($method, $uri, $options)->wait();
@@ -790,7 +811,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (array_keys($options['headers']) === range(0, count($options['headers']) - 1)) {
                 throw new InvalidArgumentException('The headers array must have header name as keys.');
             }
-            $modify['set_headers'] = $options['headers'];
+            $headers = $options['headers'];
+            self::castDeprecatedHeaderOptionValues($headers);
+            $modify['set_headers'] = $headers;
             unset($options['headers']);
         }
 
@@ -909,6 +932,30 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         return $request;
+    }
+
+    /**
+     * @param array<array-key, mixed> $headers
+     */
+    private static function castDeprecatedHeaderOptionValues(array &$headers): void
+    {
+        foreach ($headers as $name => $value) {
+            if (\is_array($value)) {
+                foreach ($value as $index => $item) {
+                    if ($item === null || (!\is_string($item) && \is_scalar($item))) {
+                        $value[$index] = (string) $item;
+                    }
+                }
+
+                $headers[$name] = $value;
+
+                continue;
+            }
+
+            if ($value === null || (!\is_string($value) && \is_scalar($value))) {
+                $headers[$name] = (string) $value;
+            }
+        }
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -128,6 +128,26 @@ class ClientTest extends TestCase
         self::assertSame('1.1', $mock->getLastRequest()->getProtocolVersion());
     }
 
+    public function testRequestWithUppercaseMethodSendsUppercaseMethod()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $client->request('GET', 'http://foo.com');
+
+        self::assertSame('GET', $mock->getLastRequest()->getMethod());
+    }
+
+    public function testRequestAsyncWithUppercaseMethodSendsUppercaseMethod()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $client->requestAsync('POST', 'http://foo.com')->wait();
+
+        self::assertSame('POST', $mock->getLastRequest()->getMethod());
+    }
+
     public function testClientHasOptions()
     {
         $client = new Client([
@@ -919,6 +939,30 @@ class ClientTest extends TestCase
         self::assertNotNull($sent);
         self::assertSame(['bar'], $sent->getHeader('X-Foo'));
         self::assertSame(['zero'], $sent->getHeader('0'));
+    }
+
+    public function testEasyRequestHeadersHandleNumericHeaderNames()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $client->request('GET', 'http://foo.com', ['headers' => ['0' => 'zero']]);
+
+        $sent = $mock->getLastRequest();
+        self::assertNotNull($sent);
+        self::assertSame(['zero'], $sent->getHeader('0'));
+    }
+
+    public function testEasyRequestHeadersPreserveStringValueArrays()
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mock]);
+
+        $client->request('GET', 'http://foo.com', ['headers' => ['X-Foo' => ['bar', 'baz']]]);
+
+        $sent = $mock->getLastRequest();
+        self::assertNotNull($sent);
+        self::assertSame(['bar', 'baz'], $sent->getHeader('X-Foo'));
     }
 
     public function testCanSetCustomHandler()


### PR DESCRIPTION
This updates the easy request path so Guzzle owns compatibility normalization before values reach PSR-7. Explicit request methods passed to Client::request() or Client::requestAsync() are normalized to uppercase with a Guzzle deprecation when needed, preserving Guzzle 7's existing effective behavior while avoiding PSR-7 method-casing deprecations. Request option header values are normalized before constructing or modifying PSR-7 messages so scalar and null values keep working through Guzzle's request option compatibility layer, while unsupported values fail before they reach PSR-7.