### PR TITLE
Ignore cURL interim 1xx responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Classify generic response-aware request failures as `ResponseException`
 - Classify response-aware transfer failures as `ResponseTransferException`
 - Reject short non-streamed stream-handler response bodies with valid `Content-Length` as `ResponseTransferException`
+- Stop treating cURL non-`101` informational responses as final responses, so failures after only an interim `1xx` are no-response failures and `on_headers` runs for the final response instead
 - Treat response sink rewind failures as `ResponseException` and skip non-seekable sink rewinds
 - Ignore stream source close failures after a complete response body transfer
 - Throw `GuzzleHttp\Exception\InvalidArgumentException` for invalid built-in handler options

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -239,6 +239,16 @@ as `RequestException` or `ConnectException`:
 This applies to both the cURL and stream handlers; the exact error codes and
 messages each one maps onto these classes are an implementation detail.
 
+The cURL handler no longer treats non-`101` informational responses such as
+`100 Continue`, `102 Processing`, or `103 Early Hints` as the final response.
+If a cURL transfer fails after receiving only one of those interim responses,
+Guzzle now reports a no-response failure such as `NetworkException` instead of
+a `ResponseTransferException` carrying the interim `1xx` response. Code that
+previously caught this path with `RequestException` or
+`RequestExceptionInterface` should catch `NetworkExceptionInterface` or
+`TransferException` instead. `101 Switching Protocols` is unchanged and is still
+surfaced as a response.
+
 The stream handler now rejects a drained, non-streamed response when a valid,
 positive `Content-Length` declares more bytes than the handler receives, raising
 `ResponseTransferException`. This matches the cURL handler for identity-coded
@@ -320,6 +330,12 @@ argument. Existing userland callbacks that accept only the response continue to
 work, but callbacks that inspect all arguments, for example with
 `func_get_args()` or a variadic parameter, will observe the additional
 `Psr\Http\Message\RequestInterface` argument.
+
+The built-in handlers invoke `on_headers` for the final response headers and for
+`101 Switching Protocols`, but not for other informational `1xx` responses such
+as `100 Continue` or `103 Early Hints`. Guzzle does not expose a separate Early
+Hints API; a dedicated interim-response hook may be added in a future minor
+release.
 
 #### Sink Resource Ownership
 

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -471,7 +471,7 @@ First-party handlers should not silently ignore documented handler-owned options
 
 ### Callback Semantics
 
