### PR TITLE
Fix unparseable SetCookie expires handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - `CurlMultiHandler` now rejects the promise when `CurlFactory::finish()` throws, preserving sibling transfers
-- `SetCookie` now normalizes unparseable textual `Expires` values to `null` instead of storing `false`, avoiding cookies incorrectly appearing permanently expired
+- `SetCookie` now normalizes unparseable `Expires` values to `null` instead of `false`
 
 
 ## 7.10.5 - 2025-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - `CurlMultiHandler` now rejects the promise when `CurlFactory::finish()` throws, preserving sibling transfers
+- `SetCookie` now normalizes unparseable textual `Expires` values to `null` instead of storing `false`, avoiding cookies incorrectly appearing permanently expired
 
 
 ## 7.10.5 - 2025-05-27

--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -298,7 +298,15 @@ class SetCookie
             trigger_deprecation('guzzlehttp/guzzle', '7.4', 'Not passing an int, string or null to %s::%s() is deprecated and will cause an error in 8.0.', __CLASS__, __FUNCTION__);
         }
 
-        $this->data['Expires'] = null === $timestamp ? null : (\is_numeric($timestamp) ? (int) $timestamp : \strtotime((string) $timestamp));
+        if (null === $timestamp) {
+            $this->data['Expires'] = null;
+        } elseif (\is_numeric($timestamp)) {
+            $this->data['Expires'] = (int) $timestamp;
+        } else {
+            // Store unparseable dates as session cookies, not as expired cookies.
+            $expires = \strtotime((string) $timestamp);
+            $this->data['Expires'] = $expires === false ? null : $expires;
+        }
     }
 
     /**

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -22,6 +22,23 @@ class SetCookieTest extends TestCase
         self::assertIsInt($cookie->getExpires());
     }
 
+    public function testUnparseableExpiresBecomesNull()
+    {
+        $cookie = new SetCookie();
+        $cookie->setExpires('this-is-not-a-date');
+
+        self::assertNull($cookie->getExpires(), 'an unparseable Expires must be normalized to null, not stored as false');
+        self::assertFalse($cookie->isExpired(), 'an unparseable Expires must not make the cookie permanently expired');
+    }
+
+    public function testUnparseableExpiresFromStringBecomesNull()
+    {
+        $cookie = SetCookie::fromString('foo=bar; Expires=garbage');
+
+        self::assertNull($cookie->getExpires());
+        self::assertFalse($cookie->isExpired());
+    }
+
     public function testAddsExpiresBasedOnMaxAge()
     {
         $t = \time();


### PR DESCRIPTION
This fixes how SetCookie handles textual Expires values that PHP cannot parse. Previously strtotime() could return false and that value was stored as the cookie expiry, which made the cookie look permanently expired and caused it to be dropped. The change normalizes that case to null so the cookie is treated as session-scoped, while preserving the existing behavior for null, numeric timestamps, and valid date strings.