### PR TITLE
Refine transfer exception catch boundaries

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -151,33 +151,23 @@ failures. Keep catching `ConnectException` only when handling connection
 establishment failures specifically.
 
 Guzzle 8.0 also makes response-aware request failures explicit. Guzzle 7.x does
-not have `ResponseException`; response-aware request failures remain under
+not have `ResponseException`, and response-aware request failures remain under
 `RequestException` throughout Guzzle 7.x. In Guzzle 8.0, `ResponseException` is
 the base class for request failures where response headers were received and a
 response object is available. `ResponseTransferException` is used for
 transfer-level failures after headers, including response-aware network,
 protocol, content-decoding, partial-body, and response-body transfer failures.
 `BadResponseException` and `TooManyRedirectsException` also extend
-`ResponseException`. Only this branch exposes response access:
-`RequestException` no longer stores responses, no longer accepts a response
-constructor argument, and no longer has `getResponse()` or `hasResponse()`
-methods. Catch `ResponseException`, or test with `instanceof ResponseException`,
-before calling `getResponse()`. If you instantiate `RequestException` directly,
-its third constructor argument is now the exception code, followed by the
-previous exception. If you used the removed `getHandlerContext()` methods to
-classify failures, use the more granular exception classes above instead. Use
-`on_stats` when you need handler timing or statistics. If a handler throws
-`Error`, `TypeError`, or another non-`Exception` `Throwable` before returning a
-promise, `Client::sendAsync()` now returns a rejected promise; waiting on it
-rethrows the original throwable. During request and response body handling,
-Guzzle still wraps `\Exception` failures as `RequestException` or
-`ResponseException` where appropriate, while non-`Exception` throwables
-propagate unchanged; native cURL callbacks continue to handle `\Throwable` where
-required.
+`ResponseException`.
+
+Only this branch exposes response access: `RequestException` no longer stores
+responses, no longer accepts a response constructor argument, and no longer has
+`getResponse()` or `hasResponse()` methods. Catch `ResponseException`, or test
+with `instanceof ResponseException`, before calling `getResponse()`.
 
 Timeout exception classes are now split by the transport phase the handler can
-determine. `ConnectTimeoutException` is thrown for detected connect timeouts (DNS
-resolution, TCP connect, proxy CONNECT, or TLS handshake). It extends
+determine. `ConnectTimeoutException` is thrown for detected connect timeouts
+(DNS resolution, TCP connect, proxy CONNECT, or TLS handshake). It extends
 `ConnectException`, so code that catches `ConnectException` will also catch
 connect timeouts. `NetworkTimeoutException` is thrown for other detected
 transport timeouts before response headers are received. It extends
@@ -188,17 +178,22 @@ extends `ResponseTransferException` and exposes the response.
 Timeouts that originate from caller-supplied PSR-7 streams are not transport
 timeouts. Reading the request body stream, including size detection,
 stringification, rewind, and upload reads, is a `RequestException` before a
