### PR TITLE
Ignore request-level transport sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.11.1 - Upcoming
+
+### Fixed
+
+- Ignore request-level `transport_sharing`, matching other unknown request options
+
+
 ## 7.11.0 - 2026-06-02
 
 ### Added

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -279,13 +279,6 @@ class CurlFactory implements CurlFactoryInterface
 
     private static function triggerUnsupportedRequestOptionDeprecations(array $options): void
     {
-        if (
-            \array_key_exists('transport_sharing', $options)
-            && CurlShareHandleState::normalizeMode($options['transport_sharing'], 'transport_sharing') !== TransportSharing::NONE
-        ) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "transport_sharing" request option to a cURL handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because transport sharing must be configured when creating the Client, CurlHandler, or CurlMultiHandler.');
-        }
-
         if (\array_key_exists('stream_context', $options)) {
             \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "stream_context" request option to a cURL handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because cURL handlers ignore PHP stream context options.');
         }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -47,6 +47,26 @@ class StreamHandler
     private $lastHeaders = [];
 
     /**
+     * @var string
+     */
+    private $transportSharingMode;
+
+    /**
+     * Accepts an associative array of options:
+     *
+     * - transport_sharing: Optional transport sharing mode.
+     *
+     * @param array{transport_sharing?: mixed} $options Array of options to use with the handler
+     */
+    public function __construct(array $options = [])
+    {
+        $this->transportSharingMode = CurlShareHandleState::normalizeMode(
+            $options['transport_sharing'] ?? null,
+            'transport_sharing'
+        );
+    }
+
+    /**
      * Sends an HTTP request.
      *
      * @param RequestInterface $request Request to send.
@@ -75,6 +95,7 @@ class StreamHandler
         $startTime = isset($options['on_stats']) ? Utils::currentTime() : null;
 
         self::triggerUnsupportedRequestOptionDeprecations($request, $options);
+        $this->assertTransportSharingSupported();
 
         try {
             // Does not support the expect header.
@@ -474,14 +495,6 @@ class StreamHandler
 
     private static function triggerUnsupportedRequestOptionDeprecations(RequestInterface $request, array $options): void
     {
-        if (\array_key_exists('transport_sharing', $options)) {
-            $transportSharingMode = CurlShareHandleState::normalizeMode($options['transport_sharing'], 'transport_sharing');
-
-            if ($transportSharingMode === TransportSharing::HANDLER_REQUIRE) {
-                throw new \InvalidArgumentException('The "transport_sharing" option requires transport sharing, but the stream handler does not support it.');
-            }
-        }
-
         if (
             \array_key_exists('curl', $options)
             && $options['curl'] !== null
@@ -497,6 +510,13 @@ class StreamHandler
 
         if (\array_key_exists('expect', $options) && $options['expect'] !== false && $request->hasHeader('Expect')) {
             \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "expect" request option to the stream handler is deprecated when it adds an Expect header; guzzlehttp/guzzle 8.0 will reject this option because the stream handler does not support Expect: 100-Continue.');
+        }
+    }
+
+    private function assertTransportSharingSupported(): void
+    {
+        if ($this->transportSharingMode === TransportSharing::HANDLER_REQUIRE) {
+            throw new \InvalidArgumentException('The "transport_sharing" option requires transport sharing, but the stream handler does not support it.');
         }
     }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -121,10 +121,7 @@ final class Utils
         }
 
         if (\ini_get('allow_url_fopen')) {
-            $streamHandler = new StreamHandler();
-            if ($sharingRequired) {
-                $streamHandler = self::wrapStreamHandlerTransportSharing($streamHandler, $sharingMode);
-            }
+            $streamHandler = new StreamHandler(['transport_sharing' => $sharingMode]);
 
             $handler = $handler
                 ? Proxy::wrapStreaming($handler, $streamHandler)
@@ -134,19 +131,6 @@ final class Utils
         }
 
         return $handler;
-    }
-
-    private static function wrapStreamHandlerTransportSharing(callable $handler, string $sharingMode): callable
-    {
-        return static function (RequestInterface $request, array $options) use ($handler, $sharingMode): Promise\PromiseInterface {
-            if (\array_key_exists('transport_sharing', $options)) {
-                CurlShareHandleState::normalizeMode($options['transport_sharing'], 'transport_sharing');
-            }
-
-            $options['transport_sharing'] = $sharingMode;
-
-            return $handler($request, $options);
-        };
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -164,6 +164,39 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider requestTransportSharingOptionProvider
+     *
+     * @param mixed $transportSharing
+     */
+    public function testIgnoresRequestLevelTransportSharingOption($transportSharing): void
+    {
+        unset($_SERVER['_curl']);
+
+        $easy = (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+            'transport_sharing' => $transportSharing,
+        ]);
+
+        try {
+            if (\defined('CURLOPT_SHARE')) {
+                self::assertArrayNotHasKey(\CURLOPT_SHARE, $_SERVER['_curl']);
+            }
+        } finally {
+            if (PHP_VERSION_ID < 80000) {
+                \curl_close($easy->handle);
+            }
+        }
+    }
+
+    public static function requestTransportSharingOptionProvider(): iterable
+    {
+        yield 'null' => [null];
+        yield 'none' => [TransportSharing::NONE];
+        yield 'handler prefer' => [TransportSharing::HANDLER_PREFER];
+        yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
+        yield 'invalid' => ['invalid'];
+    }
+
     public function testRejectsEnabledShareModeWithoutShareHandle(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1053,55 +1053,74 @@ class StreamHandlerTest extends TestCase
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testStreamAcceptsDisabledTransportSharingOption()
+    public function testStreamAcceptsDisabledTransportSharingConstructorOption()
     {
         Server::flush();
         Server::enqueue([new Response(200)]);
 
-        $handler = new StreamHandler();
-        $response = $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => TransportSharing::NONE,
-        ])->wait();
+        $handler = new StreamHandler(['transport_sharing' => TransportSharing::NONE]);
+        $response = $handler(new Request('GET', Server::$url), [])->wait();
 
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testStreamAcceptsNullTransportSharingOption()
+    public function testStreamAcceptsNullTransportSharingConstructorOption()
     {
         Server::flush();
         Server::enqueue([new Response(200)]);
 
-        $handler = new StreamHandler();
-        $response = $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => null,
-        ])->wait();
+        $handler = new StreamHandler(['transport_sharing' => null]);
+        $response = $handler(new Request('GET', Server::$url), [])->wait();
 
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testStreamAcceptsPreferredTransportSharingOption()
+    public function testStreamAcceptsPreferredTransportSharingConstructorOption()
     {
         Server::flush();
         Server::enqueue([new Response(200)]);
 
-        $handler = new StreamHandler();
-        $response = $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => TransportSharing::HANDLER_PREFER,
-        ])->wait();
+        $handler = new StreamHandler(['transport_sharing' => TransportSharing::HANDLER_PREFER]);
+        $response = $handler(new Request('GET', Server::$url), [])->wait();
 
         self::assertSame(200, $response->getStatusCode());
     }
 
