### PR TITLE
Move stream transport sharing to handler state

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -362,13 +362,6 @@ final class CurlFactory implements CurlFactoryInterface
 
     private static function rejectUnsupportedRequestOptions(array $options): void
     {
-        if (
-            \array_key_exists('transport_sharing', $options)
-            && CurlShareHandleState::normalizeMode($options['transport_sharing'], 'transport_sharing') !== TransportSharing::NONE
-        ) {
-            throw new InvalidArgumentException('The "transport_sharing" option is a client constructor option, not a request option. Configure transport sharing when creating the Client, CurlHandler, or CurlMultiHandler.');
-        }
-
         if (\array_key_exists('stream_context', $options)) {
             throw new InvalidArgumentException('Passing the "stream_context" request option to a cURL handler is not supported because cURL handlers ignore PHP stream context options.');
         }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -66,6 +66,23 @@ final class StreamHandler
 
     private ?\Throwable $onStatsException = null;
 
+    private string $transportSharingMode;
+
+    /**
+     * Accepts an associative array of options:
+     *
+     * - transport_sharing: Optional transport sharing mode.
+     *
+     * @param array{transport_sharing?: mixed} $options Array of options to use with the handler
+     */
+    public function __construct(array $options = [])
+    {
+        $this->transportSharingMode = CurlShareHandleState::normalizeMode(
+            $options['transport_sharing'] ?? null,
+            'transport_sharing'
+        );
+    }
+
     /**
      * Sends an HTTP request.
      *
@@ -104,6 +121,7 @@ final class StreamHandler
         $startTime = isset($options['on_stats']) ? Utils::currentTime() : null;
 
         self::rejectUnsupportedRequestOptions($request, $options);
+        $this->assertTransportSharingSupported();
 
         $request = self::prepareRequest($request);
 
@@ -828,14 +846,6 @@ final class StreamHandler
 
     private static function rejectUnsupportedRequestOptions(RequestInterface $request, array $options): void
     {
-        if (\array_key_exists('transport_sharing', $options)) {
-            $transportSharingMode = CurlShareHandleState::normalizeMode($options['transport_sharing'], 'transport_sharing');
-
-            if (\in_array($transportSharingMode, [TransportSharing::HANDLER_REQUIRE, TransportSharing::PERSISTENT_REQUIRE], true)) {
-                throw new InvalidArgumentException('The "transport_sharing" option requires transport sharing, but the stream handler does not support it.');
-            }
-        }
-
         if (
             \array_key_exists('curl', $options)
             && $options['curl'] !== null
@@ -851,6 +861,17 @@ final class StreamHandler
 
         if (\array_key_exists('expect', $options) && $options['expect'] !== false && $request->hasHeader('Expect')) {
             throw new InvalidArgumentException('Passing the "expect" request option to the stream handler is not supported when it adds an Expect header because the stream handler does not support Expect: 100-Continue.');
+        }
+    }
+
+    private function assertTransportSharingSupported(): void
+    {
+        if ($this->transportSharingMode === TransportSharing::PERSISTENT_REQUIRE) {
+            throw new InvalidArgumentException('The "transport_sharing" option requires persistent transport sharing, which is only available through cURL share handles.');
+        }
+
+        if ($this->transportSharingMode === TransportSharing::HANDLER_REQUIRE) {
+            throw new InvalidArgumentException('The "transport_sharing" option requires transport sharing, but the stream handler does not support it.');
         }
     }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -128,10 +128,7 @@ final class Utils
         }
 
         if (\ini_get('allow_url_fopen')) {
-            $streamHandler = new StreamHandler();
-            if ($sharingRequired) {
-                $streamHandler = self::wrapStreamHandlerTransportSharing($streamHandler, $sharingMode);
-            }
+            $streamHandler = new StreamHandler(['transport_sharing' => $sharingMode]);
 
             $handler = $handler
                 ? Proxy::wrapStreaming($handler, $streamHandler)
@@ -141,24 +138,6 @@ final class Utils
         }
 
         return $handler;
-    }
-
-    /**
-     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler
-     *
-     * @return callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>
-     */
-    private static function wrapStreamHandlerTransportSharing(callable $handler, string $sharingMode): callable
-    {
-        return static function (RequestInterface $request, array $options) use ($handler, $sharingMode): PromiseInterface {
-            if (\array_key_exists('transport_sharing', $options)) {
-                CurlShareHandleState::normalizeMode($options['transport_sharing'], 'transport_sharing');
-            }
-
-            $options['transport_sharing'] = $sharingMode;
-
-            return $handler($request, $options);
-        };
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -471,15 +471,39 @@ class CurlFactoryTest extends TestCase
         }
     }
 
-    public function testRejectsRequestLevelCurlShareClientOption(): void
+    /**
+     * @dataProvider requestTransportSharingOptionProvider
+     *
+     * @param mixed $transportSharing
+     */
+    public function testIgnoresRequestLevelTransportSharingOption($transportSharing): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('transport_sharing');
-        $this->expectExceptionMessage('client constructor option');
+        unset($_SERVER['_curl']);
 
