### PR TITLE
Fix test namespaces

### DIFF
--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Tests\CookieJar;
+namespace GuzzleHttp\Tests\Cookie;
 
 use DateInterval;
 use DateTime;

--- a/tests/Cookie/FileCookieJarTest.php
+++ b/tests/Cookie/FileCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Tests\CookieJar;
+namespace GuzzleHttp\Tests\Cookie;
 
 use GuzzleHttp\Cookie\FileCookieJar;
 use GuzzleHttp\Cookie\SetCookie;

--- a/tests/Cookie/SessionCookieJarTest.php
+++ b/tests/Cookie/SessionCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Tests\CookieJar;
+namespace GuzzleHttp\Tests\Cookie;
 
 use GuzzleHttp\Cookie\SessionCookieJar;
 use GuzzleHttp\Cookie\SetCookie;

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Tests\CookieJar;
+namespace GuzzleHttp\Tests\Cookie;
 
 use GuzzleHttp\Cookie\SetCookie;
 use PHPUnit\Framework\TestCase;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlFactory;

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlShareHandleState;

--- a/tests/Handler/EasyHandleTest.php
+++ b/tests/Handler/EasyHandleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\EasyHandle;
 use PHPUnit\Framework\TestCase;

--- a/tests/Handler/MockHandlerTest.php
+++ b/tests/Handler/MockHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;

--- a/tests/Handler/Network/StreamHandlerTest.php
+++ b/tests/Handler/Network/StreamHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler\Network;
+namespace GuzzleHttp\Tests\Handler\Network;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\StreamHandler;

--- a/tests/Handler/ProxyTest.php
+++ b/tests/Handler/ProxyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Handler\Proxy;

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;

--- a/tests/InternalUtilsTest.php
+++ b/tests/InternalUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GuzzleHttp\Test;
+namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Utils;


### PR DESCRIPTION
This takes the namespace corrections from #3554 without adding the StructArmed workflow or configuration. The affected test classes now match the PSR-4 test namespace layout under GuzzleHttp\Tests.