-response and a `ResponseException` after response headers. A slow response `sink`
-write is a `ResponseException` once a response exists, or a `RequestException`
-otherwise. Whenever the timeout comes from a PSR-7 stream, the original
+response and a `ResponseException` after response headers. A slow response
+`sink` write is a `ResponseException` once a response exists, or a
+`RequestException` otherwise. Whenever the timeout comes from a PSR-7 stream,
+the original
 `GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
 
-Generic throwables from a cURL `sink` write are now wrapped instead of escaping
-the native cURL callback. They become plain `ResponseException` instances when a
-response was received, or `RequestException` instances otherwise, with the
-original throwable available via `getPrevious()`. The cURL handlers continue to
-report `CURLE_WRITE_ERROR` as `on_stats` handler error data for these write
-callback failures.
+If a handler throws `Error`, `TypeError`, or another non-`Exception`
+`Throwable` before returning a promise, `Client::sendAsync()` returns a rejected
+promise. Waiting on it rethrows the original throwable. During request and
+response body handling outside native cURL callbacks, Guzzle still wraps
+`\Exception` failures as `RequestException` or `ResponseException` where
+appropriate, while non-`Exception` throwables propagate unchanged. Native cURL
+callbacks remain different. A throwable from a cURL `sink` write is wrapped as
+`ResponseException` when a response was received, or `RequestException`
+otherwise, and the cURL handlers continue to report `CURLE_WRITE_ERROR` as
+`on_stats` handler error data.
 
 `HandlerClosedException` is new in Guzzle 8.0. It extends `TransferException`
 and is used when an explicitly closed `CurlMultiHandler` rejects transfers that
@@ -288,12 +283,16 @@ because it remains framed by `Content-Length`.
 
 The deprecated `RequestException::wrapException()` method was removed. Create a
 `RequestException` directly for request failures where Guzzle does not expose a
-response object. For failures with a response, create `ResponseException`,
-`ResponseTransferException`, `ResponseTimeoutException`, `BadResponseException`,
-`ClientException`, `ServerException`, or `TooManyRedirectsException` instead.
-`GuzzleHttp\Exception\InvalidArgumentException` remains outside the transfer
-exception hierarchy and is still used for invalid configuration or request
-option values that can be rejected before a transfer starts.
+response object. Its third constructor argument is now the exception code,
+followed by the previous exception. For failures with a response, create
+`ResponseException`, `ResponseTransferException`, `ResponseTimeoutException`,
+`BadResponseException`, `ClientException`, `ServerException`, or
+`TooManyRedirectsException` instead. If you used the removed
+`getHandlerContext()` methods to classify failures, use the more granular
+exception classes above instead, or use `on_stats` when you need handler timing
+or statistics. `GuzzleHttp\Exception\InvalidArgumentException` remains outside
+the transfer exception hierarchy and is still used for invalid configuration or
+request option values that can be rejected before a transfer starts.
 
 #### Body Summaries In HTTP Error Exceptions
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -181,16 +181,16 @@ stringification, rewind, and upload reads, is a `RequestException` before a
 response and a `ResponseException` after response headers. A slow response
 `sink` write is a `ResponseException` once a response exists, or a
 `RequestException` otherwise. Whenever the timeout comes from a PSR-7 stream,
-the original
-`GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
+the original `GuzzleHttp\Psr7\Exception\TimeoutException` is available via
+`getPrevious()`.
 
-If a handler throws `Error`, `TypeError`, or another non-`Exception`
-`Throwable` before returning a promise, `Client::sendAsync()` returns a rejected
-promise. Waiting on it rethrows the original throwable. During request and
-response body handling outside native cURL callbacks, Guzzle still wraps
-`\Exception` failures as `RequestException` or `ResponseException` where
-appropriate, while non-`Exception` throwables propagate unchanged. Native cURL
-callbacks remain different. A throwable from a cURL `sink` write is wrapped as
+If a handler throws `Error`, `TypeError`, or another non-`Exception` `Throwable`
+before returning a promise, `Client::sendAsync()` returns a rejected promise.
+Waiting on it rethrows the original throwable. During request and response body
+handling outside native cURL callbacks, Guzzle still wraps `\Exception` failures
+as `RequestException` or `ResponseException` where appropriate, while
+non-`Exception` throwables propagate unchanged. Native cURL callbacks remain
+different. A throwable from a cURL `sink` write is wrapped as
 `ResponseException` when a response was received, or `RequestException`
 otherwise, and the cURL handlers continue to report `CURLE_WRITE_ERROR` as
 `on_stats` handler error data.
@@ -242,10 +242,10 @@ as `RequestException` or `ConnectException`:
 - Response-transfer failures after response headers were received are
   `ResponseTransferException`. This includes response-aware cURL connection,
   network, protocol, content-decoding, partial-body, and response body transfer
-  failures. Response-body network stalls are
-  `ResponseTimeoutException`, while `sink` write failures, progress callback
-  failures, deterministic response size/platform-limit failures, or request-body
-  stalls after headers are plain `ResponseException` instances.
+  failures. Response-body network stalls are `ResponseTimeoutException`, while
+  `sink` write failures, progress callback failures, deterministic response
+  size/platform-limit failures, or request-body stalls after headers are plain
+  `ResponseException` instances.
 - Post-transfer response finalization failures are also plain
   `ResponseException`. A seekable response sink that fails to rewind does not
   become a `ResponseTransferException`. Non-seekable sinks are not rewound, and
@@ -257,10 +257,10 @@ This applies to both the cURL and stream handlers; the exact error codes and
 messages each one maps onto these classes are an implementation detail.
 
 The cURL handler no longer treats non-`101` informational responses such as
