### PR TITLE
Detect short stream handler response bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Classify stream transport failures without a response as `NetworkException`, with timeouts as `NetworkTimeoutException`
 - Classify generic response-aware request failures as `ResponseException`
 - Classify response-aware transfer failures as `ResponseTransferException`
+- Reject short non-streamed stream-handler response bodies with valid positive `Content-Length` as `ResponseTransferException`
 - Treat response sink rewind failures as `ResponseException` and skip non-seekable sink rewinds
 - Ignore stream source close failures after a complete response body transfer
 - Throw `GuzzleHttp\Exception\InvalidArgumentException` for invalid built-in handler options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Classify stream transport failures without a response as `NetworkException`, with timeouts as `NetworkTimeoutException`
 - Classify generic response-aware request failures as `ResponseException`
 - Classify response-aware transfer failures as `ResponseTransferException`
-- Reject short non-streamed stream-handler response bodies with valid positive `Content-Length` as `ResponseTransferException`
+- Reject short non-streamed stream-handler response bodies with valid `Content-Length` as `ResponseTransferException`
 - Treat response sink rewind failures as `ResponseException` and skip non-seekable sink rewinds
 - Ignore stream source close failures after a complete response body transfer
 - Throw `GuzzleHttp\Exception\InvalidArgumentException` for invalid built-in handler options

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -232,6 +232,18 @@ as `RequestException` or `ConnectException`:
 This applies to both the cURL and stream handlers; the exact error codes and
 messages each one maps onto these classes are an implementation detail.
 
