### PR TITLE
docs(request-options): Document that X-Guzzle-Redirect-History cannot be trusted

### DIFF
--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -60,7 +60,7 @@ You can also pass an associative array containing the following key value pairs:
 
 - on_redirect: (callable) PHP callable that is invoked when a redirect is encountered. The callable is invoked with the original request, the redirect response that was received, and the effective URI. Any return value from the on_redirect function is ignored.
 
-- track_redirects: (bool) When set to `true`, each redirected URI and status code encountered will be tracked in the `X-Guzzle-Redirect-History` and `X-Guzzle-Redirect-Status-History` headers respectively. All URIs and status codes will be stored in the order which the redirects were encountered.
+- track_redirects: (bool) When set to `true`, each redirected URI and status code encountered will be tracked in the `X-Guzzle-Redirect-History` and `X-Guzzle-Redirect-Status-History` headers respectively. All URIs and status codes will be stored in the order which the redirects were encountered. **Security warning: `X-Guzzle-Redirect-History` and `X-Guzzle-Redirect-Status-History` can contain attacker-controlled values. When no redirect was triggered a malicious server can send arbitrary data in those headers, so they cannot be trusted.**
 
   Note: When tracking redirects the `X-Guzzle-Redirect-History` header will exclude the initial request's URI and the `X-Guzzle-Redirect-Status-History` header will exclude the final status code.
 


### PR DESCRIPTION
Note that this behavior was already reported to the Guzzle security team, where it was decided that this is not considered a vulnerability.

Description
Even when allow_redirects.track_redirects is enabled, the response can expose an attacker-controlled X-Guzzle-Redirect-History value. A downstream consumer may incorrectly trust this header as redirect metadata generated by the HTTP client.

PoC (self-contained, no external server)
This uses Guzzle’s MockHandler to simulate an attacker response.

```php
<?php
require 'vendor/autoload.php';

use GuzzleHttp\Client;
use GuzzleHttp\Handler\MockHandler;
use GuzzleHttp\HandlerStack;
use GuzzleHttp\Psr7\Response;

// Simulated attacker-controlled origin response.
$mock = new MockHandler([
  new Response(200, [
    'Content-Type' => 'application/pdf',
    'X-Guzzle-Redirect-History' => '/etc/passwd',
  ], 'attacker-controlled body content'),
]);

$stack = HandlerStack::create($mock);
$client = new Client(['handler' => $stack]);

$response = $client->request('GET', 'https://attacker.example/document.pdf', [
  'allow_redirects' => [
    'max' => 5,
    'track_redirects' => true,
  ],
]);

$history = $response->getHeaderLine('X-Guzzle-Redirect-History');

echo "Observed X-Guzzle-Redirect-History: " . $history . PHP_EOL;
echo "Body: " . (string) $response->getBody() . PHP_EOL;
```

Why this is dangerous
If application code treats this header as trusted and passes it into file/network operations, attacker-controlled values can trigger downstream vulnerabilities (for example LFI/SSRF/path confusion), depending on consumer logic.

Downstream misuse pattern example
```php
$redirect = $response->getHeaderLine('X-Guzzle-Redirect-History');
// Incorrect trust assumption:
$result = $extractor->extract($redirect);
```

I'm proposing a warning for the docs, should we add anything there?

It might also be a good idea to deprecate track_redirects - as it cannot be trusted whether actual redirects happened implementers need to build their own array of redirects with `on_redirect` callbacks.