### PR TITLE
Validate Content-Length handling and classify transfer failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
 - Classify request-body stream read timeouts as `RequestException` or `ResponseException` by phase
 - Classify cURL PSR-7 response sink write timeouts as `ResponseException` or `RequestException` by phase
-- Classify cURL response sink write throwables as `ResponseException` or `RequestException`
+- Classify cURL response sink write failures as `ResponseException` or `RequestException`
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Throw `NetworkTimeoutException` for cURL no-response timeout errors
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
 - Classify request-body stream read timeouts as `RequestException` or `ResponseException` by phase
-- Classify cURL PSR-7 response sink write timeouts by response phase
+- Classify cURL PSR-7 response sink write timeouts as `ResponseException` or `RequestException` by phase
 - Classify cURL response sink write throwables as `ResponseException` or `RequestException`
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Throw `ConnectTimeoutException` for connect timeouts
 - Throw `NetworkTimeoutException` for cURL no-response timeout errors
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
-- Classify request-body stream read timeouts as `RequestException` or `ResponseException` by phase
-- Classify cURL PSR-7 response sink write timeouts as `ResponseException` or `RequestException` by phase
-- Classify cURL response sink write failures as `ResponseException` or `RequestException`
+- Classify request-body stream size detection, read, stringification, and rewind failures as `RequestException` or `ResponseException` by phase
+- Classify cURL response sink write failures, including timeouts, as `ResponseException` or `RequestException` by phase
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Throw `ConnectTimeoutException` for connect timeouts
 - Throw `NetworkTimeoutException` for cURL no-response timeout errors
 - Throw `ResponseTimeoutException` for response-aware transfer timeouts
-- Classify cURL PSR-7 request-body upload timeouts by response phase
+- Classify request-body stream read timeouts as `RequestException` or `ResponseException` by phase
 - Classify cURL PSR-7 response sink write timeouts by response phase
 - Classify cURL response sink write throwables as `ResponseException` or `RequestException`
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Declare strict types across remaining source files
 - Reject invalid `idn_conversion`, `retries`, and built-in handler `on_stats` option values before use
 - Reject invalid `SetCookie` constructor field types instead of coercing them
-- Reject malformed or conflicting request `Content-Length` values in built-in handlers
+- Reject malformed, conflicting, or unrepresentable request `Content-Length` values in built-in handlers
 - Reject conflicting raw cURL request options, including request-level `CURLOPT_SHARE`
 - Reject selected request options ignored by incompatible built-in handlers
 - Support retry delay callbacks with retry count only or full retry context
@@ -59,6 +59,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Classify generic response-aware request failures as `ResponseException`
 - Classify response-aware transfer failures as `ResponseTransferException`
 - Reject short non-streamed stream-handler response bodies with valid `Content-Length` as `ResponseTransferException`
+- Reject unrepresentable built-in handler response sizes and byte counts as `ResponseException`
 - Ignore cURL informational responses other than `101 Switching Protocols` before the final response
 - Treat response sink rewind failures as `ResponseException` and skip non-seekable sink rewinds
 - Ignore stream source close failures after a complete response body transfer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject unrepresentable built-in handler response sizes and byte counts as `ResponseException`
 - Ignore cURL informational responses other than `101 Switching Protocols` before the final response
 - Treat response sink rewind failures as `ResponseException` and skip non-seekable sink rewinds
+- Classify redirect request-body rewind failures as `ResponseException`
 - Ignore stream source close failures after a complete response body transfer
 - Throw `GuzzleHttp\Exception\InvalidArgumentException` for invalid built-in handler options
 - Classify built-in cURL handle, `sink`, and HTTP/3 setup failures as `RequestException`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Declare strict types across remaining source files
 - Reject invalid `idn_conversion`, `retries`, and built-in handler `on_stats` option values before use
 - Reject invalid `SetCookie` constructor field types instead of coercing them
+- Reject malformed or conflicting request `Content-Length` values in built-in handlers
 - Reject conflicting raw cURL request options, including request-level `CURLOPT_SHARE`
 - Reject selected request options ignored by incompatible built-in handlers
 - Support retry delay callbacks with retry count only or full retry context

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -183,9 +183,9 @@ Timeouts that originate from caller-supplied PSR-7 streams are not transport
 timeouts. Reading the request body stream, including size detection,
 stringification, rewind, and upload reads, is a `RequestException` before a
 response and a `ResponseException` after response headers. A slow response `sink`
-write is also a `ResponseException`. Whenever the timeout comes from a PSR-7
-stream, the original `GuzzleHttp\Psr7\Exception\TimeoutException` is available
-via `getPrevious()`.
+write is a `ResponseException` once a response exists, or a `RequestException`
+otherwise. Whenever the timeout comes from a PSR-7 stream, the original
+`GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
 
 Generic throwables from a cURL `sink` write are now wrapped instead of escaping
 the native cURL callback. They become plain `ResponseException` instances when a

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -81,6 +81,17 @@ $client->request('GET', 'https://example.com');
 The convenience methods such as `$client->get()`, `$client->post()`, and their
 async variants continue to use uppercase standard methods.
 
+The built-in cURL and stream handlers now reject request `Content-Length` values
+that are malformed or conflicting before starting a transfer. Requests that
+previously succeeded after passing an invalid `Content-Length` header may now
+fail with `RequestException`. Duplicate `Content-Length` values are accepted
+only when every member has the same decimal value, including values with leading
+zeros. Valid lengths larger than `PHP_INT_MAX` now fail before the request is
+sent because built-in handlers cannot safely size such transfers on the current
+platform.
+Applications that set this header manually should send one valid non-negative
+decimal length or omit it and let Guzzle prepare the body headers.
+
 #### Exception Hierarchy and Classification
 
 Some Guzzle 8.0 exception changes add intermediate classes, while others
@@ -143,14 +154,17 @@ Guzzle 8.0 also makes response-aware request failures explicit. Guzzle 7.x does
 not have `ResponseException`; response-aware request failures remain under
 `RequestException` throughout Guzzle 7.x. In Guzzle 8.0, `ResponseException` is
 the base class for request failures where response headers were received and a
-response object is available. `ResponseTransferException`,
-`BadResponseException`, and `TooManyRedirectsException` extend it. Only this
-branch exposes response access: `RequestException` no longer stores responses,
-no longer accepts a response constructor argument, and no longer has
-`getResponse()` or `hasResponse()` methods. Catch `ResponseException`, or test
-with `instanceof ResponseException`, before calling `getResponse()`. If you
-instantiate `RequestException` directly, its third constructor argument is now
-the exception code, followed by the previous exception. If you used the removed
+response object is available. `ResponseTransferException` is used for
+transfer-level failures after headers, including response-aware network,
+protocol, content-decoding, partial-body, and response-body transfer failures.
+`BadResponseException` and
+`TooManyRedirectsException` also extend `ResponseException`. Only this branch
+exposes response access: `RequestException` no longer stores responses, no
+longer accepts a response constructor argument, and no longer has `getResponse()`
+or `hasResponse()` methods. Catch `ResponseException`, or test with `instanceof
+ResponseException`, before calling `getResponse()`. If you instantiate
+`RequestException` directly, its third constructor argument is now the exception
+code, followed by the previous exception. If you used the removed
 `getHandlerContext()` methods to classify failures, use the more granular
 exception classes above instead. Use `on_stats` when you need handler timing or
 statistics.
@@ -161,18 +175,18 @@ resolution, TCP connect, proxy CONNECT, or TLS handshake). It extends
 `ConnectException`, so code that catches `ConnectException` will also catch
 connect timeouts. `NetworkTimeoutException` is thrown for other detected
 timeouts before response headers are received. It extends `NetworkException`,
-but not `ConnectException`. `ResponseTimeoutException` is thrown for timeouts
-after response headers are received. It extends `ResponseTransferException` and
-exposes the response. These phases apply however the timeout is detected,
-including timeouts that originate from a slow PSR-7 stream. A request body that
-stalls before any response is received is a `NetworkTimeoutException`, and a
-stall reading the response body off the network is a `ResponseTimeoutException`.
-A timeout from a caller-supplied PSR-7 stream after response headers are
-received is a plain `ResponseException` rather than `ResponseTimeoutException`.
-This covers a slow `sink` write and a request body that stalls after the server
-has already sent response headers. Whenever the timeout comes from a PSR-7
-stream, the original `GuzzleHttp\Psr7\Exception\TimeoutException` is available
-via `getPrevious()`.
+but not `ConnectException`. `ResponseTimeoutException` is thrown for response
+transfer timeouts after response headers are received. It extends
+`ResponseTransferException` and exposes the response. These phases apply however
+the timeout is detected, including timeouts that originate from a slow PSR-7
+stream. A request body that stalls before any response is received is a
+`NetworkTimeoutException`, and a stall reading the response body off the network
+is a `ResponseTimeoutException`. A timeout from a caller-supplied PSR-7 stream
+after response headers are received is a plain `ResponseException` rather than
+`ResponseTimeoutException`. This covers a slow `sink` write and a request body
+that stalls after the server has already sent response headers. Whenever the
+timeout comes from a PSR-7 stream, the original
+`GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
 
 Generic throwables from a cURL `sink` write are now wrapped instead of escaping
 the native cURL callback. They become plain `ResponseException` instances when a
@@ -226,15 +240,18 @@ as `RequestException` or `ConnectException`:
 - Other failures with no response, such as send and receive errors and
   no-response HTTP/2 and HTTP/3 protocol errors, are `NetworkException`.
 - Response-transfer failures after response headers were received are
-  `ResponseTransferException`. Response-body network stalls are
-  `ResponseTimeoutException`, while `sink` write failures or request-body stalls
-  after headers are plain `ResponseException` instances.
+  `ResponseTransferException`. This includes response-aware cURL connection,
+  network, protocol, content-decoding, partial-body, and response body transfer
+  failures. Response-body network stalls are
+  `ResponseTimeoutException`, while `sink` write failures, progress callback
+  failures, deterministic response size/platform-limit failures, or request-body
+  stalls after headers are plain `ResponseException` instances.
 - Post-transfer response finalization failures are also plain
   `ResponseException`. A seekable response sink that fails to rewind does not
   become a `ResponseTransferException`. Non-seekable sinks are not rewound, and
   source close cleanup after a complete stream-handler download is best effort.
-- Other failures that occur after a response was received are
-  `ResponseException`.
+- Other non-transfer or local failures that occur after a response was received
+  are `ResponseException`.
 
 This applies to both the cURL and stream handlers; the exact error codes and
 messages each one maps onto these classes are an implementation detail.
@@ -250,16 +267,19 @@ previously caught this path with `RequestException` or
 surfaced as a response.
 
 The stream handler now rejects a drained, non-streamed response when a valid,
-positive `Content-Length` declares more bytes than the handler receives, raising
-`ResponseTransferException`. This matches the cURL handler for identity-coded
-responses, compressed responses with `decode_content` disabled, and unsupported
-compressed codings that the stream handler leaves raw. It does not apply to
-`stream => true` responses, decoded gzip or deflate responses, chunked or other
-`Transfer-Encoding` responses, conflicting or malformed `Content-Length` values,
-or lengths above `PHP_INT_MAX`. Responses to `HEAD`, any `1xx`, `204`, `304`,
-and successful `CONNECT` requests are never checked because they are bodiless by
-framing. `205 Reset Content` is checked because it remains framed by
-`Content-Length`.
+positive `Content-Length` declares more bytes than the handler receives or
+cannot be represented as a PHP integer on the current platform. Short bodies
+raise `ResponseTransferException`; platform-size failures raise plain
+`ResponseException` with the underlying `OverflowException` available via
+`getPrevious()`. This matches the cURL handler for identity-coded responses,
+compressed responses with `decode_content` disabled, and unsupported compressed
+codings that the stream handler leaves raw. It does not apply to
+`stream => true` responses, decoded gzip or deflate responses after
+`Content-Length` has been removed, chunked or other `Transfer-Encoding`
+responses, or conflicting or malformed `Content-Length` values. Responses to
+`HEAD`, any `1xx`, `204`, `304`, and successful `CONNECT` requests are never
+checked because they are bodiless by framing. `205 Reset Content` is checked
+because it remains framed by `Content-Length`.
 
 The deprecated `RequestException::wrapException()` method was removed. Create a
 `RequestException` directly for request failures where Guzzle does not expose a

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -169,24 +169,23 @@ code, followed by the previous exception. If you used the removed
 exception classes above instead. Use `on_stats` when you need handler timing or
 statistics.
 
