### PR TITLE
Add StructArmed to QA

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@
 /phpunit.xml.dist      export-ignore
 /tests/                export-ignore
 /vendor-bin/           export-ignore
+/structarmed.php       export-ignore

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -76,3 +76,26 @@ jobs:
 
       - name: Execute Composer Normalize
         run: make static-composer-normalize-check
+
+  structarmed:
+    name: StructArmed
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Download dependencies
+        run: composer update --no-interaction --no-progress
+
+      - name: Download StructArmed
+        run: composer require --dev boundwize/structarmed:^0.9 --no-interaction --no-progress
+
+      - name: Execute StructArmed
+        run: vendor/bin/structarmed analyze

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->skip([
+        // no namespace on purpose
+        __DIR__ . '/tests/bootstrap-phpstan.php',
+
+        // multiple classes in a file
+        // can be splitted into multiple files if needed
+        __DIR__ . '/tests/ClientTest.php',
+        __DIR__ . '/tests/Exception/RequestExceptionTest.php',
+        __DIR__ . '/tests/RedirectMiddlewareTest.php',
+        __DIR__ . '/tests/PrepareBodyMiddlewareTest.php',
+        __DIR__ . '/tests/UtilsTest.php',
+    ])
+    ->withPreset(Preset::PSR4());

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Tests\CookieJar;
+namespace GuzzleHttp\Tests\Cookie;
 
 use DateInterval;
 use DateTime;

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Tests\CookieJar;
+namespace GuzzleHttp\Tests\Cookie;
 
 use GuzzleHttp\Cookie\FileCookieJar;
 use GuzzleHttp\Cookie\SetCookie;

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Tests\CookieJar;
+namespace GuzzleHttp\Tests\Cookie;
 
 use GuzzleHttp\Cookie\SessionCookieJar;
 use GuzzleHttp\Cookie\SetCookie;

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Tests\CookieJar;
+namespace GuzzleHttp\Tests\Cookie;
 
 use GuzzleHttp\Cookie\SetCookie;
 use PHPUnit\Framework\TestCase;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlFactory;

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlShareHandleState;

--- a/tests/Handler/EasyHandleTest.php
+++ b/tests/Handler/EasyHandleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\EasyHandle;
 use PHPUnit\Framework\TestCase;

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;

--- a/tests/Handler/Network/StreamHandlerTest.php
+++ b/tests/Handler/Network/StreamHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler\Network;
+namespace GuzzleHttp\Tests\Handler\Network;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\StreamHandler;

--- a/tests/Handler/ProxyTest.php
+++ b/tests/Handler/ProxyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Handler\Proxy;

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;

--- a/tests/InternalUtilsTest.php
+++ b/tests/InternalUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test;
+namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Utils;


### PR DESCRIPTION
Hi, this PR adds StructArmed to github workflow static analysis for QA.

https://github.com/boundwize/structarmed

StructArmed is a configurable PHP architecture guard, that we can define layers and rules, then keep them enforced. 

This PR uses the PSR4 preset for starter, and already found violations that fixed and included in this PR.

Since it support php 7.x as well, this only add on github workflow on php 8.2 👍 
