### PR TITLE
Classify cURL sink write failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
 - Classify cURL PSR-7 request-body upload timeouts by response phase
 - Classify cURL PSR-7 response sink write timeouts by response phase
+- Classify cURL response sink write throwables as `ResponseException` or `RequestException`
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -174,6 +174,13 @@ has already sent response headers. Whenever the timeout comes from a PSR-7
 stream, the original `GuzzleHttp\Psr7\Exception\TimeoutException` is available
 via `getPrevious()`.
 
+Generic throwables from a cURL `sink` write are now wrapped instead of escaping
+the native cURL callback. They become plain `ResponseException` instances when a
+response was received, or `RequestException` instances otherwise, with the
+original throwable available via `getPrevious()`. The cURL handlers continue to
+report `CURLE_WRITE_ERROR` as `on_stats` handler error data for these write
+callback failures.
+
 `HandlerClosedException` is new in Guzzle 8.0. It extends `TransferException`
 and is used when an explicitly closed `CurlMultiHandler` rejects transfers that
 are still pending, including delayed transfers. Existing Guzzle 7.x code should
@@ -220,8 +227,8 @@ as `RequestException` or `ConnectException`:
   no-response HTTP/2 and HTTP/3 protocol errors, are `NetworkException`.
 - Response-transfer failures after response headers were received are
   `ResponseTransferException`. Response-body network stalls are
-  `ResponseTimeoutException`, while a slow `sink` write or request-body stall
-  after headers is a plain `ResponseException`.
+  `ResponseTimeoutException`, while `sink` write failures or request-body stalls
+  after headers are plain `ResponseException` instances.
 - Post-transfer response finalization failures are also plain
   `ResponseException`. A seekable response sink that fails to rewind does not
   become a `ResponseTransferException`. Non-seekable sinks are not rewound, and

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -698,12 +698,17 @@ final class CurlFactory implements CurlFactoryInterface
         return !$easy->response
             || $easy->errno !== 0
             || $easy->bodyReadTimeoutException !== null
-            || $easy->sinkWriteTimeoutException !== null;
+            || $easy->sinkWriteTimeoutException !== null
+            || $easy->sinkWriteException !== null;
     }
 
     private static function shouldRetryFailedRewind(EasyHandle $easy): bool
     {
-        if ($easy->bodyReadTimeoutException !== null || $easy->sinkWriteTimeoutException !== null) {
+        if (
+            $easy->bodyReadTimeoutException !== null
+            || $easy->sinkWriteTimeoutException !== null
+            || $easy->sinkWriteException !== null
+        ) {
             return false;
         }
 
@@ -844,6 +849,34 @@ final class CurlFactory implements CurlFactoryInterface
                     'The cURL handler timed out while transferring the response body',
                     $easy->request,
                     $easy->sinkWriteTimeoutException
+                )
+            );
+        }
+
+        if ($easy->sinkWriteException) {
+            $message = $easy->sinkWriteException->getMessage() !== ''
+                ? $easy->sinkWriteException->getMessage()
+                : 'The cURL handler failed while writing the response body';
+
+            if ($easy->response) {
+                /** @var PromiseInterface<ResponseInterface, mixed> */
+                return P\Create::rejectionFor(
+                    new ResponseException(
+                        $message,
+                        $easy->request,
+                        $easy->response,
+                        $easy->sinkWriteException
+                    )
+                );
+            }
+
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(
+                new RequestException(
+                    $message,
+                    $easy->request,
+                    0,
+                    $easy->sinkWriteException
                 )
             );
         }
@@ -1387,6 +1420,10 @@ final class CurlFactory implements CurlFactoryInterface
                 return $sink->write($write);
             } catch (TimeoutException $e) {
                 $easy->sinkWriteTimeoutException = $e;
+
+                return 0;
+            } catch (\Throwable $e) {
+                $easy->sinkWriteException = $e;
 
                 return 0;
             }

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -78,6 +78,11 @@ final class EasyHandle
     public ?TimeoutException $sinkWriteTimeoutException = null;
 
     /**
+     * @var \Throwable|null Exception during response sink write.
+     */
+    public ?\Throwable $sinkWriteException = null;
+
+    /**
      * Attach a response to the easy handle based on the received headers.
      *
      * @throws \RuntimeException if no headers have been received or the first

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3249,6 +3249,188 @@ class CurlFactoryTest extends TestCase
     /**
      * @dataProvider curlHandlerProvider
      */
