### PR TITLE
Improve request body failure messages

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1189,7 +1189,11 @@ final class CurlFactory implements CurlFactoryInterface
         try {
             $size = $body->getSize();
         } catch (\RuntimeException $e) {
-            throw new RequestException($e->getMessage(), $easy->request, 0, $e);
+            $message = $e instanceof TimeoutException
+                ? 'Timed out while determining the request body size'
+                : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to determine the request body size');
+
+            throw new RequestException($message, $easy->request, 0, $e);
         }
 
         if ($size === null || $size > 0) {
@@ -1254,12 +1258,11 @@ final class CurlFactory implements CurlFactoryInterface
             try {
                 $conf[\CURLOPT_POSTFIELDS] = (string) $request->getBody();
             } catch (\Throwable $e) {
-                throw new RequestException(
-                    $e->getMessage() !== '' ? $e->getMessage() : 'Failed to read the request body',
-                    $request,
-                    0,
-                    $e
-                );
+                $message = $e instanceof TimeoutException
+                    ? 'Timed out while reading the request body'
+                    : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to read the request body');
+
+                throw new RequestException($message, $request, 0, $e);
             }
             // Don't duplicate the Content-Length header
             $this->removeHeader('Content-Length', $conf);
@@ -1282,12 +1285,11 @@ final class CurlFactory implements CurlFactoryInterface
                     $body->rewind();
                 }
             } catch (\Throwable $e) {
-                throw new RequestException(
-                    $e->getMessage() !== '' ? $e->getMessage() : 'Failed to rewind the request body',
-                    $request,
-                    0,
-                    $e
-                );
+                $message = $e instanceof TimeoutException
+                    ? 'Timed out while rewinding the request body'
+                    : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to rewind the request body');
+
+                throw new RequestException($message, $request, 0, $e);
             }
             /**
              * @return int|string

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -159,7 +159,11 @@ final class StreamHandler
         try {
             $bodySize = $request->getBody()->getSize();
         } catch (\RuntimeException $e) {
-            throw new RequestException($e->getMessage(), $request, 0, $e);
+            $message = $e instanceof TimeoutException
+                ? 'Timed out while determining the request body size'
+                : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to determine the request body size');
+
+            throw new RequestException($message, $request, 0, $e);
         }
 
         if (($request->getMethod() === 'PUT' || $request->getMethod() === 'POST') && 0 === $bodySize) {
@@ -799,7 +803,11 @@ final class StreamHandler
         try {
             $body = (string) $request->getBody();
         } catch (\RuntimeException $e) {
-            throw new RequestException($e->getMessage(), $request, 0, $e);
+            $message = $e instanceof TimeoutException
+                ? 'Timed out while reading the request body'
+                : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to read the request body');
+
+            throw new RequestException($message, $request, 0, $e);
         }
 
         if ('' !== $body) {

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -118,7 +119,11 @@ class PrepareBodyMiddleware
         try {
             return $request->getBody()->getSize();
         } catch (\RuntimeException $e) {
-            throw new RequestException($e->getMessage(), $request, 0, $e);
+            $message = $e instanceof TimeoutException
+                ? 'Timed out while determining the request body size'
+                : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to determine the request body size');
+
+            throw new RequestException($message, $request, 0, $e);
         }
     }
 }

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -221,7 +221,7 @@ class RedirectMiddleware
             Psr7\Message::rewindBody($request);
         } catch (\RuntimeException $e) {
             throw new ResponseException(
-                'Redirect failed because the request body could not be rewound: '.$e->getMessage(),
+                'Redirect failed because the request body could not be rewound',
                 $request,
                 $response,
                 $e

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -3541,11 +3541,33 @@ class CurlFactoryTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('Unable to determine stream size: timed out', $e->getMessage());
+            self::assertSame('Timed out while determining the request body size', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
+        }
+    }
+
+    public function testRequestBodyGetSizeFailureUsesFallbackMessageWhenMessageEmpty(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \RuntimeException('');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function () use ($previous): ?int {
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, []);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('Failed to determine the request body size', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
         }
     }
 
@@ -3702,7 +3724,7 @@ class CurlFactoryTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('Unable to read from stream: timed out', $e->getMessage());
+            self::assertSame('Timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
@@ -3714,6 +3736,30 @@ class CurlFactoryTest extends TestCase
         }
 
         self::assertTrue($castCalled);
+    }
+
+    public function testBodyAsStringRequestBodyReadFailureUsesFallbackMessageWhenMessageEmpty(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \RuntimeException('');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+            '__toString' => static function () use ($previous): string {
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, [
+                'curl' => ['body_as_string' => true],
+            ]);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('Failed to read the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        }
     }
 
     public function testBodyAsStringRequestBodyReadFailureRejectsAsRequestException(): void
@@ -3804,7 +3850,7 @@ class CurlFactoryTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('Unable to rewind stream: timed out', $e->getMessage());
+            self::assertSame('Timed out while rewinding the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
@@ -3812,6 +3858,31 @@ class CurlFactoryTest extends TestCase
         }
 
         self::assertTrue($rewindCalled);
+    }
+
+    public function testStreamingRequestBodyRewindFailureUsesFallbackMessageWhenMessageEmpty(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \RuntimeException('');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+            'rewind' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, []);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('Failed to rewind the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        }
     }
 
     /**

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -176,7 +176,7 @@ class StreamHandlerTest extends TestCase
             self::fail('Expected RequestException');
         } catch (RequestException $e) {
             self::assertSame($request, $e->getRequest());
-            self::assertSame('Unable to determine stream size: timed out', $e->getMessage());
+            self::assertSame('Timed out while determining the request body size', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(ResponseException::class, $e);
@@ -184,6 +184,28 @@ class StreamHandlerTest extends TestCase
         }
 
         self::assertFalse($called);
+    }
+
+    public function testRequestBodyGetSizeFailureUsesFallbackMessageWhenMessageEmpty(): void
+    {
+        $handler = new StreamHandler();
+        $previous = new \RuntimeException('');
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            'getSize' => static function () use ($previous): ?int {
+                throw $previous;
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, []);
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame('Failed to determine the request body size', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        }
     }
 
     public function testNormalizesEquivalentRequestContentLengthValues(): void
@@ -322,7 +344,7 @@ class StreamHandlerTest extends TestCase
             $exceptionRequest = $e->getRequest();
             self::assertSame($request->getMethod(), $exceptionRequest->getMethod());
             self::assertSame((string) $request->getUri(), (string) $exceptionRequest->getUri());
-            self::assertSame('Unable to read stream contents: timed out', $e->getMessage());
+            self::assertSame('Timed out while reading the request body', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
             self::assertInstanceOf(RequestExceptionInterface::class, $e);
             self::assertNotInstanceOf(NetworkExceptionInterface::class, $e);
@@ -334,6 +356,30 @@ class StreamHandlerTest extends TestCase
         self::assertSame($exceptionRequest->getMethod(), $stats->getRequest()->getMethod());
         self::assertSame((string) $exceptionRequest->getUri(), (string) $stats->getRequest()->getUri());
         self::assertSame($exception, $stats->getHandlerErrorData());
+    }
+
+    public function testRequestBodyReadFailureUsesFallbackMessageWhenMessageEmpty(): void
+    {
+        $handler = new StreamHandler();
+        $previous = new \RuntimeException('');
+        $body = FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            '__toString' => static function () use ($previous): string {
+                throw $previous;
+            },
+        ]);
+        $request = new Request('PUT', Server::$url, [], $body);
+
+        try {
+            $handler($request, [])->wait();
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            $exceptionRequest = $e->getRequest();
+            self::assertSame($request->getMethod(), $exceptionRequest->getMethod());
+            self::assertSame((string) $request->getUri(), (string) $exceptionRequest->getUri());
+            self::assertSame('Failed to read the request body', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        }
     }
 
     /**

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Tests;
 
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -249,6 +250,55 @@ class PrepareBodyMiddlewareTest extends TestCase
         self::assertInstanceOf(PromiseInterface::class, $p);
         $response = $p->wait();
         self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * @dataProvider requestBodyGetSizeFailureMessageProvider
+     */
+    public function testRequestBodyGetSizeFailureUsesExpectedMessage(\RuntimeException $previous, string $expected): void
+    {
+        $body = FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function () use ($previous): ?int {
+                throw $previous;
+            },
+        ]);
+        $handler = new MockHandler([
+            static function (): ResponseInterface {
+                self::fail('The request should fail before reaching the handler.');
+            },
+        ]);
+        $stack = new HandlerStack($handler);
+        $stack->push(Middleware::prepareBody());
+        $composed = $stack->resolve();
+        $request = new Request('POST', 'http://example.com', [], $body);
+
+        try {
+            $composed($request, [])->wait();
+
+            self::fail('Expected RequestException');
+        } catch (RequestException $e) {
+            self::assertSame($request, $e->getRequest());
+            self::assertSame($expected, $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        }
+    }
+
+    public static function requestBodyGetSizeFailureMessageProvider(): iterable
+    {
+        return [
+            'timeout' => [
+                new Psr7\Exception\TimeoutException('Unable to determine stream size: timed out'),
+                'Timed out while determining the request body size',
+            ],
+            'empty message' => [
+                new \RuntimeException(''),
+                'Failed to determine the request body size',
+            ],
+            'custom message' => [
+                new \RuntimeException('cannot stat custom stream'),
+                'cannot stat custom stream',
+            ],
+        ];
     }
 }
 

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -351,7 +351,7 @@ class RedirectMiddlewareTest extends TestCase
             self::assertSame($request, $e->getRequest());
             self::assertSame(307, $e->getResponse()->getStatusCode());
             self::assertSame(
-                'Redirect failed because the request body could not be rewound: cannot rewind',
+                'Redirect failed because the request body could not be rewound',
                 $e->getMessage()
             );
             self::assertSame($previous, $e->getPrevious());


### PR DESCRIPTION
This improves the top-level messages Guzzle emits when local request-body preparation fails. PSR-7 stream timeouts now keep the low-level stream message as the previous exception while presenting contextual messages for determining the request body size, reading the request body, or rewinding the request body.

Custom non-empty stream messages continue to pass through unchanged, empty stream messages now use contextual fallback messages, and redirect rewind failures now describe the failed redirect operation without duplicating the lower-level reason.