+The stream handler now rejects a drained, non-streamed response when a valid,
+positive `Content-Length` declares more bytes than the handler receives, raising
+`ResponseTransferException`. This matches the cURL handler for identity-coded
+responses, compressed responses with `decode_content` disabled, and unsupported
+compressed codings that the stream handler leaves raw. It does not apply to
+`stream => true` responses, decoded gzip or deflate responses, chunked or other
+`Transfer-Encoding` responses, conflicting or malformed `Content-Length` values,
+or lengths above `PHP_INT_MAX`. Responses to `HEAD`, any `1xx`, `204`, `304`,
+and successful `CONNECT` requests are never checked because they are bodiless by
+framing. `205 Reset Content` is checked because it remains framed by
+`Content-Length`.
+
 The deprecated `RequestException::wrapException()` method was removed. Create a
 `RequestException` directly for request failures where Guzzle does not expose a
 response object. For failures with a response, create `ResponseException`,

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -385,17 +385,18 @@ final class StreamHandler
         StreamInterface $sink,
         string $contentLength
     ): StreamInterface {
+        // Keep the existing loose read bound, but only reject short bodies when
+        // the Content-Length is a valid framing promise for this response.
+        $copyLimit = (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1;
+        $declaredLength = self::declaredResponseBodyLength($request, $response);
+
         try {
             $target = $this->createResponseSink($request, $response, $sink);
             // If a content-length header is provided, then stop reading once
             // that number of bytes has been read. This can prevent infinitely
             // reading from a stream when dealing with servers that do not
             // honor Connection: Close headers.
-            Psr7\Utils::copyToStream(
-                $source,
-                $target,
-                (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1
-            );
+            $copied = Psr7\Utils::copyToStream($source, $target, $copyLimit);
         } catch (ResponseException $e) {
             throw $e;
         } catch (TimeoutException $e) {
@@ -416,14 +417,22 @@ final class StreamHandler
             );
         }
 
-        $rewindException = null;
+        $exception = null;
+
+        if ($declaredLength !== null && $copied < $declaredLength) {
+            $exception = new ResponseTransferException(
+                'The stream handler received fewer bytes than the declared Content-Length',
+                $request,
+                $response
+            );
+        }
 
         try {
-            if ($sink->isSeekable()) {
+            if ($exception === null && $sink->isSeekable()) {
                 $sink->rewind();
             }
         } catch (\Throwable $e) {
-            $rewindException = new ResponseException(
+            $exception = new ResponseException(
                 $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed to rewind the response body',
                 $request,
                 $response,
@@ -437,11 +446,57 @@ final class StreamHandler
             }
         }
 
-        if ($rewindException !== null) {
-            throw $rewindException;
+        if ($exception !== null) {
+            throw $exception;
         }
 
         return $sink;
+    }
+
+    private static function declaredResponseBodyLength(RequestInterface $request, ResponseInterface $response): ?int
+    {
+        $status = $response->getStatusCode();
+        $method = $request->getMethod();
+
+        if (
+            $method === 'HEAD'
+            || ($method === 'CONNECT' && $status >= 200 && $status < 300)
+            || $status < 200
+            || $status === 204
+            || $status === 304
+            || $response->hasHeader('Transfer-Encoding')
+        ) {
+            return null;
+        }
+
+        $length = null;
+        foreach ($response->getHeader('Content-Length') as $value) {
+            foreach (\explode(',', $value) as $part) {
+                $part = \trim($part, " \t");
+                if (\preg_match('/^[0-9]+$/', $part) !== 1) {
+                    return null;
+                }
+
+                $part = \ltrim($part, '0');
+                $part = $part === '' ? '0' : $part;
+                if ($length !== null && $part !== $length) {
+                    return null;
+                }
+
+                $length = $part;
+            }
+        }
+
+        if ($length === null || $length === '0') {
+            return null;
+        }
+
+        $max = (string) \PHP_INT_MAX;
+        if (\strlen($length) > \strlen($max) || (\strlen($length) === \strlen($max) && $length > $max)) {
+            return null;
+        }
+
+        return (int) $length;
     }
 
     private function createResponseSink(

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -578,6 +578,304 @@ class StreamHandlerTest extends TestCase
         \fclose($stream);
     }
 
+    public function testThrowsResponseTransferExceptionWhenContentLengthBodyIsShort(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $stats = null;
+        $exception = null;
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+        ]);
+
+        try {
+            $this->invokeStreamHandlerCreateResponse(
+                $handler,
+                $request,
+                [
+                    'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                        $stats = $transferStats;
+                    },
+                ],
+                Psr7\Utils::streamFor('ab')
+            )->wait();
+            self::fail('Expected ResponseTransferException');
+        } catch (ResponseTransferException $e) {
+            $exception = $e;
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+            self::assertSame('The stream handler received fewer bytes than the declared Content-Length', $e->getMessage());
+            self::assertNull($e->getPrevious());
+            self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertInstanceOf(ResponseTransferException::class, $exception);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame($exception->getResponse(), $stats->getResponse());
+        self::assertSame($exception, $stats->getHandlerErrorData());
+    }
+
+    public function testExactContentLengthBodySucceeds(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('abc'))->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('abc', (string) $response->getBody());
+    }
+
+    public function testOverlongContentLengthBodySucceedsAndStopsAtDeclaredLength(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('abcdef'))->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('abc', (string) $response->getBody());
+    }
+
+    /**
+     * @dataProvider bodilessStatusProvider
+     */
+    public function testBodilessStatusWithPositiveContentLengthSucceeds(int $status, string $reason): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            "HTTP/1.1 {$status} {$reason}",
+            'Content-Length: 3',
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor(''))->wait();
+
+        self::assertSame($status, $response->getStatusCode());
+    }
+
+    public static function bodilessStatusProvider(): array
+    {
+        return [
+            '100 Continue' => [100, 'Continue'],
+            '101 Switching Protocols' => [101, 'Switching Protocols'],
+            '204 No Content' => [204, 'No Content'],
+            '304 Not Modified' => [304, 'Not Modified'],
+        ];
+    }
+
+    public function testShortContentLengthBodyOn205Rejects(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 205 Reset Content',
+            'Content-Length: 3',
+        ]);
+
+        try {
+            $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('ab'))->wait();
+            self::fail('Expected ResponseTransferException');
+        } catch (ResponseTransferException $e) {
+            self::assertSame(205, $e->getResponse()->getStatusCode());
+        }
+    }
+
+    public function testExactContentLengthBodyOn205Succeeds(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 205 Reset Content',
+            'Content-Length: 3',
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('abc'))->wait();
+
+        self::assertSame(205, $response->getStatusCode());
+    }
+
+    public function testConnect2xxWithPositiveContentLengthSucceeds(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('CONNECT', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 Connection Established',
+            'Content-Length: 3',
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor(''))->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testLeadingZeroContentLengthIsEnforced(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 0003',
+        ]);
+
+        $this->expectException(ResponseTransferException::class);
+
+        $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('ab'))->wait();
+    }
+
+    public function testDuplicateIdenticalContentLengthIsEnforced(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+            'Content-Length: 3',
+        ]);
+
+        $this->expectException(ResponseTransferException::class);
+
+        $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('ab'))->wait();
+    }
+
+    public function testConflictingContentLengthSkipsShortBodyCheck(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+            'Content-Length: 5',
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('ab'))->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('ab', (string) $response->getBody());
+    }
+
+    public function testContentLengthAbovePhpIntMaxSkipsShortBodyCheck(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $overflow = '99999999999999999999999999';
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            "Content-Length: {$overflow}",
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('ab'))->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('ab', (string) $response->getBody());
+    }
+
+    public function testAttemptsSourceCloseWhenContentLengthBodyIsShort(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $closeCalled = false;
+        $source = FnStream::decorate(Psr7\Utils::streamFor('ab'), [
+            'close' => static function () use (&$closeCalled): void {
+                $closeCalled = true;
+
+                throw new \RuntimeException('close failed');
+            },
+        ]);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+        ]);
+
+        try {
+            $this->invokeStreamHandlerCreateResponse($handler, $request, [], $source)->wait();
+            self::fail('Expected ResponseTransferException');
+        } catch (ResponseTransferException $e) {
+            self::assertSame('The stream handler received fewer bytes than the declared Content-Length', $e->getMessage());
+            self::assertNull($e->getPrevious());
+        }
+
+        self::assertTrue($closeCalled);
+    }
+
+    public function testTransferEncodingWithBogusContentLengthDoesNotTriggerShortBody(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Transfer-Encoding: chunked',
+            'Content-Length: 100',
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('abc'))->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('abc', (string) $response->getBody());
+    }
+
+    public function testShortRawBodyWithUnsupportedEncodingAndDecodeOnThrows(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Encoding: br',
+            'Content-Length: 10',
+        ]);
+
+        try {
+            $this->invokeStreamHandlerCreateResponse($handler, $request, ['decode_content' => true], Psr7\Utils::streamFor('rawbytes'))->wait();
+            self::fail('Expected ResponseTransferException');
+        } catch (ResponseTransferException $e) {
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+        }
+    }
+
+    public function testShortRawBodyWithGzipEncodingAndDecodeOffThrows(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Encoding: gzip',
+            'Content-Length: 10',
+        ]);
+
+        try {
+            $this->invokeStreamHandlerCreateResponse($handler, $request, ['decode_content' => false], Psr7\Utils::streamFor('rawbytes'))->wait();
+            self::fail('Expected ResponseTransferException');
+        } catch (ResponseTransferException $e) {
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+        }
+    }
+
     public function testDoesNotDrainWhenHeadRequest(): void
     {
         Server::flush();


### PR DESCRIPTION
This makes the stream handler reject drained, non-streamed responses when a valid positive Content-Length promises more bytes than were copied, surfacing the failure as ResponseTransferException to match the cURL handler's partial-file behavior. The check deliberately ignores bodiless responses, Transfer-Encoding responses, decoded gzip or deflate bodies, malformed or conflicting Content-Length values, and streamed responses so this stays limited to the declared-length case covered by PSR-7's new copy byte count.