### PR TITLE
Document 7.11 deprecation changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Deprecated
 
 - Deprecated non-iterable `Pool` request collections, which will be rejected in 8.0
-- Deprecated non-uppercase easy request HTTP methods
-- Deprecated invalid `headers` request option values
+- Deprecated non-uppercase easy request methods; 8.0 preserves method casing
+- Deprecated non-string `headers` request option values, which will be rejected in 8.0
+- Deprecated empty `headers` request option value arrays, which will be rejected in 8.0
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
 - Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE`, which will be rejected in 8.0
 - Deprecated scalar-coerced `idn_conversion` request option values, which will be rejected in 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated scalar-coerced `idn_conversion` request option values, which will be rejected in 8.0
 - Deprecated invalid documented request option value types, which will be rejected in 8.0
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
-- Deprecated `RequestException::wrapException()` for removal in 8.0
+- Deprecated `RequestException::wrapException()`, which will be removed in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,14 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Deprecated
 
 - Deprecated non-iterable `Pool` request collections, which will be rejected in 8.0
+- Deprecated non-uppercase easy request HTTP methods
+- Deprecated invalid `headers` request option values
 - Deprecated empty and malformed request protocol versions, which will be rejected in 8.0
 - Deprecated conflicting raw cURL request options, including `CURLOPT_SHARE`, which will be rejected in 8.0
 - Deprecated scalar-coerced `idn_conversion` request option values, which will be rejected in 8.0
 - Deprecated invalid documented request option value types, which will be rejected in 8.0
 - Deprecated selected request options ignored by incompatible built-in handlers, which will be rejected in 8.0
-- Deprecated `RequestException::wrapException()`, which will be removed in 8.0
+- Deprecated `RequestException::wrapException()` for removal in 8.0
 - Deprecated `RetryMiddleware::exponentialDelay()`, which will be removed in 8.0
 
 


### PR DESCRIPTION
This updates the 7.11 changelog to describe the easy request deprecations added before release. It now mentions non-uppercase easy request methods, the `headers` request option value cases that will be rejected in 8.0, and keeps the `RequestException::wrapException()` entry consistent with the other removal deprecations.