### PR TITLE
Clamp cookie Max-Age expiry calculation

### DIFF
--- a/src/Cookie/SetCookie.php
+++ b/src/Cookie/SetCookie.php
@@ -149,8 +149,11 @@ class SetCookie
         // Extract the Expires value and turn it into a UNIX timestamp if needed
         $maxAge = $this->getMaxAge();
         if (!$this->getExpires() && $maxAge) {
-            // Calculate the Expires date
-            $this->setExpires(\time() + $maxAge);
+            $now = \time();
+            // Clamp absurd Max-Age values so integer addition cannot promote to float.
+            $expires = $maxAge > \PHP_INT_MAX - $now ? \PHP_INT_MAX : $now + $maxAge;
+
+            $this->setExpires($expires);
         }
     }
 

--- a/tests/Cookie/CookieJarTest.php
+++ b/tests/Cookie/CookieJarTest.php
@@ -493,6 +493,19 @@ class CookieJarTest extends TestCase
         self::assertTrue($cookie->getHostOnly());
     }
 
+    public function testExtractsCookieWithHugeMaxAge(): void
+    {
+        $this->jar->extractCookies(
+            new Request('GET', 'https://example.com/'),
+            new Response(200, ['Set-Cookie' => 'sid=abc; Max-Age='.\PHP_INT_MAX.'; Path=/'])
+        );
+
+        $cookie = $this->jar->getCookieByName('sid');
+
+        self::assertInstanceOf(SetCookie::class, $cookie);
+        self::assertSame(\PHP_INT_MAX, $cookie->getExpires());
+    }
+
     public function testDoesNotSendHostOnlyCookieToSubdomain(): void
     {
         $this->jar->extractCookies(

--- a/tests/Cookie/SetCookieTest.php
+++ b/tests/Cookie/SetCookieTest.php
@@ -170,6 +170,14 @@ class SetCookieTest extends TestCase
         self::assertNull($cookie->getMaxAge());
     }
 
+    public function testClampsMaxAgeThatWouldOverflowExpiry(): void
+    {
+        $cookie = SetCookie::fromString('foo=bar; Max-Age='.\PHP_INT_MAX);
+
+        self::assertSame(\PHP_INT_MAX, $cookie->getMaxAge());
+        self::assertSame(\PHP_INT_MAX, $cookie->getExpires());
+    }
+
     public function testIgnoresHugeNumericExpires(): void
     {
         $cookie = SetCookie::fromString('foo=bar; Expires=999999999999999999999999');


### PR DESCRIPTION
This updates cookie expiry calculation derived from Max-Age to clamp very large values before adding the current timestamp, so the resulting Expires value remains an integer while preserving normal cookie behavior. It also includes regression coverage for direct SetCookie parsing and CookieJar extraction with very large Max-Age values.