### PR TITLE
Ignore request-level handler option

### DIFF
--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -663,27 +663,6 @@ Constant
 $response = $client->request('PUT', '/put', ['json' => ['foo' => 'bar']]);
 ```
 
-Here's an example of using the `tap` middleware to see what request is sent over the wire.
-
-```php
-use GuzzleHttp\Middleware;
-
-// Create a middleware that echoes parts of the request.
-$tapMiddleware = Middleware::tap(function ($request) {
-    echo $request->getHeaderLine('Content-Type');
-    // application/json
-    echo $request->getBody();
-    // {"foo":"bar"}
-});
-
-// The $handler variable is the handler passed in the
-// options to the client constructor.
-$response = $client->request('PUT', '/put', [
-    'json'    => ['foo' => 'bar'],
-    'handler' => $tapMiddleware($handler)
-]);
-```
-
 > [!NOTE]
 > This request option does not support customizing the Content-Type header or any of the options from PHP's [json_encode()](http://www.php.net/manual/en/function.json-encode.php) function. If you need to customize these settings, then you must pass the JSON encoded data into the request yourself using the `body` request option and you must specify the correct Content-Type header using the `headers` request option.
 >

--- a/src/Client.php
+++ b/src/Client.php
@@ -183,7 +183,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * Asynchronously send an HTTP request.
      *
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -271,7 +270,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * Send an HTTP request.
      *
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -375,7 +373,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * @param string              $method HTTP method
      * @param string|UriInterface $uri    URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -491,7 +488,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      * @param string              $method HTTP method.
      * @param string|UriInterface $uri    URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -813,10 +809,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
     private static function assertRequestOptionTypes(array $options): void
     {
-        if (isset($options['handler']) && !\is_callable($options['handler'])) {
-            self::invalidRequestOptionType('handler', 'callable', $options['handler']);
-        }
-
         if (isset($options['allow_redirects'])) {
             if (!\is_bool($options['allow_redirects']) && !\is_array($options['allow_redirects'])) {
                 self::invalidRequestOptionType('allow_redirects', 'bool|array', $options['allow_redirects']);
@@ -1206,7 +1198,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         self::assertRequestProtocolVersion($request);
 
         /** @var callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $handler */
-        $handler = $options['handler'];
+        $handler = $this->config['handler'];
 
         try {
             /** @var PromiseInterface<ResponseInterface, mixed> */

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -30,7 +30,6 @@ interface ClientInterface
      *
      * @param RequestInterface $request Request to send
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -110,7 +109,6 @@ interface ClientInterface
      *
      * @param RequestInterface $request Request to send
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -195,7 +193,6 @@ interface ClientInterface
      * @param string              $method HTTP method.
      * @param string|UriInterface $uri    URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -280,7 +277,6 @@ interface ClientInterface
      * @param string              $method HTTP method
      * @param string|UriInterface $uri    URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -30,7 +30,6 @@ trait ClientTrait
      * @param string              $method HTTP method.
      * @param string|UriInterface $uri    URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -114,7 +113,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -201,7 +199,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -288,7 +285,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -375,7 +371,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -462,7 +457,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -549,7 +543,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -637,7 +630,6 @@ trait ClientTrait
      * @param string              $method HTTP method
      * @param string|UriInterface $uri    URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -721,7 +713,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -808,7 +799,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -895,7 +885,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -982,7 +971,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -1069,7 +1057,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,
@@ -1156,7 +1143,6 @@ trait ClientTrait
      *
      * @param string|UriInterface $uri URI object or string.
      * @param array{
-     *     handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *     base_uri?: string|UriInterface,
      *     allow_redirects?: bool|array{
      *         max?: int,

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -44,7 +44,6 @@ class Pool implements PromisorInterface
      * @param array{
      *     concurrency?: int|(callable(int): int),
      *     options?: array{
-     *         handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *         base_uri?: string|UriInterface,
      *         allow_redirects?: bool|array{
      *             max?: int,
@@ -169,7 +168,6 @@ class Pool implements PromisorInterface
      * @param array{
      *     concurrency?: int|(callable(int): int),
      *     options?: array{
-     *         handler?: callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>,
      *         base_uri?: string|UriInterface,
      *         allow_redirects?: bool|array{
      *             max?: int,

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2124,36 +2124,6 @@ class ClientTest extends TestCase
         self::assertSame(['zero'], $sent->getHeader('0'));
     }
 
-    public function testRequestLevelHandlerIsIgnored(): void
-    {
-        $mock = new MockHandler([new Response(500)]);
-        $client = new Client(['handler' => $mock]);
-        $mock2 = new MockHandler([new Response(200)]);
-
-        self::assertSame(
-            500,
-            $client->send(new Request('GET', 'http://foo.com'), [
-                'handler' => $mock2,
-            ])->getStatusCode()
-        );
-        self::assertSame($mock2, $mock->getLastOptions()['handler']);
-        self::assertCount(1, $mock2);
-    }
-
-    public function testNonCallableRequestLevelHandlerIsIgnored(): void
-    {
-        $mock = new MockHandler([new Response(200)]);
-        $client = new Client(['handler' => $mock]);
-
-        self::assertSame(
-            200,
-            $client->send(new Request('GET', 'http://foo.com'), [
-                'handler' => false,
-            ])->getStatusCode()
-        );
-        self::assertFalse($mock->getLastOptions()['handler']);
-    }
-
     public function testProperlyBuildsQuery(): void
     {
         $mock = new MockHandler([new Response()]);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1277,7 +1277,11 @@ class ClientTest extends TestCase
         self::assertTrue($sent->hasHeader('Accept-Encoding'));
 
         $mock = new MockHandler([new Response()]);
-        $client->get('http://foo.com', ['handler' => $mock]);
+        $client = new Client([
+            'curl' => [\CURLOPT_ENCODING => ''],
+            'handler' => $mock,
+        ]);
+        $client->get('http://foo.com');
         self::assertSame([\CURLOPT_ENCODING => ''], $mock->getLastOptions()['curl']);
     }
 
@@ -1306,11 +1310,6 @@ class ClientTest extends TestCase
 
     public static function invalidRequestOptionTypeProvider(): iterable
     {
-        yield 'handler' => [
-            ['handler' => false],
-            'Passing bool to request option "handler" is invalid; expected callable.',
-        ];
-
         yield 'allow_redirects' => [
             ['allow_redirects' => 'true'],
             'Passing string to request option "allow_redirects" is invalid; expected bool|array.',
@@ -2125,17 +2124,34 @@ class ClientTest extends TestCase
         self::assertSame(['zero'], $sent->getHeader('0'));
     }
 
-    public function testCanSetCustomHandler(): void
+    public function testRequestLevelHandlerIsIgnored(): void
     {
         $mock = new MockHandler([new Response(500)]);
         $client = new Client(['handler' => $mock]);
         $mock2 = new MockHandler([new Response(200)]);
+
         self::assertSame(
-            200,
+            500,
             $client->send(new Request('GET', 'http://foo.com'), [
                 'handler' => $mock2,
             ])->getStatusCode()
         );
+        self::assertSame($mock2, $mock->getLastOptions()['handler']);
+        self::assertCount(1, $mock2);
+    }
+
+    public function testNonCallableRequestLevelHandlerIsIgnored(): void
+    {
+        $mock = new MockHandler([new Response(200)]);
+        $client = new Client(['handler' => $mock]);
+
+        self::assertSame(
+            200,
+            $client->send(new Request('GET', 'http://foo.com'), [
+                'handler' => false,
+            ])->getStatusCode()
+        );
+        self::assertFalse($mock->getLastOptions()['handler']);
     }
 
     public function testProperlyBuildsQuery(): void


### PR DESCRIPTION
This makes handler a client constructor option only. Request-level handler values are left in the request options array as opaque custom data, but the client always uses the handler configured on the Client instance to send the transfer.

The request option PHPDoc entries and request option type validation for handler are removed, while the constructor configuration remains documented and unchanged.