### PR TITLE
Reject cURL multi promises when finish throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Fixed
 
-- `CurlMultiHandler` now rejects the affected promise when `CurlFactory::finish()` throws, without interrupting sibling transfers
+- `CurlMultiHandler` now rejects the promise when `CurlFactory::finish()` throws, preserving sibling transfers
 
 
 ## 7.10.5 - 2025-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Fixed
 
-- `CurlMultiHandler`: an exception thrown from `CurlFactory::finish()` (most commonly a throwing `on_stats` callback) no longer escapes the event loop. The affected request's promise is now rejected with the exception, and other in-flight transfers on the same handler continue to settle normally.
+- `CurlMultiHandler` now rejects the affected promise when `CurlFactory::finish()` throws, without interrupting sibling transfers
 
 
 ## 7.10.5 - 2025-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.10.6 - Upcoming
+
+### Fixed
+
+- `CurlMultiHandler`: an exception thrown from `CurlFactory::finish()` (most commonly a throwing `on_stats` callback) no longer escapes the event loop. The affected request's promise is now rejected with the exception, and other in-flight transfers on the same handler continue to settle normally.
+
+
 ## 7.10.5 - 2025-05-27
 
 ### Fixed

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -329,9 +329,16 @@ class CurlMultiHandler
             $entry = $this->handles[$id];
             unset($this->handles[$id], $this->delays[$id]);
             $entry['easy']->errno = $done['result'];
-            $entry['deferred']->resolve(
-                CurlFactory::finish($this, $entry['easy'], $this->factory)
-            );
+
+            try {
+                $result = CurlFactory::finish($this, $entry['easy'], $this->factory);
+            } catch (\Throwable $e) {
+                $entry['deferred']->reject($e);
+
+                continue;
+            }
+
+            $entry['deferred']->resolve($result);
         }
     }
 

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -153,6 +153,74 @@ class CurlMultiHandlerTest extends TestCase
         self::assertGreaterThanOrEqual($expected, Utils::currentTime());
     }
 
+    public function testManualTickRejectsPromiseWhenFinishThrows(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
+        $handler = new CurlMultiHandler(['select_timeout' => 0]);
+        $previous = new \RuntimeException('stats failed');
+        $promise = $handler(new Request('GET', Server::$url), [
+            'on_stats' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $deadline = \microtime(true) + 5;
+            while (P\Is::pending($promise) && \microtime(true) < $deadline) {
+                $handler->tick();
+            }
+
+            self::assertTrue(P\Is::rejected($promise));
+
+            try {
+                $promise->wait();
+                self::fail('Expected RuntimeException');
+            } catch (\RuntimeException $e) {
+                self::assertSame($previous, $e);
+            }
+        } finally {
+            Server::flush();
+        }
+    }
+
+    public function testFinishThrowDoesNotAffectSiblingTransfers(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200), new Response(200)]);
+
+        $handler = new CurlMultiHandler(['select_timeout' => 0]);
+        $previous = new \RuntimeException('stats failed');
+
+        $bad = $handler(new Request('GET', Server::$url), [
+            'on_stats' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+        $good = $handler(new Request('GET', Server::$url), []);
+
+        try {
+            $deadline = \microtime(true) + 5;
+            while ((P\Is::pending($bad) || P\Is::pending($good)) && \microtime(true) < $deadline) {
+                $handler->tick();
+            }
+
+            self::assertTrue(P\Is::fulfilled($good));
+            self::assertSame(200, $good->wait()->getStatusCode());
+
+            self::assertTrue(P\Is::rejected($bad));
+            try {
+                $bad->wait();
+                self::fail('Expected RuntimeException');
+            } catch (\RuntimeException $e) {
+                self::assertSame($previous, $e);
+            }
+        } finally {
+            Server::flush();
+        }
+    }
+
     public function testUsesTimeoutEnvironmentVariables()
     {
         unset($_SERVER['GUZZLE_CURL_SELECT_TIMEOUT']);


### PR DESCRIPTION
This backports the cURL multi settlement guard from 8.0 to 7.10. When CurlFactory::finish() throws while processing a completed transfer, CurlMultiHandler now rejects that transfer's promise and keeps draining the multi message queue instead of letting the exception escape through the event loop. The change also adds coverage for manual ticks and sibling transfer isolation, and records the fix in the 7.10.6 changelog.