### PR TITLE
Drop decoded stream content length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - `CurlMultiHandler` now rejects the promise when `CurlFactory::finish()` throws, preserving sibling transfers
 - `SetCookie` now normalizes unparseable `Expires` values to `null` instead of `false`
+- Stream handler now removes the decoded `Content-Length` for `gzip` and `deflate` responses, preserving the original value as `x-encoded-content-length` instead of rewriting it to the compressed size and potentially truncating seekable decoded bodies
 
 
 ## 7.10.5 - 2025-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - `CurlMultiHandler` now rejects the promise when `CurlFactory::finish()` throws, preserving sibling transfers
 - `SetCookie` now normalizes unparseable `Expires` values to `null` instead of `false`
-- Stream handler now drops decoded `gzip`/`deflate` `Content-Length`, preserving the original as `x-encoded-content-length` to avoid truncation
+- Fix stream handler decoded `gzip`/`deflate` truncation by dropping invalid `Content-Length`
 
 
 ## 7.10.5 - 2025-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - `CurlMultiHandler` now rejects the promise when `CurlFactory::finish()` throws, preserving sibling transfers
 - `SetCookie` now normalizes unparseable `Expires` values to `null` instead of `false`
-- Stream handler now removes the decoded `Content-Length` for `gzip` and `deflate` responses, preserving the original value as `x-encoded-content-length` instead of rewriting it to the compressed size and potentially truncating seekable decoded bodies
+- Stream handler now drops decoded `gzip`/`deflate` `Content-Length`, preserving the original as `x-encoded-content-length` to avoid truncation
 
 
 ## 7.10.5 - 2025-05-27

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -213,15 +213,12 @@ class StreamHandler
                     // Remove content-encoding header
                     unset($headers[$normalizedKeys['content-encoding']]);
 
-                    // Fix content-length header
+                    // The decoded length cannot be known without inflating the
+                    // stream, so keep the original length for inspection and
+                    // drop the now-unknown Content-Length header.
                     if (isset($normalizedKeys['content-length'])) {
                         $headers['x-encoded-content-length'] = $headers[$normalizedKeys['content-length']];
-                        $length = (int) $stream->getSize();
-                        if ($length === 0) {
-                            unset($headers[$normalizedKeys['content-length']]);
-                        } else {
-                            $headers[$normalizedKeys['content-length']] = [(string) $length];
-                        }
+                        unset($headers[$normalizedKeys['content-length']]);
                     }
                 }
             }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -232,6 +232,40 @@ class StreamHandlerTest extends TestCase
         self::assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == $response->getBody()->getSize());
     }
 
+    public function testDecodedGzipLargerThanEncodedReturnsFullBodyAndDropsContentLength()
+    {
+        $decoded = \str_repeat('A', 1000);
+        $gzip = \gzencode($decoded);
+        self::assertIsString($gzip);
+
+        $resource = \fopen('php://temp', 'r+');
+        self::assertIsResource($resource);
+        \fwrite($resource, $gzip);
+        \rewind($resource);
+
+        $handler = new StreamHandler();
+        $request = new Request('GET', 'http://example.com');
+
+        $ref = new \ReflectionObject($handler);
+        $lastHeaders = $ref->getProperty('lastHeaders');
+        $lastHeaders->setAccessible(true);
+        $lastHeaders->setValue($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Encoding: gzip',
+            'Content-Length: '.\strlen($gzip),
+        ]);
+        $createResponse = $ref->getMethod('createResponse');
+        $createResponse->setAccessible(true);
+
+        /** @var ResponseInterface $response */
+        $response = $createResponse->invoke($handler, $request, ['decode_content' => true], $resource, null)->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($decoded, (string) $response->getBody());
+        self::assertFalse($response->hasHeader('Content-Length'));
+        self::assertSame((string) \strlen($gzip), $response->getHeaderLine('x-encoded-content-length'));
+    }
+
     public function testAutomaticallyDecompressGzipHead()
     {
         Server::flush();
@@ -246,7 +280,7 @@ class StreamHandlerTest extends TestCase
         $request = new Request('HEAD', Server::$url);
         $response = $handler($request, ['decode_content' => true])->wait();
 
-        // Verify that the content-length matches the encoded size.
+        // Verify that the content-length is removed after decoding.
         self::assertTrue(!$response->hasHeader('content-length') || $response->getHeaderLine('content-length') == \strlen($content));
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -248,14 +248,18 @@ class StreamHandlerTest extends TestCase
 
         $ref = new \ReflectionObject($handler);
         $lastHeaders = $ref->getProperty('lastHeaders');
-        $lastHeaders->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $lastHeaders->setAccessible(true);
+        }
         $lastHeaders->setValue($handler, [
             'HTTP/1.1 200 OK',
             'Content-Encoding: gzip',
             'Content-Length: '.\strlen($gzip),
         ]);
         $createResponse = $ref->getMethod('createResponse');
-        $createResponse->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $createResponse->setAccessible(true);
+        }
 
         /** @var ResponseInterface $response */
         $response = $createResponse->invoke($handler, $request, ['decode_content' => true], $resource, null)->wait();


### PR DESCRIPTION
This fixes the stream handler response decoding path so gzip and deflate responses no longer expose a Content-Length derived from the compressed stream size after the body has been decoded. The original encoded length is still preserved as x-encoded-content-length. This prevents decoded bodies from seekable sources from being truncated when the decoded body is larger than the compressed payload, and it adds a regression test for that case.