### PR TITLE
Clarify NetworkException upgrade guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add generic and structured PHPDoc annotations to client request/config option, async promise, handler, middleware, pool, and mock handler APIs
 - Add CIDR notation support for IP no-proxy rules
 - Add `ConnectTimeoutException` for connect-phase timeouts, extending `ConnectException`
+- Add `NetworkException` as the base class for no-response network failures
 - Add `NetworkTimeoutException` and `ResponseTimeoutException`
 - Add `ResponseTransferException` for transfer-level failures after response headers are received
 - Add PSR-17 `request_factory`, `stream_factory`, and `uri_factory` request options for client-created requests, request body streams, and URIs
@@ -85,6 +86,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Removed `RedirectMiddleware::$defaultSettings`; use `RedirectMiddleware::DEFAULT_SETTINGS`
 - Removed the deprecated `RetryMiddleware::exponentialDelay()` method
 - Removed the deprecated `RequestException::wrapException()` method
+- Removed exception handler context access; use the more granular exception hierarchy for failure classification
 - Removed response access from `RequestException`; use `ResponseException`
 - Removed `Utils::isHostInNoProxy()`; use `ProxyOptions` helpers for Guzzle 8 no-proxy matching
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add generic and structured PHPDoc annotations to client request/config option, async promise, handler, middleware, pool, and mock handler APIs
 - Add CIDR notation support for IP no-proxy rules
 - Add `ConnectTimeoutException` for connect-phase timeouts, extending `ConnectException`
-- Add `NetworkException` as the base class for no-response network failures
+- Add `NetworkException` for no-response network failures
 - Add `NetworkTimeoutException` and `ResponseTimeoutException`
 - Add `ResponseTransferException` for transfer-level failures after response headers are received
 - Add PSR-17 `request_factory`, `stream_factory`, and `uri_factory` request options for client-created requests, request body streams, and URIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Removed `RedirectMiddleware::$defaultSettings`; use `RedirectMiddleware::DEFAULT_SETTINGS`
 - Removed the deprecated `RetryMiddleware::exponentialDelay()` method
 - Removed the deprecated `RequestException::wrapException()` method
-- Removed exception handler context access; use the more granular exception hierarchy for failure classification
+- Removed `RequestException::getHandlerContext()` and `ConnectException::getHandlerContext()`; use the more granular exception hierarchy for failure classification
 - Removed response access from `RequestException`; use `ResponseException`
 - Removed `Utils::isHostInNoProxy()`; use `ProxyOptions` helpers for Guzzle 8 no-proxy matching
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -153,10 +153,12 @@ response constructor argument, and no longer has `getResponse()` or
 instantiate `RequestException` directly, its third constructor argument is now
 the exception code, followed by the previous exception.
 
