### PR TITLE
Remove exception handler context

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -500,13 +500,14 @@ responses into exceptions: `http_errors` turns 4xx responses into
 middleware can throw `TooManyRedirectsException`. `Client::sendRequest()`
 follows PSR-18 and returns redirect, 4xx, and 5xx responses normally instead.
 
-If a non-network request failure occurs before Guzzle has a response object, it
-throws `RequestException`. This includes invalid or handler-unsupported HTTP
-protocol versions, malformed response data that cannot be parsed into a PSR-7
-response, and no-response transfers aborted by application code.
-`RequestException` exposes `getRequest()`, but not `getResponse()`. When
-handling these cases separately, catch no-response transport failures first,
-response-aware failures second, and other request failures last.
+All `TransferException` instances expose `getRequest()`. If a non-network
+request failure occurs before Guzzle has a response object, it throws
+`RequestException`. This includes invalid or handler-unsupported HTTP protocol
+versions, malformed response data that cannot be parsed into a PSR-7 response,
+and no-response transfers aborted by application code. `RequestException` does
+not expose `getResponse()`. When handling these cases separately, catch
+no-response transport failures first, response-aware failures second, and other
+request failures last.
 
 ```php
 use GuzzleHttp\Exception\NetworkException;

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -12,49 +12,11 @@ use Psr\Http\Message\RequestInterface;
  */
 class NetworkException extends TransferException implements NetworkExceptionInterface
 {
-    private RequestInterface $request;
-
-    private array $handlerContext;
-
     public function __construct(
         string $message,
         RequestInterface $request,
-        ?\Throwable $previous = null,
-        array $handlerContext = []
+        ?\Throwable $previous = null
     ) {
-        parent::__construct($message, 0, $previous);
-        $this->request = $request;
-        $this->handlerContext = $handlerContext;
-    }
-
-    /**
-     * Get the request that caused the exception
-     */
-    public function getRequest(): RequestInterface
-    {
-        return $this->request;
-    }
-
-    /**
-     * Get contextual information about the error from the underlying handler.
-     *
-     * The contents of this array will vary depending on which handler you are
-     * using. It may also be just an empty array. Relying on this data will
-     * couple you to a specific handler, but can give more debug information
-     * when needed.
-     *
-     * @deprecated since 7.11. Use TransferStats from the "on_stats" request
-     *             option for handler context instead.
-     */
-    public function getHandlerContext(): array
-    {
-        \trigger_deprecation(
-            'guzzlehttp/guzzle',
-            '7.11',
-            '%s is deprecated and will be removed in 8.0. Use TransferStats from the "on_stats" request option for handler context instead.',
-            __METHOD__
-        );
-
-        return $this->handlerContext;
+        parent::__construct($message, $request, 0, $previous);
     }
 }

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -15,20 +15,13 @@ use Psr\Http\Message\ResponseInterface;
  */
 class RequestException extends TransferException implements RequestExceptionInterface
 {
-    private RequestInterface $request;
-
-    private array $handlerContext;
-
     public function __construct(
         string $message,
         RequestInterface $request,
         int $code = 0,
-        ?\Throwable $previous = null,
-        array $handlerContext = []
+        ?\Throwable $previous = null
     ) {
-        parent::__construct($message, $code, $previous);
-        $this->request = $request;
-        $this->handlerContext = $handlerContext;
+        parent::__construct($message, $request, $code, $previous);
     }
 
     /**
@@ -37,14 +30,12 @@ class RequestException extends TransferException implements RequestExceptionInte
      * @param RequestInterface             $request        Request sent
      * @param ResponseInterface|null       $response       Response received, if any
      * @param \Throwable|null              $previous       Previous exception
-     * @param array                        $handlerContext Optional handler context
      * @param BodySummarizerInterface|null $bodySummarizer Optional body summarizer
      */
     public static function create(
         RequestInterface $request,
         ?ResponseInterface $response = null,
         ?\Throwable $previous = null,
-        array $handlerContext = [],
         ?BodySummarizerInterface $bodySummarizer = null
     ): self {
         if (!$response) {
@@ -52,8 +43,7 @@ class RequestException extends TransferException implements RequestExceptionInte
                 'Error completing request',
                 $request,
                 0,
-                $previous,
-                $handlerContext
+                $previous
             );
         }
 
@@ -86,44 +76,13 @@ class RequestException extends TransferException implements RequestExceptionInte
         }
 
         if ($level === 4) {
-            return new ClientException($message, $request, $response, $previous, $handlerContext);
+            return new ClientException($message, $request, $response, $previous);
         }
 
         if ($level === 5) {
-            return new ServerException($message, $request, $response, $previous, $handlerContext);
+            return new ServerException($message, $request, $response, $previous);
         }
 
-        return new ResponseException($message, $request, $response, $previous, $handlerContext);
-    }
-
-    /**
-     * Get the request that caused the exception
-     */
-    public function getRequest(): RequestInterface
-    {
-        return $this->request;
-    }
-
-    /**
-     * Get contextual information about the error from the underlying handler.
-     *
-     * The contents of this array will vary depending on which handler you are
-     * using. It may also be just an empty array. Relying on this data will
-     * couple you to a specific handler, but can give more debug information
-     * when needed.
-     *
-     * @deprecated since 7.11. Use TransferStats from the "on_stats" request
-     *             option for handler context instead.
-     */
-    public function getHandlerContext(): array
-    {
-        \trigger_deprecation(
-            'guzzlehttp/guzzle',
-            '7.11',
-            '%s is deprecated and will be removed in 8.0. Use TransferStats from the "on_stats" request option for handler context instead.',
-            __METHOD__
-        );
-
-        return $this->handlerContext;
+        return new ResponseException($message, $request, $response, $previous);
     }
 }

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -18,10 +18,9 @@ class ResponseException extends RequestException
         string $message,
         RequestInterface $request,
         ResponseInterface $response,
-        ?\Throwable $previous = null,
-        array $handlerContext = []
+        ?\Throwable $previous = null
     ) {
-        parent::__construct($message, $request, $response->getStatusCode(), $previous, $handlerContext);
+        parent::__construct($message, $request, $response->getStatusCode(), $previous);
         $this->response = $response;
     }
 

--- a/src/Exception/TransferException.php
+++ b/src/Exception/TransferException.php
@@ -4,9 +4,30 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Exception;
 
+use Psr\Http\Message\RequestInterface;
+
 /**
  * Base exception for transfer failures.
  */
 class TransferException extends \RuntimeException implements GuzzleException
 {
+    private RequestInterface $request;
+
+    public function __construct(
+        string $message,
+        RequestInterface $request,
+        int $code = 0,
+        ?\Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->request = $request;
+    }
+
+    /**
+     * Get the request that caused the exception.
+     */
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
 }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -709,8 +709,7 @@ final class CurlFactory implements CurlFactoryInterface
                     'An error was encountered while creating the response',
                     $easy->request,
                     0,
-                    $easy->createResponseException,
-                    $ctx
+                    $easy->createResponseException
                 )
             );
         }
@@ -725,8 +724,7 @@ final class CurlFactory implements CurlFactoryInterface
                         'An error was encountered during the on_headers event',
                         $easy->request,
                         $easy->response,
-                        $easy->onHeadersException,
-                        $ctx
+                        $easy->onHeadersException
                     )
                 );
             }
@@ -737,8 +735,7 @@ final class CurlFactory implements CurlFactoryInterface
                     'An error was encountered during the on_headers event',
                     $easy->request,
                     0,
-                    $easy->onHeadersException,
-                    $ctx
+                    $easy->onHeadersException
                 )
             );
         }
@@ -751,8 +748,7 @@ final class CurlFactory implements CurlFactoryInterface
                         'An error was encountered during the progress event',
                         $easy->request,
                         $easy->response,
-                        $easy->progressException,
-                        $ctx
+                        $easy->progressException
                     )
                 );
             }
@@ -763,8 +759,7 @@ final class CurlFactory implements CurlFactoryInterface
                     'An error was encountered during the progress event',
                     $easy->request,
                     0,
-                    $easy->progressException,
-                    $ctx
+                    $easy->progressException
                 )
             );
         }
@@ -779,8 +774,7 @@ final class CurlFactory implements CurlFactoryInterface
                         'The cURL handler timed out while transferring the request body',
                         $easy->request,
                         $easy->response,
-                        $easy->bodyReadTimeoutException,
-                        $ctx
+                        $easy->bodyReadTimeoutException
                     )
                 );
             }
@@ -790,8 +784,7 @@ final class CurlFactory implements CurlFactoryInterface
                 new NetworkTimeoutException(
                     'The cURL handler timed out while transferring the request body',
                     $easy->request,
-                    $easy->bodyReadTimeoutException,
-                    $ctx
+                    $easy->bodyReadTimeoutException
                 )
             );
         }
@@ -806,8 +799,7 @@ final class CurlFactory implements CurlFactoryInterface
                         'The cURL handler timed out while transferring the response body',
                         $easy->request,
                         $easy->response,
-                        $easy->sinkWriteTimeoutException,
-                        $ctx
+                        $easy->sinkWriteTimeoutException
                     )
                 );
             }
@@ -817,8 +809,7 @@ final class CurlFactory implements CurlFactoryInterface
                 new NetworkTimeoutException(
                     'The cURL handler timed out while transferring the response body',
                     $easy->request,
-                    $easy->sinkWriteTimeoutException,
-                    $ctx
+                    $easy->sinkWriteTimeoutException
                 )
             );
         }
@@ -831,8 +822,7 @@ final class CurlFactory implements CurlFactoryInterface
                         'The transfer was aborted by the progress callback',
                         $easy->request,
                         $easy->response,
-                        null,
-                        $ctx
+                        null
                     )
                 );
             }
@@ -843,8 +833,7 @@ final class CurlFactory implements CurlFactoryInterface
                     'The transfer was aborted by the progress callback',
                     $easy->request,
                     0,
-                    null,
-                    $ctx
+                    null
                 )
             );
         }
@@ -869,20 +858,20 @@ final class CurlFactory implements CurlFactoryInterface
 
         if ($easy->errno === \CURLE_OPERATION_TIMEOUTED) {
             if ($easy->response !== null) {
-                $error = new ResponseTimeoutException($message, $easy->request, $easy->response, null, $ctx);
+                $error = new ResponseTimeoutException($message, $easy->request, $easy->response);
             } elseif (self::isConnectTimeoutError($ctx['error'] ?? '')) {
-                $error = new ConnectTimeoutException($message, $easy->request, null, $ctx);
+                $error = new ConnectTimeoutException($message, $easy->request);
             } else {
-                $error = new NetworkTimeoutException($message, $easy->request, null, $ctx);
+                $error = new NetworkTimeoutException($message, $easy->request);
             }
         } elseif ($easy->response) {
-            $error = new ResponseException($message, $easy->request, $easy->response, null, $ctx);
+            $error = new ResponseException($message, $easy->request, $easy->response);
         } elseif (self::isConnectionError($easy->errno)) {
-            $error = new ConnectException($message, $easy->request, null, $ctx);
+            $error = new ConnectException($message, $easy->request);
         } elseif (self::isNetworkError($easy->errno)) {
-            $error = new NetworkException($message, $easy->request, null, $ctx);
+            $error = new NetworkException($message, $easy->request);
         } else {
-            $error = new RequestException($message, $easy->request, 0, null, $ctx);
+            $error = new RequestException($message, $easy->request);
         }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -327,7 +327,7 @@ final class CurlMultiHandler
 
             if ($explicit) {
                 $this->captureFailure($failure, function () use ($entry): void {
-                    $entry['deferred']->reject(new HandlerClosedException('The cURL multi handler was closed before the transfer completed.'));
+                    $entry['deferred']->reject(new HandlerClosedException('The cURL multi handler was closed before the transfer completed.', $entry['easy']->request));
                 });
             }
         }
@@ -377,7 +377,7 @@ final class CurlMultiHandler
 
             if ($reject) {
                 $this->captureFailure($failure, function () use ($entry): void {
-                    $entry['deferred']->reject(new HandlerClosedException('The cURL multi handler was closed before the transfer completed.'));
+                    $entry['deferred']->reject(new HandlerClosedException('The cURL multi handler was closed before the transfer completed.', $entry['easy']->request));
                 });
             }
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -401,8 +401,7 @@ final class StreamHandler
                 'The stream handler timed out while transferring the response body',
                 $request,
                 $response,
-                $e,
-                ['timed_out' => true]
+                $e
             );
         }
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -76,7 +76,7 @@ final class Middleware
                         if ($code < 400) {
                             return $response;
                         }
-                        throw RequestException::create($request, $response, null, [], $bodySummarizer);
+                        throw RequestException::create($request, $response, null, $bodySummarizer);
                     }
                 );
             };

--- a/tests/Exception/ConnectTimeoutExceptionTest.php
+++ b/tests/Exception/ConnectTimeoutExceptionTest.php
@@ -22,7 +22,7 @@ class ConnectTimeoutExceptionTest extends TestCase
     {
         $req = new Request('GET', '/');
         $prev = new \Exception();
-        $e = new ConnectTimeoutException('foo', $req, $prev, ['foo' => 'bar']);
+        $e = new ConnectTimeoutException('foo', $req, $prev);
 
         self::assertInstanceOf(ConnectException::class, $e);
         self::assertInstanceOf(NetworkException::class, $e);
@@ -31,7 +31,6 @@ class ConnectTimeoutExceptionTest extends TestCase
         self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
         self::assertSame($req, $e->getRequest());
         self::assertSame('foo', $e->getMessage());
-        self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
     }
 }

--- a/tests/Exception/NetworkTimeoutExceptionTest.php
+++ b/tests/Exception/NetworkTimeoutExceptionTest.php
@@ -22,7 +22,7 @@ class NetworkTimeoutExceptionTest extends TestCase
     {
         $req = new Request('GET', '/');
         $prev = new \Exception();
-        $e = new NetworkTimeoutException('foo', $req, $prev, ['foo' => 'bar']);
+        $e = new NetworkTimeoutException('foo', $req, $prev);
 
         self::assertInstanceOf(NetworkException::class, $e);
         self::assertInstanceOf(NetworkExceptionInterface::class, $e);
@@ -31,7 +31,6 @@ class NetworkTimeoutExceptionTest extends TestCase
         self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
         self::assertSame($req, $e->getRequest());
         self::assertSame('foo', $e->getMessage());
-        self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
     }
 }

--- a/tests/Exception/ResponseExceptionTest.php
+++ b/tests/Exception/ResponseExceptionTest.php
@@ -17,12 +17,12 @@ use Psr\Http\Client\RequestExceptionInterface;
  */
 class ResponseExceptionTest extends TestCase
 {
-    public function testCarriesRequestResponseAndContext(): void
+    public function testCarriesRequestAndResponse(): void
     {
         $req = new Request('GET', '/');
         $res = new Response(418);
         $prev = new \Exception();
-        $e = new ResponseException('foo', $req, $res, $prev, ['foo' => 'bar']);
+        $e = new ResponseException('foo', $req, $res, $prev);
 
         self::assertInstanceOf(RequestException::class, $e);
         self::assertInstanceOf(RequestExceptionInterface::class, $e);
@@ -31,7 +31,6 @@ class ResponseExceptionTest extends TestCase
         self::assertSame($res, $e->getResponse());
         self::assertSame('foo', $e->getMessage());
         self::assertSame(418, $e->getCode());
-        self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
     }
 }

--- a/tests/Exception/ResponseTimeoutExceptionTest.php
+++ b/tests/Exception/ResponseTimeoutExceptionTest.php
@@ -24,7 +24,7 @@ class ResponseTimeoutExceptionTest extends TestCase
         $req = new Request('GET', '/');
         $res = new Response(200);
         $prev = new \Exception();
-        $e = new ResponseTimeoutException('foo', $req, $res, $prev, ['foo' => 'bar']);
+        $e = new ResponseTimeoutException('foo', $req, $res, $prev);
 
         self::assertInstanceOf(ResponseException::class, $e);
         self::assertInstanceOf(RequestException::class, $e);
@@ -34,7 +34,6 @@ class ResponseTimeoutExceptionTest extends TestCase
         self::assertSame($req, $e->getRequest());
         self::assertSame($res, $e->getResponse());
         self::assertSame('foo', $e->getMessage());
-        self::assertSame('bar', $e->getHandlerContext()['foo']);
         self::assertSame($prev, $e->getPrevious());
     }
 }

--- a/tests/Exception/TransferExceptionTest.php
+++ b/tests/Exception/TransferExceptionTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Tests\Exception;
 
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientExceptionInterface;
 
@@ -16,12 +17,14 @@ class TransferExceptionTest extends TestCase
 {
     public function testIsGuzzleException()
     {
+        $req = new Request('GET', '/');
         $prev = new \Exception();
-        $e = new TransferException('foo', 123, $prev);
+        $e = new TransferException('foo', $req, 123, $prev);
 
         self::assertInstanceOf(\RuntimeException::class, $e);
         self::assertInstanceOf(GuzzleException::class, $e);
         self::assertInstanceOf(ClientExceptionInterface::class, $e);
+        self::assertSame($req, $e->getRequest());
         self::assertSame('foo', $e->getMessage());
         self::assertSame(123, $e->getCode());
         self::assertSame($prev, $e->getPrevious());

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2283,7 +2283,8 @@ class CurlFactoryTest extends TestCase
     public function testCreatesConnectExceptionForConnectionErrors(int $errno): void
     {
         $factory = new CurlFactory(1);
-        $easy = $factory->create(new Psr7\Request('GET', Server::$url), []);
+        $request = new Psr7\Request('GET', Server::$url);
+        $easy = $factory->create($request, []);
         $easy->errno = $errno;
         $response = CurlFactory::finish(
             static function (): void {

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1404,7 +1404,6 @@ class CurlFactoryTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame('The transfer was aborted by the progress callback', $e->getMessage());
-            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
         } finally {
             Server::flush();
 
@@ -1435,7 +1434,6 @@ class CurlFactoryTest extends TestCase
         } catch (RequestException $e) {
             self::assertSame('An error was encountered during the progress event', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
         } finally {
             Server::flush();
 
@@ -1468,7 +1466,6 @@ class CurlFactoryTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame('The transfer was aborted by the progress callback', $e->getMessage());
-            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
         }
     }
 
@@ -1497,7 +1494,6 @@ class CurlFactoryTest extends TestCase
         } catch (RequestException $e) {
             self::assertSame('An error was encountered during the progress event', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
         }
     }
 
@@ -2302,7 +2298,7 @@ class CurlFactoryTest extends TestCase
         } catch (ConnectTimeoutException $e) {
             self::fail('Expected non-timeout ConnectException');
         } catch (ConnectException $e) {
-            self::assertSame($errno, $e->getHandlerContext()['errno']);
+            self::assertSame($request, $e->getRequest());
         }
     }
 
@@ -2344,7 +2340,6 @@ class CurlFactoryTest extends TestCase
         } catch (NetworkException $e) {
             self::assertNotInstanceOf(ConnectException::class, $e);
             self::assertSame($request, $e->getRequest());
-            self::assertSame($errno, $e->getHandlerContext()['errno']);
         }
     }
 
@@ -2386,7 +2381,6 @@ class CurlFactoryTest extends TestCase
         } catch (ResponseException $e) {
             self::assertSame($request, $e->getRequest());
             self::assertSame($response, $e->getResponse());
-            self::assertSame($errno, $e->getHandlerContext()['errno']);
         }
     }
 
@@ -2413,7 +2407,6 @@ class CurlFactoryTest extends TestCase
             self::assertNotInstanceOf(ConnectException::class, $e);
             self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
             self::assertSame($request, $e->getRequest());
-            self::assertSame(\CURLE_OPERATION_TIMEOUTED, $e->getHandlerContext()['errno']);
         }
     }
 
@@ -2437,8 +2430,6 @@ class CurlFactoryTest extends TestCase
             self::assertInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
             self::assertSame($request, $e->getRequest());
-            self::assertSame(\CURLE_OPERATION_TIMEOUTED, $e->getHandlerContext()['errno']);
-            self::assertSame('Connection timeout after 5003 ms', $e->getHandlerContext()['error']);
         }
     }
 
@@ -2463,8 +2454,6 @@ class CurlFactoryTest extends TestCase
             self::assertInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(ConnectException::class, $e);
             self::assertSame($request, $e->getRequest());
-            self::assertSame(\CURLE_OPERATION_TIMEOUTED, $e->getHandlerContext()['errno']);
-            self::assertSame('Timeout was reached', $e->getHandlerContext()['error']);
         }
     }
 
@@ -2518,7 +2507,6 @@ class CurlFactoryTest extends TestCase
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertSame($request, $e->getRequest());
             self::assertSame($response, $e->getResponse());
-            self::assertSame(\CURLE_OPERATION_TIMEOUTED, $e->getHandlerContext()['errno']);
         }
     }
 
@@ -2544,8 +2532,6 @@ class CurlFactoryTest extends TestCase
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertSame($request, $e->getRequest());
             self::assertSame($response, $e->getResponse());
-            self::assertSame(\CURLE_OPERATION_TIMEOUTED, $e->getHandlerContext()['errno']);
-            self::assertSame('Connection timed out after 5003 milliseconds', $e->getHandlerContext()['error']);
         }
     }
 
@@ -2557,6 +2543,13 @@ class CurlFactoryTest extends TestCase
         }
 
         return $reflection->invoke(null, $easy, $ctx);
+    }
+
+    private static function assertResponseInfoWasNotExposed(array $context): void
+    {
+        self::assertArrayNotHasKey('http_code', $context);
+        self::assertArrayNotHasKey('header_size', $context);
+        self::assertArrayNotHasKey('content_type', $context);
     }
 
     public function testAddsTimeouts(): void
@@ -2688,7 +2681,6 @@ class CurlFactoryTest extends TestCase
             self::assertFalse($called);
             self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
-            self::assertResponseInfoWasNotExposed($e->getHandlerContext());
             self::assertInstanceOf(TransferStats::class, $stats);
             self::assertFalse($stats->hasResponse());
             self::assertNull($stats->getResponse());
@@ -2723,7 +2715,6 @@ class CurlFactoryTest extends TestCase
             );
             self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertSame($easy->createResponseException, $e->getPrevious());
-            self::assertResponseInfoWasNotExposed($e->getHandlerContext());
         }
     }
 
@@ -2950,7 +2941,6 @@ class CurlFactoryTest extends TestCase
             self::assertSame($request, $e->getRequest());
             self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
             self::assertInstanceOf(NetworkExceptionInterface::class, $e);
         } catch (ResponseTimeoutException $e) {
             // PHP versions without read-callback abort support (< 8.1.17, and
@@ -3000,8 +2990,6 @@ class CurlFactoryTest extends TestCase
             self::assertSame($request, $e->getRequest());
             self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
-            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
             self::assertInstanceOf(NetworkException::class, $e);
             self::assertInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
@@ -3045,8 +3033,6 @@ class CurlFactoryTest extends TestCase
             self::assertSame($response, $e->getResponse());
             self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $e->getHandlerContext()['errno']);
-            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
             self::assertInstanceOf(ResponseException::class, $e);
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
@@ -3086,7 +3072,6 @@ class CurlFactoryTest extends TestCase
             self::assertSame($request, $e->getRequest());
             self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame([], $e->getHandlerContext());
             self::assertInstanceOf(NetworkException::class, $e);
             self::assertInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
@@ -3136,8 +3121,6 @@ class CurlFactoryTest extends TestCase
             self::assertSame(200, $e->getResponse()->getStatusCode());
             self::assertSame('The cURL handler timed out while transferring the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame(\CURLE_WRITE_ERROR, $e->getHandlerContext()['errno']);
-            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
             self::assertInstanceOf(ResponseException::class, $e);
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
@@ -3183,8 +3166,6 @@ class CurlFactoryTest extends TestCase
             self::assertSame($request, $e->getRequest());
             self::assertSame('The cURL handler timed out while transferring the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame(\CURLE_WRITE_ERROR, $e->getHandlerContext()['errno']);
-            self::assertTrue($e->getHandlerContext()['timed_out'] ?? false);
             self::assertInstanceOf(NetworkException::class, $e);
             self::assertInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
@@ -3427,15 +3408,7 @@ class CurlFactoryTest extends TestCase
             );
             self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
-            self::assertResponseInfoWasNotExposed($e->getHandlerContext());
         }
-    }
-
-    private static function assertResponseInfoWasNotExposed(array $context): void
-    {
-        self::assertArrayNotHasKey('http_code', $context);
-        self::assertArrayNotHasKey('header_size', $context);
-        self::assertArrayNotHasKey('content_type', $context);
     }
 
     private static function assertAuthenticatedProxyConnectionReuseOptions(): void

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -535,7 +535,8 @@ class CurlMultiHandlerTest extends TestCase
         $progressCalls = 0;
         $closed = false;
 
-        $promise = $handler(new Request('GET', Server::$url), [
+        $request = new Request('GET', Server::$url);
+        $promise = $handler($request, [
             'timeout' => 5,
             'progress' => static function (
                 $downloadSize,

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -379,7 +379,8 @@ class CurlMultiHandlerTest extends TestCase
         self::assertIsResource($sink);
 
         $handler = new CurlMultiHandler();
-        $promise = $handler(new Request('GET', Server::$url), [
+        $request = new Request('GET', Server::$url);
+        $promise = $handler($request, [
             'delay' => 10000,
             'sink' => $sink,
         ]);
@@ -571,6 +572,7 @@ class CurlMultiHandlerTest extends TestCase
                 self::fail('Expected HandlerClosedException.');
             } catch (HandlerClosedException $e) {
                 self::assertSame('The cURL multi handler was closed before the transfer completed.', $e->getMessage());
+                self::assertSame($request, $e->getRequest());
             }
 
             try {
@@ -596,7 +598,9 @@ class CurlMultiHandlerTest extends TestCase
         $progressCalls = 0;
         $closed = false;
 
-        $activePromise = $handler(new Request('GET', Server::$url), [
+        $activeRequest = new Request('GET', Server::$url);
+        $delayedRequest = new Request('GET', Server::$url);
+        $activePromise = $handler($activeRequest, [
             'timeout' => 5,
             'progress' => static function (
                 $downloadSize,
@@ -613,7 +617,7 @@ class CurlMultiHandlerTest extends TestCase
             },
         ]);
 
-        $delayedPromise = $handler(new Request('GET', Server::$url), [
+        $delayedPromise = $handler($delayedRequest, [
             'delay' => 10000,
         ]);
 
@@ -633,12 +637,13 @@ class CurlMultiHandlerTest extends TestCase
             self::assertTrue(P\Is::rejected($activePromise));
             self::assertTrue(P\Is::rejected($delayedPromise));
 
-            foreach ([$activePromise, $delayedPromise] as $promise) {
+            foreach ([[$activePromise, $activeRequest], [$delayedPromise, $delayedRequest]] as [$promise, $request]) {
                 try {
                     $promise->wait();
                     self::fail('Expected HandlerClosedException.');
                 } catch (HandlerClosedException $e) {
                     self::assertSame('The cURL multi handler was closed before the transfer completed.', $e->getMessage());
+                    self::assertSame($request, $e->getRequest());
                 }
             }
         } finally {

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1474,7 +1474,6 @@ class StreamHandlerTest extends TestCase
             self::assertSame(200, $e->getResponse()->getStatusCode());
             self::assertSame('The stream handler timed out while transferring the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertSame(['timed_out' => true], $e->getHandlerContext());
         }
 
         self::assertTrue($writeCalled);
@@ -1776,7 +1775,6 @@ class StreamHandlerTest extends TestCase
             self::assertSame(200, $e->getResponse()->getStatusCode());
             self::assertSame('The stream handler timed out while transferring the response body', $e->getMessage());
             self::assertInstanceOf(Psr7\Exception\TimeoutException::class, $e->getPrevious());
-            self::assertSame(['timed_out' => true], $e->getHandlerContext());
         }
 
         self::assertInstanceOf(TransferStats::class, $stats);
@@ -1811,7 +1809,6 @@ class StreamHandlerTest extends TestCase
             self::assertSame(200, $e->getResponse()->getStatusCode());
             self::assertSame('The stream handler timed out while transferring the response body', $e->getMessage());
             self::assertInstanceOf(Psr7\Exception\TimeoutException::class, $e->getPrevious());
-            self::assertSame(['timed_out' => true], $e->getHandlerContext());
         }
 
         self::assertInstanceOf(TransferStats::class, $stats);

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -323,9 +323,6 @@ class PoolTest extends TestCase
         foreach ($rejected as $reason) {
             self::assertInstanceOf(RequestException::class, $reason);
             self::assertNotInstanceOf(ResponseException::class, $reason);
-            self::assertArrayNotHasKey('http_code', $reason->getHandlerContext());
-            self::assertArrayNotHasKey('header_size', $reason->getHandlerContext());
-            self::assertArrayNotHasKey('content_type', $reason->getHandlerContext());
         }
     }
 


### PR DESCRIPTION
This removes handler context from Guzzle exceptions after the 7.11 deprecation. TransferException now carries the request common to transfer failures, response-aware exceptions continue to expose the response, and handler diagnostics remain available through TransferStats.