+    public function testGenericSinkWriteFailureRejectsAsResponseExceptionThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, [], 'abc'),
+        ]);
+        $request = new Psr7\Request('GET', Server::$url);
+        $handler = $handlerFactory();
+        $previous = new \RuntimeException('sink failed');
+        $stats = null;
+        $writeCalled = false;
+        $sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor(), [
+            'write' => static function (string $data) use (&$writeCalled, $previous): int {
+                $writeCalled = true;
+
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $handler($request, [
+                'sink' => $sink,
+                'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                    $stats = $transferStats;
+                },
+            ])->wait();
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+            self::assertSame('sink failed', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+
+        self::assertTrue($writeCalled);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame(200, $stats->getResponse()->getStatusCode());
+        self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
+    }
+
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testSinkWriteErrorRejectsAsResponseExceptionThroughCurlHandlers(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, [], 'abc'),
+        ]);
+        $request = new Psr7\Request('GET', Server::$url);
+        $handler = $handlerFactory();
+        $previous = new \Error('sink fatal');
+        $writeCalled = false;
+        $sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor(), [
+            'write' => static function (string $data) use (&$writeCalled, $previous): int {
+                $writeCalled = true;
+
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $handler($request, ['sink' => $sink])->wait();
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+
+        self::assertTrue($writeCalled);
+    }
+
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testSinkWriteFailureUsesFallbackMessageWhenThrowableMessageEmpty(callable $handlerFactory): void
+    {
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200, [], 'abc'),
+        ]);
+        $request = new Psr7\Request('GET', Server::$url);
+        $handler = $handlerFactory();
+        $sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor(), [
+            'write' => static function (string $data): int {
+                throw new \RuntimeException('');
+            },
+        ]);
+
+        try {
+            $handler($request, ['sink' => $sink])->wait();
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertSame('The cURL handler failed while writing the response body', $e->getMessage());
+        } finally {
+            Server::flush();
+
+            if (\method_exists($handler, 'close')) {
+                $handler->close();
+            }
+        }
+    }
+
+    /**
+     * @dataProvider curlHandlerProvider
+     */
+    public function testSinkWriteReturningTooFewBytesRejectsAsResponseExceptionWithoutPrevious(callable $handlerFactory): void
+    {
+        $body = \str_repeat('x', 1024);
+        $scenarios = [
+            'return zero' => false,
+            'short positive' => true,
+        ];
+
+        foreach ($scenarios as $label => $positiveShort) {
+            Server::flush();
+            Server::enqueue([
+                new Psr7\Response(200, [], $body),
+            ]);
+            $request = new Psr7\Request('GET', Server::$url);
+            $handler = $handlerFactory();
+            $callbackRan = false;
+            $sawPositiveShort = false;
+            $sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor(), [
+                'write' => static function (string $data) use ($positiveShort, &$callbackRan, &$sawPositiveShort): int {
+                    $callbackRan = true;
+                    $written = $positiveShort ? \strlen($data) - 1 : 0;
+                    if ($written > 0 && $written < \strlen($data)) {
+                        $sawPositiveShort = true;
+                    }
+
+                    return $written;
+                },
+            ]);
+
+            try {
+                $handler($request, ['sink' => $sink])->wait();
+
+                self::fail("Expected ResponseException ({$label})");
+            } catch (ResponseException $e) {
+                self::assertSame(200, $e->getResponse()->getStatusCode(), $label);
+                self::assertNull($e->getPrevious(), $label);
+                self::assertNotInstanceOf(ResponseTransferException::class, $e, $label);
+            } finally {
+                Server::flush();
+
+                if (\method_exists($handler, 'close')) {
+                    $handler->close();
+                }
+            }
+
+            self::assertTrue($callbackRan, "the short-write callback must run ({$label})");
+            if ($positiveShort) {
+                self::assertTrue($sawPositiveShort, "expected a genuinely positive short write ({$label})");
+            }
+        }
+    }
+
+    /**
+     * @dataProvider curlHandlerProvider
+     */
     public function testNonSeekableSinkSucceedsWithoutRewindThroughCurlHandlers(callable $handlerFactory): void
     {
         Server::flush();
@@ -3346,6 +3528,66 @@ class CurlFactoryTest extends TestCase
         self::assertNull($stats->getResponse());
         self::assertSame($request, $stats->getRequest());
         self::assertSame(\CURLE_WRITE_ERROR, $stats->getHandlerErrorData());
+    }
+
+    public function testGenericSinkWriteFailureWithoutResponseRejectsAsRequestExceptionWithoutRetry(): void
+    {
+        $factory = new CurlFactory(3);
+        $request = new Psr7\Request('GET', Server::$url);
+        $easy = $factory->create($request, []);
+        $previous = new \RuntimeException('sink failed');
+        $easy->sinkWriteException = $previous;
+        $retried = false;
+        $handler = static function () use (&$retried): P\PromiseInterface {
+            $retried = true;
+
+            return P\Create::promiseFor(new Psr7\Response(200));
+        };
+
+        try {
+            CurlFactory::finish($handler, $easy, $factory)->wait();
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('sink failed', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkException::class, $e);
+        }
+
+        self::assertFalse($retried, 'A sink write failure must never trigger a request-body rewind retry');
+    }
+
+    public function testGenericSinkWriteFailureWithResponseRejectsWithoutRetryWhenErrnoIsZero(): void
+    {
+        $factory = new CurlFactory(3);
+        $request = new Psr7\Request('GET', Server::$url);
+        $response = new Psr7\Response(200, [], 'abc');
+        $easy = $factory->create($request, []);
+        $previous = new \RuntimeException('sink failed');
+        $easy->response = $response;
+        $easy->sinkWriteException = $previous;
+        $retried = false;
+        $handler = static function () use (&$retried): P\PromiseInterface {
+            $retried = true;
+
+            return P\Create::promiseFor(new Psr7\Response(200));
+        };
+
+        try {
+            CurlFactory::finish($handler, $easy, $factory)->wait();
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($response, $e->getResponse());
+            self::assertSame('sink failed', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+        }
+
+        self::assertFalse($retried, 'A sink write failure must never trigger a request-body rewind retry');
     }
 
     public function testInvokesOnStatsOnSuccess(): void


### PR DESCRIPTION
This wraps generic throwables from cURL response sink writes in Guzzle request exceptions instead of allowing them to escape from the native callback. When response headers have been received, the failure is reported as a ResponseException with the original throwable as the previous exception; otherwise it falls back to RequestException. The existing timeout path remains separate so PSR-7 sink write timeouts keep their current classification.