### PR TITLE
Ignore body summary failures

### DIFF
--- a/src/BodySummarizer.php
+++ b/src/BodySummarizer.php
@@ -20,8 +20,12 @@ final class BodySummarizer implements BodySummarizerInterface
      */
     public function summarize(MessageInterface $message): ?string
     {
-        return $this->truncateAt === null
-            ? Psr7\Message::bodySummary($message)
-            : Psr7\Message::bodySummary($message, $this->truncateAt);
+        try {
+            return $this->truncateAt === null
+                ? Psr7\Message::bodySummary($message)
+                : Psr7\Message::bodySummary($message, $this->truncateAt);
+        } catch (\RuntimeException $e) {
+            return null;
+        }
     }
 }

--- a/tests/BodySummarizerTest.php
+++ b/tests/BodySummarizerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\BodySummarizer;
+use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
@@ -29,5 +30,17 @@ class BodySummarizerTest extends TestCase
 
         self::assertSame('abc (truncated...)', (new BodySummarizer(3))->summarize($response));
         self::assertSame(3, $body->tell());
+    }
+
+    public function testSummarizeReturnsNullWhenBodySummaryFails(): void
+    {
+        $body = FnStream::decorate(Utils::streamFor('abcdef'), [
+            'tell' => static function (): int {
+                throw new \RuntimeException('tell failed');
+            },
+        ]);
+        $response = new Response(200, [], $body);
+
+        self::assertNull((new BodySummarizer())->summarize($response));
     }
 }


### PR DESCRIPTION
This keeps response exception creation on the original HTTP failure path when Guzzle cannot summarize the response body. If the PSR-7 body summary throws a runtime exception, the summarizer now omits the body snippet instead of letting that secondary failure replace the exception being built.