### PR TITLE
Clarify transfer timeout documentation

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -404,10 +404,13 @@ undocumented internal lazy cURL multi handle. Applications that used it to set
 
 #### Timeout Option Validation
 
-The built-in cURL and stream handlers now validate timeout option values before
-applying them. `timeout`, `connect_timeout`, and `read_timeout` must be `0` or at
-least `0.001` seconds when provided. Positive values below 1 millisecond now
-throw `InvalidArgumentException` instead of being converted to no timeout.
+Built-in handlers validate timeout option values when they apply those options.
+`timeout` is applied by both built-in transports. `connect_timeout` is applied by
+cURL handlers and accepted without effect by the stream handler. `read_timeout`
+is applied by the stream handler and accepted without effect by cURL handlers.
+When a built-in handler applies a timeout option, positive values below `0.001`
+seconds now throw `InvalidArgumentException` instead of being converted to no
+timeout.
 
 #### Proxy Option Validation
 
@@ -480,8 +483,11 @@ timeouts, redirects, proxy URLs, TLS verification or client credentials,
 progress/debug callbacks, sink handling, cookies, protocols, or cURL share
 handles. Use first-class Guzzle request options for those settings.
 
-The cURL handlers also reject stream-only `stream_context` and `read_timeout`
-options, while the stream handler rejects cURL-only options it cannot honor.
+The cURL handlers also reject stream-only `stream_context` options, but accept
+`read_timeout` without effect. The stream handler rejects cURL-only options it
+cannot honor, but accepts `connect_timeout` without effect. These timeout options
+are intentionally best-effort so shared request configuration can be reused
+across transports.
 
 #### Native Type Declarations
 

--- a/docs/contributing/exception-guidelines.md
+++ b/docs/contributing/exception-guidelines.md
@@ -1,10 +1,13 @@
 # Exception guidelines (contributor reference)
 
 Guzzle code must be deliberate about which exception it throws, because
-`GuzzleHttp\Client` is a PSR-18 client: PSR-18 requires that **every** exception
-escaping `sendRequest()` implement `Psr\Http\Client\ClientExceptionInterface`.
-All Guzzle exceptions implement it via `GuzzleHttp\Exception\GuzzleException`, so
-"throw a Guzzle exception" and "stay PSR-18 compliant" are the same rule.
+`GuzzleHttp\Client` is a PSR-18 client: PSR-18 requires transfer failures
+escaping `sendRequest()` to implement
+`Psr\Http\Client\ClientExceptionInterface`. All Guzzle transfer exceptions
+implement it via `GuzzleHttp\Exception\GuzzleException`, so "throw a Guzzle
+exception" and "stay PSR-18 compliant" are the same rule. Exceptions thrown by
+user callbacks that are documented to escape unwrapped, such as `on_stats`, are
+not normalized into Guzzle exceptions.
 
 This document covers the two exceptions contributors most often have to choose
 between — `InvalidArgumentException` (caller error) and `RequestException`
@@ -61,6 +64,14 @@ that stream: `RequestException` while reading the request body before a response
 or `ResponseException` once a response exists. It is never a
 `NetworkTimeoutException`. The original `TimeoutException` is attached via
 `getPrevious()`.
+
+Note: `ResponseException` extends `RequestException`, so it (and every subtype,
+including `ResponseTransferException` and `ResponseTimeoutException`) is a PSR-18
+`RequestExceptionInterface`. PSR-18 defines no interface for "a response was
+received, then the transfer failed": its `NetworkExceptionInterface` is a
+no-response interface, so among PSR-18's request-bound interfaces only
+`RequestExceptionInterface` remains once Guzzle holds a response. This is a
+deliberate classification, not a claim that the request message was malformed.
 
 ## `GuzzleHttp\Exception\InvalidArgumentException`
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1002,13 +1002,23 @@ Defaults to the value of the `default_socket_timeout` PHP ini setting
 Constant
 `GuzzleHttp\RequestOptions::READ_TIMEOUT`
 
-The timeout applies to individual read operations on a streamed body (when the `stream` option is enabled).
+The timeout applies to individual read operations on a streamed body (when the
+`stream` option is enabled). It is implemented by the PHP stream handler. cURL
+handlers accept this option without effect so shared request configuration can
+be reused across transports. With Guzzle's default handler selection, streamed
+responses (`stream` => `true`) use the stream handler when PHP streams are
+available.
 
 When a read on the streamed PSR-7 body times out, `read()` throws
-`GuzzleHttp\Psr7\Exception\TimeoutException`. This PSR-7 class sits outside the
-`GuzzleHttp\Exception\GuzzleException` hierarchy, so catch it explicitly. If you
-detach the body and read the raw PHP stream resource instead, functions such as
-`fgets()` return `false` on timeout, following PHP's stream semantics.
+`GuzzleHttp\Psr7\Exception\TimeoutException`. A non-timeout read failure, for
+example the connection is reset mid-body or the body stream has been detached,
+throws a plain `\RuntimeException`. Both types sit outside the
+`GuzzleHttp\Exception\GuzzleException` hierarchy: they are raised after the
+request has resolved and the response object has been returned, which is outside
+the `Client::sendRequest()` transfer that PSR-18 governs. Catch them explicitly
+when reading a streamed body. If you detach the body and read the raw PHP stream
+resource instead, functions such as `fgets()` return `false` on timeout,
+following PHP's stream semantics.
 
 ```php
 $response = $client->request('GET', '/stream', [
@@ -1348,6 +1358,13 @@ bytes throws `GuzzleHttp\Exception\RequestException` before a response and
 `GuzzleHttp\Exception\ResponseException` after response headers. A slow response
 `sink` write also throws `ResponseException`. In every case the original
 `GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
+
+Timeout detection is best-effort: it relies on the stream exposing PHP's
+`timed_out` metadata. The network socket Guzzle opens for the stream handler
+exposes this metadata, but a caller-supplied request-body or `sink` stream might
+not, for example a custom `StreamInterface` implementation. When the metadata is
+absent, the failure is not recognized as a timeout and surfaces as an ordinary
+read/write error instead.
 
 ## version
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -546,6 +546,9 @@ final class StreamHandler
                 return $written;
             },
             'getMetadata' => static function (?string $key = null) use ($sink) {
+                // Force timed_out to false so Utils::writeAll() can't reclassify a sink-write
+                // failure as a transport timeout. Sink write failures are ResponseException;
+                // source-read timeouts are ResponseTimeoutException.
                 if ($key === 'timed_out') {
                     return false;
                 }


### PR DESCRIPTION
This clarifies how Guzzle classifies transfer timeouts and caller-provided stream failures in the 8.0 documentation. It explains that streamed response-body reads happen after the response has been returned, documents that timeout detection for caller streams depends on timed_out metadata, describes the best-effort behavior of the timeout options across cURL and stream handlers, and adds contributor guidance for response-aware exceptions and unwrapped on_stats failures.