-        (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
-            'transport_sharing' => TransportSharing::HANDLER_REQUIRE,
+        $easy = (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+            'transport_sharing' => $transportSharing,
         ]);
+
+        try {
+            if (\defined('CURLOPT_SHARE')) {
+                self::assertArrayNotHasKey(\CURLOPT_SHARE, $_SERVER['_curl']);
+            }
+        } finally {
+            if (PHP_VERSION_ID < 80000) {
+                \curl_close($easy->handle);
+            }
+        }
+    }
+
+    public static function requestTransportSharingOptionProvider(): iterable
+    {
+        yield 'null' => [null];
+        yield 'none' => [TransportSharing::NONE];
+        yield 'handler prefer' => [TransportSharing::HANDLER_PREFER];
+        yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
+        yield 'persistent prefer' => [TransportSharing::PERSISTENT_PREFER];
+        yield 'persistent require' => [TransportSharing::PERSISTENT_REQUIRE];
+        yield 'invalid' => ['invalid'];
     }
 
     public function testRejectsStreamContextOption(): void

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -2457,47 +2457,40 @@ class StreamHandlerTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testStreamAcceptsDisabledTransportSharingOption(): void
+    public function testStreamAcceptsDisabledTransportSharingConstructorOption(): void
     {
         Server::flush();
         Server::enqueue([new Response(200)]);
 
-        $handler = new StreamHandler();
-        $response = $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => TransportSharing::NONE,
-        ])->wait();
+        $handler = new StreamHandler(['transport_sharing' => TransportSharing::NONE]);
+        $response = $handler(new Request('GET', Server::$url), [])->wait();
 
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testStreamAcceptsNullTransportSharingOption(): void
+    public function testStreamAcceptsNullTransportSharingConstructorOption(): void
     {
         Server::flush();
         Server::enqueue([new Response(200)]);
 
-        $handler = new StreamHandler();
-        $response = $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => null,
-        ])->wait();
+        $handler = new StreamHandler(['transport_sharing' => null]);
+        $response = $handler(new Request('GET', Server::$url), [])->wait();
 
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testStreamAcceptsPreferredTransportSharingOption(): void
+    public function testStreamAcceptsPreferredTransportSharingConstructorOption(): void
     {
         Server::flush();
         Server::enqueue([new Response(200), new Response(200)]);
 
-        $handler = new StreamHandler();
-        $response = $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => TransportSharing::HANDLER_PREFER,
-        ])->wait();
+        $handler = new StreamHandler(['transport_sharing' => TransportSharing::HANDLER_PREFER]);
+        $response = $handler(new Request('GET', Server::$url), [])->wait();
 
         self::assertSame(200, $response->getStatusCode());
 
-        $response = $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => TransportSharing::PERSISTENT_PREFER,
-        ])->wait();
+        $handler = new StreamHandler(['transport_sharing' => TransportSharing::PERSISTENT_PREFER]);
+        $response = $handler(new Request('GET', Server::$url), [])->wait();
 
         self::assertSame(200, $response->getStatusCode());
     }
@@ -2505,22 +2498,49 @@ class StreamHandlerTest extends TestCase
     /**
      * @dataProvider requiredTransportSharingModeProvider
      */
-    public function testStreamRejectsRequiredTransportSharingOption(string $transportSharing): void
+    public function testStreamRejectsRequiredTransportSharingConstructorOption(string $transportSharing): void
     {
-        $handler = new StreamHandler();
+        $handler = new StreamHandler(['transport_sharing' => $transportSharing]);
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('transport_sharing');
 
-        $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => $transportSharing,
-        ]);
+        $handler(new Request('GET', Server::$url), []);
     }
 
     public static function requiredTransportSharingModeProvider(): iterable
     {
         yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
         yield 'persistent require' => [TransportSharing::PERSISTENT_REQUIRE];
+    }
+
+    /**
+     * @dataProvider requestTransportSharingOptionProvider
+     *
+     * @param mixed $transportSharing
+     */
+    public function testStreamIgnoresRequestLevelTransportSharingOption($transportSharing): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
+        $handler = new StreamHandler();
+        $response = $handler(new Request('GET', Server::$url), [
+            'transport_sharing' => $transportSharing,
+        ])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public static function requestTransportSharingOptionProvider(): iterable
+    {
+        yield 'null' => [null];
+        yield 'none' => [TransportSharing::NONE];
+        yield 'handler prefer' => [TransportSharing::HANDLER_PREFER];
+        yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
+        yield 'persistent prefer' => [TransportSharing::PERSISTENT_PREFER];
+        yield 'persistent require' => [TransportSharing::PERSISTENT_REQUIRE];
+        yield 'invalid' => ['invalid'];
     }
 
     public function testStreamRejectsCurlOption(): void


### PR DESCRIPTION
This moves the stream handler's transport sharing mode from request-option plumbing into immutable handler constructor state. Utils now passes the selected sharing mode when constructing the stream fallback instead of wrapping the handler and injecting transport_sharing into each request.

Request-level transport_sharing remains a nonexistent request option for the built-in handlers. The cURL and stream handlers ignore it rather than treating it as an override or validation target, while required sharing configured on the stream handler still fails when a request is routed to a handler that cannot satisfy it.