### PR TITLE
Tidy 8.0 merge-up follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject built-in cURL `progress` throwables with `ResponseException` when a response exists, otherwise `RequestException`
 - Release built-in cURL easy handles before invoking `on_stats`
 - Prefer `CURLOPT_XFERINFOFUNCTION` for built-in cURL progress callbacks when available
-- Reject cURL multi handler promises when transfer completion callbacks throw during manual event-loop ticks
 - Made `MessageFormatter` final and required `Middleware::log()` formatters to implement `MessageFormatterInterface`
 - Made `GuzzleHttp\Handler\CurlFactory`, `GuzzleHttp\Handler\CurlHandler`, `GuzzleHttp\Handler\CurlMultiHandler`, `GuzzleHttp\Handler\MockHandler`, and `GuzzleHttp\Handler\StreamHandler` final
 - Made static utility classes non-instantiable and declared `GuzzleHttp\Handler\Proxy` final

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -705,6 +705,48 @@ class CurlMultiHandlerTest extends TestCase
         }
     }
 
+    public function testFinishThrowDoesNotAffectSiblingTransfers(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200), new Response(200)]);
+
+        $handler = new CurlMultiHandler(['select_timeout' => 0]);
+        $previous = new \RuntimeException('stats failed');
+
+        $bad = $handler(new Request('GET', Server::$url), [
+            'on_stats' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+        $good = $handler(new Request('GET', Server::$url), []);
+
+        try {
+            $deadline = \microtime(true) + 5;
+
+            while (P\Is::pending($bad) || P\Is::pending($good)) {
+                if (\microtime(true) >= $deadline) {
+                    self::fail('Timed out waiting for cURL multi transfers.');
+                }
+
+                $handler->tick();
+            }
+
+            self::assertTrue(P\Is::fulfilled($good));
+            self::assertSame(200, $good->wait()->getStatusCode());
+
+            self::assertTrue(P\Is::rejected($bad));
+            try {
+                $bad->wait();
+                self::fail('Expected RuntimeException');
+            } catch (\RuntimeException $e) {
+                self::assertSame($previous, $e);
+            }
+        } finally {
+            $handler->close();
+            Server::flush();
+        }
+    }
+
     public function testWaitFalseRejectsPromiseWhenFinishThrows(): void
     {
         Server::flush();

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GuzzleHttp\Test\Handler;
+namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\CurlVersion;
 use PHPUnit\Framework\TestCase;

--- a/tests/ProxyOptionsTest.php
+++ b/tests/ProxyOptionsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GuzzleHttp\Test;
+namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\ProxyOptions;
 use GuzzleHttp\Psr7;

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GuzzleHttp\Test;
+namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Handler\CurlVersion;

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -25,7 +25,7 @@ class UtilsTest extends TestCase
             [false, 'bool(false)'],
             [10, 'int(10)'],
             [1.0, 'float(1)'],
-            [new StrClass(), 'object(GuzzleHttp\Test\StrClass)'],
+            [new StrClass(), 'object(GuzzleHttp\Tests\StrClass)'],
             [['foo'], 'array(1)'],
         ];
     }


### PR DESCRIPTION
This cleans up the 8.0 side of the recent 7.x merge-up. It fixes the remaining test namespaces so they match the GuzzleHttp\Tests PSR-4 layout, keeps the cURL multi sibling-transfer coverage in 8.0 style, and removes the duplicate 8.0 changelog entry now covered by the 7.10.6 section.