-    public function testStreamRejectsRequiredTransportSharingOption()
+    public function testStreamRejectsRequiredTransportSharingConstructorOption()
     {
-        $handler = new StreamHandler();
+        $handler = new StreamHandler(['transport_sharing' => TransportSharing::HANDLER_REQUIRE]);
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('transport_sharing');
 
-        $handler(new Request('GET', Server::$url), [
-            'transport_sharing' => TransportSharing::HANDLER_REQUIRE,
-        ]);
+        $handler(new Request('GET', Server::$url), []);
+    }
+
+    /**
+     * @dataProvider requestTransportSharingOptionProvider
+     *
+     * @param mixed $transportSharing
+     */
+    public function testStreamIgnoresRequestLevelTransportSharingOption($transportSharing)
+    {
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
+        $handler = new StreamHandler();
+        $response = $handler(new Request('GET', Server::$url), [
+            'transport_sharing' => $transportSharing,
+        ])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function requestTransportSharingOptionProvider(): iterable
+    {
+        yield 'null' => [null];
+        yield 'none' => [TransportSharing::NONE];
+        yield 'handler prefer' => [TransportSharing::HANDLER_PREFER];
+        yield 'handler require' => [TransportSharing::HANDLER_REQUIRE];
+        yield 'invalid' => ['invalid'];
     }
 
     public function testDrainsResponseAndReadsAllContentWhenContentLengthIsZero()


### PR DESCRIPTION
This makes request-level transport_sharing behave like other unknown request options in the built-in handlers. The cURL handler no longer deprecates it, and the stream handler no longer interprets or rejects it when it appears in request options.

The stream handler now stores transport sharing mode as constructor state, so Utils can pass the selected default-handler mode directly instead of injecting transport_sharing into request options. Required sharing configured on the stream handler still fails when a request is routed to a handler that cannot satisfy it.