### PR TITLE
Classify response teardown failures consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Classify generic response-aware request failures as `ResponseException`
 - Classify response-aware transfer failures as `ResponseTransferException`
 - Treat response sink rewind failures as `ResponseException` and skip non-seekable sink rewinds
+- Ignore stream source close failures after a complete response body transfer
 - Throw `GuzzleHttp\Exception\InvalidArgumentException` for invalid built-in handler options
 - Classify built-in cURL handle, `sink`, and HTTP/3 setup failures as `RequestException`
 - Throw `ConnectTimeoutException` for connect timeouts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Classify stream transport failures without a response as `NetworkException`, with timeouts as `NetworkTimeoutException`
 - Classify generic response-aware request failures as `ResponseException`
 - Classify response-aware transfer failures as `ResponseTransferException`
+- Treat response sink rewind failures as `ResponseException` and skip non-seekable sink rewinds
 - Throw `GuzzleHttp\Exception\InvalidArgumentException` for invalid built-in handler options
 - Classify built-in cURL handle, `sink`, and HTTP/3 setup failures as `RequestException`
 - Throw `ConnectTimeoutException` for connect timeouts

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -219,9 +219,13 @@ as `RequestException` or `ConnectException`:
 - Other failures with no response, such as send and receive errors and
   no-response HTTP/2 and HTTP/3 protocol errors, are `NetworkException`.
 - Response-transfer failures after response headers were received are
-  `ResponseTransferException`; response-body network stalls are
+  `ResponseTransferException`. Response-body network stalls are
   `ResponseTimeoutException`, while a slow `sink` write or request-body stall
   after headers is a plain `ResponseException`.
+- Post-transfer response finalization failures are also plain
+  `ResponseException`. A seekable response sink that fails to rewind does not
+  become a `ResponseTransferException`. Non-seekable sinks are not rewound, and
+  source close cleanup after a complete stream-handler download is best effort.
 - Other failures that occur after a response was received are
   `ResponseException`.
 

--- a/docs/contributing/exception-guidelines.md
+++ b/docs/contributing/exception-guidelines.md
@@ -39,6 +39,11 @@ that they could fix by changing their code?
       (e.g. "the cURL extension is not available") ──► \RuntimeException (bare SPL is fine here)
 ```
 
+Use `ResponseTransferException` only for failures reading the response body off
+the network after response headers were received. Local response finalization
+failures, such as rewinding a response sink after the body has been received,
+are plain `ResponseException` failures.
+
 ## `GuzzleHttp\Exception\InvalidArgumentException`
 
 `final class InvalidArgumentException extends \InvalidArgumentException implements GuzzleException`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -501,9 +501,9 @@ failures use `ResponseException`. This is the only branch that exposes
 failed sink rewind, stay plain `ResponseException`. With Guzzle request methods,
 middleware can also turn completed responses into exceptions: `http_errors`
 turns 4xx responses into `ClientException` and 5xx responses into
-`ServerException`, and redirect middleware can throw `TooManyRedirectsException`.
-`Client::sendRequest()` follows PSR-18 and returns redirect, 4xx, and 5xx
-responses normally instead.
+`ServerException`, and redirect middleware can throw
+`TooManyRedirectsException`. `Client::sendRequest()` follows PSR-18 and returns
+redirect, 4xx, and 5xx responses normally instead.
 
 All `TransferException` instances expose `getRequest()`. If a non-network
 request failure occurs before Guzzle has a response object, it throws

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -495,13 +495,15 @@ failure, Guzzle uses a more specific subtype such as `ConnectException`,
 
 If Guzzle has parsed response headers into a response object, later transfer
 failures use `ResponseException`. This is the only branch that exposes
-`getResponse()`. Transfer-level failures in this branch use
+`getResponse()`. Failures while reading the response body off the network use
 `ResponseTransferException`, with response timeouts as
-`ResponseTimeoutException`. With Guzzle request methods, middleware can also
-turn completed responses into exceptions: `http_errors` turns 4xx responses into
-`ClientException` and 5xx responses into `ServerException`, and redirect
-middleware can throw `TooManyRedirectsException`. `Client::sendRequest()`
-follows PSR-18 and returns redirect, 4xx, and 5xx responses normally instead.
+`ResponseTimeoutException`. Local response finalization failures, such as a
+failed sink rewind, stay plain `ResponseException`. With Guzzle request methods,
+middleware can also turn completed responses into exceptions: `http_errors`
+turns 4xx responses into `ClientException` and 5xx responses into
+`ServerException`, and redirect middleware can throw `TooManyRedirectsException`.
+`Client::sendRequest()` follows PSR-18 and returns redirect, 4xx, and 5xx
+responses normally instead.
 
 All `TransferException` instances expose `getRequest()`. If a non-network
 request failure occurs before Guzzle has a response object, it throws

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1132,7 +1132,8 @@ PHP temp stream
 Constant
 `GuzzleHttp\RequestOptions::SINK`
 
-Pass a string to specify the path to a file that will store the contents of the response body:
+Pass a string to specify the path to a file that will store the contents of the
+response body:
 
 ```php
 $client->request('GET', '/stream/20', ['sink' => '/path/to/file']);