-`100 Continue`, `102 Processing`, or `103 Early Hints` as the final response.
-If a cURL transfer fails after receiving only one of those interim responses,
-Guzzle now reports a no-response failure such as `NetworkException` instead of
-a `ResponseTransferException` carrying the interim `1xx` response. Code that
+`100 Continue`, `102 Processing`, or `103 Early Hints` as the final response. If
+a cURL transfer fails after receiving only one of those interim responses,
+Guzzle now reports a no-response failure such as `NetworkException` instead of a
+`ResponseTransferException` carrying the interim `1xx` response. Code that
 previously caught this path with `RequestException` or
 `RequestExceptionInterface` should catch `NetworkExceptionInterface` or
 `TransferException` instead. `101 Switching Protocols` is unchanged and is still

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -157,17 +157,23 @@ the base class for request failures where response headers were received and a
 response object is available. `ResponseTransferException` is used for
 transfer-level failures after headers, including response-aware network,
 protocol, content-decoding, partial-body, and response-body transfer failures.
-`BadResponseException` and
-`TooManyRedirectsException` also extend `ResponseException`. Only this branch
-exposes response access: `RequestException` no longer stores responses, no
-longer accepts a response constructor argument, and no longer has `getResponse()`
-or `hasResponse()` methods. Catch `ResponseException`, or test with `instanceof
-ResponseException`, before calling `getResponse()`. If you instantiate
-`RequestException` directly, its third constructor argument is now the exception
-code, followed by the previous exception. If you used the removed
-`getHandlerContext()` methods to classify failures, use the more granular
-exception classes above instead. Use `on_stats` when you need handler timing or
-statistics.
+`BadResponseException` and `TooManyRedirectsException` also extend
+`ResponseException`. Only this branch exposes response access:
+`RequestException` no longer stores responses, no longer accepts a response
+constructor argument, and no longer has `getResponse()` or `hasResponse()`
+methods. Catch `ResponseException`, or test with `instanceof ResponseException`,
+before calling `getResponse()`. If you instantiate `RequestException` directly,
+its third constructor argument is now the exception code, followed by the
+previous exception. If you used the removed `getHandlerContext()` methods to
+classify failures, use the more granular exception classes above instead. Use
+`on_stats` when you need handler timing or statistics. If a handler throws
+`Error`, `TypeError`, or another non-`Exception` `Throwable` before returning a
+promise, `Client::sendAsync()` now returns a rejected promise; waiting on it
+rethrows the original throwable. During request and response body handling,
+Guzzle still wraps `\Exception` failures as `RequestException` or
+`ResponseException` where appropriate, while non-`Exception` throwables
+propagate unchanged; native cURL callbacks continue to handle `\Throwable` where
+required.
 
 Timeout exception classes are now split by the transport phase the handler can
 determine. `ConnectTimeoutException` is thrown for detected connect timeouts (DNS

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27,7 +27,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$ch of function curl_getinfo expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 4
+			count: 2
 			path: src/Handler/CurlFactory.php
 
 		-

--- a/src/BodySummarizer.php
+++ b/src/BodySummarizer.php
@@ -22,7 +22,7 @@ final class BodySummarizer implements BodySummarizerInterface
     {
         try {
             return Psr7\Message::bodySummary($message, $this->truncateAt);
-        } catch (\RuntimeException $e) {
+        } catch (\Exception $e) {
             return null;
         }
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1202,7 +1202,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         try {
             /** @var PromiseInterface<ResponseInterface, mixed> */
             return P\Create::promiseFor($handler($request, $options));
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             /** @var PromiseInterface<ResponseInterface, mixed> */
             return P\Create::rejectionFor($e);
         }

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -32,8 +32,6 @@ use Psr\Http\Message\UriInterface;
  */
 final class CurlFactory implements CurlFactoryInterface
 {
-    public const CURL_VERSION_STR = 'curl_version';
-
     private const CURL_CONNECTION_ERRORS = [
         5 => true,   // CURLE_COULDNT_RESOLVE_PROXY
         6 => true,   // CURLE_COULDNT_RESOLVE_HOST
@@ -622,7 +620,7 @@ final class CurlFactory implements CurlFactoryInterface
             if ($body->isSeekable()) {
                 $body->rewind();
             }
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             $reason = new ResponseException(
                 $e->getMessage() !== '' ? $e->getMessage() : 'Failed to rewind the response body',
                 $easy->request,
@@ -732,19 +730,10 @@ final class CurlFactory implements CurlFactoryInterface
 
     private static function createErrorContext(EasyHandle $easy): array
     {
-        $ctx = [
+        return [
             'errno' => $easy->errno,
             'error' => \curl_error($easy->handle),
         ];
-
-        if (!$easy->createResponseException) {
-            $ctx['appconnect_time'] = \curl_getinfo($easy->handle, \CURLINFO_APPCONNECT_TIME);
-            $ctx += \curl_getinfo($easy->handle);
-        }
-
-        CurlVersion::addToHandlerContext($ctx);
-
-        return $ctx;
     }
 
     /**
@@ -1188,7 +1177,7 @@ final class CurlFactory implements CurlFactoryInterface
         $body = $easy->request->getBody();
         try {
             $size = $body->getSize();
-        } catch (\RuntimeException $e) {
+        } catch (\Exception $e) {
             $message = $e instanceof TimeoutException
                 ? 'Timed out while determining the request body size'
                 : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to determine the request body size');
@@ -1257,7 +1246,7 @@ final class CurlFactory implements CurlFactoryInterface
         if (($contentLength !== null && $contentLength < 1000000) || !empty($options['_body_as_string'])) {
             try {
                 $conf[\CURLOPT_POSTFIELDS] = (string) $request->getBody();
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 $message = $e instanceof TimeoutException
                     ? 'Timed out while reading the request body'
                     : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to read the request body');
@@ -1284,7 +1273,7 @@ final class CurlFactory implements CurlFactoryInterface
                 if ($body->isSeekable()) {
                     $body->rewind();
                 }
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 $message = $e instanceof TimeoutException
                     ? 'Timed out while rewinding the request body'
                     : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to rewind the request body');
@@ -1722,7 +1711,7 @@ final class CurlFactory implements CurlFactoryInterface
             if ($body->tell() > 0) {
                 $body->rewind();
             }
-        } catch (\RuntimeException $e) {
+        } catch (\Exception $e) {
             $ctx['error'] = 'The connection unexpectedly failed without '
                 .'providing an error. The request would have been retried, '
                 .'but attempting to rewind the request body failed. '

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -110,17 +110,6 @@ final class CurlVersion
         }
     }
 
-    public static function addToHandlerContext(array &$context): void
-    {
-        $version = self::get();
-
-        if (null === $version) {
-            throw new \RuntimeException('Unable to determine cURL version.');
-        }
-
-        $context[CurlFactory::CURL_VERSION_STR] = $version;
-    }
-
     private static function get(): ?string
     {
         $versionInfo = self::getVersionInfo();

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -133,7 +133,7 @@ final class EasyHandle
 
                 try {
                     $bodyLength = $this->sink->getSize();
-                } catch (\RuntimeException $e) {
+                } catch (\Exception $e) {
                     $bodyLength = null;
                 }
                 if ($bodyLength) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -158,7 +158,7 @@ final class StreamHandler
         // the behavior of `CurlHandler`
         try {
             $bodySize = $request->getBody()->getSize();
-        } catch (\RuntimeException $e) {
+        } catch (\Exception $e) {
             $message = $e instanceof TimeoutException
                 ? 'Timed out while determining the request body size'
                 : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to determine the request body size');
@@ -424,7 +424,7 @@ final class StreamHandler
                 );
             } catch (\OverflowException $e) {
                 throw new ResponseException($e->getMessage(), $request, $response, $e);
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 // Any other response-body transfer failure surfaces as a
                 // ResponseTransferException carrying the response.
                 throw new ResponseTransferException(
@@ -447,7 +447,7 @@ final class StreamHandler
                 if ($sink->isSeekable()) {
                     $sink->rewind();
                 }
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 throw new ResponseException(
                     $e->getMessage() !== '' ? $e->getMessage() : 'Failed to rewind the response body',
                     $request,
@@ -460,7 +460,7 @@ final class StreamHandler
         } finally {
             try {
                 $source->close();
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 // Best-effort cleanup after the response body has been received.
             }
         }
@@ -530,7 +530,7 @@ final class StreamHandler
                         $response,
                         $e
                     );
-                } catch (\Throwable $e) {
+                } catch (\Exception $e) {
                     throw new ResponseException(
                         $e->getMessage() !== '' ? $e->getMessage() : 'Failed to write the response body',
                         $request,
@@ -805,7 +805,7 @@ final class StreamHandler
 
         try {
             $body = (string) $request->getBody();
-        } catch (\RuntimeException $e) {
+        } catch (\Exception $e) {
             $message = $e instanceof TimeoutException
                 ? 'Timed out while reading the request body'
                 : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to read the request body');

--- a/src/PrepareBodyMiddleware.php
+++ b/src/PrepareBodyMiddleware.php
@@ -118,7 +118,7 @@ class PrepareBodyMiddleware
     {
         try {
             return $request->getBody()->getSize();
-        } catch (\RuntimeException $e) {
+        } catch (\Exception $e) {
             $message = $e instanceof TimeoutException
                 ? 'Timed out while determining the request body size'
                 : ($e->getMessage() !== '' ? $e->getMessage() : 'Failed to determine the request body size');

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -219,7 +219,7 @@ class RedirectMiddleware
         $modify['uri'] = $uri;
         try {
             Psr7\Message::rewindBody($request);
-        } catch (\RuntimeException $e) {
+        } catch (\Exception $e) {
             throw new ResponseException(
                 'Redirect failed because the request body could not be rewound',
                 $request,

--- a/tests/BodySummarizerTest.php
+++ b/tests/BodySummarizerTest.php
@@ -36,11 +36,29 @@ class BodySummarizerTest extends TestCase
     {
         $body = FnStream::decorate(Utils::streamFor('abcdef'), [
             'tell' => static function (): int {
-                throw new \RuntimeException('tell failed');
+                throw new \Exception('tell failed');
             },
         ]);
         $response = new Response(200, [], $body);
 
         self::assertNull((new BodySummarizer())->summarize($response));
+    }
+
+    public function testSummarizePropagatesBodySummaryError(): void
+    {
+        $previous = new \Error('tell bug');
+        $body = FnStream::decorate(Utils::streamFor('abcdef'), [
+            'tell' => static function () use ($previous): int {
+                throw $previous;
+            },
+        ]);
+        $response = new Response(200, [], $body);
+
+        try {
+            (new BodySummarizer())->summarize($response);
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Promise\Is;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -53,6 +54,27 @@ class ClientTest extends TestCase
         $received = Server::received(true);
         self::assertCount(1, $received);
         self::assertSame('test=foo', $received[0]->getUri()->getQuery());
+    }
+
+    public function testSendAsyncRejectsWhenHandlerThrowsThrowable(): void
+    {
+        $previous = new \Error('handler failed');
+        $client = new Client([
+            'handler' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+
+        $promise = $client->sendAsync(new Request('GET', 'http://example.com'));
+
+        self::assertTrue(Is::rejected($promise));
+
+        try {
+            $promise->wait();
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
     }
 
     public function testCanSendSynchronously(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1442,7 +1442,7 @@ class CurlFactoryTest extends TestCase
         Server::flush();
         Server::enqueue([new Psr7\Response(200, [], 'abc')]);
         $handler = $handlerFactory();
-        $previous = new \RuntimeException('progress failed');
+        $previous = new \Error('progress failed');
 
         try {
             $handler(new Psr7\Request('GET', Server::$url), [
@@ -1493,7 +1493,7 @@ class CurlFactoryTest extends TestCase
     public function testProgressThrowableRejectsWithRequestException(): void
     {
         $factory = new CurlFactory(1);
-        $previous = new \RuntimeException('boom');
+        $previous = new \Error('boom');
         $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
             'progress' => static function () use ($previous): void {
                 throw $previous;
@@ -3336,7 +3336,7 @@ class CurlFactoryTest extends TestCase
     public function testStreamingRequestBodyReadFailureAbortsReadCallback(): void
     {
         $factory = new CurlFactory(3);
-        $previous = new \RuntimeException('boom while reading');
+        $previous = new \Error('boom while reading');
         $readCalled = false;
         $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
             'getSize' => static function (): ?int {
@@ -3574,7 +3574,7 @@ class CurlFactoryTest extends TestCase
     public function testRequestBodyReadFailureRejectsAsRequestExceptionWithoutResponseAndWithoutRetry(): void
     {
         $factory = new CurlFactory(3);
-        $previous = new \RuntimeException('boom while reading');
+        $previous = new \Exception('boom while reading');
         $stats = null;
         $request = new Psr7\Request('PUT', Server::$url, [], 'payload');
         $easy = $factory->create($request, [
@@ -3658,7 +3658,7 @@ class CurlFactoryTest extends TestCase
     public function testRequestBodyReadFailureRejectsAsResponseExceptionWithResponseAndErrnoZero(): void
     {
         $factory = new CurlFactory(3);
-        $previous = new \RuntimeException('boom while reading');
+        $previous = new \Exception('boom while reading');
         $stats = null;
         $request = new Psr7\Request('PUT', Server::$url, [], 'payload');
         $response = new Psr7\Response(200, [], 'early');
@@ -3765,7 +3765,7 @@ class CurlFactoryTest extends TestCase
     public function testBodyAsStringRequestBodyReadFailureRejectsAsRequestException(): void
     {
         $factory = new CurlFactory(3);
-        $previous = new \RuntimeException('boom while reading');
+        $previous = new \Exception('boom while reading');
         $castCalled = false;
         $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
             '__toString' => static function () use (&$castCalled, $previous): string {
@@ -3794,10 +3794,31 @@ class CurlFactoryTest extends TestCase
         self::assertTrue($castCalled);
     }
 
+    public function testBodyAsStringRequestBodyReadErrorPropagates(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \Error('boom while reading');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+            '__toString' => static function () use ($previous): string {
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, [
+                'curl' => ['body_as_string' => true],
+            ]);
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
+    }
+
     public function testStreamingRequestBodyRewindFailureRejectsAsRequestException(): void
     {
         $factory = new CurlFactory(3);
-        $previous = new \RuntimeException('boom while rewinding');
+        $previous = new \Exception('boom while rewinding');
         $rewindCalled = false;
         $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
             'getSize' => static function (): ?int {
@@ -3825,6 +3846,28 @@ class CurlFactoryTest extends TestCase
         }
 
         self::assertTrue($rewindCalled);
+    }
+
+    public function testStreamingRequestBodyRewindErrorPropagates(): void
+    {
+        $factory = new CurlFactory(3);
+        $previous = new \Error('boom while rewinding');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function (): ?int {
+                return null;
+            },
+            'rewind' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+
+        try {
+            $factory->create($request, []);
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
     }
 
     public function testStreamingRequestBodyRewindTimeoutRejectsAsRequestException(): void
@@ -4369,7 +4412,7 @@ class CurlFactoryTest extends TestCase
     {
         $factory = new CurlFactory(1);
         $request = new Psr7\Request('GET', Server::$url);
-        $previous = new \RuntimeException('rewind failed');
+        $previous = new \Exception('rewind failed');
         $response = new Psr7\Response(
             200,
             [],
@@ -4419,6 +4462,39 @@ class CurlFactoryTest extends TestCase
         self::assertTrue($stats->hasResponse());
         self::assertSame($response, $stats->getResponse());
         self::assertSame($exception, $stats->getHandlerErrorData());
+    }
+
+    public function testSeekableBodyRewindErrorPropagates(): void
+    {
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('GET', Server::$url);
+        $previous = new \Error('rewind failed');
+        $response = new Psr7\Response(
+            200,
+            [],
+            Psr7\FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+                'isSeekable' => static function (): bool {
+                    return true;
+                },
+                'rewind' => static function () use ($previous): void {
+                    throw $previous;
+                },
+            ])
+        );
+        $easy = $factory->create($request, []);
+        $easy->response = $response;
+
+        try {
+            CurlFactory::finish(
+                static function (): void {
+                },
+                $easy,
+                $factory
+            )->wait();
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
     }
 
     public function testOnStatsExceptionEscapesOnSeekableBodyRewindFailureAfterHandleRelease(): void

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1925,7 +1925,7 @@ class StreamHandlerTest extends TestCase
         $request = new Request('GET', Server::$url);
         $stats = null;
         $exception = null;
-        $previous = new \RuntimeException('sink failed');
+        $previous = new \Exception('sink failed');
         $sink = FnStream::decorate(Psr7\Utils::streamFor(), [
             'write' => static function (string $data) use ($previous): int {
                 throw $previous;
@@ -1959,11 +1959,31 @@ class StreamHandlerTest extends TestCase
         self::assertSame($exception, $stats->getHandlerErrorData());
     }
 
+    public function testSinkWriteErrorPropagates(): void
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $previous = new \Error('sink bug');
+        $sink = FnStream::decorate(Psr7\Utils::streamFor(), [
+            'write' => static function (string $data) use ($previous): int {
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $handler($request, ['sink' => $sink]);
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
+    }
+
     public function testThrowsResponseTransferExceptionWhenResponseBodyReadFails(): void
     {
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
-        $previous = new \RuntimeException('SSL: Connection reset by peer');
+        $previous = new \Exception('SSL: Connection reset by peer');
         $stats = null;
         $source = FnStream::decorate(Psr7\Utils::streamFor('abc'), [
             'read' => static function (int $length) use ($previous): string {
@@ -2000,6 +2020,30 @@ class StreamHandlerTest extends TestCase
             self::assertTrue($stats->hasResponse());
             self::assertSame($e->getResponse(), $stats->getResponse());
             self::assertSame($e, $stats->getHandlerErrorData());
+        }
+    }
+
+    public function testResponseBodyReadErrorPropagates(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $previous = new \Error('source bug');
+        $source = FnStream::decorate(Psr7\Utils::streamFor('abc'), [
+            'read' => static function (int $length) use ($previous): string {
+                throw $previous;
+            },
+        ]);
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Length: 3',
+        ]);
+
+        try {
+            $this->invokeStreamHandlerCreateResponse($handler, $request, [], $source);
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
         }
     }
 
@@ -2118,7 +2162,7 @@ class StreamHandlerTest extends TestCase
         $this->queueRes();
         $handler = new StreamHandler();
         $request = new Request('GET', Server::$url);
-        $previous = new \RuntimeException('rewind failed');
+        $previous = new \Exception('rewind failed');
         $exception = null;
         $stats = null;
         $sink = FnStream::decorate(Psr7\Utils::streamFor(), [
@@ -2150,6 +2194,26 @@ class StreamHandlerTest extends TestCase
         self::assertTrue($stats->hasResponse());
         self::assertSame($exception->getResponse(), $stats->getResponse());
         self::assertSame($exception, $stats->getHandlerErrorData());
+    }
+
+    public function testSeekableSinkRewindErrorPropagates(): void
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $request = new Request('GET', Server::$url);
+        $previous = new \Error('rewind bug');
+        $sink = FnStream::decorate(Psr7\Utils::streamFor(), [
+            'rewind' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+
+        try {
+            $handler($request, ['sink' => $sink]);
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
     }
 
     public function testNonSeekableSinkSucceedsWithoutRewind(): void

--- a/tests/PrepareBodyMiddlewareTest.php
+++ b/tests/PrepareBodyMiddlewareTest.php
@@ -255,7 +255,7 @@ class PrepareBodyMiddlewareTest extends TestCase
     /**
      * @dataProvider requestBodyGetSizeFailureMessageProvider
      */
-    public function testRequestBodyGetSizeFailureUsesExpectedMessage(\RuntimeException $previous, string $expected): void
+    public function testRequestBodyGetSizeFailureUsesExpectedMessage(\Exception $previous, string $expected): void
     {
         $body = FnStream::decorate(Psr7\Utils::streamFor('payload'), [
             'getSize' => static function () use ($previous): ?int {
@@ -298,7 +298,37 @@ class PrepareBodyMiddlewareTest extends TestCase
                 new \RuntimeException('cannot stat custom stream'),
                 'cannot stat custom stream',
             ],
+            'custom exception' => [
+                new \Exception('custom stream exception'),
+                'custom stream exception',
+            ],
         ];
+    }
+
+    public function testRequestBodyGetSizeErrorPropagates(): void
+    {
+        $previous = new \Error('custom stream bug');
+        $body = FnStream::decorate(Psr7\Utils::streamFor('payload'), [
+            'getSize' => static function () use ($previous): ?int {
+                throw $previous;
+            },
+        ]);
+        $handler = new MockHandler([
+            static function (): ResponseInterface {
+                self::fail('The request should fail before reaching the handler.');
+            },
+        ]);
+        $stack = new HandlerStack($handler);
+        $stack->push(Middleware::prepareBody());
+        $composed = $stack->resolve();
+        $request = new Request('POST', 'http://example.com', [], $body);
+
+        try {
+            $composed($request, [])->wait();
+            self::fail('Expected Error');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
     }
 }
 


### PR DESCRIPTION
This refines the transfer exception boundaries so synchronous handler throwables become rejected promises without being wrapped, while ordinary stream transfer and finalization failures are still handled as Guzzle request or response failures. It also avoids hiding PHP Error and TypeError from caller-provided streams, keeps the intentional cURL callback behavior, and removes the stale cURL version handler-context data now that exception handler context is no longer exposed.