### PR TITLE
Use Guzzle exceptions for invalid middleware options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Classify redirect request-body rewind failures as `ResponseException`
 - Ignore stream source close failures after a complete response body transfer
 - Throw `GuzzleHttp\Exception\InvalidArgumentException` for invalid built-in handler options
+- Throw `GuzzleHttp\Exception\InvalidArgumentException` for invalid redirect, cookie, and retry middleware options
 - Classify built-in cURL handle, `sink`, and HTTP/3 setup failures as `RequestException`
 - Throw `ConnectTimeoutException` for connect timeouts
 - Throw `NetworkTimeoutException` for cURL no-response timeout errors

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp;
 
 use GuzzleHttp\Cookie\CookieJarInterface;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Promise as P;
@@ -37,7 +38,7 @@ final class Middleware
                 if (empty($options['cookies'])) {
                     return $handler($request, $options);
                 } elseif (!$options['cookies'] instanceof CookieJarInterface) {
-                    throw new \InvalidArgumentException('cookies must be an instance of GuzzleHttp\Cookie\CookieJarInterface');
+                    throw new InvalidArgumentException('cookies must be an instance of GuzzleHttp\Cookie\CookieJarInterface');
                 }
                 $cookieJar = $options['cookies'];
                 $request = $cookieJar->withCookieHeader($request);

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -67,7 +68,7 @@ class RedirectMiddleware
         if ($options['allow_redirects'] === true) {
             $options['allow_redirects'] = self::DEFAULT_SETTINGS;
         } elseif (!\is_array($options['allow_redirects'])) {
-            throw new \InvalidArgumentException('allow_redirects must be true, false, or array');
+            throw new InvalidArgumentException('allow_redirects must be true, false, or array');
         } else {
             // Merge the default settings with the provided settings
             $options['allow_redirects'] += self::DEFAULT_SETTINGS;
@@ -190,7 +191,7 @@ class RedirectMiddleware
             $requestMethod = $request->getMethod();
             $streamFactory = $options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory();
             if (!$streamFactory instanceof StreamFactoryInterface) {
-                throw new \InvalidArgumentException(\sprintf(
+                throw new InvalidArgumentException(\sprintf(
                     '%s must be an instance of %s',
                     RequestOptions::STREAM_FACTORY,
                     StreamFactoryInterface::class
@@ -203,7 +204,7 @@ class RedirectMiddleware
 
         $uriFactory = $options[RequestOptions::URI_FACTORY] ?? new HttpFactory();
         if (!$uriFactory instanceof UriFactoryInterface) {
-            throw new \InvalidArgumentException(\sprintf(
+            throw new InvalidArgumentException(\sprintf(
                 '%s must be an instance of %s',
                 RequestOptions::URI_FACTORY,
                 UriFactoryInterface::class

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp;
 
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -56,7 +57,7 @@ class RetryMiddleware
         if (!isset($options['retries'])) {
             $options['retries'] = 0;
         } elseif (!\is_int($options['retries'])) {
-            throw new \InvalidArgumentException('retries must be an integer');
+            throw new InvalidArgumentException('retries must be an integer');
         }
 
         /** @var PromiseInterface<ResponseInterface, mixed> */

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\BodySummarizer;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Cookie\SetCookie;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Handler\MockHandler;
@@ -45,6 +46,18 @@ class MiddlewareTest extends TestCase
         $f = $m($h);
         $f(new Request('GET', 'http://foo.com'), ['cookies' => $jar])->wait();
         self::assertCount(1, $jar);
+    }
+
+    public function testRejectsInvalidCookiesOptionDirectly(): void
+    {
+        $f = Middleware::cookies()(new MockHandler([new Response(200)]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('cookies must be an instance of GuzzleHttp\Cookie\CookieJarInterface');
+
+        $f(new Request('GET', 'http://foo.com'), [
+            'cookies' => new \stdClass(),
+        ]);
     }
 
     public function testThrowsExceptionOnHttpClientError(): void

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Handler\MockHandler;
@@ -81,13 +82,25 @@ class RedirectMiddlewareTest extends TestCase
         $stack = new HandlerStack($mock);
         $stack->push(Middleware::redirect());
 
-        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('idn_conversion must be true, false, null, or an integer IDNA_* bitmask');
 
         $stack->resolve()(new Request('GET', 'http://example.com'), [
             'allow_redirects' => ['max' => 2],
             'idn_conversion' => '0',
         ])->wait();
+    }
+
+    public function testRejectsInvalidAllowRedirectsOptionDirectly(): void
+    {
+        $middleware = new RedirectMiddleware(new MockHandler([new Response(200)]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('allow_redirects must be true, false, or array');
+
+        $middleware(new Request('GET', 'http://example.com'), [
+            'allow_redirects' => 'yes',
+        ]);
     }
 
     public function testRedirectsWithRelativeUri(): void
@@ -271,7 +284,7 @@ class RedirectMiddlewareTest extends TestCase
         });
         $request = new Request('POST', 'http://example.com/', [], 'payload');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
 
         $redirectMiddleware->modifyRequest($request, [
@@ -484,7 +497,7 @@ class RedirectMiddlewareTest extends TestCase
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('uri_factory must be an instance of Psr\\Http\\Message\\UriFactoryInterface');
 
         $handler($request, [

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\Create;
@@ -127,6 +128,19 @@ class RetryMiddlewareTest extends TestCase
         $this->expectExceptionMessage('Passing string to request option "retries" is invalid; expected int.');
 
         $c->send(new Request('GET', 'http://test.com'), ['retries' => '0']);
+    }
+
+    public function testRejectsNonIntegerRetriesOptionDirectly(): void
+    {
+        $decider = static function (): bool {
+            return false;
+        };
+        $handler = Middleware::retry($decider)(new MockHandler([new Response(200)]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('retries must be an integer');
+
+        $handler(new Request('GET', 'http://test.com'), ['retries' => '0']);
     }
 
     public function testCanRetryExceptions(): void


### PR DESCRIPTION
This updates redirect, cookie, and retry middleware invalid option checks to throw GuzzleHttp\Exception\InvalidArgumentException instead of the bare SPL type. The Guzzle exception still extends \InvalidArgumentException, so existing catches continue to work while these send-path failures also implement GuzzleException.