@@ -1145,7 +1146,8 @@ $resource = \GuzzleHttp\Psr7\Utils::tryFopen('/path/to/file', 'w');
 $client->request('GET', '/stream/20', ['sink' => $resource]);
 ```
 
-Pass a `Psr\Http\Message\StreamInterface` object to stream the response body to an open PSR-7 stream.
+Pass a `Psr\Http\Message\StreamInterface` object to stream the response body to
+an open PSR-7 stream.
 
 ```php
 $resource = \GuzzleHttp\Psr7\Utils::tryFopen('/path/to/file', 'w');
@@ -1153,13 +1155,20 @@ $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
 $client->request('GET', '/stream/20', ['sink' => $stream]);
 ```
 
-With Guzzle's built-in cURL and PHP stream handlers, non-streaming responses use the sink stream as the response body.
+With Guzzle's built-in cURL and PHP stream handlers, non-streaming responses use
+the sink stream as the response body. The handlers rewind seekable sink streams
+before returning the response. If the sink is not seekable, the request still
+succeeds and the response body is left at the sink's current position, usually
+EOF.
 
 If `sink` is a string path, Guzzle opens the file and owns that stream.
 
-If `sink` is a PHP resource, the caller owns the resource and is responsible for closing it. Closing or destroying the response body detaches Guzzle's wrapper without closing the original resource.
+If `sink` is a PHP resource, the caller owns the resource and is responsible for
+closing it. Closing or destroying the response body detaches Guzzle's wrapper
+without closing the original resource.
 
-If `sink` is a `Psr\Http\Message\StreamInterface`, Guzzle uses that stream object as-is and its own `close()` behavior applies.
+If `sink` is a `Psr\Http\Message\StreamInterface`, Guzzle uses that stream
+object as-is and its own `close()` behavior applies.
 
 ## ssl_key
 

--- a/src/Exception/ResponseTransferException.php
+++ b/src/Exception/ResponseTransferException.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace GuzzleHttp\Exception;
 
 /**
- * Exception thrown when a transfer fails after response headers are received.
+ * Exception thrown when a response body transfer fails after response headers
+ * are received.
  */
 class ResponseTransferException extends ResponseException
 {

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -626,6 +626,8 @@ final class CurlFactory implements CurlFactoryInterface
             );
 
             if ($onStats !== null && $stats !== null) {
+                // Report the ResponseException rather than errno 0 to match the
+                // stream handler's response finalization stats.
                 $onStats(new TransferStats(
                     $easy->request,
                     $response,

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -610,14 +610,37 @@ final class CurlFactory implements CurlFactoryInterface
         // Return the response if it is present and there is no error.
         $factory->release($easy);
 
-        if ($onStats !== null && $stats !== null) {
-            $onStats($stats);
+        // Rewind the body of the response if possible. Failures here are local
+        // response finalization errors, not response-transfer failures.
+        $body = $response->getBody();
+        try {
+            if ($body->isSeekable()) {
+                $body->rewind();
+            }
+        } catch (\Throwable $e) {
+            $reason = new ResponseException(
+                $e->getMessage() !== '' ? $e->getMessage() : 'The cURL handler failed to rewind the response body',
+                $easy->request,
+                $response,
+                $e
+            );
+
+            if ($onStats !== null && $stats !== null) {
+                $onStats(new TransferStats(
+                    $easy->request,
+                    $response,
+                    $stats->getTransferTime(),
+                    $reason,
+                    $stats->getHandlerStats()
+                ));
+            }
+
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor($reason);
         }
 
-        // Rewind the body of the response if possible.
-        $body = $response->getBody();
-        if ($body->isSeekable()) {
-            $body->rewind();
+        if ($onStats !== null && $stats !== null) {
+            $onStats($stats);
         }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -399,8 +399,6 @@ final class StreamHandler
                 $target,
                 (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1
             );
-            $sink->seek(0);
-            $source->close();
         } catch (ResponseException $e) {
             throw $e;
         } catch (TimeoutException $e) {
@@ -411,16 +409,39 @@ final class StreamHandler
                 $e
             );
         } catch (\Throwable $e) {
-            // Any other failure after headers — including failing to rewind a
-            // non-seekable caller sink or to close the source once the body has
-            // been fully received — surfaces as a ResponseTransferException that
-            // still carries the complete response.
+            // Any other failure while reading the response body off the network
+            // surfaces as a ResponseTransferException carrying the response.
             throw new ResponseTransferException(
                 $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed while transferring the response body',
                 $request,
                 $response,
                 $e
             );
+        }
+
+        $rewindException = null;
+
+        try {
+            if ($sink->isSeekable()) {
+                $sink->rewind();
+            }
+        } catch (\Throwable $e) {
+            $rewindException = new ResponseException(
+                $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed to rewind the response body',
+                $request,
+                $response,
+                $e
+            );
+        } finally {
+            try {
+                $source->close();
+            } catch (\Throwable $e) {
+                // Best-effort cleanup after the response body has been received.
+            }
+        }
+
+        if ($rewindException !== null) {
+            throw $rewindException;
         }
 
         return $sink;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3258,6 +3258,8 @@ class CurlFactoryTest extends TestCase
         $request = new Psr7\Request('GET', Server::$url);
         $handler = $handlerFactory();
         $underlying = Psr7\Utils::streamFor();
+        $stats = null;
+        $statsCalled = 0;
         $rewindCalled = false;
         $seekCalled = false;
         $sink = Psr7\FnStream::decorate($underlying, [
@@ -3277,7 +3279,13 @@ class CurlFactoryTest extends TestCase
         ]);
 
         try {
-            $response = $handler($request, ['sink' => $sink])->wait();
+            $response = $handler($request, [
+                'sink' => $sink,
+                'on_stats' => static function (TransferStats $transferStats) use (&$stats, &$statsCalled): void {
+                    ++$statsCalled;
+                    $stats = $transferStats;
+                },
+            ])->wait();
 
             self::assertSame(200, $response->getStatusCode());
             self::assertSame($sink, $response->getBody());
@@ -3293,6 +3301,11 @@ class CurlFactoryTest extends TestCase
         self::assertFalse($seekCalled);
         $underlying->rewind();
         self::assertSame('abc', $underlying->getContents());
+        self::assertSame(1, $statsCalled);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame($response, $stats->getResponse());
+        self::assertSame(0, $stats->getHandlerErrorData());
     }
 
     public function testSinkWritePsr7TimeoutRejectsAsNetworkTimeoutWithoutResponse(): void
@@ -3504,6 +3517,9 @@ class CurlFactoryTest extends TestCase
                 $error = $stats->getHandlerErrorData();
                 self::assertInstanceOf(ResponseException::class, $error);
                 self::assertSame($rewindFailure, $error->getPrevious());
+                self::assertNotInstanceOf(ResponseTransferException::class, $error);
+                self::assertNotInstanceOf(ResponseTimeoutException::class, $error);
+                self::assertNotInstanceOf(NetworkExceptionInterface::class, $error);
 
                 throw $statsFailure;
             },

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3472,6 +3472,60 @@ class CurlFactoryTest extends TestCase
         self::assertSame($exception, $stats->getHandlerErrorData());
     }
 
+    public function testOnStatsExceptionEscapesOnSeekableBodyRewindFailureAfterHandleRelease(): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $rewindFailure = new \RuntimeException('rewind failed');
+        $statsFailure = new \RuntimeException('stats failed');
+        $response = new Psr7\Response(
+            200,
+            [],
+            Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+                'isSeekable' => static function (): bool {
+                    return true;
+                },
+                'rewind' => static function () use ($rewindFailure): void {
+                    throw $rewindFailure;
+                },
+            ])
+        );
+        $easy = null;
+        $called = false;
+        $easy = $factory->create($request, [
+            'on_stats' => static function (TransferStats $stats) use (&$easy, $factory, &$called, $response, $rewindFailure, $statsFailure): void {
+                $called = true;
+                self::assertInstanceOf(EasyHandle::class, $easy);
+                self::assertTrue($stats->hasResponse());
+                self::assertSame($response, $stats->getResponse());
+                self::assertArrayNotHasKey('handle', \get_object_vars($easy));
+                self::assertCount(1, self::readIdleHandles($factory));
+
+                $error = $stats->getHandlerErrorData();
+                self::assertInstanceOf(ResponseException::class, $error);
+                self::assertSame($rewindFailure, $error->getPrevious());
+
+                throw $statsFailure;
+            },
+        ]);
+        $easy->response = $response;
+
+        try {
+            CurlFactory::finish(
+                static function (): void {
+                },
+                $easy,
+                $factory
+            );
+
+            self::fail('Expected RuntimeException');
+        } catch (\RuntimeException $e) {
+            self::assertSame($statsFailure, $e);
+        }
+
+        self::assertTrue($called);
+    }
+
     public function testInvokesOnStatsAfterErrorHandleRelease(): void
     {
         $factory = new CurlFactory(1);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3246,6 +3246,55 @@ class CurlFactoryTest extends TestCase
         self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
     }
 
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testNonSeekableSinkSucceedsWithoutRewindThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, ['Content-Length' => '3'], 'abc'),
+        ]);
+        $request = new Psr7\Request('GET', Server::$url);
+        $handler = $handlerFactory();
+        $underlying = Psr7\Utils::streamFor();
+        $rewindCalled = false;
+        $seekCalled = false;
+        $sink = Psr7\FnStream::decorate($underlying, [
+            'isSeekable' => static function (): bool {
+                return false;
+            },
+            'rewind' => static function () use (&$rewindCalled): void {
+                $rewindCalled = true;
+
+                throw new \RuntimeException('must not rewind a non-seekable sink');
+            },
+            'seek' => static function ($offset, $whence = \SEEK_SET) use (&$seekCalled): void {
+                $seekCalled = true;
+
+                throw new \RuntimeException('must not seek a non-seekable sink');
+            },
+        ]);
+
+        try {
+            $response = $handler($request, ['sink' => $sink])->wait();
+
+            self::assertSame(200, $response->getStatusCode());
+            self::assertSame($sink, $response->getBody());
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+
+        self::assertFalse($rewindCalled);
+        self::assertFalse($seekCalled);
+        $underlying->rewind();
+        self::assertSame('abc', $underlying->getContents());
+    }
+
     public function testSinkWritePsr7TimeoutRejectsAsNetworkTimeoutWithoutResponse(): void
     {
         $factory = new CurlFactory(3);
@@ -3365,6 +3414,62 @@ class CurlFactoryTest extends TestCase
 
         self::assertTrue($called);
         self::assertSame(200, $promise->wait()->getStatusCode());
+    }
+
+    public function testSurfacesSeekableBodyRewindFailureAsResponseException(): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $previous = new \RuntimeException('rewind failed');
+        $response = new Psr7\Response(
+            200,
+            [],
+            Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+                'isSeekable' => static function (): bool {
+                    return true;
+                },
+                'rewind' => static function () use ($previous): void {
+                    throw $previous;
+                },
+            ])
+        );
+        $easy = null;
+        $exception = null;
+        $stats = null;
+        $easy = $factory->create($request, [
+            'on_stats' => static function (TransferStats $transferStats) use (&$easy, $factory, &$stats): void {
+                $stats = $transferStats;
+                self::assertInstanceOf(EasyHandle::class, $easy);
+                self::assertArrayNotHasKey('handle', \get_object_vars($easy));
+                self::assertCount(1, self::readIdleHandles($factory));
+            },
+        ]);
+        $easy->response = $response;
+
+        try {
+            CurlFactory::finish(
+                static function (): void {
+                },
+                $easy,
+                $factory
+            )->wait();
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            $exception = $e;
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($response, $e->getResponse());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+            self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertInstanceOf(ResponseException::class, $exception);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame($response, $stats->getResponse());
+        self::assertSame($exception, $stats->getHandlerErrorData());
     }
 
     public function testInvokesOnStatsAfterErrorHandleRelease(): void

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1731,6 +1731,8 @@ class StreamHandlerTest extends TestCase
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
         $underlying = Psr7\Utils::streamFor();
+        $stats = null;
+        $statsCalled = 0;
         $rewindCalled = false;
         $seekCalled = false;
         $sink = FnStream::decorate($underlying, [
@@ -1749,7 +1751,13 @@ class StreamHandlerTest extends TestCase
             },
         ]);
 
-        $response = $handler($request, ['sink' => $sink])->wait();
+        $response = $handler($request, [
+            'sink' => $sink,
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats, &$statsCalled): void {
+                ++$statsCalled;
+                $stats = $transferStats;
+            },
+        ])->wait();
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame($sink, $response->getBody());
@@ -1757,6 +1765,11 @@ class StreamHandlerTest extends TestCase
         self::assertFalse($seekCalled);
         $underlying->rewind();
         self::assertSame('hi there', $underlying->getContents());
+        self::assertSame(1, $statsCalled);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame($response, $stats->getResponse());
+        self::assertNull($stats->getHandlerErrorData());
     }
 
     public function testIgnoresSourceCloseFailureAfterCompleteBody(): void

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1686,28 +1686,147 @@ class StreamHandlerTest extends TestCase
         }
     }
 
-    public function testThrowsResponseTransferExceptionWhenSinkRewindFails(): void
+    public function testSurfacesSeekableSinkRewindFailureAsResponseException(): void
     {
         $this->queueRes();
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
-        $previous = new \RuntimeException('Stream is not seekable');
+        $previous = new \RuntimeException('rewind failed');
+        $exception = null;
+        $stats = null;
         $sink = FnStream::decorate(Psr7\Utils::streamFor(), [
-            'seek' => static function ($offset, $whence = \SEEK_SET) use ($previous): void {
+            'rewind' => static function () use ($previous): void {
                 throw $previous;
             },
         ]);
 
         try {
-            $handler($request, ['sink' => $sink])->wait();
-            self::fail('Expected ResponseTransferException');
-        } catch (ResponseTransferException $e) {
+            $handler($request, [
+                'sink' => $sink,
+                'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                    $stats = $transferStats;
+                },
+            ])->wait();
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            $exception = $e;
             self::assertSame($request, $e->getRequest());
             self::assertSame(200, $e->getResponse()->getStatusCode());
             self::assertSame($previous, $e->getPrevious());
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         }
+
+        self::assertInstanceOf(ResponseException::class, $exception);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame($exception->getResponse(), $stats->getResponse());
+        self::assertSame($exception, $stats->getHandlerErrorData());
+    }
+
+    public function testNonSeekableSinkSucceedsWithoutRewind(): void
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $underlying = Psr7\Utils::streamFor();
+        $rewindCalled = false;
+        $seekCalled = false;
+        $sink = FnStream::decorate($underlying, [
+            'isSeekable' => static function (): bool {
+                return false;
+            },
+            'rewind' => static function () use (&$rewindCalled): void {
+                $rewindCalled = true;
+
+                throw new \RuntimeException('must not rewind a non-seekable sink');
+            },
+            'seek' => static function ($offset, $whence = \SEEK_SET) use (&$seekCalled): void {
+                $seekCalled = true;
+
+                throw new \RuntimeException('must not seek a non-seekable sink');
+            },
+        ]);
+
+        $response = $handler($request, ['sink' => $sink])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($sink, $response->getBody());
+        self::assertFalse($rewindCalled);
+        self::assertFalse($seekCalled);
+        $underlying->rewind();
+        self::assertSame('hi there', $underlying->getContents());
+    }
+
+    public function testIgnoresSourceCloseFailureAfterCompleteBody(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $closeCalled = false;
+        $throwOnClose = true;
+        $source = FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+            'close' => static function () use (&$closeCalled, &$throwOnClose): void {
+                $closeCalled = true;
+
+                if ($throwOnClose) {
+                    $throwOnClose = false;
+
+                    throw new \RuntimeException('close failed');
+                }
+            },
+        ]);
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], $source)->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('abc', (string) $response->getBody());
+        self::assertTrue($closeCalled);
+    }
+
+    public function testAttemptsSourceCloseWhenSinkRewindFails(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $rewindFailure = new \RuntimeException('rewind failed');
+        $closeFailure = new \RuntimeException('close failed');
+        $closeCalled = false;
+        $throwOnClose = true;
+        $source = FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+            'close' => static function () use (&$closeCalled, &$throwOnClose, $closeFailure): void {
+                $closeCalled = true;
+
+                if ($throwOnClose) {
+                    $throwOnClose = false;
+
+                    throw $closeFailure;
+                }
+            },
+        ]);
+        $sink = FnStream::decorate(Psr7\Utils::streamFor(), [
+            'rewind' => static function () use ($rewindFailure): void {
+                throw $rewindFailure;
+            },
+        ]);
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+        ]);
+
+        try {
+            $this->invokeStreamHandlerCreateResponse($handler, $request, ['sink' => $sink], $source)->wait();
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertSame($rewindFailure, $e->getPrevious());
+            self::assertNotSame($closeFailure, $e->getPrevious());
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+        }
+
+        self::assertTrue($closeCalled);
     }
 
     public function testInvokesOnStatsOnSuccess(): void


### PR DESCRIPTION
This change keeps ResponseTransferException focused on failures that happen while reading the response body from the network. The built-in stream handler now skips rewinding non-seekable sinks, reports rewind failures on seekable sinks as ResponseException, and treats source close after a complete drain as best-effort cleanup. The cURL path now reports response body rewind failures the same way and preserves the existing behavior where on_stats exceptions escape after the handle has been released.