-Timeout exception classes are now split by the phase the handler can determine.
-`ConnectTimeoutException` is thrown for detected connect timeouts (DNS
+Timeout exception classes are now split by the transport phase the handler can
+determine. `ConnectTimeoutException` is thrown for detected connect timeouts (DNS
 resolution, TCP connect, proxy CONNECT, or TLS handshake). It extends
 `ConnectException`, so code that catches `ConnectException` will also catch
 connect timeouts. `NetworkTimeoutException` is thrown for other detected
-timeouts before response headers are received. It extends `NetworkException`,
-but not `ConnectException`. `ResponseTimeoutException` is thrown for response
-transfer timeouts after response headers are received. It extends
-`ResponseTransferException` and exposes the response. These phases apply however
-the timeout is detected, including timeouts that originate from a slow PSR-7
-stream. A request body that stalls before any response is received is a
-`NetworkTimeoutException`, and a stall reading the response body off the network
-is a `ResponseTimeoutException`. A timeout from a caller-supplied PSR-7 stream
-after response headers are received is a plain `ResponseException` rather than
-`ResponseTimeoutException`. This covers a slow `sink` write and a request body
-that stalls after the server has already sent response headers. Whenever the
-timeout comes from a PSR-7 stream, the original
-`GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
+transport timeouts before response headers are received. It extends
+`NetworkException`, but not `ConnectException`. `ResponseTimeoutException` is
+thrown for response transfer timeouts after response headers are received. It
+extends `ResponseTransferException` and exposes the response.
+
+Timeouts that originate from caller-supplied PSR-7 streams are not transport
+timeouts. Reading the request body stream, including size detection,
+stringification, rewind, and upload reads, is a `RequestException` before a
+response and a `ResponseException` after response headers. A slow response `sink`
+write is also a `ResponseException`. Whenever the timeout comes from a PSR-7
+stream, the original `GuzzleHttp\Psr7\Exception\TimeoutException` is available
+via `getPrevious()`.
 
 Generic throwables from a cURL `sink` write are now wrapped instead of escaping
 the native cURL callback. They become plain `ResponseException` instances when a

--- a/docs/contributing/exception-guidelines.md
+++ b/docs/contributing/exception-guidelines.md
@@ -53,6 +53,15 @@ Deterministic platform-limit failures, such as a response length or byte count
 that cannot be represented as a PHP integer, are also plain `ResponseException`
 failures when a response exists.
 
+**Timeouts: transport vs. caller-supplied streams.** A `*TimeoutException` means
+the network transport timed out, such as cURL `CURLE_OPERATION_TIMEDOUT` or a
+stream send/connect timeout message. A timeout surfaced as a psr7
+`TimeoutException` from a caller stream is classified like any other failure of
+that stream: `RequestException` while reading the request body before a response,
+or `ResponseException` once a response exists. It is never a
+`NetworkTimeoutException`. The original `TimeoutException` is attached via
+`getPrevious()`.
+
 ## `GuzzleHttp\Exception\InvalidArgumentException`
 
 `final class InvalidArgumentException extends \InvalidArgumentException implements GuzzleException`

--- a/docs/contributing/exception-guidelines.md
+++ b/docs/contributing/exception-guidelines.md
@@ -30,8 +30,10 @@ that they could fix by changing their code?
    ├─ Is it happening while sending a specific request (RequestInterface in scope)?
    │  ├─ Network failure, no response yet ──► NetworkException / ConnectException
    │  │                                        / ConnectTimeoutException / NetworkTimeoutException
-   │  ├─ A response was received, then it failed ──► ResponseException / ResponseTransferException
-   │  │                                              / ResponseTimeoutException / BadResponseException
+   │  ├─ A response was received, then it failed
+   │  │  ├─ transfer failure ──► ResponseTransferException / ResponseTimeoutException
+   │  │  ├─ local/callback/finalization failure ──► ResponseException
+   │  │  └─ bad response policy failure ──► BadResponseException
    │  └─ Cannot even begin sending this request
    │     (curl handle init, sink directory missing, unsupported protocol) ──► RequestException
    │
@@ -39,10 +41,17 @@ that they could fix by changing their code?
       (e.g. "the cURL extension is not available") ──► \RuntimeException (bare SPL is fine here)
 ```
 
-Use `ResponseTransferException` only for failures reading the response body off
-the network after response headers were received. Local response finalization
-failures, such as rewinding a response sink after the body has been received,
-are plain `ResponseException` failures.
+Use `ResponseTransferException` for transfer-level failures after response
+headers were received and a response object exists. This includes response-aware
+connection, network, protocol, content-decoding, partial-body, and response-body
+transfer failures.
+
+Do not use `ResponseTransferException` for local sink writes, request-body stream
+failures, progress callback failures, `on_headers` failures, or response
+finalization such as rewinding a response sink after the body has been received.
+Deterministic platform-limit failures, such as a response length or byte count
+that cannot be represented as a PHP integer, are also plain `ResponseException`
+failures when a response exists.
 
 ## `GuzzleHttp\Exception\InvalidArgumentException`
 
@@ -171,9 +180,10 @@ of Guzzle's own lifecycle APIs.
    it a request — invalid options are not a malformed request.
 4. **Never** throw for 4xx/5xx from `sendRequest()` — that is `http_errors`
    middleware, which PSR-18 mode disables.
-5. Pick `Network*`/`Connect*` (no response) vs `Response*` (response received)
-   vs `RequestException` (can't start) by transfer phase; see the hierarchy in
-   `UPGRADING.md`.
+5. Pick `Network*`/`Connect*` (no response), `ResponseTransferException`
+   (response-aware transfer failure), plain `ResponseException` (other
+   response-aware failure), or `RequestException` (can't start) by transfer
+   phase; see the hierarchy in `UPGRADING.md`.
 
 ## For consumers (catching)
 

--- a/docs/contributing/exception-guidelines.md
+++ b/docs/contributing/exception-guidelines.md
@@ -55,7 +55,7 @@ failures when a response exists.
 
 **Timeouts: transport vs. caller-supplied streams.** A `*TimeoutException` means
 the network transport timed out, such as cURL `CURLE_OPERATION_TIMEDOUT` or a
-stream send/connect timeout message. A timeout surfaced as a psr7
+stream send/connect timeout message. A timeout surfaced as a PSR-7
 `TimeoutException` from a caller stream is classified like any other failure of
 that stream: `RequestException` while reading the request body before a response,
 or `ResponseException` once a response exists. It is never a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -493,12 +493,12 @@ or moving bytes over the network. When the handler can determine a more specific
 failure, Guzzle uses a more specific subtype such as `ConnectException`,
 `ConnectTimeoutException`, or `NetworkTimeoutException`.
 
-If Guzzle has parsed response headers into a response object, later transfer
-failures use `ResponseException`. This is the only branch that exposes
-`getResponse()`. Failures while reading the response body off the network use
-`ResponseTransferException`, with response timeouts as
-`ResponseTimeoutException`. Local response finalization failures, such as a
-failed sink rewind, stay plain `ResponseException`. With Guzzle request methods,
+If Guzzle has parsed response headers into a response object, later failures use
+`ResponseException`. This is the only branch that exposes `getResponse()`.
+Transfer failures after headers use `ResponseTransferException`, with response
+timeouts as `ResponseTimeoutException`. Local response failures, such as a sink
+write, failed sink rewind, or response length that cannot be represented on the
+current platform, stay plain `ResponseException`. With Guzzle request methods,
 middleware can also turn completed responses into exceptions: `http_errors`
 turns 4xx responses into `ClientException` and 5xx responses into
 `ServerException`, and redirect middleware can throw

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -827,7 +827,15 @@ The function accepts the following positional arguments:
 - the total number of bytes expected to be uploaded
 - the number of bytes uploaded so far
 
-With the built-in cURL handlers, returning a truthy value aborts the transfer and rejects the request promise with a `GuzzleHttp\Exception\ResponseException` when a response is available, or a `GuzzleHttp\Exception\RequestException` otherwise. If the callable throws, the built-in cURL handlers abort the transfer and reject the promise with the same response-aware classification while wrapping the thrown exception. The built-in stream handler treats progress callbacks as notifications only and ignores return values.
+With the built-in cURL handlers, returning a truthy value aborts the transfer and
+rejects the request promise with a `GuzzleHttp\Exception\ResponseException` when a
+response is available, or a `GuzzleHttp\Exception\RequestException` otherwise. If
+the callable throws, the built-in cURL handlers abort the transfer and reject the
+promise with the same response-aware classification while wrapping the thrown
+exception. If a built-in handler receives a progress byte count that cannot be
+represented as a PHP integer, the transfer is rejected before the callback is
+invoked. The built-in stream handler treats progress callbacks as notifications
+only and ignores return values.
 
 ```php
 // Send a GET request to /get?foo=bar

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1325,18 +1325,20 @@ Constant
 $client->request('GET', '/delay/5', ['timeout' => 3.14]);
 ```
 
-Built-in handlers use the most specific timeout exception they can determine
-from the underlying transfer. Connect timeouts throw
+Built-in handlers use the most specific transport timeout exception they can
+determine. Connect timeouts throw
 `GuzzleHttp\Exception\ConnectTimeoutException`, which extends
-`ConnectException`. Other timeouts before a response is received throw
-`GuzzleHttp\Exception\NetworkTimeoutException`. Timeouts after a response is
-received throw `GuzzleHttp\Exception\ResponseTimeoutException`, which extends
-`GuzzleHttp\Exception\ResponseTransferException` and exposes the response.
+`ConnectException`. Other transport timeouts before a response is received throw
+`GuzzleHttp\Exception\NetworkTimeoutException`. Transport timeouts after a
+response is received throw `GuzzleHttp\Exception\ResponseTimeoutException`, which
+extends `GuzzleHttp\Exception\ResponseTransferException` and exposes the
+response.
 
-Timeouts that originate from a slow PSR-7 stream follow the same phase rule, with
-one exception: a slow `sink` write, or a request body that stalls after response
-headers are received, throws a plain `GuzzleHttp\Exception\ResponseException`
-rather than `ResponseTimeoutException`. In every case the original
+Timeouts from caller-supplied PSR-7 streams are not transport timeouts. A request
+body stream timeout while detecting size, buffering, rewinding, or reading upload
+bytes throws `GuzzleHttp\Exception\RequestException` before a response and
+`GuzzleHttp\Exception\ResponseException` after response headers. A slow response
+`sink` write also throws `ResponseException`. In every case the original
 `GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
 
 ## version

--- a/src/Exception/ResponseTransferException.php
+++ b/src/Exception/ResponseTransferException.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace GuzzleHttp\Exception;
 
 /**
- * Exception thrown when a response body transfer fails after response headers
- * are received.
+ * Exception thrown when a response transfer fails after response headers are
+ * received.
  */
 class ResponseTransferException extends ResponseException
 {

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -183,11 +183,16 @@ final class CurlFactory implements CurlFactoryInterface
         $this->rejectPersistentRequireConnectionReuseConflicts($options);
         self::rejectConflictingCurlOptions($options);
 
+        $contentLength = self::requestContentLength($request);
+        if ($contentLength !== null) {
+            $request = $request->withHeader('Content-Length', $contentLength);
+        }
+
         $easy = new EasyHandle();
         $easy->request = $request;
         $easy->options = $options;
         $conf = $this->getDefaultConf($easy);
-        $this->applyMethod($easy, $conf);
+        $this->applyMethod($easy, $conf, $contentLength);
         $this->applyHandlerOptions($easy, $conf);
         $this->applyHeaders($easy, $conf);
         unset($conf['_headers']);
@@ -661,11 +666,13 @@ final class CurlFactory implements CurlFactoryInterface
             ];
         }
 
+        $handlerErrorData = $easy->responseBodySizeException ?? $easy->errno;
+
         return new TransferStats(
             $easy->request,
             $easy->response,
             $curlStats['total_time'],
-            $easy->errno,
+            $handlerErrorData,
             $curlStats
         );
     }
@@ -697,18 +704,20 @@ final class CurlFactory implements CurlFactoryInterface
     {
         return !$easy->response
             || $easy->errno !== 0
-            || $easy->bodyReadTimeoutException !== null
+            || self::hasLocalFailure($easy);
+    }
+
+    private static function hasLocalFailure(EasyHandle $easy): bool
+    {
+        return $easy->bodyReadTimeoutException !== null
             || $easy->sinkWriteTimeoutException !== null
-            || $easy->sinkWriteException !== null;
+            || $easy->sinkWriteException !== null
+            || $easy->responseBodySizeException !== null;
     }
 
     private static function shouldRetryFailedRewind(EasyHandle $easy): bool
     {
-        if (
-            $easy->bodyReadTimeoutException !== null
-            || $easy->sinkWriteTimeoutException !== null
-            || $easy->sinkWriteException !== null
-        ) {
+        if (self::hasLocalFailure($easy)) {
             return false;
         }
 
@@ -739,7 +748,7 @@ final class CurlFactory implements CurlFactoryInterface
     /**
      * @return PromiseInterface<ResponseInterface, mixed>
      */
-    private static function createRejection(EasyHandle $easy, array $ctx): PromiseInterface
+    private static function createRejection(EasyHandle $easy, array $ctx, ?\Throwable $previous = null): PromiseInterface
     {
         if ($easy->createResponseException) {
             /** @var PromiseInterface<ResponseInterface, mixed> */
@@ -756,50 +765,18 @@ final class CurlFactory implements CurlFactoryInterface
         // If an exception was encountered during the onHeaders event, then
         // return a rejected promise that wraps that exception.
         if ($easy->onHeadersException) {
-            if ($easy->response) {
-                /** @var PromiseInterface<ResponseInterface, mixed> */
-                return P\Create::rejectionFor(
-                    new ResponseException(
-                        'An error was encountered during the on_headers event',
-                        $easy->request,
-                        $easy->response,
-                        $easy->onHeadersException
-                    )
-                );
-            }
-
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(
-                new RequestException(
-                    'An error was encountered during the on_headers event',
-                    $easy->request,
-                    0,
-                    $easy->onHeadersException
-                )
+            return self::createRequestOrResponseRejection(
+                $easy,
+                'An error was encountered during the on_headers event',
+                $easy->onHeadersException
             );
         }
 
         if ($easy->progressException) {
-            if ($easy->response) {
-                /** @var PromiseInterface<ResponseInterface, mixed> */
-                return P\Create::rejectionFor(
-                    new ResponseException(
-                        'An error was encountered during the progress event',
-                        $easy->request,
-                        $easy->response,
-                        $easy->progressException
-                    )
-                );
-            }
-
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(
-                new RequestException(
-                    'An error was encountered during the progress event',
-                    $easy->request,
-                    0,
-                    $easy->progressException
-                )
+            return self::createRequestOrResponseRejection(
+                $easy,
+                'An error was encountered during the progress event',
+                $easy->progressException
             );
         }
 
@@ -858,50 +835,21 @@ final class CurlFactory implements CurlFactoryInterface
                 ? $easy->sinkWriteException->getMessage()
                 : 'The cURL handler failed while writing the response body';
 
-            if ($easy->response) {
-                /** @var PromiseInterface<ResponseInterface, mixed> */
-                return P\Create::rejectionFor(
-                    new ResponseException(
-                        $message,
-                        $easy->request,
-                        $easy->response,
-                        $easy->sinkWriteException
-                    )
-                );
-            }
+            return self::createRequestOrResponseRejection($easy, $message, $easy->sinkWriteException);
+        }
 
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(
-                new RequestException(
-                    $message,
-                    $easy->request,
-                    0,
-                    $easy->sinkWriteException
-                )
+        if ($easy->responseBodySizeException) {
+            return self::createRequestOrResponseRejection(
+                $easy,
+                $easy->responseBodySizeException->getMessage(),
+                $easy->responseBodySizeException
             );
         }
 
         if ($easy->progressAborted && $easy->errno === \CURLE_ABORTED_BY_CALLBACK) {
-            if ($easy->response) {
-                /** @var PromiseInterface<ResponseInterface, mixed> */
-                return P\Create::rejectionFor(
-                    new ResponseException(
-                        'The transfer was aborted by the progress callback',
-                        $easy->request,
-                        $easy->response,
-                        null
-                    )
-                );
-            }
-
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(
-                new RequestException(
-                    'The transfer was aborted by the progress callback',
-                    $easy->request,
-                    0,
-                    null
-                )
+            return self::createRequestOrResponseRejection(
+                $easy,
+                'The transfer was aborted by the progress callback'
             );
         }
 
@@ -925,26 +873,47 @@ final class CurlFactory implements CurlFactoryInterface
 
         if ($easy->errno === \CURLE_OPERATION_TIMEOUTED) {
             if ($easy->response !== null) {
-                $error = new ResponseTimeoutException($message, $easy->request, $easy->response);
+                $error = new ResponseTimeoutException($message, $easy->request, $easy->response, $previous);
             } elseif (self::isConnectTimeoutError($ctx['error'] ?? '')) {
-                $error = new ConnectTimeoutException($message, $easy->request);
+                $error = new ConnectTimeoutException($message, $easy->request, $previous);
             } else {
-                $error = new NetworkTimeoutException($message, $easy->request);
+                $error = new NetworkTimeoutException($message, $easy->request, $previous);
             }
         } elseif ($easy->response) {
             $error = self::isResponseTransferError($easy->errno)
-                ? new ResponseTransferException($message, $easy->request, $easy->response)
-                : new ResponseException($message, $easy->request, $easy->response);
+                ? new ResponseTransferException($message, $easy->request, $easy->response, $previous)
+                : new ResponseException($message, $easy->request, $easy->response, $previous);
         } elseif (self::isConnectionError($easy->errno)) {
-            $error = new ConnectException($message, $easy->request);
+            $error = new ConnectException($message, $easy->request, $previous);
         } elseif (self::isNetworkError($easy->errno)) {
-            $error = new NetworkException($message, $easy->request);
+            $error = new NetworkException($message, $easy->request, $previous);
         } else {
-            $error = new RequestException($message, $easy->request);
+            $error = new RequestException($message, $easy->request, 0, $previous);
         }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */
         return P\Create::rejectionFor($error);
+    }
+
+    /**
+     * @return PromiseInterface<ResponseInterface, mixed>
+     */
+    private static function createRequestOrResponseRejection(
+        EasyHandle $easy,
+        string $message,
+        ?\Throwable $previous = null
+    ): PromiseInterface {
+        if ($easy->response !== null) {
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(
+                new ResponseException($message, $easy->request, $easy->response, $previous)
+            );
+        }
+
+        /** @var PromiseInterface<ResponseInterface, mixed> */
+        return P\Create::rejectionFor(
+            new RequestException($message, $easy->request, 0, $previous)
+        );
     }
 
     private static function isConnectionError(int $errno): bool
@@ -1213,13 +1182,35 @@ final class CurlFactory implements CurlFactoryInterface
         return $type !== 'ENG' && $type !== 'PROV';
     }
 
-    private function applyMethod(EasyHandle $easy, array &$conf): void
+    private static function responseContentLengthOverflows(EasyHandle $easy): bool
+    {
+        if ($easy->response === null) {
+            return false;
+        }
+
+        $length = HeaderProcessor::parseContentLengthForResponseBody($easy->request, $easy->response);
+        if (!HeaderProcessor::contentLengthExceedsPlatformLimit($length)) {
+            return false;
+        }
+
+        $easy->responseBodySizeException = new \OverflowException('Content-Length exceeds the maximum integer size supported on this platform');
+
+        return true;
+    }
+
+    private function applyMethod(EasyHandle $easy, array &$conf, ?string $contentLength): void
     {
         $body = $easy->request->getBody();
-        $size = $body->getSize();
+        try {
+            $size = $body->getSize();
+        } catch (TimeoutException $e) {
+            throw $e;
+        } catch (\RuntimeException $e) {
+            throw new RequestException($e->getMessage(), $easy->request, 0, $e);
+        }
 
         if ($size === null || $size > 0) {
-            $this->applyBody($easy, $conf);
+            $this->applyBody($easy, $conf, $contentLength);
 
             return;
         }
@@ -1241,25 +1232,48 @@ final class CurlFactory implements CurlFactoryInterface
         }
     }
 
-    private function applyBody(EasyHandle $easy, array &$conf): void
+    private static function requestContentLength(RequestInterface $request): ?string
+    {
+        try {
+            $length = HeaderProcessor::parseContentLength($request->getHeader('Content-Length'));
+        } catch (\RuntimeException $e) {
+            throw new RequestException(
+                'Invalid Content-Length request header',
+                $request,
+                0,
+                $e
+            );
+        }
+
+        if (HeaderProcessor::contentLengthExceedsPlatformLimit($length)) {
+            throw new RequestException(
+                'Content-Length exceeds the maximum integer size supported on this platform',
+                $request
+            );
+        }
+
+        return $length;
+    }
+
+    private function applyBody(EasyHandle $easy, array &$conf, ?string $contentLengthHeader): void
     {
         $request = $easy->request;
         $options = $easy->options;
-        $size = $request->hasHeader('Content-Length')
-            ? (int) $request->getHeaderLine('Content-Length')
-            : null;
+        $contentLength = HeaderProcessor::contentLengthToInt($contentLengthHeader);
 
         // Send the body as a string if the size is less than 1MB OR if the
         // [curl][body_as_string] request value is set.
-        if (($size !== null && $size < 1000000) || !empty($options['_body_as_string'])) {
+        if (($contentLength !== null && $contentLength < 1000000) || !empty($options['_body_as_string'])) {
             $conf[\CURLOPT_POSTFIELDS] = (string) $request->getBody();
             // Don't duplicate the Content-Length header
             $this->removeHeader('Content-Length', $conf);
             $this->removeHeader('Transfer-Encoding', $conf);
         } else {
             $conf[\CURLOPT_UPLOAD] = true;
-            if ($size !== null) {
-                $conf[\CURLOPT_INFILESIZE] = $size;
+            if ($contentLength !== null) {
+                $conf[\CURLOPT_INFILESIZE] = $contentLength;
+                $this->removeHeader('Content-Length', $conf);
+            } elseif ($contentLengthHeader !== null) {
                 $this->removeHeader('Content-Length', $conf);
             }
             $body = $request->getBody();
@@ -1416,8 +1430,22 @@ final class CurlFactory implements CurlFactoryInterface
         }
         $easy->sink = $sink;
         $conf[\CURLOPT_WRITEFUNCTION] = static function ($ch, string $write) use ($easy, $sink): int {
+            $length = \strlen($write);
+
             try {
-                return $sink->write($write);
+                $newResponseBodyBytes = TransferByteCounter::add(
+                    $easy->responseBodyBytes,
+                    $length,
+                    'Response body exceeds the maximum integer size supported on this platform'
+                );
+            } catch (\OverflowException $e) {
+                $easy->responseBodySizeException = $e;
+
+                return 0;
+            }
+
+            try {
+                $written = $sink->write($write);
             } catch (TimeoutException $e) {
                 $easy->sinkWriteTimeoutException = $e;
 
@@ -1427,6 +1455,12 @@ final class CurlFactory implements CurlFactoryInterface
 
                 return 0;
             }
+
+            if ($written === $length) {
+                $easy->responseBodyBytes = $newResponseBodyBytes;
+            }
+
+            return $written;
         };
 
         $timeoutRequiresNoSignal = false;
@@ -1616,7 +1650,12 @@ final class CurlFactory implements CurlFactoryInterface
                 }
 
                 try {
-                    if ($progress((int) $downloadSize, (int) $downloaded, (int) $uploadSize, (int) $uploaded)) {
+                    if ($progress(
+                        TransferByteCounter::progressValueToInt($downloadSize),
+                        TransferByteCounter::progressValueToInt($downloaded),
+                        TransferByteCounter::progressValueToInt($uploadSize),
+                        TransferByteCounter::progressValueToInt($uploaded)
+                    )) {
                         $easy->progressAborted = true;
 
                         return 1;
@@ -1670,7 +1709,7 @@ final class CurlFactory implements CurlFactoryInterface
                 .'but attempting to rewind the request body failed. '
                 .'Exception: '.$e;
 
-            return self::createRejection($easy, $ctx);
+            return self::createRejection($easy, $ctx, $e);
         }
 
         // Retry no more than 3 times before giving up.
@@ -1732,6 +1771,9 @@ final class CurlFactory implements CurlFactoryInterface
 
                         return -1;
                     }
+                }
+                if (self::responseContentLengthOverflows($easy)) {
+                    return -1;
                 }
             } elseif ($startingResponse) {
                 $startingResponse = false;

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -624,7 +624,7 @@ final class CurlFactory implements CurlFactoryInterface
             }
         } catch (\Throwable $e) {
             $reason = new ResponseException(
-                $e->getMessage() !== '' ? $e->getMessage() : 'The cURL handler failed to rewind the response body',
+                $e->getMessage() !== '' ? $e->getMessage() : 'Failed to rewind the response body',
                 $easy->request,
                 $response,
                 $e
@@ -713,6 +713,7 @@ final class CurlFactory implements CurlFactoryInterface
             || $easy->bodyReadException !== null
             || $easy->sinkWriteTimeoutException !== null
             || $easy->sinkWriteException !== null
+            || $easy->sinkWriteIncomplete
             || $easy->responseBodySizeException !== null;
     }
 
@@ -782,11 +783,10 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         if ($easy->bodyReadTimeoutException) {
-            // Reading the request body stalled: a caller-source failure, not the
-            // network. Classify by phase (see contributing exception guidelines).
+            // Reading the request body stalled, which is a caller-stream failure.
             return self::createRequestOrResponseRejection(
                 $easy,
-                'The cURL handler timed out while reading the request body',
+                'Timed out while reading the request body',
                 $easy->bodyReadTimeoutException
             );
         }
@@ -794,18 +794,17 @@ final class CurlFactory implements CurlFactoryInterface
         if ($easy->bodyReadException) {
             $message = $easy->bodyReadException->getMessage() !== ''
                 ? $easy->bodyReadException->getMessage()
-                : 'The cURL handler failed while reading the request body';
+                : 'Failed to read the request body';
 
             return self::createRequestOrResponseRejection($easy, $message, $easy->bodyReadException);
         }
 
         if ($easy->sinkWriteTimeoutException) {
-            // Writing the response body to the caller's sink stalled: a
-            // caller-stream failure, not the network. Classify by phase (see
-            // contributing exception guidelines).
+            // Writing the response body to the caller's sink stalled, which is a
+            // caller-stream failure.
             return self::createRequestOrResponseRejection(
                 $easy,
-                'The cURL handler timed out while writing the response body',
+                'Timed out while writing the response body',
                 $easy->sinkWriteTimeoutException
             );
         }
@@ -813,9 +812,13 @@ final class CurlFactory implements CurlFactoryInterface
         if ($easy->sinkWriteException) {
             $message = $easy->sinkWriteException->getMessage() !== ''
                 ? $easy->sinkWriteException->getMessage()
-                : 'The cURL handler failed while writing the response body';
+                : 'Failed to write the response body';
 
             return self::createRequestOrResponseRejection($easy, $message, $easy->sinkWriteException);
+        }
+
+        if ($easy->sinkWriteIncomplete) {
+            return self::createRequestOrResponseRejection($easy, 'Unable to write to stream');
         }
 
         if ($easy->responseBodySizeException) {
@@ -1216,7 +1219,7 @@ final class CurlFactory implements CurlFactoryInterface
             $length = HeaderProcessor::parseContentLength($request->getHeader('Content-Length'));
         } catch (\RuntimeException $e) {
             throw new RequestException(
-                'Invalid Content-Length request header',
+                'Invalid Content-Length request header: '.$e->getMessage(),
                 $request,
                 0,
                 $e
@@ -1246,7 +1249,7 @@ final class CurlFactory implements CurlFactoryInterface
                 $conf[\CURLOPT_POSTFIELDS] = (string) $request->getBody();
             } catch (\Throwable $e) {
                 throw new RequestException(
-                    $e->getMessage() !== '' ? $e->getMessage() : 'The cURL handler failed while reading the request body',
+                    $e->getMessage() !== '' ? $e->getMessage() : 'Failed to read the request body',
                     $request,
                     0,
                     $e
@@ -1274,7 +1277,7 @@ final class CurlFactory implements CurlFactoryInterface
                 }
             } catch (\Throwable $e) {
                 throw new RequestException(
-                    $e->getMessage() !== '' ? $e->getMessage() : 'The cURL handler failed to rewind the request body',
+                    $e->getMessage() !== '' ? $e->getMessage() : 'Failed to rewind the request body',
                     $request,
                     0,
                     $e
@@ -1460,9 +1463,13 @@ final class CurlFactory implements CurlFactoryInterface
                 return 0;
             }
 
-            if ($written === $length) {
-                $easy->responseBodyBytes = $newResponseBodyBytes;
+            if ($written !== $length) {
+                $easy->sinkWriteIncomplete = true;
+
+                return 0;
             }
+
+            $easy->responseBodyBytes = $newResponseBodyBytes;
 
             return $written;
         };

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -800,27 +800,13 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         if ($easy->sinkWriteTimeoutException) {
-            $ctx['timed_out'] = true;
-
-            if ($easy->response) {
-                /** @var PromiseInterface<ResponseInterface, mixed> */
-                return P\Create::rejectionFor(
-                    new ResponseException(
-                        'The cURL handler timed out while writing the response body',
-                        $easy->request,
-                        $easy->response,
-                        $easy->sinkWriteTimeoutException
-                    )
-                );
-            }
-
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(
-                new NetworkTimeoutException(
-                    'The cURL handler timed out while transferring the response body',
-                    $easy->request,
-                    $easy->sinkWriteTimeoutException
-                )
+            // Writing the response body to the caller's sink stalled: a
+            // caller-stream failure, not the network. Classify by phase (see
+            // contributing exception guidelines).
+            return self::createRequestOrResponseRejection(
+                $easy,
+                'The cURL handler timed out while writing the response body',
+                $easy->sinkWriteTimeoutException
             );
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1172,13 +1172,15 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         $length = HeaderProcessor::parseContentLengthForResponseBody($easy->request, $easy->response);
-        if (!HeaderProcessor::contentLengthExceedsPlatformLimit($length)) {
-            return false;
+        try {
+            HeaderProcessor::assertContentLengthWithinPlatformLimit($length);
+        } catch (\OverflowException $e) {
+            $easy->responseBodySizeException = $e;
+
+            return true;
         }
 
-        $easy->responseBodySizeException = new \OverflowException('Content-Length exceeds the maximum integer size supported on this platform');
-
-        return true;
+        return false;
     }
 
     private function applyMethod(EasyHandle $easy, array &$conf, ?string $contentLength): void
@@ -1226,10 +1228,14 @@ final class CurlFactory implements CurlFactoryInterface
             );
         }
 
-        if (HeaderProcessor::contentLengthExceedsPlatformLimit($length)) {
+        try {
+            HeaderProcessor::assertContentLengthWithinPlatformLimit($length);
+        } catch (\OverflowException $e) {
             throw new RequestException(
-                'Content-Length exceeds the maximum integer size supported on this platform',
-                $request
+                $e->getMessage(),
+                $request,
+                0,
+                $e
             );
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -710,6 +710,7 @@ final class CurlFactory implements CurlFactoryInterface
     private static function hasLocalFailure(EasyHandle $easy): bool
     {
         return $easy->bodyReadTimeoutException !== null
+            || $easy->bodyReadException !== null
             || $easy->sinkWriteTimeoutException !== null
             || $easy->sinkWriteException !== null
             || $easy->responseBodySizeException !== null;
@@ -803,6 +804,14 @@ final class CurlFactory implements CurlFactoryInterface
                     $easy->bodyReadTimeoutException
                 )
             );
+        }
+
+        if ($easy->bodyReadException) {
+            $message = $easy->bodyReadException->getMessage() !== ''
+                ? $easy->bodyReadException->getMessage()
+                : 'The cURL handler failed while reading the request body';
+
+            return self::createRequestOrResponseRejection($easy, $message, $easy->bodyReadException);
         }
 
         if ($easy->sinkWriteTimeoutException) {
@@ -1264,21 +1273,47 @@ final class CurlFactory implements CurlFactoryInterface
         // Send the body as a string if the size is less than 1MB OR if the
         // [curl][body_as_string] request value is set.
         if (($contentLength !== null && $contentLength < 1000000) || !empty($options['_body_as_string'])) {
-            $conf[\CURLOPT_POSTFIELDS] = (string) $request->getBody();
+            try {
+                $conf[\CURLOPT_POSTFIELDS] = (string) $request->getBody();
+            } catch (TimeoutException $e) {
+                throw $e;
+            } catch (\Throwable $e) {
+                throw new RequestException(
+                    $e->getMessage() !== '' ? $e->getMessage() : 'The cURL handler failed while reading the request body',
+                    $request,
+                    0,
+                    $e
+                );
+            }
             // Don't duplicate the Content-Length header
             $this->removeHeader('Content-Length', $conf);
             $this->removeHeader('Transfer-Encoding', $conf);
         } else {
             $conf[\CURLOPT_UPLOAD] = true;
-            if ($contentLength !== null) {
-                $conf[\CURLOPT_INFILESIZE] = $contentLength;
-                $this->removeHeader('Content-Length', $conf);
-            } elseif ($contentLengthHeader !== null) {
+
+            if ($contentLengthHeader !== null) {
+                // Never let cURL emit our header; it sizes the upload via CURLOPT_INFILESIZE.
                 $this->removeHeader('Content-Length', $conf);
             }
+
+            if ($contentLength !== null) {
+                $conf[\CURLOPT_INFILESIZE] = $contentLength;
+            }
+
             $body = $request->getBody();
-            if ($body->isSeekable()) {
-                $body->rewind();
+            try {
+                if ($body->isSeekable()) {
+                    $body->rewind();
+                }
+            } catch (TimeoutException $e) {
+                throw $e;
+            } catch (\Throwable $e) {
+                throw new RequestException(
+                    $e->getMessage() !== '' ? $e->getMessage() : 'The cURL handler failed to rewind the request body',
+                    $request,
+                    0,
+                    $e
+                );
             }
             /**
              * @return int|string
@@ -1288,6 +1323,10 @@ final class CurlFactory implements CurlFactoryInterface
                     return $body->read($length);
                 } catch (TimeoutException $e) {
                     $easy->bodyReadTimeoutException = $e;
+
+                    return self::CURL_READFUNC_ABORT;
+                } catch (\Throwable $e) {
+                    $easy->bodyReadException = $e;
 
                     return self::CURL_READFUNC_ABORT;
                 }
@@ -1626,22 +1665,22 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         // The streaming read callback (set by applyBody) aborts the upload on a
-        // body read timeout by returning CURL_READFUNC_ABORT, but PHP ignores
+        // body read failure by returning CURL_READFUNC_ABORT, but PHP ignores
         // that integer return before 8.1.17/8.2.4. Install a progress callback
         // so older PHP still has a cross-version abort path; the failure is
-        // classified from `$easy->bodyReadTimeoutException` regardless of errno
+        // classified from the stored request-body exception regardless of errno
         // (a truncated request may reach the server first on those versions).
-        $abortsOnBodyReadTimeout = isset($conf[\CURLOPT_READFUNCTION]);
+        $abortsOnBodyReadFailure = isset($conf[\CURLOPT_READFUNCTION]);
 
-        if ($progress !== null || $abortsOnBodyReadTimeout) {
+        if ($progress !== null || $abortsOnBodyReadFailure) {
             /** @var (callable(int, int, int, int): mixed)|null $progress */
             $conf[\CURLOPT_NOPROGRESS] = false;
             $progressCallback = static function ($resource, $downloadSize, $downloaded, $uploadSize, $uploaded) use ($easy, $progress): int {
-                // Abort the transfer when the request body read timed out (the
+                // Abort the transfer when the request body read failed (the
                 // cross-version abort path, since older PHP ignores the read
                 // callback's return). progressAborted is left unset so the
-                // failure is classified from `$easy->bodyReadTimeoutException`.
-                if ($easy->bodyReadTimeoutException !== null) {
+                // failure is classified from the stored request-body exception.
+                if ($easy->bodyReadTimeoutException !== null || $easy->bodyReadException !== null) {
                     return 1;
                 }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -782,27 +782,12 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         if ($easy->bodyReadTimeoutException) {
-            $ctx['timed_out'] = true;
-
-            if ($easy->response) {
-                /** @var PromiseInterface<ResponseInterface, mixed> */
-                return P\Create::rejectionFor(
-                    new ResponseException(
-                        'The cURL handler timed out while transferring the request body',
-                        $easy->request,
-                        $easy->response,
-                        $easy->bodyReadTimeoutException
-                    )
-                );
-            }
-
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(
-                new NetworkTimeoutException(
-                    'The cURL handler timed out while transferring the request body',
-                    $easy->request,
-                    $easy->bodyReadTimeoutException
-                )
+            // Reading the request body stalled: a caller-source failure, not the
+            // network. Classify by phase (see contributing exception guidelines).
+            return self::createRequestOrResponseRejection(
+                $easy,
+                'The cURL handler timed out while reading the request body',
+                $easy->bodyReadTimeoutException
             );
         }
 
@@ -1212,8 +1197,6 @@ final class CurlFactory implements CurlFactoryInterface
         $body = $easy->request->getBody();
         try {
             $size = $body->getSize();
-        } catch (TimeoutException $e) {
-            throw $e;
         } catch (\RuntimeException $e) {
             throw new RequestException($e->getMessage(), $easy->request, 0, $e);
         }
@@ -1275,8 +1258,6 @@ final class CurlFactory implements CurlFactoryInterface
         if (($contentLength !== null && $contentLength < 1000000) || !empty($options['_body_as_string'])) {
             try {
                 $conf[\CURLOPT_POSTFIELDS] = (string) $request->getBody();
-            } catch (TimeoutException $e) {
-                throw $e;
             } catch (\Throwable $e) {
                 throw new RequestException(
                     $e->getMessage() !== '' ? $e->getMessage() : 'The cURL handler failed while reading the request body',
@@ -1305,8 +1286,6 @@ final class CurlFactory implements CurlFactoryInterface
                 if ($body->isSeekable()) {
                     $body->rewind();
                 }
-            } catch (TimeoutException $e) {
-                throw $e;
             } catch (\Throwable $e) {
                 throw new RequestException(
                     $e->getMessage() !== '' ? $e->getMessage() : 'The cURL handler failed to rewind the request body',

--- a/src/Handler/CurlHandler.php
+++ b/src/Handler/CurlHandler.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Handler;
 
-use GuzzleHttp\Exception\NetworkTimeoutException;
-use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\TransportSharing;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -73,16 +70,7 @@ final class CurlHandler
             \usleep((int) ($options['delay'] * 1000));
         }
 
-        try {
-            $easy = $this->factory->create($request, $options);
-        } catch (TimeoutException $e) {
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(new NetworkTimeoutException(
-                'The cURL handler timed out while transferring the request body',
-                $request,
-                $e
-            ));
-        }
+        $easy = $this->factory->create($request, $options);
 
         \curl_exec($easy->handle);
         $easy->errno = \curl_errno($easy->handle);

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -579,7 +579,8 @@ final class CurlMultiHandler
     {
         while ($done = \curl_multi_info_read($this->getMultiHandle())) {
             if ($done['msg'] !== \CURLMSG_DONE) {
-                // if it's not done, then it would be premature to remove the handle. ref https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216
+                // If it is not done, removing the handle would be premature.
+                // See https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216.
                 continue;
             }
             if (!isset($done['handle'])) {

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -7,11 +7,9 @@ namespace GuzzleHttp\Handler;
 use Closure;
 use GuzzleHttp\Exception\HandlerClosedException;
 use GuzzleHttp\Exception\InvalidArgumentException;
-use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
@@ -141,16 +139,7 @@ final class CurlMultiHandler
     {
         $this->assertOpen();
 
-        try {
-            $easy = $this->factory->create($request, $options);
-        } catch (TimeoutException $e) {
-            /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(new NetworkTimeoutException(
-                'The cURL handler timed out while transferring the request body',
-                $request,
-                $e
-            ));
-        }
+        $easy = $this->factory->create($request, $options);
 
         $id = (int) $easy->handle;
 

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -73,6 +73,11 @@ final class EasyHandle
     public ?TimeoutException $bodyReadTimeoutException = null;
 
     /**
+     * @var \Throwable|null Exception during request body read.
+     */
+    public ?\Throwable $bodyReadException = null;
+
+    /**
      * @var TimeoutException|null Exception during response sink write timeout.
      */
     public ?TimeoutException $sinkWriteTimeoutException = null;

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -83,6 +83,16 @@ final class EasyHandle
     public ?\Throwable $sinkWriteException = null;
 
     /**
+     * @var int Number of response body bytes accepted by the sink.
+     */
+    public int $responseBodyBytes = 0;
+
+    /**
+     * @var \OverflowException|null Unrepresentable response body size or byte count.
+     */
+    public ?\OverflowException $responseBodySizeException = null;
+
+    /**
      * Attach a response to the easy handle based on the received headers.
      *
      * @throws \RuntimeException if no headers have been received or the first
@@ -91,6 +101,8 @@ final class EasyHandle
     public function createResponse(): void
     {
         $this->response = null;
+        $this->responseBodyBytes = 0;
+        $this->responseBodySizeException = null;
 
         [$ver, $status, $reason, $headers] = HeaderProcessor::parseHeaders($this->headers);
 
@@ -109,7 +121,11 @@ final class EasyHandle
             if (isset($normalizedKeys['content-length'])) {
                 $headers['x-encoded-content-length'] = $headers[$normalizedKeys['content-length']];
 
-                $bodyLength = (int) $this->sink->getSize();
+                try {
+                    $bodyLength = $this->sink->getSize();
+                } catch (\RuntimeException $e) {
+                    $bodyLength = null;
+                }
                 if ($bodyLength) {
                     $headers[$normalizedKeys['content-length']] = [(string) $bodyLength];
                 } else {

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -88,6 +88,11 @@ final class EasyHandle
     public ?\Throwable $sinkWriteException = null;
 
     /**
+     * @var bool Whether the response sink accepted a different byte count.
+     */
+    public bool $sinkWriteIncomplete = false;
+
+    /**
      * @var int Number of response body bytes accepted by the sink.
      */
     public int $responseBodyBytes = 0;

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -129,9 +129,13 @@ final class HeaderProcessor
         return (int) $length;
     }
 
-    public static function contentLengthExceedsPlatformLimit(?string $length): bool
+    public static function assertContentLengthWithinPlatformLimit(?string $length): void
     {
-        return $length !== null && self::contentLengthToInt($length) === null;
+        if ($length === null || self::contentLengthToInt($length) !== null) {
+            return;
+        }
+
+        throw new \OverflowException('Content-Length exceeds the maximum integer size supported on this platform');
     }
 
     public static function parseContentLengthForResponseBody(RequestInterface $request, ResponseInterface $response): ?string

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -78,7 +78,7 @@ final class HeaderProcessor
     }
 
     /**
-     * Returns a normalized decimal string.
+     * Returns a normalized decimal Content-Length, or null when absent.
      *
      * @param string[] $values
      *
@@ -92,13 +92,13 @@ final class HeaderProcessor
             foreach (\explode(',', $value) as $part) {
                 $part = \trim($part, " \t");
                 if (\preg_match('/^[0-9]+$/D', $part) !== 1) {
-                    throw new \RuntimeException('Content-Length header value is invalid');
+                    throw new \RuntimeException('value is not a non-negative decimal integer');
                 }
 
                 $part = \ltrim($part, '0');
                 $part = $part === '' ? '0' : $part;
                 if ($length !== null && $part !== $length) {
-                    throw new \RuntimeException('Content-Length header values conflict');
+                    throw new \RuntimeException('values conflict');
                 }
 
                 $length = $part;

--- a/src/Handler/HeaderProcessor.php
+++ b/src/Handler/HeaderProcessor.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Utils;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @internal
@@ -73,6 +75,89 @@ final class HeaderProcessor
         }
 
         return [$version, (int) $status, $reason, Utils::headersFromLines($headers)];
+    }
+
+    /**
+     * Returns a normalized decimal string.
+     *
+     * @param string[] $values
+     *
+     * @throws \RuntimeException when Content-Length is malformed or conflicting.
+     */
+    public static function parseContentLength(array $values): ?string
+    {
+        $length = null;
+
+        foreach ($values as $value) {
+            foreach (\explode(',', $value) as $part) {
+                $part = \trim($part, " \t");
+                if (\preg_match('/^[0-9]+$/D', $part) !== 1) {
+                    throw new \RuntimeException('Content-Length header value is invalid');
+                }
+
+                $part = \ltrim($part, '0');
+                $part = $part === '' ? '0' : $part;
+                if ($length !== null && $part !== $length) {
+                    throw new \RuntimeException('Content-Length header values conflict');
+                }
+
+                $length = $part;
+            }
+        }
+
+        if ($length === null) {
+            return null;
+        }
+
+        return $length;
+    }
+
+    public static function contentLengthToInt(?string $length): ?int
+    {
+        if ($length === null) {
+            return null;
+        }
+
+        $max = (string) \PHP_INT_MAX;
+        if (
+            \strlen($length) > \strlen($max)
+            || (\strlen($length) === \strlen($max) && \strcmp($length, $max) > 0)
+        ) {
+            return null;
+        }
+
+        return (int) $length;
+    }
+
+    public static function contentLengthExceedsPlatformLimit(?string $length): bool
+    {
+        return $length !== null && self::contentLengthToInt($length) === null;
+    }
+
+    public static function parseContentLengthForResponseBody(RequestInterface $request, ResponseInterface $response): ?string
+    {
+        if (!self::responseCanHaveContentLengthBody($request, $response)) {
+            return null;
+        }
+
+        try {
+            return self::parseContentLength($response->getHeader('Content-Length'));
+        } catch (\RuntimeException $e) {
+            return null;
+        }
+    }
+
+    private static function responseCanHaveContentLengthBody(RequestInterface $request, ResponseInterface $response): bool
+    {
+        $status = $response->getStatusCode();
+        $method = $request->getMethod();
+
+        return $method !== 'HEAD'
+            && !($method === 'CONNECT' && $status >= 200 && $status < 300)
+            && $status >= 200
+            && $status !== 204
+            && $status !== 304
+            && !$response->hasHeader('Transfer-Encoding');
     }
 
     /**

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\ResponseTimeoutException;
 use GuzzleHttp\Exception\ResponseTransferException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\ProxyOptions;
@@ -120,7 +121,7 @@ final class StreamHandler
                 throw $e;
             }
 
-            if (!$e instanceof NetworkException) {
+            if (!$e instanceof TransferException) {
                 $message = $e->getMessage();
                 if (self::isSendError($message)) {
                     $e = self::isConnectTimeoutError($message)
@@ -132,7 +133,7 @@ final class StreamHandler
                     $e = new ConnectException($message, $request, $e);
                 } elseif (self::isNetworkError($message)) {
                     $e = new NetworkException($message, $request, $e);
-                } elseif (!$e instanceof RequestException) {
+                } else {
                     $e = new RequestException($message, $request, 0, $e);
                 }
             }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -412,7 +412,7 @@ final class StreamHandler
                 throw $e;
             } catch (TimeoutException $e) {
                 throw new ResponseTimeoutException(
-                    'The stream handler timed out while transferring the response body',
+                    'Timed out while transferring the response body',
                     $request,
                     $response,
                     $e
@@ -420,10 +420,10 @@ final class StreamHandler
             } catch (\OverflowException $e) {
                 throw new ResponseException($e->getMessage(), $request, $response, $e);
             } catch (\Throwable $e) {
-                // Any other failure while reading the response body off the network
-                // surfaces as a ResponseTransferException carrying the response.
+                // Any other response-body transfer failure surfaces as a
+                // ResponseTransferException carrying the response.
                 throw new ResponseTransferException(
-                    $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed while transferring the response body',
+                    $e->getMessage() !== '' ? $e->getMessage() : 'Failed while transferring the response body',
                     $request,
                     $response,
                     $e
@@ -432,7 +432,7 @@ final class StreamHandler
 
             if ($declaredLength !== null && $copied < $declaredLength) {
                 throw new ResponseTransferException(
-                    'The stream handler received fewer bytes than the declared Content-Length',
+                    'Response body ended before the declared Content-Length was reached',
                     $request,
                     $response
                 );
@@ -444,7 +444,7 @@ final class StreamHandler
                 }
             } catch (\Throwable $e) {
                 throw new ResponseException(
-                    $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed to rewind the response body',
+                    $e->getMessage() !== '' ? $e->getMessage() : 'Failed to rewind the response body',
                     $request,
                     $response,
                     $e
@@ -486,7 +486,7 @@ final class StreamHandler
             $length = HeaderProcessor::parseContentLength($request->getHeader('Content-Length'));
         } catch (\RuntimeException $e) {
             throw new RequestException(
-                'Invalid Content-Length request header',
+                'Invalid Content-Length request header: '.$e->getMessage(),
                 $request,
                 0,
                 $e
@@ -516,14 +516,14 @@ final class StreamHandler
                     $written = $sink->write($data);
                 } catch (TimeoutException $e) {
                     throw new ResponseException(
-                        'The stream handler timed out while writing the response body',
+                        'Timed out while writing the response body',
                         $request,
                         $response,
                         $e
                     );
                 } catch (\Throwable $e) {
                     throw new ResponseException(
-                        $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed while writing the response body',
+                        $e->getMessage() !== '' ? $e->getMessage() : 'Failed to write the response body',
                         $request,
                         $response,
                         $e
@@ -661,7 +661,7 @@ final class StreamHandler
             function () use ($uri, $contextResource, $readTimeout) {
                 $resource = @\fopen((string) $uri, 'r', false, $contextResource);
 
-                // See https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_http_response_header_predefined_variable
+                // PHP 8.5 deprecates the local $http_response_header variable.
                 if (function_exists('http_get_last_response_headers')) {
                     $http_response_header = \http_get_last_response_headers();
                 }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -465,14 +465,14 @@ final class StreamHandler
     private static function declaredResponseBodyLength(RequestInterface $request, ResponseInterface $response): ?int
     {
         $parsed = HeaderProcessor::parseContentLengthForResponseBody($request, $response);
-        if (HeaderProcessor::contentLengthExceedsPlatformLimit($parsed)) {
-            $overflow = new \OverflowException('Content-Length exceeds the maximum integer size supported on this platform');
-
+        try {
+            HeaderProcessor::assertContentLengthWithinPlatformLimit($parsed);
+        } catch (\OverflowException $e) {
             throw new ResponseException(
-                'Content-Length exceeds the maximum integer size supported on this platform',
+                $e->getMessage(),
                 $request,
                 $response,
-                $overflow
+                $e
             );
         }
 
@@ -494,10 +494,14 @@ final class StreamHandler
             );
         }
 
-        if (HeaderProcessor::contentLengthExceedsPlatformLimit($length)) {
+        try {
+            HeaderProcessor::assertContentLengthWithinPlatformLimit($length);
+        } catch (\OverflowException $e) {
             throw new RequestException(
-                'Content-Length exceeds the maximum integer size supported on this platform',
-                $request
+                $e->getMessage(),
+                $request,
+                0,
+                $e
             );
         }
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -120,9 +120,7 @@ final class StreamHandler
                 throw $e;
             }
 
-            if ($e instanceof TimeoutException) {
-                $e = new NetworkTimeoutException('The stream handler timed out while transferring the request body', $request, $e);
-            } elseif (!$e instanceof NetworkException) {
+            if (!$e instanceof NetworkException) {
                 $message = $e->getMessage();
                 if (self::isSendError($message)) {
                     $e = self::isConnectTimeoutError($message)
@@ -159,8 +157,6 @@ final class StreamHandler
         // the behavior of `CurlHandler`
         try {
             $bodySize = $request->getBody()->getSize();
-        } catch (TimeoutException $e) {
-            throw new NetworkTimeoutException('The stream handler timed out while preparing the request body', $request, $e);
         } catch (\RuntimeException $e) {
             throw new RequestException($e->getMessage(), $request, 0, $e);
         }
@@ -795,7 +791,11 @@ final class StreamHandler
             ],
         ];
 
-        $body = (string) $request->getBody();
+        try {
+            $body = (string) $request->getBody();
+        } catch (\RuntimeException $e) {
+            throw new RequestException($e->getMessage(), $request, 0, $e);
+        }
 
         if ('' !== $body) {
             $context['http']['content'] = $body;

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -104,16 +104,9 @@ final class StreamHandler
 
         self::rejectUnsupportedRequestOptions($request, $options);
 
+        $request = self::prepareRequest($request);
+
         try {
-            // Does not support the expect header.
-            $request = $request->withoutHeader('Expect');
-
-            // Append a content-length header if body size is zero to match
-            // the behavior of `CurlHandler`
-            if (($request->getMethod() === 'PUT' || $request->getMethod() === 'POST') && 0 === $request->getBody()->getSize()) {
-                $request = $request->withHeader('Content-Length', '0');
-            }
-
             return $this->createResponse(
                 $request,
                 $options,
@@ -150,6 +143,33 @@ final class StreamHandler
             /** @var PromiseInterface<ResponseInterface, mixed> */
             return P\Create::rejectionFor($e);
         }
+    }
+
+    private static function prepareRequest(RequestInterface $request): RequestInterface
+    {
+        $contentLength = self::requestContentLength($request);
+        if ($contentLength !== null) {
+            $request = $request->withHeader('Content-Length', $contentLength);
+        }
+
+        // Does not support the expect header.
+        $request = $request->withoutHeader('Expect');
+
+        // Append a content-length header if body size is zero to match
+        // the behavior of `CurlHandler`
+        try {
+            $bodySize = $request->getBody()->getSize();
+        } catch (TimeoutException $e) {
+            throw new NetworkTimeoutException('The stream handler timed out while preparing the request body', $request, $e);
+        } catch (\RuntimeException $e) {
+            throw new RequestException($e->getMessage(), $request, 0, $e);
+        }
+
+        if (($request->getMethod() === 'PUT' || $request->getMethod() === 'POST') && 0 === $bodySize) {
+            $request = $request->withHeader('Content-Length', '0');
+        }
+
+        return $request;
     }
 
     private function isOnStatsException(\Throwable $e): bool
@@ -267,7 +287,7 @@ final class StreamHandler
         // no body.
         if ($sink !== $stream) {
             try {
-                $this->drain($request, $response, $stream, $sink, $response->getHeaderLine('Content-Length'));
+                $this->drain($request, $response, $stream, $sink);
             } catch (ResponseException $e) {
                 $this->invokeStats($options, $request, $startTime, $response, $e);
 
@@ -373,71 +393,69 @@ final class StreamHandler
     /**
      * Drains the source stream into the "sink" client option.
      *
-     * @param string $contentLength Header specifying the amount of
-     *                              data to read.
-     *
      * @throws \RuntimeException when the sink option is invalid.
      */
     private function drain(
         RequestInterface $request,
         ResponseInterface $response,
         StreamInterface $source,
-        StreamInterface $sink,
-        string $contentLength
+        StreamInterface $sink
     ): StreamInterface {
-        // Keep the existing loose read bound, but only reject short bodies when
-        // the Content-Length is a valid framing promise for this response.
-        $copyLimit = (\strlen($contentLength) > 0 && (int) $contentLength > 0) ? (int) $contentLength : -1;
-        $declaredLength = self::declaredResponseBodyLength($request, $response);
-
         try {
-            $target = $this->createResponseSink($request, $response, $sink);
-            // If a content-length header is provided, then stop reading once
-            // that number of bytes has been read. This can prevent infinitely
-            // reading from a stream when dealing with servers that do not
-            // honor Connection: Close headers.
-            $copied = Psr7\Utils::copyToStream($source, $target, $copyLimit);
-        } catch (ResponseException $e) {
-            throw $e;
-        } catch (TimeoutException $e) {
-            throw new ResponseTimeoutException(
-                'The stream handler timed out while transferring the response body',
-                $request,
-                $response,
-                $e
-            );
-        } catch (\Throwable $e) {
-            // Any other failure while reading the response body off the network
-            // surfaces as a ResponseTransferException carrying the response.
-            throw new ResponseTransferException(
-                $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed while transferring the response body',
-                $request,
-                $response,
-                $e
-            );
-        }
+            $declaredLength = self::declaredResponseBodyLength($request, $response);
+            $copyLimit = $declaredLength ?? -1;
 
-        $exception = null;
-
-        if ($declaredLength !== null && $copied < $declaredLength) {
-            $exception = new ResponseTransferException(
-                'The stream handler received fewer bytes than the declared Content-Length',
-                $request,
-                $response
-            );
-        }
-
-        try {
-            if ($exception === null && $sink->isSeekable()) {
-                $sink->rewind();
+            try {
+                $target = $this->createResponseSink($request, $response, $sink);
+                // If a content-length header is provided, then stop reading once
+                // that number of bytes has been read. This can prevent infinitely
+                // reading from a stream when dealing with servers that do not
+                // honor Connection: Close headers.
+                $copied = Psr7\Utils::copyToStream($source, $target, $copyLimit);
+            } catch (ResponseException $e) {
+                throw $e;
+            } catch (TimeoutException $e) {
+                throw new ResponseTimeoutException(
+                    'The stream handler timed out while transferring the response body',
+                    $request,
+                    $response,
+                    $e
+                );
+            } catch (\OverflowException $e) {
+                throw new ResponseException($e->getMessage(), $request, $response, $e);
+            } catch (\Throwable $e) {
+                // Any other failure while reading the response body off the network
+                // surfaces as a ResponseTransferException carrying the response.
+                throw new ResponseTransferException(
+                    $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed while transferring the response body',
+                    $request,
+                    $response,
+                    $e
+                );
             }
-        } catch (\Throwable $e) {
-            $exception = new ResponseException(
-                $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed to rewind the response body',
-                $request,
-                $response,
-                $e
-            );
+
+            if ($declaredLength !== null && $copied < $declaredLength) {
+                throw new ResponseTransferException(
+                    'The stream handler received fewer bytes than the declared Content-Length',
+                    $request,
+                    $response
+                );
+            }
+
+            try {
+                if ($sink->isSeekable()) {
+                    $sink->rewind();
+                }
+            } catch (\Throwable $e) {
+                throw new ResponseException(
+                    $e->getMessage() !== '' ? $e->getMessage() : 'The stream handler failed to rewind the response body',
+                    $request,
+                    $response,
+                    $e
+                );
+            }
+
+            return $sink;
         } finally {
             try {
                 $source->close();
@@ -445,58 +463,48 @@ final class StreamHandler
                 // Best-effort cleanup after the response body has been received.
             }
         }
-
-        if ($exception !== null) {
-            throw $exception;
-        }
-
-        return $sink;
     }
 
     private static function declaredResponseBodyLength(RequestInterface $request, ResponseInterface $response): ?int
     {
-        $status = $response->getStatusCode();
-        $method = $request->getMethod();
+        $parsed = HeaderProcessor::parseContentLengthForResponseBody($request, $response);
+        if (HeaderProcessor::contentLengthExceedsPlatformLimit($parsed)) {
+            $overflow = new \OverflowException('Content-Length exceeds the maximum integer size supported on this platform');
 
-        if (
-            $method === 'HEAD'
-            || ($method === 'CONNECT' && $status >= 200 && $status < 300)
-            || $status < 200
-            || $status === 204
-            || $status === 304
-            || $response->hasHeader('Transfer-Encoding')
-        ) {
-            return null;
+            throw new ResponseException(
+                'Content-Length exceeds the maximum integer size supported on this platform',
+                $request,
+                $response,
+                $overflow
+            );
         }
 
-        $length = null;
-        foreach ($response->getHeader('Content-Length') as $value) {
-            foreach (\explode(',', $value) as $part) {
-                $part = \trim($part, " \t");
-                if (\preg_match('/^[0-9]+$/', $part) !== 1) {
-                    return null;
-                }
+        $length = HeaderProcessor::contentLengthToInt($parsed);
 
-                $part = \ltrim($part, '0');
-                $part = $part === '' ? '0' : $part;
-                if ($length !== null && $part !== $length) {
-                    return null;
-                }
+        return $length !== null && $length > 0 ? $length : null;
+    }
 
-                $length = $part;
-            }
+    private static function requestContentLength(RequestInterface $request): ?string
+    {
+        try {
+            $length = HeaderProcessor::parseContentLength($request->getHeader('Content-Length'));
+        } catch (\RuntimeException $e) {
+            throw new RequestException(
+                'Invalid Content-Length request header',
+                $request,
+                0,
+                $e
+            );
         }
 
-        if ($length === null || $length === '0') {
-            return null;
+        if (HeaderProcessor::contentLengthExceedsPlatformLimit($length)) {
+            throw new RequestException(
+                'Content-Length exceeds the maximum integer size supported on this platform',
+                $request
+            );
         }
 
-        $max = (string) \PHP_INT_MAX;
-        if (\strlen($length) > \strlen($max) || (\strlen($length) === \strlen($max) && $length > $max)) {
-            return null;
-        }
-
-        return (int) $length;
+        return $length;
     }
 
     private function createResponseSink(
@@ -1099,7 +1107,12 @@ final class StreamHandler
                 if ($code == \STREAM_NOTIFY_PROGRESS) {
                     // The upload progress cannot be determined. Use 0 for cURL compatibility:
                     // https://curl.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html
-                    $value((int) $total, (int) $transferred, 0, 0);
+                    $value(
+                        TransferByteCounter::progressValueToInt($total),
+                        TransferByteCounter::progressValueToInt($transferred),
+                        0,
+                        0
+                    );
                 }
             }
         );

--- a/src/Handler/TransferByteCounter.php
+++ b/src/Handler/TransferByteCounter.php
@@ -30,7 +30,12 @@ final class TransferByteCounter
             throw new \UnexpectedValueException('Progress byte count must be an integer or float');
         }
 
-        if (!\is_finite($value) || $value < 0 || $value > \PHP_INT_MAX) {
+        if (
+            !\is_finite($value)
+            || $value < 0
+            || $value > \PHP_INT_MAX
+            || (\PHP_INT_SIZE === 8 && $value >= (float) \PHP_INT_MAX)
+        ) {
             throw new \OverflowException('Progress byte count exceeds the maximum integer size supported on this platform');
         }
 

--- a/src/Handler/TransferByteCounter.php
+++ b/src/Handler/TransferByteCounter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Handler;
+
+/**
+ * @internal
+ */
+final class TransferByteCounter
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function progressValueToInt($value): int
+    {
+        if (\is_float($value) && (!\is_finite($value) || $value < 0 || $value > \PHP_INT_MAX)) {
+            throw new \OverflowException('Progress byte count exceeds the maximum integer size supported on this platform');
+        }
+
+        if (\is_int($value) && $value < 0) {
+            throw new \OverflowException('Progress byte count exceeds the maximum integer size supported on this platform');
+        }
+
+        return (int) $value;
+    }
+
+    public static function add(int $current, int $delta, string $message): int
+    {
+        if ($current < 0 || $delta < 0) {
+            throw new \OverflowException($message);
+        }
+
+        if ($delta > \PHP_INT_MAX - $current) {
+            throw new \OverflowException($message);
+        }
+
+        return $current + $delta;
+    }
+}

--- a/src/Handler/TransferByteCounter.php
+++ b/src/Handler/TransferByteCounter.php
@@ -18,15 +18,28 @@ final class TransferByteCounter
      */
     public static function progressValueToInt($value): int
     {
-        if (\is_float($value) && (!\is_finite($value) || $value < 0 || $value > \PHP_INT_MAX)) {
+        if (\is_int($value)) {
+            if ($value < 0) {
+                throw new \OverflowException('Progress byte count exceeds the maximum integer size supported on this platform');
+            }
+
+            return $value;
+        }
+
+        if (!\is_float($value)) {
+            throw new \UnexpectedValueException('Progress byte count must be an integer or float');
+        }
+
+        if (!\is_finite($value) || $value < 0 || $value > \PHP_INT_MAX) {
             throw new \OverflowException('Progress byte count exceeds the maximum integer size supported on this platform');
         }
 
-        if (\is_int($value) && $value < 0) {
+        $intValue = (int) $value;
+        if ($intValue < 0) {
             throw new \OverflowException('Progress byte count exceeds the maximum integer size supported on this platform');
         }
 
-        return (int) $value;
+        return $intValue;
     }
 
     public static function add(int $current, int $delta, string $message): int

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp;
 
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -35,9 +36,10 @@ class PrepareBodyMiddleware
     public function __invoke(RequestInterface $request, array $options): PromiseInterface
     {
         $fn = $this->nextHandler;
+        $bodySize = self::bodySize($request);
 
         // Don't do anything if the request has no body.
-        if ($request->getBody()->getSize() === 0) {
+        if ($bodySize === 0) {
             return $fn($request, $options);
         }
 
@@ -56,16 +58,15 @@ class PrepareBodyMiddleware
         if (!$request->hasHeader('Content-Length')
             && !$request->hasHeader('Transfer-Encoding')
         ) {
-            $size = $request->getBody()->getSize();
-            if ($size !== null) {
-                $modify['set_headers']['Content-Length'] = (string) $size;
+            if ($bodySize !== null) {
+                $modify['set_headers']['Content-Length'] = (string) $bodySize;
             } else {
                 $modify['set_headers']['Transfer-Encoding'] = 'chunked';
             }
         }
 
         // Add the expect header if needed.
-        $this->addExpectHeader($request, $options, $modify);
+        $this->addExpectHeader($request, $options, $modify, $bodySize);
 
         return $fn(Psr7\Utils::modifyRequest($request, $modify), $options);
     }
@@ -73,8 +74,12 @@ class PrepareBodyMiddleware
     /**
      * Add expect header
      */
-    private function addExpectHeader(RequestInterface $request, array $options, array &$modify): void
-    {
+    private function addExpectHeader(
+        RequestInterface $request,
+        array $options,
+        array &$modify,
+        ?int $bodySize
+    ): void {
         // Determine if the Expect header should be used
         if ($request->hasHeader('Expect')) {
             return;
@@ -102,10 +107,18 @@ class PrepareBodyMiddleware
         // Always add if the body cannot be rewound, the size cannot be
         // determined, or the size is greater than the cutoff threshold
         $body = $request->getBody();
-        $size = $body->getSize();
 
-        if ($size === null || $size >= (int) $expect || !$body->isSeekable()) {
+        if ($bodySize === null || $bodySize >= (int) $expect || !$body->isSeekable()) {
             $modify['set_headers']['Expect'] = '100-Continue';
+        }
+    }
+
+    private static function bodySize(RequestInterface $request): ?int
+    {
+        try {
+            return $request->getBody()->getSize();
+        } catch (\RuntimeException $e) {
+            throw new RequestException($e->getMessage(), $request, 0, $e);
         }
     }
 }

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\HttpFactory;
@@ -219,7 +220,7 @@ class RedirectMiddleware
         try {
             Psr7\Message::rewindBody($request);
         } catch (\RuntimeException $e) {
-            throw new BadResponseException(
+            throw new ResponseException(
                 'Redirect failed because the request body could not be rewound: '.$e->getMessage(),
                 $request,
                 $response,

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -216,7 +216,16 @@ class RedirectMiddleware
         }
 
         $modify['uri'] = $uri;
-        Psr7\Message::rewindBody($request);
+        try {
+            Psr7\Message::rewindBody($request);
+        } catch (\RuntimeException $e) {
+            throw new BadResponseException(
+                'Redirect failed because the request body could not be rewound: '.$e->getMessage(),
+                $request,
+                $response,
+                $e
+            );
+        }
 
         // Add the Referer header if it is told to do so and only
         // add the header if we are not redirecting from https to http.

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3329,6 +3329,38 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public function testStreamingRequestBodyReadFailureAbortsReadCallback(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \RuntimeException('boom while reading');
+        $readCalled = false;
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+            'read' => static function (int $length) use (&$readCalled, $previous): string {
+                $readCalled = true;
+
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+        $easy = $factory->create($request, []);
+
+        try {
+            $callback = $_SERVER['_curl'][\CURLOPT_READFUNCTION];
+
+            self::assertSame(0x10000000, $callback($easy->handle, null, 8192));
+            self::assertTrue($readCalled);
+            self::assertSame($previous, $easy->bodyReadException);
+            self::assertNull($easy->bodyReadTimeoutException);
+        } finally {
+            if (\array_key_exists('handle', \get_object_vars($easy))) {
+                $factory->release($easy);
+            }
+        }
+    }
+
     public function testStreamingUploadInstallsProgressAbortForBodyReadTimeout(): void
     {
         $factory = new CurlFactory(3);
@@ -3351,6 +3383,33 @@ class CurlFactoryTest extends TestCase
             self::assertSame(0, $progress($easy->handle, 0, 0, 0, 0));
 
             $easy->bodyReadTimeoutException = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
+            self::assertSame(1, $progress($easy->handle, 0, 0, 0, 0));
+            self::assertFalse($easy->progressAborted);
+        } finally {
+            if (\array_key_exists('handle', \get_object_vars($easy))) {
+                $factory->release($easy);
+            }
+        }
+    }
+
+    public function testStreamingUploadInstallsProgressAbortForBodyReadFailure(): void
+    {
+        $factory = new CurlFactory(3);
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+        $easy = $factory->create($request, []);
+
+        try {
+            self::assertArrayHasKey(self::progressCallbackOption(), $_SERVER['_curl']);
+            $progress = $_SERVER['_curl'][self::progressCallbackOption()];
+
+            self::assertSame(0, $progress($easy->handle, 0, 0, 0, 0));
+
+            $easy->bodyReadException = new \RuntimeException('boom while reading');
             self::assertSame(1, $progress($easy->handle, 0, 0, 0, 0));
             self::assertFalse($easy->progressAborted);
         } finally {
@@ -3460,6 +3519,47 @@ class CurlFactoryTest extends TestCase
         self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $stats->getHandlerErrorData());
     }
 
+    public function testRequestBodyReadFailureRejectsAsRequestExceptionWithoutResponseAndWithoutRetry(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \RuntimeException('boom while reading');
+        $stats = null;
+        $request = new Psr7\Request('PUT', Server::$url, [], 'payload');
+        $easy = $factory->create($request, [
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
+            },
+        ]);
+        $easy->bodyReadException = $previous;
+        $easy->errno = 0;
+        $retried = false;
+        $handler = static function () use (&$retried): P\PromiseInterface {
+            $retried = true;
+
+            return P\Create::promiseFor(new Psr7\Response());
+        };
+
+        try {
+            CurlFactory::finish($handler, $easy, $factory)->wait();
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('boom while reading', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertFalse($retried);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertFalse($stats->hasResponse());
+        self::assertNull($stats->getResponse());
+        self::assertSame($request, $stats->getRequest());
+        self::assertSame(0, $stats->getHandlerErrorData());
+    }
+
     public function testStreamingRequestBodyReadPsr7TimeoutRejectsAsResponseExceptionWithResponse(): void
     {
         $factory = new CurlFactory(3);
@@ -3503,6 +3603,50 @@ class CurlFactoryTest extends TestCase
         self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $stats->getHandlerErrorData());
     }
 
+    public function testRequestBodyReadFailureRejectsAsResponseExceptionWithResponseAndErrnoZero(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \RuntimeException('boom while reading');
+        $stats = null;
+        $request = new Psr7\Request('PUT', Server::$url, [], 'payload');
+        $response = new Psr7\Response(200, [], 'early');
+        $easy = $factory->create($request, [
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
+            },
+        ]);
+        $easy->response = $response;
+        $easy->bodyReadException = $previous;
+        $easy->errno = 0;
+        $retried = false;
+        $handler = static function () use (&$retried): P\PromiseInterface {
+            $retried = true;
+
+            return P\Create::promiseFor(new Psr7\Response());
+        };
+
+        try {
+            CurlFactory::finish($handler, $easy, $factory)->wait();
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($response, $e->getResponse());
+            self::assertSame('boom while reading', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertFalse($retried);
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertSame($response, $stats->getResponse());
+        self::assertSame($request, $stats->getRequest());
+        self::assertSame(0, $stats->getHandlerErrorData());
+    }
+
     /**
      * @dataProvider curlHandlerProvider
      */
@@ -3541,6 +3685,71 @@ class CurlFactoryTest extends TestCase
         }
 
         self::assertTrue($castCalled);
+    }
+
+    public function testBodyAsStringRequestBodyReadFailureRejectsAsRequestException(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \RuntimeException('boom while reading');
+        $castCalled = false;
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+            '__toString' => static function () use (&$castCalled, $previous): string {
+                $castCalled = true;
+
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, [
+                'curl' => ['body_as_string' => true],
+            ]);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('boom while reading', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertTrue($castCalled);
+    }
+
+    public function testStreamingRequestBodyRewindFailureRejectsAsRequestException(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \RuntimeException('boom while rewinding');
+        $rewindCalled = false;
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+            'rewind' => static function () use (&$rewindCalled, $previous): void {
+                $rewindCalled = true;
+
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, []);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('boom while rewinding', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertTrue($rewindCalled);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3455,7 +3455,7 @@ class CurlFactoryTest extends TestCase
             // It is still a timeout, never a silent success.
             self::assertTrue(\PHP_VERSION_ID < 80117 || (\PHP_VERSION_ID >= 80200 && \PHP_VERSION_ID < 80204));
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while reading the request body', $e->getMessage());
+            self::assertSame('Timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
             self::assertNotInstanceOf(ResponseTransferException::class, $e);
@@ -3465,7 +3465,7 @@ class CurlFactoryTest extends TestCase
             // (and on older PHP the progress callback may abort before a
             // response arrives), so no usable response is received.
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while reading the request body', $e->getMessage());
+            self::assertSame('Timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
@@ -3506,7 +3506,7 @@ class CurlFactoryTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while reading the request body', $e->getMessage());
+            self::assertSame('Timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
@@ -3614,7 +3614,7 @@ class CurlFactoryTest extends TestCase
         } catch (ResponseException $e) {
             self::assertSame($request, $e->getRequest());
             self::assertSame($response, $e->getResponse());
-            self::assertSame('The cURL handler timed out while reading the request body', $e->getMessage());
+            self::assertSame('Timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
             self::assertNotInstanceOf(ResponseTransferException::class, $e);
@@ -3844,7 +3844,7 @@ class CurlFactoryTest extends TestCase
         } catch (ResponseException $e) {
             self::assertSame($request, $e->getRequest());
             self::assertSame(200, $e->getResponse()->getStatusCode());
-            self::assertSame('The cURL handler timed out while writing the response body', $e->getMessage());
+            self::assertSame('Timed out while writing the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
             self::assertNotInstanceOf(ResponseTransferException::class, $e);
@@ -3982,7 +3982,7 @@ class CurlFactoryTest extends TestCase
 
             self::fail('Expected ResponseException');
         } catch (ResponseException $e) {
-            self::assertSame('The cURL handler failed while writing the response body', $e->getMessage());
+            self::assertSame('Failed to write the response body', $e->getMessage());
         } finally {
             Server::flush();
 
@@ -4030,6 +4030,7 @@ class CurlFactoryTest extends TestCase
                 self::fail("Expected ResponseException ({$label})");
             } catch (ResponseException $e) {
                 self::assertSame(200, $e->getResponse()->getStatusCode(), $label);
+                self::assertSame('Unable to write to stream', $e->getMessage(), $label);
                 self::assertNull($e->getPrevious(), $label);
                 self::assertNotInstanceOf(ResponseTransferException::class, $e, $label);
             } finally {
@@ -4134,7 +4135,7 @@ class CurlFactoryTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while writing the response body', $e->getMessage());
+            self::assertSame('Timed out while writing the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -4109,7 +4109,7 @@ class CurlFactoryTest extends TestCase
         self::assertSame(0, $stats->getHandlerErrorData());
     }
 
-    public function testSinkWritePsr7TimeoutRejectsAsNetworkTimeoutWithoutResponse(): void
+    public function testSinkWritePsr7TimeoutRejectsAsRequestExceptionWithoutResponse(): void
     {
         $factory = new CurlFactory(3);
         $previous = new Psr7\Exception\TimeoutException('Unable to write to stream: timed out');
@@ -4131,15 +4131,14 @@ class CurlFactoryTest extends TestCase
         try {
             CurlFactory::finish($handler, $easy, $factory)->wait();
 
-            self::fail('Expected NetworkTimeoutException');
-        } catch (NetworkTimeoutException $e) {
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while transferring the response body', $e->getMessage());
+            self::assertSame('The cURL handler timed out while writing the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertInstanceOf(NetworkException::class, $e);
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         }
 
         self::assertInstanceOf(TransferStats::class, $stats);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2990,10 +2990,14 @@ class CurlFactoryTest extends TestCase
             'Content-Length' => $length,
         ], 'foo');
 
-        $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('Content-Length exceeds the maximum integer size supported on this platform');
-
-        $factory->create($request, []);
+        try {
+            $factory->create($request, []);
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('Content-Length exceeds the maximum integer size supported on this platform', $e->getMessage());
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(\OverflowException::class, $e->getPrevious());
+        }
     }
 
     public function testRejectsInvalidCurlRequestContentLengthWithEmptyBody(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1386,6 +1386,26 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public function testProgressOverflowValueAbortsCurlTransfer(): void
+    {
+        $f = new CurlFactory(3);
+        $easy = $f->create(new Psr7\Request('GET', Server::$url), [
+            'progress' => static function (): void {
+                self::fail('Progress callback should not receive overflowing values');
+            },
+        ]);
+
+        try {
+            $callback = $_SERVER['_curl'][self::progressCallbackOption()];
+
+            self::assertSame(1, $callback($easy->handle, \INF, 0.0, 0.0, 0.0));
+            self::assertFalse($easy->progressAborted);
+            self::assertInstanceOf(\OverflowException::class, $easy->progressException);
+        } finally {
+            $f->release($easy);
+        }
+    }
+
     /**
      * @dataProvider curlHandlerProvider
      */
@@ -2471,6 +2491,121 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public function testUnrepresentableResponseContentLengthCreatesResponseException(): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $stats = null;
+        $easy = $factory->create($request, [
+            'on_stats' => static function (TransferStats $transferStats) use (&$stats): void {
+                $stats = $transferStats;
+            },
+        ]);
+        $overflow = ((string) \PHP_INT_MAX).'0';
+
+        $header = self::receiveCurlHeaders($easy, [
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: {$overflow}\r\n",
+        ]);
+        self::assertSame(-1, $header($easy->handle, "\r\n"));
+        $easy->errno = \CURLE_WRITE_ERROR;
+
+        try {
+            self::finishEasy($easy, $factory);
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+            self::assertSame('Content-Length exceeds the maximum integer size supported on this platform', $e->getMessage());
+            self::assertInstanceOf(\OverflowException::class, $e->getPrevious());
+        }
+
+        self::assertInstanceOf(TransferStats::class, $stats);
+        self::assertTrue($stats->hasResponse());
+        self::assertInstanceOf(\OverflowException::class, $stats->getHandlerErrorData());
+    }
+
+    public function testOnHeadersExceptionWinsOverUnrepresentableResponseContentLength(): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $previous = new \RuntimeException('on headers failed');
+        $easy = $factory->create($request, [
+            'on_headers' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+        $overflow = ((string) \PHP_INT_MAX).'0';
+
+        $header = self::receiveCurlHeaders($easy, [
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Length: {$overflow}\r\n",
+        ]);
+        self::assertSame(-1, $header($easy->handle, "\r\n"));
+        $easy->errno = \CURLE_WRITE_ERROR;
+
+        try {
+            self::finishEasy($easy, $factory);
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertSame('An error was encountered during the on_headers event', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+        }
+    }
+
+    public function testResponseBodyByteCountOverflowCreatesResponseException(): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $response = new Psr7\Response(200);
+        $easy = $factory->create($request, []);
+        $write = $_SERVER['_curl'][\CURLOPT_WRITEFUNCTION];
+        $easy->response = $response;
+        $easy->responseBodyBytes = \PHP_INT_MAX - 1;
+
+        self::assertSame(0, $write($easy->handle, 'ab'));
+        self::assertInstanceOf(\OverflowException::class, $easy->responseBodySizeException);
+
+        try {
+            self::finishEasy($easy, $factory);
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertNotInstanceOf(ResponseTransferException::class, $e);
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($response, $e->getResponse());
+            self::assertSame($easy->responseBodySizeException, $e->getPrevious());
+        }
+    }
+
+    /**
+     * @param list<string> $headers
+     */
+    private static function receiveCurlHeaders(EasyHandle $easy, array $headers): callable
+    {
+        $header = $_SERVER['_curl'][\CURLOPT_HEADERFUNCTION];
+
+        foreach ($headers as $line) {
+            self::assertSame(\strlen($line), $header($easy->handle, $line));
+        }
+
+        return $header;
+    }
+
+    private static function finishEasy(EasyHandle $easy, CurlFactory $factory): void
+    {
+        CurlFactory::finish(
+            static function (): void {
+            },
+            $easy,
+            $factory
+        )->wait();
+    }
+
     public static function curlResponseTransferErrorProvider(): iterable
     {
         yield 'partial file' => [18];
@@ -2772,6 +2907,106 @@ class CurlFactoryTest extends TestCase
         $f->create($request, []);
         self::assertEquals(1, $_SERVER['_curl'][\CURLOPT_UPLOAD]);
         self::assertIsCallable($_SERVER['_curl'][\CURLOPT_READFUNCTION]);
+    }
+
+    /**
+     * @dataProvider validCurlRequestContentLengthProvider
+     *
+     * @param string|string[] $contentLength
+     */
+    public function testUsesParsedRequestContentLengthForCurlUpload($contentLength): void
+    {
+        $factory = new CurlFactory(3);
+        $request = new Psr7\Request('PUT', Server::$url, [
+            'Content-Length' => $contentLength,
+        ], 'foo');
+
+        $factory->create($request, []);
+
+        self::assertTrue((bool) $_SERVER['_curl'][\CURLOPT_UPLOAD]);
+        self::assertSame(1000000, $_SERVER['_curl'][\CURLOPT_INFILESIZE]);
+    }
+
+    public static function validCurlRequestContentLengthProvider(): iterable
+    {
+        return [
+            'plain' => ['1000000'],
+            'leading zeros' => ['001000000'],
+            'comma equivalent' => ['001000000, 1000000'],
+            'duplicate equivalent' => [['001000000', '1000000']],
+        ];
+    }
+
+    public function testNormalizesEquivalentRequestContentLengthForCurlHeaders(): void
+    {
+        $factory = new CurlFactory(3);
+        $request = new Psr7\Request('GET', Server::$url, [
+            'Content-Length' => ['0003', '3'],
+        ]);
+
+        $factory->create($request, []);
+
+        self::assertContains('Content-Length: 3', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+        self::assertNotContains('Content-Length: 0003', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+    }
+
+    /**
+     * @dataProvider invalidCurlRequestContentLengthProvider
+     *
+     * @param string|string[] $contentLength
+     */
+    public function testRejectsInvalidCurlRequestContentLength($contentLength): void
+    {
+        $factory = new CurlFactory(3);
+        $request = new Psr7\Request('PUT', Server::$url, [
+            'Content-Length' => $contentLength,
+        ], 'foo');
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('Invalid Content-Length request header');
+
+        $factory->create($request, []);
+    }
+
+    public static function invalidCurlRequestContentLengthProvider(): iterable
+    {
+        return [
+            'empty' => [''],
+            'empty comma member' => ['3,'],
+            'non digit' => ['abc'],
+            'partial numeric' => ['3abc'],
+            'signed' => ['-1'],
+            'decimal' => ['3.0'],
+            'conflicting comma' => ['3, 5'],
+            'conflicting duplicate' => [['3', '5']],
+        ];
+    }
+
+    public function testRejectsUnrepresentableRequestContentLengthForCurlUpload(): void
+    {
+        $factory = new CurlFactory(3);
+        $length = ((string) \PHP_INT_MAX).'0';
+        $request = new Psr7\Request('PUT', Server::$url, [
+            'Content-Length' => $length,
+        ], 'foo');
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('Content-Length exceeds the maximum integer size supported on this platform');
+
+        $factory->create($request, []);
+    }
+
+    public function testRejectsInvalidCurlRequestContentLengthWithEmptyBody(): void
+    {
+        $factory = new CurlFactory(3);
+        $request = new Psr7\Request('POST', Server::$url, [
+            'Content-Length' => 'abc',
+        ]);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('Invalid Content-Length request header');
+
+        $factory->create($request, []);
     }
 
     public function testEnsuresDirExistsBeforeThrowingWarning(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3447,14 +3447,6 @@ class CurlFactoryTest extends TestCase
             $handler($request, [])->wait();
 
             self::fail('Expected the upload read timeout to reject the transfer');
-        } catch (NetworkTimeoutException $e) {
-            // On PHP >= 8.1.17 / 8.2.4 the read callback aborts synchronously
-            // (and on older PHP the progress callback may abort before a
-            // response arrives), so no usable response is received.
-            self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
-            self::assertSame($previous, $e->getPrevious());
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
         } catch (ResponseException $e) {
             // PHP versions without read-callback abort support (< 8.1.17, and
             // 8.2.0-8.2.3 since the fix shipped in 8.1.17 and 8.2.4) ignore the
@@ -3463,10 +3455,20 @@ class CurlFactoryTest extends TestCase
             // It is still a timeout, never a silent success.
             self::assertTrue(\PHP_VERSION_ID < 80117 || (\PHP_VERSION_ID >= 80200 && \PHP_VERSION_ID < 80204));
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame('The cURL handler timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
             self::assertNotInstanceOf(ResponseTransferException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        } catch (RequestException $e) {
+            // On PHP >= 8.1.17 / 8.2.4 the read callback aborts synchronously
+            // (and on older PHP the progress callback may abort before a
+            // response arrives), so no usable response is received.
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('The cURL handler timed out while reading the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         } finally {
             Server::flush();
@@ -3479,7 +3481,7 @@ class CurlFactoryTest extends TestCase
         self::assertTrue($readCalled);
     }
 
-    public function testStreamingRequestBodyReadPsr7TimeoutRejectsAsNetworkTimeoutWithoutResponse(): void
+    public function testStreamingRequestBodyReadPsr7TimeoutRejectsAsRequestExceptionWithoutResponse(): void
     {
         $factory = new CurlFactory(3);
         $previous = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
@@ -3501,15 +3503,14 @@ class CurlFactoryTest extends TestCase
         try {
             CurlFactory::finish($handler, $easy, $factory)->wait();
 
-            self::fail('Expected NetworkTimeoutException');
-        } catch (NetworkTimeoutException $e) {
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame('The cURL handler timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertInstanceOf(NetworkException::class, $e);
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         }
 
         self::assertInstanceOf(TransferStats::class, $stats);
@@ -3517,6 +3518,31 @@ class CurlFactoryTest extends TestCase
         self::assertNull($stats->getResponse());
         self::assertSame($request, $stats->getRequest());
         self::assertSame(\CURLE_ABORTED_BY_CALLBACK, $stats->getHandlerErrorData());
+    }
+
+    public function testRequestBodyGetSizeTimeoutRejectsAsRequestException(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new Psr7\Exception\TimeoutException('Unable to determine stream size: timed out');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function () use ($previous): ?int {
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, []);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('Unable to determine stream size: timed out', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
     }
 
     public function testRequestBodyReadFailureRejectsAsRequestExceptionWithoutResponseAndWithoutRetry(): void
@@ -3588,7 +3614,7 @@ class CurlFactoryTest extends TestCase
         } catch (ResponseException $e) {
             self::assertSame($request, $e->getRequest());
             self::assertSame($response, $e->getResponse());
-            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame('The cURL handler timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
             self::assertNotInstanceOf(ResponseTransferException::class, $e);
@@ -3650,7 +3676,7 @@ class CurlFactoryTest extends TestCase
     /**
      * @dataProvider curlHandlerProvider
      */
-    public function testStringRequestBodyReadPsr7TimeoutRejectsAsNetworkTimeoutThroughCurlHandlers(callable $handlerFactory): void
+    public function testBodyAsStringRequestBodyReadPsr7TimeoutRejectsAsRequestExceptionThroughCurlHandlers(callable $handlerFactory): void
     {
         $previous = new Psr7\Exception\TimeoutException('Unable to read from stream: timed out');
         $castCalled = false;
@@ -3669,15 +3695,14 @@ class CurlFactoryTest extends TestCase
                 'curl' => ['body_as_string' => true],
             ])->wait();
 
-            self::fail('Expected NetworkTimeoutException');
-        } catch (NetworkTimeoutException $e) {
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('The cURL handler timed out while transferring the request body', $e->getMessage());
+            self::assertSame('Unable to read from stream: timed out', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertInstanceOf(NetworkException::class, $e);
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         } finally {
             if (\method_exists($handler, 'close')) {
                 $handler->close();
@@ -3743,6 +3768,39 @@ class CurlFactoryTest extends TestCase
         } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
             self::assertSame('boom while rewinding', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertTrue($rewindCalled);
+    }
+
+    public function testStreamingRequestBodyRewindTimeoutRejectsAsRequestException(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new Psr7\Exception\TimeoutException('Unable to rewind stream: timed out');
+        $rewindCalled = false;
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+            'rewind' => static function () use (&$rewindCalled, $previous): void {
+                $rewindCalled = true;
+
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, []);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('Unable to rewind stream: timed out', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);

--- a/tests/Handler/EasyHandleTest.php
+++ b/tests/Handler/EasyHandleTest.php
@@ -61,4 +61,28 @@ class EasyHandleTest extends TestCase
         self::assertNotNull($easy->response, '101 is terminal and must be kept as a response');
         self::assertSame(101, $easy->response->getStatusCode());
     }
+
+    public function testDecodedContentLengthIsOmittedWhenSinkSizeOverflows(): void
+    {
+        $easy = new EasyHandle();
+        $easy->headers = [
+            'HTTP/1.1 200 OK',
+            'Content-Encoding: gzip',
+            'Content-Length: 3',
+        ];
+        $easy->options = ['decode_content' => true];
+        $easy->sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+            'getSize' => static function (): int {
+                throw new \OverflowException('too large');
+            },
+        ]);
+
+        $easy->createResponse();
+
+        self::assertNotNull($easy->response);
+        self::assertFalse($easy->response->hasHeader('Content-Encoding'));
+        self::assertFalse($easy->response->hasHeader('Content-Length'));
+        self::assertSame('gzip', $easy->response->getHeaderLine('x-encoded-content-encoding'));
+        self::assertSame('3', $easy->response->getHeaderLine('x-encoded-content-length'));
+    }
 }

--- a/tests/Handler/HeaderProcessorTest.php
+++ b/tests/Handler/HeaderProcessorTest.php
@@ -29,6 +29,84 @@ class HeaderProcessorTest extends TestCase
         self::assertSame(['X-Foo' => ['bar', 'baz'], 'X-Bar' => ['qux']], $headers);
     }
 
+    /**
+     * @dataProvider validContentLengthProvider
+     *
+     * @param string[] $values
+     */
+    public function testParsesContentLength(array $values, ?string $expected): void
+    {
+        self::assertSame($expected, HeaderProcessor::parseContentLength($values));
+    }
+
+    public static function validContentLengthProvider(): iterable
+    {
+        $max = (string) \PHP_INT_MAX;
+
+        return [
+            'absent' => [[], null],
+            'zero' => [['0'], '0'],
+            'zero with leading zeros' => [['0000'], '0'],
+            'simple' => [['3'], '3'],
+            'leading zeros' => [['0003'], '3'],
+            'comma equivalent' => [['003, 3'], '3'],
+            'duplicate equivalent' => [['003', '3'], '3'],
+            'php int max' => [[$max], $max],
+            'larger than php int max' => [[$max.'0'], $max.'0'],
+        ];
+    }
+
+    /**
+     * @dataProvider contentLengthToIntProvider
+     */
+    public function testConvertsContentLengthToIntWhenRepresentable(?string $length, ?int $expected): void
+    {
+        self::assertSame($expected, HeaderProcessor::contentLengthToInt($length));
+    }
+
+    public static function contentLengthToIntProvider(): iterable
+    {
+        $max = (string) \PHP_INT_MAX;
+
+        return [
+            'absent' => [null, null],
+            'zero' => ['0', 0],
+            'simple' => ['3', 3],
+            'php int max' => [$max, \PHP_INT_MAX],
+            'equal length too large' => [\str_repeat('9', \strlen($max)), null],
+            'longer than php int max' => [$max.'0', null],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidContentLengthProvider
+     *
+     * @param string[] $values
+     */
+    public function testRejectsInvalidContentLength(array $values): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        HeaderProcessor::parseContentLength($values);
+    }
+
+    public static function invalidContentLengthProvider(): iterable
+    {
+        return [
+            'empty' => [['']],
+            'ows only' => [[" \t"]],
+            'empty first member' => [[', 3']],
+            'empty last member' => [['3,']],
+            'empty middle member' => [['3,,3']],
+            'signed positive' => [['+3']],
+            'signed negative' => [['-3']],
+            'decimal' => [['3.0']],
+            'partial numeric' => [['3abc']],
+            'conflicting comma' => [['3, 5']],
+            'conflicting duplicate' => [['3', '5']],
+        ];
+    }
+
     public function testRejectsEmptyHeaderData(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Handler/HeaderProcessorTest.php
+++ b/tests/Handler/HeaderProcessorTest.php
@@ -78,6 +78,23 @@ class HeaderProcessorTest extends TestCase
         ];
     }
 
+    public function testAcceptsRepresentableContentLengthPlatformLimits(): void
+    {
+        HeaderProcessor::assertContentLengthWithinPlatformLimit(null);
+        HeaderProcessor::assertContentLengthWithinPlatformLimit('0');
+        HeaderProcessor::assertContentLengthWithinPlatformLimit((string) \PHP_INT_MAX);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsUnrepresentableContentLengthPlatformLimit(): void
+    {
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Content-Length exceeds the maximum integer size supported on this platform');
+
+        HeaderProcessor::assertContentLengthWithinPlatformLimit(((string) \PHP_INT_MAX).'0');
+    }
+
     /**
      * @dataProvider invalidContentLengthProvider
      *

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\ResponseTimeoutException;
 use GuzzleHttp\Exception\ResponseTransferException;
 use GuzzleHttp\Handler\StreamHandler;
+use GuzzleHttp\Handler\TransferByteCounter;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Request;
@@ -95,6 +96,83 @@ class StreamHandlerTest extends TestCase
             self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertSame('HTTP protocol version must be a valid HTTP version number.', $e->getMessage());
         }
+    }
+
+    /**
+     * @dataProvider invalidRequestContentLengthProvider
+     *
+     * @param string|string[] $contentLength
+     */
+    public function testRejectsInvalidRequestContentLength($contentLength): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url, [
+            'Content-Length' => $contentLength,
+        ]);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('Invalid Content-Length request header');
+
+        $handler($request, []);
+    }
+
+    public static function invalidRequestContentLengthProvider(): iterable
+    {
+        return [
+            'empty' => [''],
+            'empty comma member' => ['3,'],
+            'non digit' => ['abc'],
+            'partial numeric' => ['3abc'],
+            'signed' => ['-1'],
+            'decimal' => ['3.0'],
+            'conflicting comma' => ['3, 5'],
+            'conflicting duplicate' => [['3', '5']],
+        ];
+    }
+
+    public function testNormalizesEquivalentRequestContentLengthValues(): void
+    {
+        $request = new Request('GET', Server::$url, [
+            'Content-Length' => ['0000', '0'],
+        ]);
+        $reflection = new \ReflectionMethod(StreamHandler::class, 'prepareRequest');
+        if (\PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
+        $prepared = $reflection->invoke(null, $request);
+
+        self::assertInstanceOf(RequestInterface::class, $prepared);
+        self::assertSame(['0'], $prepared->getHeader('Content-Length'));
+    }
+
+    public function testRejectsUnrepresentableRequestContentLength(): void
+    {
+        $length = ((string) \PHP_INT_MAX).'0';
+        $request = new Request('GET', Server::$url, [
+            'Content-Length' => $length,
+        ]);
+        $reflection = new \ReflectionMethod(StreamHandler::class, 'prepareRequest');
+        if (\PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('Content-Length exceeds the maximum integer size supported on this platform');
+
+        $reflection->invoke(null, $request);
+    }
+
+    public function testRejectsInvalidRequestContentLengthBeforeAddingEmptyBodyDefault(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('PUT', Server::$url, [
+            'Content-Length' => 'abc',
+        ]);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('Invalid Content-Length request header');
+
+        $handler($request, []);
     }
 
     public function testAddsErrorToResponse(): void
@@ -775,7 +853,7 @@ class StreamHandlerTest extends TestCase
         self::assertSame('ab', (string) $response->getBody());
     }
 
-    public function testContentLengthAbovePhpIntMaxSkipsShortBodyCheck(): void
+    public function testContentLengthAbovePhpIntMaxRejectsNonStreamedResponse(): void
     {
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
@@ -786,10 +864,58 @@ class StreamHandlerTest extends TestCase
             "Content-Length: {$overflow}",
         ]);
 
-        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('ab'))->wait();
+        try {
+            $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor('ab'))->wait();
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertResponseContentLengthPlatformException($e);
+        }
+    }
+
+    public function testContentLengthAbovePhpIntMaxAllowsStreamedResponse(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $overflow = '99999999999999999999999999';
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            "Content-Length: {$overflow}",
+        ]);
+
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, ['stream' => true], Psr7\Utils::streamFor('ab'))->wait();
 
         self::assertSame(200, $response->getStatusCode());
+        self::assertSame($overflow, $response->getHeaderLine('Content-Length'));
         self::assertSame('ab', (string) $response->getBody());
+    }
+
+    public function testAttemptsSourceCloseWhenContentLengthOverflows(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $closeCalled = false;
+        $source = FnStream::decorate(Psr7\Utils::streamFor('ab'), [
+            'close' => static function () use (&$closeCalled): void {
+                $closeCalled = true;
+
+                throw new \RuntimeException('close failed');
+            },
+        ]);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 99999999999999999999999999',
+        ]);
+
+        try {
+            $this->invokeStreamHandlerCreateResponse($handler, $request, [], $source)->wait();
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertResponseContentLengthPlatformException($e);
+        }
+
+        self::assertTrue($closeCalled);
     }
 
     public function testAttemptsSourceCloseWhenContentLengthBodyIsShort(): void
@@ -1505,6 +1631,14 @@ class StreamHandlerTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('hi there', (string) $response->getBody());
+    }
+
+    public function testProgressOverflowValueThrows(): void
+    {
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Progress byte count exceeds the maximum integer size supported on this platform');
+
+        TransferByteCounter::progressValueToInt(\INF);
     }
 
     public function testEmitsProgressInformationAndDebugInformation(): void
@@ -2607,6 +2741,13 @@ class StreamHandlerTest extends TestCase
                 return $new;
             }
         };
+    }
+
+    private static function assertResponseContentLengthPlatformException(ResponseException $e): void
+    {
+        self::assertNotInstanceOf(ResponseTransferException::class, $e);
+        self::assertSame('Content-Length exceeds the maximum integer size supported on this platform', $e->getMessage());
+        self::assertInstanceOf(\OverflowException::class, $e->getPrevious());
     }
 
     /**

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -154,6 +154,38 @@ class StreamHandlerTest extends TestCase
         self::assertFalse($called);
     }
 
+    public function testRequestBodyGetSizeTimeoutRejectsAsRequestExceptionWithoutStats(): void
+    {
+        $handler = new StreamHandler();
+        $called = false;
+        $previous = new Psr7\Exception\TimeoutException('Unable to determine stream size: timed out');
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            'getSize' => static function () use ($previous): ?int {
+                throw $previous;
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [
+                'on_stats' => static function () use (&$called): void {
+                    $called = true;
+                },
+            ]);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('Unable to determine stream size: timed out', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+
+        self::assertFalse($called);
+    }
+
     public function testNormalizesEquivalentRequestContentLengthValues(): void
     {
         $request = new Request('GET', Server::$url, [
@@ -259,7 +291,7 @@ class StreamHandlerTest extends TestCase
         self::assertFalse($this->matchesStreamHandlerError('isNetworkError', 'HTTP request failed!'));
     }
 
-    public function testThrowsNetworkTimeoutExceptionWhenRequestBodyReadTimesOut(): void
+    public function testRejectsRequestExceptionWhenRequestBodyReadTimesOut(): void
     {
         $handler = new StreamHandler();
         $previous = new Psr7\Exception\TimeoutException('Unable to read stream contents: timed out');
@@ -271,6 +303,7 @@ class StreamHandlerTest extends TestCase
         $request = new Request('PUT', Server::$url, [], $body);
         $stats = null;
         $exception = null;
+        $exceptionRequest = null;
 
         try {
             $handler($request, [
@@ -279,21 +312,23 @@ class StreamHandlerTest extends TestCase
                 },
             ])->wait();
 
-            self::fail('Expected NetworkTimeoutException');
-        } catch (NetworkTimeoutException $e) {
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
             $exception = $e;
-            self::assertSame($request, $e->getRequest());
-            self::assertSame('The stream handler timed out while transferring the request body', $e->getMessage());
+            $exceptionRequest = $e->getRequest();
+            self::assertSame($request->getMethod(), $exceptionRequest->getMethod());
+            self::assertSame((string) $request->getUri(), (string) $exceptionRequest->getUri());
+            self::assertSame('Unable to read stream contents: timed out', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
-            self::assertInstanceOf(NetworkException::class, $e);
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
         }
 
         self::assertInstanceOf(TransferStats::class, $stats);
         self::assertFalse($stats->hasResponse());
-        self::assertSame($request, $stats->getRequest());
+        self::assertSame($exceptionRequest->getMethod(), $stats->getRequest()->getMethod());
+        self::assertSame((string) $exceptionRequest->getUri(), (string) $stats->getRequest()->getUri());
         self::assertSame($exception, $stats->getHandlerErrorData());
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -148,7 +148,10 @@ class StreamHandlerTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('Invalid Content-Length request header', $e->getMessage());
+            self::assertSame(
+                'Invalid Content-Length request header: value is not a non-negative decimal integer',
+                $e->getMessage()
+            );
         }
 
         self::assertFalse($called);
@@ -743,7 +746,7 @@ class StreamHandlerTest extends TestCase
             $exception = $e;
             self::assertSame($request, $e->getRequest());
             self::assertSame(200, $e->getResponse()->getStatusCode());
-            self::assertSame('The stream handler received fewer bytes than the declared Content-Length', $e->getMessage());
+            self::assertSame('Response body ended before the declared Content-Length was reached', $e->getMessage());
             self::assertNull($e->getPrevious());
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
@@ -999,7 +1002,7 @@ class StreamHandlerTest extends TestCase
             $this->invokeStreamHandlerCreateResponse($handler, $request, [], $source)->wait();
             self::fail('Expected ResponseTransferException');
         } catch (ResponseTransferException $e) {
-            self::assertSame('The stream handler received fewer bytes than the declared Content-Length', $e->getMessage());
+            self::assertSame('Response body ended before the declared Content-Length was reached', $e->getMessage());
             self::assertNull($e->getPrevious());
         }
 
@@ -1997,7 +2000,7 @@ class StreamHandlerTest extends TestCase
             $exception = $e;
             self::assertSame($request, $e->getRequest());
             self::assertSame(200, $e->getResponse()->getStatusCode());
-            self::assertSame('The stream handler timed out while writing the response body', $e->getMessage());
+            self::assertSame('Timed out while writing the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
             self::assertNotInstanceOf(ResponseTransferException::class, $e);
@@ -2178,7 +2181,7 @@ class StreamHandlerTest extends TestCase
         } catch (ResponseTransferException $e) {
             self::assertSame($request, $e->getRequest());
             self::assertSame(200, $e->getResponse()->getStatusCode());
-            self::assertSame('The stream handler failed while transferring the response body', $e->getMessage());
+            self::assertSame('Failed while transferring the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
         }
     }
@@ -2199,7 +2202,7 @@ class StreamHandlerTest extends TestCase
             $handler($request, ['sink' => $sink])->wait();
             self::fail('Expected ResponseException');
         } catch (ResponseException $e) {
-            self::assertSame('The stream handler failed while writing the response body', $e->getMessage());
+            self::assertSame('Failed to write the response body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertNotInstanceOf(ResponseTransferException::class, $e);
             self::assertNotInstanceOf(ResponseTimeoutException::class, $e);
@@ -2652,7 +2655,7 @@ class StreamHandlerTest extends TestCase
             $exception = $e;
             self::assertSame($request, $e->getRequest());
             self::assertSame(200, $e->getResponse()->getStatusCode());
-            self::assertSame('The stream handler timed out while transferring the response body', $e->getMessage());
+            self::assertSame('Timed out while transferring the response body', $e->getMessage());
             self::assertInstanceOf(Psr7\Exception\TimeoutException::class, $e->getPrevious());
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         }
@@ -2687,7 +2690,7 @@ class StreamHandlerTest extends TestCase
             $exception = $e;
             self::assertSame($request, $e->getRequest());
             self::assertSame(200, $e->getResponse()->getStatusCode());
-            self::assertSame('The stream handler timed out while transferring the response body', $e->getMessage());
+            self::assertSame('Timed out while transferring the response body', $e->getMessage());
             self::assertInstanceOf(Psr7\Exception\TimeoutException::class, $e->getPrevious());
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -130,6 +130,30 @@ class StreamHandlerTest extends TestCase
         ];
     }
 
+    public function testPrepareRequestFailureDoesNotInvokeOnStats(): void
+    {
+        $handler = new StreamHandler();
+        $called = false;
+        $request = new Request('GET', Server::$url, [
+            'Content-Length' => 'abc',
+        ]);
+
+        try {
+            $handler($request, [
+                'on_stats' => static function () use (&$called): void {
+                    $called = true;
+                },
+            ]);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('Invalid Content-Length request header', $e->getMessage());
+        }
+
+        self::assertFalse($called);
+    }
+
     public function testNormalizesEquivalentRequestContentLengthValues(): void
     {
         $request = new Request('GET', Server::$url, [

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\ConnectTimeoutException;
-use GuzzleHttp\Exception\NetworkException;
-use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\ResponseTimeoutException;
@@ -252,7 +249,7 @@ class StreamHandlerTest extends TestCase
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'fopen(): Failed to open stream: Operation timed out'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'stream_socket_client(): Unable to connect to example.test:443 (Operation timed out)'));
         // Windows WSAETIMEDOUT (errno 10060) wording matches for both connect-phase
-        // and post-connect send timeouts; the end-to-end tests prove which classifier wins.
+        // and post-connect send timeouts; the send-error matcher is checked first.
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond'));
         self::assertTrue($this->matchesStreamHandlerError('isConnectTimeoutError', 'Send of 65536 bytes failed with errno=10060 A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond'));
         self::assertFalse($this->matchesStreamHandlerError('isConnectTimeoutError', 'HTTP request failed!'));
@@ -335,14 +332,16 @@ class StreamHandlerTest extends TestCase
         self::assertSame($exception, $stats->getHandlerErrorData());
     }
 
-    public function testClassifiesPostConnectSendTimeoutAsNetworkTimeout(): void
+    /**
+     * @dataProvider transportLookingRequestBodyFailureMessageProvider
+     */
+    public function testRequestBodyFailureIsNotRepromotedToNetworkExceptionByMessage(string $message): void
     {
-        // A real send() ETIMEDOUT can't be triggered, so the request-body read
-        // is only a seam to feed a representative send-failure message in.
         $handler = new StreamHandler();
-        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
-            '__toString' => static function (): string {
-                throw new \RuntimeException('Send of 65536 bytes failed with errno=110 Connection timed out');
+        $previous = new \RuntimeException($message);
+        $body = FnStream::decorate(Psr7\Utils::streamFor('x'), [
+            '__toString' => static function () use ($previous): string {
+                throw $previous;
             },
         ]);
         $request = new Request('PUT', Server::$url, [], $body);
@@ -350,177 +349,32 @@ class StreamHandlerTest extends TestCase
         try {
             $handler($request, [])->wait();
 
-            self::fail('Expected NetworkTimeoutException');
-        } catch (NetworkTimeoutException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(ConnectException::class, $e);
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            $exceptionRequest = $e->getRequest();
+            self::assertSame($request->getMethod(), $exceptionRequest->getMethod());
+            self::assertSame((string) $request->getUri(), (string) $exceptionRequest->getUri());
+            self::assertSame($message, $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+            self::assertInstanceOf(RequestExceptionInterface::class, $e);
+            self::assertNotInstanceOf(ResponseException::class, $e);
+            self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
         }
     }
 
-    public function testClassifiesConnectTimeoutMessageAsConnectTimeout(): void
+    public static function transportLookingRequestBodyFailureMessageProvider(): iterable
     {
-        // Without the "Send of ..." marker, a connect-timeout message stays a connect timeout.
-        $handler = new StreamHandler();
-        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
-            '__toString' => static function (): string {
-                throw new \RuntimeException('fopen(): Failed to open stream: Connection timed out');
-            },
-        ]);
-        $request = new Request('PUT', Server::$url, [], $body);
-
-        try {
-            $handler($request, [])->wait();
-
-            self::fail('Expected ConnectTimeoutException');
-        } catch (ConnectTimeoutException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertInstanceOf(ConnectException::class, $e);
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-        }
-    }
-
-    public function testClassifiesPostConnectSendFailureAsNetwork(): void
-    {
-        // A non-timeout send failure (e.g. peer reset) is a network error, not a timeout.
-        $handler = new StreamHandler();
-        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
-            '__toString' => static function (): string {
-                throw new \RuntimeException('Send of 65536 bytes failed with errno=104 Connection reset by peer');
-            },
-        ]);
-        $request = new Request('PUT', Server::$url, [], $body);
-
-        try {
-            $handler($request, [])->wait();
-
-            self::fail('Expected NetworkException');
-        } catch (NetworkException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
-            self::assertNotInstanceOf(ConnectException::class, $e);
-            self::assertNotInstanceOf(RequestExceptionInterface::class, $e);
-        }
-    }
-
-    public function testClassifiesWindowsSendTimeoutAsNetworkTimeout(): void
-    {
-        // Windows WSAETIMEDOUT (errno 10060) write timeout on an established
-        // connection. The body-read seam only feeds a representative message in.
-        $handler = new StreamHandler();
-        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
-            '__toString' => static function (): string {
-                throw new \RuntimeException('Send of 65536 bytes failed with errno=10060 A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond');
-            },
-        ]);
-        $request = new Request('PUT', Server::$url, [], $body);
-
-        try {
-            $handler($request, [])->wait();
-
-            self::fail('Expected NetworkTimeoutException');
-        } catch (NetworkTimeoutException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(ConnectException::class, $e);
-        }
-    }
-
-    public function testClassifiesWindowsConnectTimeoutAsConnectTimeout(): void
-    {
-        // The same WSAETIMEDOUT wording without the "Send of ..." marker is a
-        // connect-phase timeout and must be a ConnectTimeoutException.
-        $handler = new StreamHandler();
-        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
-            '__toString' => static function (): string {
-                throw new \RuntimeException('A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond');
-            },
-        ]);
-        $request = new Request('PUT', Server::$url, [], $body);
-
-        try {
-            $handler($request, [])->wait();
-
-            self::fail('Expected ConnectTimeoutException');
-        } catch (ConnectTimeoutException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertInstanceOf(ConnectException::class, $e);
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-        }
-    }
-
-    public function testClassifiesConnectionResetAsNetwork(): void
-    {
-        // A post-connect reset (e.g. TLS "SSL: Connection reset by peer") is a network error.
-        $handler = new StreamHandler();
-        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
-            '__toString' => static function (): string {
-                throw new \RuntimeException('SSL: Connection reset by peer');
-            },
-        ]);
-        $request = new Request('PUT', Server::$url, [], $body);
-
-        try {
-            $handler($request, [])->wait();
-
-            self::fail('Expected NetworkException');
-        } catch (NetworkException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(ConnectException::class, $e);
-            self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
-        }
-    }
-
-    public function testClassifiesUnexpectedEofAsNetwork(): void
-    {
-        // OpenSSL 3.0+ surfaces a peer closing the connection without a TLS
-        // close_notify (an empty reply, like cURL's CURLE_GOT_NOTHING) as
-        // "unexpected eof while reading". The handshake already completed, so
-        // there is no "Failed to enable crypto", and it is a network error.
-        $handler = new StreamHandler();
-        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
-            '__toString' => static function (): string {
-                throw new \RuntimeException('SSL operation failed with code 1. OpenSSL Error messages: error:0A000126:SSL routines::unexpected eof while reading');
-            },
-        ]);
-        $request = new Request('PUT', Server::$url, [], $body);
-
-        try {
-            $handler($request, [])->wait();
-
-            self::fail('Expected NetworkException');
-        } catch (NetworkException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(ConnectException::class, $e);
-            self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
-        }
-    }
-
-    public function testClassifiesHandshakeUnexpectedEofAsConnect(): void
-    {
-        // The same OpenSSL EOF during the handshake co-emits "Failed to enable
-        // crypto", which is matched as a connection error first, so it stays a
-        // connect error instead of being reclassified as a network error.
-        $handler = new StreamHandler();
-        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
-            '__toString' => static function (): string {
-                throw new \RuntimeException('SSL operation failed with code 1. OpenSSL Error messages: error:0A000126:SSL routines::unexpected eof while reading. Failed to enable crypto');
-            },
-        ]);
-        $request = new Request('PUT', Server::$url, [], $body);
-
-        try {
-            $handler($request, [])->wait();
-
-            self::fail('Expected ConnectException');
-        } catch (ConnectException $e) {
-            self::assertSame($request, $e->getRequest());
-            self::assertInstanceOf(NetworkExceptionInterface::class, $e);
-            self::assertNotInstanceOf(NetworkTimeoutException::class, $e);
-        }
+        return [
+            'connect timeout' => ['Operation timed out'],
+            'fopen connect timeout' => ['fopen(): Failed to open stream: Connection timed out'],
+            'send timeout' => ['Send of 65536 bytes failed with errno=110 Connection timed out'],
+            'send failure' => ['Send of 65536 bytes failed with errno=104 Connection reset by peer'],
+            'windows timeout' => ['A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond'],
+            'windows send timeout' => ['Send of 65536 bytes failed with errno=10060 A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond'],
+            'tls reset' => ['SSL: Connection reset by peer'],
+            'unexpected eof' => ['SSL operation failed with code 1. OpenSSL Error messages: error:0A000126:SSL routines::unexpected eof while reading'],
+            'handshake eof' => ['SSL operation failed with code 1. OpenSSL Error messages: error:0A000126:SSL routines::unexpected eof while reading. Failed to enable crypto'],
+        ];
     }
 
     public function testRejectsHttp3(): void

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -212,10 +212,14 @@ class StreamHandlerTest extends TestCase
             $reflection->setAccessible(true);
         }
 
-        $this->expectException(RequestException::class);
-        $this->expectExceptionMessage('Content-Length exceeds the maximum integer size supported on this platform');
-
-        $reflection->invoke(null, $request);
+        try {
+            $reflection->invoke(null, $request);
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame('Content-Length exceeds the maximum integer size supported on this platform', $e->getMessage());
+            self::assertSame($request, $e->getRequest());
+            self::assertInstanceOf(\OverflowException::class, $e->getPrevious());
+        }
     }
 
     public function testRejectsInvalidRequestContentLengthBeforeAddingEmptyBodyDefault(): void

--- a/tests/Handler/TransferByteCounterTest.php
+++ b/tests/Handler/TransferByteCounterTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Handler;
+
+use GuzzleHttp\Handler\TransferByteCounter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Handler\TransferByteCounter
+ */
+class TransferByteCounterTest extends TestCase
+{
+    /**
+     * @dataProvider validProgressValueProvider
+     *
+     * @param mixed $value
+     */
+    public function testProgressValueNarrowsToInt($value, int $expected): void
+    {
+        self::assertSame($expected, TransferByteCounter::progressValueToInt($value));
+    }
+
+    public static function validProgressValueProvider(): array
+    {
+        return [
+            'zero int' => [0, 0],
+            'small int' => [42, 42],
+            'int max' => [\PHP_INT_MAX, \PHP_INT_MAX],
+            'zero float' => [0.0, 0],
+            'small float' => [10.0, 10],
+            'megabyte float' => [1048576.0, 1048576],
+        ];
+    }
+
+    /**
+     * @dataProvider overflowingProgressValueProvider
+     *
+     * @param mixed $value
+     */
+    public function testProgressValueRejectsOutOfRangeValues($value): void
+    {
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Progress byte count exceeds the maximum integer size supported on this platform');
+
+        TransferByteCounter::progressValueToInt($value);
+    }
+
+    public static function overflowingProgressValueProvider(): array
+    {
+        return [
+            'negative int' => [-1],
+            'int min' => [\PHP_INT_MIN],
+            'negative float' => [-1.0],
+            'positive infinity' => [\INF],
+            'negative infinity' => [-\INF],
+            'not a number' => [\NAN],
+            'finite above max' => [1.0e19],
+        ];
+    }
+
+    /**
+     * @dataProvider nonNumericProgressValueProvider
+     *
+     * @param mixed $value
+     */
+    public function testProgressValueRejectsNonNumericValues($value): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Progress byte count must be an integer or float');
+
+        TransferByteCounter::progressValueToInt($value);
+    }
+
+    public static function nonNumericProgressValueProvider(): array
+    {
+        return [
+            'numeric string' => ['5'],
+            'empty string' => [''],
+            'null' => [null],
+            'array' => [[]],
+            'true' => [true],
+            'false' => [false],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    public function testProgressFloatAtIntMaxBoundaryIsRejectedOnSixtyFourBit(): void
+    {
+        if (\PHP_INT_SIZE !== 8) {
+            self::markTestSkipped('The post-cast boundary re-check only triggers on 64-bit platforms.');
+        }
+
+        // (float) PHP_INT_MAX rounds up to 2**63, which is not greater than
+        // PHP_INT_MAX after float promotion but casts to PHP_INT_MIN.
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Progress byte count exceeds the maximum integer size supported on this platform');
+
+        TransferByteCounter::progressValueToInt((float) \PHP_INT_MAX);
+    }
+
+    /**
+     * @dataProvider addableByteCountProvider
+     */
+    public function testAddReturnsSum(int $current, int $delta, int $expected): void
+    {
+        self::assertSame($expected, TransferByteCounter::add($current, $delta, 'unused'));
+    }
+
+    public static function addableByteCountProvider(): array
+    {
+        return [
+            'zero plus zero' => [0, 0, 0],
+            'zero plus delta' => [0, 5, 5],
+            'mid range' => [5, 7, 12],
+            'reaches int max' => [\PHP_INT_MAX - 1, 1, \PHP_INT_MAX],
+        ];
+    }
+
+    /**
+     * @dataProvider overflowingByteCountProvider
+     */
+    public function testAddRejectsOverflowAndNegativeOperands(int $current, int $delta): void
+    {
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('byte ceiling reached');
+
+        TransferByteCounter::add($current, $delta, 'byte ceiling reached');
+    }
+
+    public static function overflowingByteCountProvider(): array
+    {
+        return [
+            'one past max' => [\PHP_INT_MAX, 1],
+            'two past max minus one' => [\PHP_INT_MAX - 1, 2],
+            'max plus max' => [\PHP_INT_MAX, \PHP_INT_MAX],
+            'negative current' => [-1, 0],
+            'negative delta' => [0, -1],
+            'both negative' => [-1, -1],
+        ];
+    }
+}

--- a/tests/Handler/TransferByteCounterTest.php
+++ b/tests/Handler/TransferByteCounterTest.php
@@ -89,11 +89,11 @@ class TransferByteCounterTest extends TestCase
     public function testProgressFloatAtIntMaxBoundaryIsRejectedOnSixtyFourBit(): void
     {
         if (\PHP_INT_SIZE !== 8) {
-            self::markTestSkipped('The post-cast boundary re-check only triggers on 64-bit platforms.');
+            self::markTestSkipped('The rounded PHP_INT_MAX float guard only triggers on 64-bit platforms.');
         }
 
         // (float) PHP_INT_MAX rounds up to 2**63, which is not greater than
-        // PHP_INT_MAX after float promotion but casts to PHP_INT_MIN.
+        // PHP_INT_MAX after float promotion, so reject it before casting.
         $this->expectException(\OverflowException::class);
         $this->expectExceptionMessage('Progress byte count exceeds the maximum integer size supported on this platform');
 

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -320,6 +321,41 @@ class RedirectMiddlewareTest extends TestCase
         self::assertInstanceOf(RedirectTestRequest::class, $lastRequest);
         self::assertInstanceOf(RedirectTestUri::class, $lastRequest->getUri());
         self::assertSame('http://example.com/foo', (string) $lastRequest->getUri());
+    }
+
+    public function testRedirectRequestBodyRewindFailureThrowsResponseException(): void
+    {
+        $previous = new \RuntimeException('cannot rewind');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            'tell' => static function (): int {
+                return 4;
+            },
+            'rewind' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+        $mock = new MockHandler([
+            new Response(307, ['Location' => 'http://example.com/redirected']),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('POST', 'http://example.com', [], $body);
+
+        try {
+            $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertNotInstanceOf(BadResponseException::class, $e);
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(307, $e->getResponse()->getStatusCode());
+            self::assertSame(
+                'Redirect failed because the request body could not be rewound: cannot rewind',
+                $e->getMessage()
+            );
+            self::assertSame($previous, $e->getPrevious());
+        }
     }
 
     public function testSendPreservesCustomUriImplementationForRelativeRedirectsWithDefaultUriFactory(): void


### PR DESCRIPTION
This hardens the built-in cURL and stream handlers around Content-Length handling and transfer accounting. Request Content-Length headers are now parsed consistently, duplicate values are accepted only when they agree, malformed or platform-unrepresentable values fail before a transfer begins, and non-streamed stream-handler responses with a valid Content-Length are rejected when the body ends short or cannot be represented safely.

The branch also tightens failure classification around response-aware transfers. Response body network and protocol failures use ResponseTransferException or ResponseTimeoutException, while local failures such as request-body stream reads, sink writes, progress callbacks, redirect rewinds, response finalization, and deterministic byte-count overflows are wrapped as RequestException or ResponseException according to whether response headers were available. Progress callback byte counts are normalized to safe integers before callbacks are invoked, and the related upgrade notes, request-option docs, exception guidance, and changelog entries have been updated.