-Exception handler context access was removed. If you used handler context to
-work out what kind of transfer failure occurred, switch to the more granular
-exception classes in the hierarchy above. If you need handler-level timing or
-statistics, collect them during the transfer with the `on_stats` request option.
+`RequestException::getHandlerContext()` and
+`ConnectException::getHandlerContext()` were removed. If you used handler
+context to work out what kind of transfer failure occurred, switch to the more
+granular exception classes in the hierarchy above. If you need handler-level
+timing or statistics, collect them during the transfer with the `on_stats`
+request option.
 
 Timeout exception classes are now split by the phase the handler can determine.
 `ConnectTimeoutException` is thrown for detected connect timeouts (DNS
@@ -186,18 +188,8 @@ not reject pending promises. If you add deterministic cleanup with
 handle `HandlerClosedException` or `TransferException` for pending promises you
 may still observe.
 
-The practical catch-order migration is to handle no-response network failures
-before request failures. If you previously caught `RequestException` as the only
-built-in handler transport failure type, add a `NetworkException` catch before
-it in Guzzle 8.0-only code, or a
-`Psr\Http\Client\NetworkExceptionInterface` catch before it in reusable code
-that supports both Guzzle 7.x and 8.0. If you previously caught
-`ConnectException` for cURL timeouts or broad no-response transport failures,
-catch `NetworkException` or `NetworkExceptionInterface` instead; keep
-`ConnectException` only for connection-establishment handling. Catch
-`ResponseException` before `RequestException` when you need response access, and
-use `TransferException` only when one catch block should handle every Guzzle
-transfer failure. After upgrading to Guzzle 8.0, use this catch order:
+When updating catch blocks for Guzzle 8.0, catch the more specific no-response
+and response-aware failures before `RequestException`. Use this catch order:
 
 ```php
 use GuzzleHttp\Exception\NetworkException;

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -91,32 +91,17 @@ failures. More specific catch blocks need auditing: Guzzle 8.0 splits timeout
 failures into connect-phase, no-response network, and response-aware timeout
 classes, and the built-in cURL and stream handlers classify more no-response
 transport failures as network failures. This section covers upgrading from
-Guzzle 7.x to Guzzle 8.0. The
-`ConnectException` inheritance change happened earlier, in Guzzle 7.0.0, when it
-moved out from under `RequestException`; see the 6.0 to 7.0 notes for that
-migration. The hierarchy changes are easiest to compare in the three trees
-below.
+Guzzle 7.x to Guzzle 8.0. The `ConnectException` inheritance change happened
+earlier, in Guzzle 7.0.0, when it moved out from under `RequestException`; see
+the 6.0 to 7.0 notes for that migration. The hierarchy changes are easiest to
+compare in the two trees below.
 
-Guzzle 7 releases before 7.11.0 use this hierarchy:
+Guzzle 7.x uses this hierarchy:
 
 ```text
 . \RuntimeException
 └── TransferException (implements GuzzleException)
     ├── ConnectException (implements NetworkExceptionInterface)
-    └── RequestException (implements RequestExceptionInterface)
-        ├── BadResponseException
-        │   ├── ClientException
-        │   └── ServerException
-        └── TooManyRedirectsException
-```
-
-Guzzle 7 releases starting with 7.11.0 use this hierarchy:
-
-```text
-. \RuntimeException
-└── TransferException (implements GuzzleException)
-    ├── NetworkException (implements NetworkExceptionInterface)
-    │   └── ConnectException
     └── RequestException (implements RequestExceptionInterface)
         ├── BadResponseException
         │   ├── ClientException
@@ -144,31 +129,34 @@ Guzzle 8.0 uses this hierarchy:
             └── TooManyRedirectsException
 ```
 
-`NetworkException` was added in Guzzle 7.11.0 as the base class for no-response
-network failures. Before 7.11.0, `ConnectException` implemented
-`Psr\Http\Client\NetworkExceptionInterface` directly and there was no
-Guzzle-specific network base class. The recommended migration path is to support
-Guzzle 7.11.0 before moving to Guzzle 8.0. Most code that previously caught
-`ConnectException` for transport-level failures should catch `NetworkException`
-instead when it can require Guzzle 7.11.0 or newer, including Guzzle 8.0. Keep
-catching `ConnectException` only when handling connection establishment failures
-specifically. Code that must support older Guzzle 7.x releases at the same time
-as Guzzle 8.0 should keep a broader `TransferException` catch at the boundary
-where all Guzzle transfer failures are handled.
+`NetworkException` is new in Guzzle 8.0 as the base class for no-response
+network failures. Throughout Guzzle 7.x, `ConnectException` implements
+`Psr\Http\Client\NetworkExceptionInterface` directly and there is no
+Guzzle-specific network base class. Reusable packages that support both Guzzle
+7.x and 8.0 should catch `Psr\Http\Client\NetworkExceptionInterface` for
+no-response network failures. Applications or packages that require Guzzle 8.0
+may catch `GuzzleHttp\Exception\NetworkException` for all no-response network
+failures. Keep catching `ConnectException` only when handling connection
+establishment failures specifically.
 
-Guzzle 8.0 also makes response-aware request failures explicit. Guzzle 7.11.0
-did not add `ResponseException`; response-aware request failures remain under
+Guzzle 8.0 also makes response-aware request failures explicit. Guzzle 7.x does
+not have `ResponseException`; response-aware request failures remain under
 `RequestException` throughout Guzzle 7.x. In Guzzle 8.0, `ResponseException` is
 the base class for request failures where response headers were received and a
 response object is available. `ResponseTransferException`,
 `ResponseTimeoutException`, `BadResponseException`, and
 `TooManyRedirectsException` extend it. Response access now belongs to this
 branch only: `RequestException` no longer stores responses, no longer accepts a
-response constructor argument, and no longer has
-`getResponse()` or `hasResponse()` methods. Catch `ResponseException`, or test
-with `instanceof ResponseException`, before calling `getResponse()`. If you
+response constructor argument, and no longer has `getResponse()` or
+`hasResponse()` methods. Catch `ResponseException`, or test with
+`instanceof ResponseException`, before calling `getResponse()`. If you
 instantiate `RequestException` directly, its third constructor argument is now
 the exception code, followed by the previous exception.
+
+Exception handler context access was removed. If you used handler context to
+work out what kind of transfer failure occurred, switch to the more granular
+exception classes in the hierarchy above. If you need handler-level timing or
+statistics, collect them during the transfer with the `on_stats` request option.
 
 Timeout exception classes are now split by the phase the handler can determine.
 `ConnectTimeoutException` is thrown for detected connect timeouts (DNS
@@ -201,8 +189,11 @@ may still observe.
 The practical catch-order migration is to handle no-response network failures
 before request failures. If you previously caught `RequestException` as the only
 built-in handler transport failure type, add a `NetworkException` catch before
-it. If you previously caught `ConnectException` for cURL timeouts or broad
-no-response transport failures, catch `NetworkException` instead; keep
+it in Guzzle 8.0-only code, or a
+`Psr\Http\Client\NetworkExceptionInterface` catch before it in reusable code
+that supports both Guzzle 7.x and 8.0. If you previously caught
+`ConnectException` for cURL timeouts or broad no-response transport failures,
+catch `NetworkException` or `NetworkExceptionInterface` instead; keep
 `ConnectException` only for connection-establishment handling. Catch
 `ResponseException` before `RequestException` when you need response access, and
 use `TransferException` only when one catch block should handle every Guzzle

--- a/docs/contributing/exception-guidelines.md
+++ b/docs/contributing/exception-guidelines.md
@@ -11,6 +11,11 @@ between — `InvalidArgumentException` (caller error) and `RequestException`
 (runtime request failure) — and the handful of cases where a bare SPL exception
 is correct.
 
+`GuzzleHttp\Exception\NetworkException` exists only in Guzzle 8.0 and newer. On
+Guzzle 7.x maintenance branches, network failures without a response use
+`ConnectException`, which implements `Psr\Http\Client\NetworkExceptionInterface`
+directly.
+
 ## The decision tree
 
 ```

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -220,10 +220,10 @@ A rejection reason may itself expose a response, for example when it is a
 
 ```php
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\NetworkException;
 use GuzzleHttp\Exception\ResponseTransferException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -240,7 +240,7 @@ $stack->push(Middleware::retry(
             return false;
         }
 
-        if ($reason instanceof NetworkException || $reason instanceof ResponseTransferException) {
+        if ($reason instanceof NetworkExceptionInterface || $reason instanceof ResponseTransferException) {
             return true;
         }
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -491,7 +491,10 @@ If a network problem prevents Guzzle from receiving a response, it throws
 `NetworkException`. This covers transport failures while opening the connection
 or moving bytes over the network. When the handler can determine a more specific
 failure, Guzzle uses a more specific subtype such as `ConnectException`,
-`ConnectTimeoutException`, or `NetworkTimeoutException`.
+`ConnectTimeoutException`, or `NetworkTimeoutException`. Code that must support
+both Guzzle 7.x and 8.0 should catch
+`Psr\Http\Client\NetworkExceptionInterface` instead, because
+`GuzzleHttp\Exception\NetworkException` is new in Guzzle 8.0.
 
 If Guzzle has parsed response headers into a response object, later transfer
 failures use `ResponseException`. This is the only branch that exposes


### PR DESCRIPTION
This follows up on removing NetworkException from 7.11 while keeping it in 8.0. The upgrade guide now treats the Guzzle 7 exception hierarchy as one hierarchy, documents NetworkException as new in 8.0, and points cross-version code at PSR-18's NetworkExceptionInterface. It also calls out that the removed handler context access is replaced for classification purposes by the more granular 8.0 exception tree, with on_stats still available for transfer stats.