### PR TITLE
Simplify body summary truncation

### DIFF
--- a/src/BodySummarizer.php
+++ b/src/BodySummarizer.php
@@ -21,9 +21,7 @@ final class BodySummarizer implements BodySummarizerInterface
     public function summarize(MessageInterface $message): ?string
     {
         try {
-            return $this->truncateAt === null
-                ? Psr7\Message::bodySummary($message)
-                : Psr7\Message::bodySummary($message, $this->truncateAt);
+            return Psr7\Message::bodySummary($message, $this->truncateAt);
         } catch (\RuntimeException $e) {
             return null;
         }


### PR DESCRIPTION
Now that Guzzle PSR-7 accepts null for Message::bodySummary()'s truncation length, BodySummarizer no longer needs to branch around the default case. This passes the nullable truncation value directly while preserving the existing RuntimeException guard added for summary failures.