### PR TITLE
Deprecate request-level handler option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.12.0 - Upcoming
+
+### Deprecated
+
+- Deprecated the request-level `handler` option, which will be ignored in 8.0
+
+
 ## 7.11.1 - Upcoming
 
 ### Fixed

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -663,27 +663,6 @@ Constant
 $response = $client->request('PUT', '/put', ['json' => ['foo' => 'bar']]);
 ```
 
-Here's an example of using the `tap` middleware to see what request is sent over the wire.
-
-```php
-use GuzzleHttp\Middleware;
-
-// Create a middleware that echoes parts of the request.
-$tapMiddleware = Middleware::tap(function ($request) {
-    echo $request->getHeaderLine('Content-Type');
-    // application/json
-    echo $request->getBody();
-    // {"foo":"bar"}
-});
-
-// The $handler variable is the handler passed in the
-// options to the client constructor.
-$response = $client->request('PUT', '/put', [
-    'json'    => ['foo' => 'bar'],
-    'handler' => $tapMiddleware($handler)
-]);
-```
-
 > [!NOTE]
 > This request option does not support customizing the Content-Type header or any of the options from PHP's [json_encode()](http://www.php.net/manual/en/function.json-encode.php) function. If you need to customize these settings, then you must pass the JSON encoded data into the request yourself using the `body` request option and you must specify the correct Content-Type header using the `headers` request option.
 >

--- a/src/Client.php
+++ b/src/Client.php
@@ -331,6 +331,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      */
     private function prepareDefaults(array $options): array
     {
+        self::warnAboutRequestLevelHandler($options);
+
         $defaults = $this->config;
 
         if (!empty($defaults['headers'])) {
@@ -364,6 +366,19 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         self::warnAboutInvalidRequestOptionTypes($result);
 
         return $result;
+    }
+
+    private static function warnAboutRequestLevelHandler(array $options): void
+    {
+        if (!\array_key_exists('handler', $options)) {
+            return;
+        }
+
+        \trigger_deprecation(
+            'guzzlehttp/guzzle',
+            '7.12',
+            'Passing the "handler" request option is deprecated; guzzlehttp/guzzle 8.0 will ignore request-level handlers. Configure the handler when creating the Client, or use a separate Client instance for requests that need a different handler.'
+        );
     }
 
     private static function warnAboutInvalidRequestOptionTypes(array $options): void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -488,7 +488,11 @@ class ClientTest extends TestCase
         self::assertTrue($sent->hasHeader('Accept-Encoding'));
 
         $mock = new MockHandler([new Response()]);
-        $client->get('http://foo.com', ['handler' => $mock]);
+        $client = new Client([
+            'curl' => [\CURLOPT_ENCODING => ''],
+            'handler' => $mock,
+        ]);
+        $client->get('http://foo.com');
         self::assertSame([\CURLOPT_ENCODING => ''], $mock->getLastOptions()['curl']);
     }
 
@@ -963,19 +967,6 @@ class ClientTest extends TestCase
         $sent = $mock->getLastRequest();
         self::assertNotNull($sent);
         self::assertSame(['bar', 'baz'], $sent->getHeader('X-Foo'));
-    }
-
-    public function testCanSetCustomHandler()
-    {
-        $mock = new MockHandler([new Response(500)]);
-        $client = new Client(['handler' => $mock]);
-        $mock2 = new MockHandler([new Response(200)]);
-        self::assertSame(
-            200,
-            $client->send(new Request('GET', 'http://foo.com'), [
-                'handler' => $mock2,
-            ])->getStatusCode()
-        );
     }
 
     public function testProperlyBuildsQuery()


### PR DESCRIPTION
This deprecates passing handler as a request option while keeping the existing 7.x behaviour intact. The handler remains configurable when constructing a Client, and callers that need different handlers for different requests should use separate Client instances.