### PR TITLE
Remove dead guard from shouldRetryFailedRewind and cover errno 65 retry

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -721,10 +721,20 @@ final class CurlFactory implements CurlFactoryInterface
             return false;
         }
 
-        if (!empty($easy->options['_err_message'])) {
-            return false;
-        }
-
+        // Two transfer outcomes warrant rewinding the body and retrying:
+        //
+        // - errno === CURLE_SEND_FAIL_REWIND (65): libcurl needed to rewind an
+        //   already-partially-sent upload to resend it (a redirect, multi-pass
+        //   auth such as NTLM/Negotiate, or a reused connection that died) but
+        //   could not, because PHP registers no seek callback for a streamed
+        //   request body. See https://bugs.php.net/bug.php?id=47204.
+        //
+        // - errno === 0: libcurl reported success yet no usable response
+        //   reached us. This is the legacy curl_multi silent-failure variant of
+        //   the same rewind problem. libcurl 7.61.1 fixed it to surface as
+        //   CURLE_SEND_FAIL_REWIND instead (curl/curl@d6cf930), so this arm is
+        //   only load-bearing for libcurl < 7.61.1 and may be removed once the
+        //   minimum supported libcurl is >= 7.61.1.
         return $easy->errno === 0 || $easy->errno === self::CURLE_SEND_FAIL_REWIND;
     }
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -2263,6 +2263,94 @@ class CurlFactoryTest extends TestCase
         $p->wait(true);
     }
 
+    /**
+     * Regression coverage for the CURLE_SEND_FAIL_REWIND (errno 65) arm of
+     * shouldRetryFailedRewind()/retryFailedRewind(). libcurl returns errno 65
+     * when it must rewind an already-partially-sent upload body (after a
+     * redirect, multi-pass auth, or a dead reused connection) but cannot,
+     * because PHP exposes no seek callback for a streamed request body
+     * (https://bugs.php.net/bug.php?id=47204). Guzzle works around this by
+     * rewinding the PSR-7 body itself and re-issuing the request.
+     *
+     * Until this commit the errno === 0 arm was covered
+     * (testRetriesWhenBodyCanBeRewound, testFailsWhenRetryMoreThanThreeTimes)
+     * but the errno === 65 arm had none, so a regression in it would have
+     * passed CI unnoticed.
+     *
+     * This test and testFailsAfterThreeRetriesOnFailedRewindErrno may be
+     * removed once Guzzle registers a CURLOPT_SEEKFUNCTION for streamed bodies
+     * so libcurl can rewind natively and never surfaces errno 65 for a seekable
+     * body. That requires PHP to expose CURLOPT_SEEKFUNCTION (it does not as of
+     * PHP 8.4) and a minimum PHP/libcurl version that includes it.
+     */
+    public function testRetriesWhenCurlReportsFailedRewindErrno(): void
+    {
+        $rewound = false;
+        $handlerCalled = false;
+
+        $handler = static function (RequestInterface $request, array $options) use (&$handlerCalled): P\PromiseInterface {
+            $handlerCalled = true;
+
+            return P\Create::promiseFor(new Psr7\Response());
+        };
+
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('test'), [
+            'tell' => static function (): int {
+                return 1;
+            },
+            'rewind' => static function () use (&$rewound): void {
+                $rewound = true;
+            },
+        ]);
+
+        $factory = new CurlFactory(1);
+        $request = new Psr7\Request('PUT', Server::$url, [], $body);
+        $easy = $factory->create($request, []);
+        // Reset the flag so the assertion below observes the retry's rewind,
+        // not the rewind applyBody() performs while creating the handle.
+        $rewound = false;
+        // Simulate libcurl returning errno 65 (failed rewind) and no response.
+        $easy->errno = 65;
+        $easy->response = null;
+
+        $response = CurlFactory::finish($handler, $easy, $factory)->wait();
+
+        self::assertTrue($rewound, 'The request body should have been rewound before retrying');
+        self::assertTrue($handlerCalled, 'The request should have been retried');
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * Companion to testRetriesWhenCurlReportsFailedRewindErrno: when libcurl
+     * keeps reporting CURLE_SEND_FAIL_REWIND (errno 65) the retry is bounded to
+     * three attempts before giving up, mirroring
+     * testFailsWhenRetryMoreThanThreeTimes for the errno === 0 arm. See that
+     * test's docblock for the removal conditions that apply to both errno-65
+     * tests.
+     */
+    public function testFailsAfterThreeRetriesOnFailedRewindErrno(): void
+    {
+        $factory = new CurlFactory(1);
+        $calls = 0;
+        $handler = static function (RequestInterface $request, array $options) use (&$mock, &$calls, $factory): P\PromiseInterface {
+            ++$calls;
+            $easy = $factory->create($request, $options);
+            // Each attempt reports a failed rewind (errno 65) with no response.
+            $easy->errno = 65;
+            $easy->response = null;
+
+            return CurlFactory::finish($mock, $easy, $factory);
+        };
+        $mock = new Handler\MockHandler([$handler, $handler, $handler]);
+        $promise = $mock(new Psr7\Request('PUT', Server::$url, [], 'test'), []);
+        $promise->wait(false);
+        self::assertSame(3, $calls);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('The cURL request was retried 3 times');
+        $promise->wait(true);
+    }
+
     public function testHandles100Continue(): void
     {
         Server::flush();


### PR DESCRIPTION
The _err_message option is never written anywhere, so the guard reading it in shouldRetryFailedRewind was unreachable; remove it. Document the errno === 0 arm as a backstop that can be dropped once the minimum libcurl is >= 7.61.1 (curl/curl@d6cf930). Add regression tests for the errno 65 (CURLE_SEND_FAIL_REWIND) retry arm, which previously had none.