-The `on_headers` option is invoked after the response headers have been received and before response body bytes are written to the configured `sink`. In Guzzle 8, the callback receives the response object and the corresponding request object. If it throws, the request promise is rejected with a `GuzzleHttp\Exception\ResponseException` that wraps the thrown exception.
+The `on_headers` option is invoked after the final response headers, or a `101 Switching Protocols` response, have been received and before response body bytes are written to the configured `sink`. Built-in handlers do not invoke it for other informational `1xx` responses. The callback receives the response object and the corresponding request object. If it throws, the request promise is rejected with a `GuzzleHttp\Exception\ResponseException` that wraps the thrown exception.
 
 The `on_stats` option is invoked when the handler has finished sending a request, with a `GuzzleHttp\TransferStats` object that describes the response received or the error encountered. Exceptions thrown by `on_stats` are not wrapped by Guzzle and may escape from the handler wait path. Built-in cURL handlers release native cURL handles before invoking `on_stats` and may invoke it per low-level transfer attempt.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -737,7 +737,7 @@ $client->request('POST', '/post', [
 ## on_headers
 
 Summary
-A callable that is invoked when the HTTP headers of the response have been received but the body has not yet begun to download.
+A callable that is invoked when the HTTP headers of the final response, or a `101 Switching Protocols` response, have been received but the body has not yet begun to download.
 
 Types
 - callable
@@ -745,7 +745,7 @@ Types
 Constant
 `GuzzleHttp\RequestOptions::ON_HEADERS`
 
-The callable accepts a `Psr\Http\Message\ResponseInterface` object and the corresponding `Psr\Http\Message\RequestInterface` object. If an exception is thrown by the callable, then the promise associated with the response will be rejected with a `GuzzleHttp\Exception\ResponseException` that wraps the exception that was thrown.
+The callable accepts a `Psr\Http\Message\ResponseInterface` object and the corresponding `Psr\Http\Message\RequestInterface` object. Built-in handlers do not invoke it for interim informational responses such as `100 Continue` or `103 Early Hints`. If an exception is thrown by the callable, then the promise associated with the response will be rejected with a `GuzzleHttp\Exception\ResponseException` that wraps the exception that was thrown.
 
 You may need to know what headers and status codes were received before data can be written to the sink.
 
@@ -764,7 +764,7 @@ $client->request('GET', 'http://httpbin.org/stream/1024', [
 ```
 
 > [!NOTE]
-> When writing HTTP handlers, the `on_headers` function must be invoked before writing data to the body of the response.
+> When writing HTTP handlers, the `on_headers` function must be invoked for the final response, or for a `101 Switching Protocols` response, before writing data to the body of the response.
 
 ## on_stats
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1722,7 +1722,7 @@ final class CurlFactory implements CurlFactoryInterface
 
                     return -1;
                 }
-                if ($onHeaders !== null) {
+                if ($onHeaders !== null && $easy->response !== null) {
                     try {
                         $onHeaders($easy->response, $easy->request);
                     } catch (\Throwable $e) {

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -94,6 +94,13 @@ final class EasyHandle
 
         [$ver, $status, $reason, $headers] = HeaderProcessor::parseHeaders($this->headers);
 
+        // Non-101 informational responses precede the final response. Do not
+        // expose them as the response for a transfer that ends before the final
+        // response arrives. 101 switches protocol and is kept as terminal.
+        if ($status < 200 && $status !== 101) {
+            return;
+        }
+
         $normalizedKeys = Utils::normalizeHeaderKeys($headers);
 
         if (!empty($this->options['decode_content']) && isset($normalizedKeys['content-encoding'])) {

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -199,12 +199,12 @@ final class RequestOptions
 
     /**
      * on_headers: (callable(ResponseInterface, RequestInterface): mixed) A callable that is invoked when the HTTP headers
-     * of the response have been received but the body has not yet begun to
-     * download. The callable is passed the response and request as
-     * {@see ResponseInterface} and
-     * {@see RequestInterface} objects, respectively. If it
-     * throws, the request promise is rejected with a RequestException wrapping
-     * the thrown exception.
+     * of the final response, or a 101 Switching Protocols response, have been
+     * received but the body has not yet begun to download. The callable is
+     * passed the response and request as {@see ResponseInterface} and
+     * {@see RequestInterface} objects, respectively. If it throws, the request
+     * promise is rejected with a GuzzleHttp\Exception\ResponseException (a
+     * RequestException subtype) wrapping the thrown exception.
      */
     public const ON_HEADERS = 'on_headers';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2345,6 +2345,60 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public function testInterimResponseFollowedByEmptyReplyIsNetworkException(): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $easy = $factory->create($request, []);
+        $easy->headers = ['HTTP/1.1 103 Early Hints', 'Link: </a.css>; rel=preload'];
+        $easy->createResponse();
+        self::assertNull($easy->response);
+        $easy->errno = \CURLE_GOT_NOTHING;
+
+        $promise = CurlFactory::finish(
+            static function (): void {
+            },
+            $easy,
+            $factory
+        );
+
+        try {
+            $promise->wait();
+            self::fail('Expected NetworkException');
+        } catch (NetworkException $e) {
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertSame($request, $e->getRequest());
+        }
+    }
+
+    public function testInterimResponseFollowedByRecvErrorIsNetworkException(): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $easy = $factory->create($request, []);
+        $easy->headers = ['HTTP/1.1 100 Continue'];
+        $easy->createResponse();
+        self::assertNull($easy->response);
+        $easy->errno = \CURLE_RECV_ERROR;
+
+        $promise = CurlFactory::finish(
+            static function (): void {
+            },
+            $easy,
+            $factory
+        );
+
+        try {
+            $promise->wait();
+            self::fail('Expected NetworkException');
+        } catch (NetworkException $e) {
+            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
+            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertSame($request, $e->getRequest());
+        }
+    }
+
     /**
      * @dataProvider curlNetworkErrorWithoutResponseProvider
      */
@@ -2827,6 +2881,69 @@ class CurlFactoryTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $handler($req, ['on_headers' => 'error!']);
+    }
+
+    public function testIgnoresInterim1xxAndInvokesOnHeadersOnceForFinalResponse(): void
+    {
+        $factory = new CurlFactory(1);
+        $statuses = [];
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'on_headers' => static function (ResponseInterface $response) use (&$statuses): void {
+                $statuses[] = $response->getStatusCode();
+            },
+        ]);
+
+        try {
+            /** @var callable $headerFn */
+            $headerFn = $_SERVER['_curl'][\CURLOPT_HEADERFUNCTION];
+
+            $headerFn($easy->handle, "HTTP/1.1 103 Early Hints\r\n");
+            $headerFn($easy->handle, "Link: </style.css>; rel=preload\r\n");
+            $headerFn($easy->handle, "\r\n");
+
+            self::assertNull($easy->response, 'interim 1xx is not stored');
+            self::assertSame([], $statuses, 'on_headers is not invoked for an interim 1xx');
+
+            $headerFn($easy->handle, "HTTP/1.1 200 OK\r\n");
+            $headerFn($easy->handle, "Content-Length: 0\r\n");
+            $headerFn($easy->handle, "\r\n");
+
+            self::assertNotNull($easy->response);
+            self::assertSame(200, $easy->response->getStatusCode());
+            self::assertSame([200], $statuses, 'on_headers fires once, for the final response');
+        } finally {
+            if (\array_key_exists('handle', \get_object_vars($easy))) {
+                $factory->release($easy);
+            }
+        }
+    }
+
+    public function testKeeps101AndInvokesOnHeaders(): void
+    {
+        $factory = new CurlFactory(1);
+        $statuses = [];
+        $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+            'on_headers' => static function (ResponseInterface $response) use (&$statuses): void {
+                $statuses[] = $response->getStatusCode();
+            },
+        ]);
+
+        try {
+            /** @var callable $headerFn */
+            $headerFn = $_SERVER['_curl'][\CURLOPT_HEADERFUNCTION];
+
+            $headerFn($easy->handle, "HTTP/1.1 101 Switching Protocols\r\n");
+            $headerFn($easy->handle, "Upgrade: websocket\r\n");
+            $headerFn($easy->handle, "\r\n");
+
+            self::assertNotNull($easy->response, '101 is kept as a response');
+            self::assertSame(101, $easy->response->getStatusCode());
+            self::assertSame([101], $statuses, 'on_headers fires for a 101 response');
+        } finally {
+            if (\array_key_exists('handle', \get_object_vars($easy))) {
+                $factory->release($easy);
+            }
+        }
     }
 
     public function testRejectsPromiseWhenOnHeadersFails(): void

--- a/tests/Handler/EasyHandleTest.php
+++ b/tests/Handler/EasyHandleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\EasyHandle;
+use GuzzleHttp\Psr7;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,5 +21,44 @@ class EasyHandleTest extends TestCase
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('The EasyHandle has been released');
         $easy->handle;
+    }
+
+    public function testCreateResponseIgnoresInterim1xxResponses(): void
+    {
+        $easy = new EasyHandle();
+        $easy->sink = Psr7\Utils::streamFor('');
+        $easy->headers = ['HTTP/1.1 103 Early Hints', 'Link: </style.css>; rel=preload'];
+
+        $easy->createResponse();
+        self::assertNull($easy->response, 'an interim 1xx must not be stored as the response');
+
+        $easy->headers = ['HTTP/1.1 200 OK', 'Content-Length: 0'];
+        $easy->createResponse();
+
+        self::assertNotNull($easy->response);
+        self::assertSame(200, $easy->response->getStatusCode());
+    }
+
+    public function testCreateResponseIgnores100Continue(): void
+    {
+        $easy = new EasyHandle();
+        $easy->sink = Psr7\Utils::streamFor('');
+        $easy->headers = ['HTTP/1.1 100 Continue'];
+
+        $easy->createResponse();
+
+        self::assertNull($easy->response);
+    }
+
+    public function testCreateResponsePreserves101SwitchingProtocols(): void
+    {
+        $easy = new EasyHandle();
+        $easy->sink = Psr7\Utils::streamFor('');
+        $easy->headers = ['HTTP/1.1 101 Switching Protocols', 'Upgrade: websocket', 'Connection: Upgrade'];
+
+        $easy->createResponse();
+
+        self::assertNotNull($easy->response, '101 is terminal and must be kept as a response');
+        self::assertSame(101, $easy->response->getStatusCode());
     }
 }


### PR DESCRIPTION
The cURL handler currently stores every header block that libcurl delivers as the response, including interim informational responses such as 100 Continue and 103 Early Hints. If a transfer fails after one of those blocks and before the final response, Guzzle can reject with a response-aware exception that carries the interim response, and on_headers can run for the interim block. This change leaves non-101 informational responses unexposed on the easy handle, while preserving 101 Switching Protocols as a terminal response to match the stream handler. That makes failures after only an interim response classify as no-response failures and keeps on_headers focused on the final response or 101. The public docs and upgrade notes were updated to describe that behavior.