### PR TITLE
Deprecate unsupported raw handler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Deprecated
 
 - Deprecated the request-level `handler` option, which will be ignored in 8.0
+- Deprecated raw cURL request options outside the built-in cURL handlers' allow-list
+- Deprecated PHP stream context options outside the built-in stream handler allow-list
 
 
 ## 7.11.1 - Upcoming

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,9 +33,17 @@ $response = $promise->wait();
 
 ## How can I add custom cURL options?
 
-cURL offers a huge number of [customizable options](https://www.php.net/curl_setopt). While Guzzle normalizes many of these options across different handlers, there are times when you need to set custom cURL options. This can be accomplished by passing an array keyed by integer `CURLOPT_*` constants in the **curl** key of a request. The special `body_as_string` key is also recognized by Guzzle's cURL handler.
+cURL offers a huge number of
+[customizable options](https://www.php.net/curl_setopt). While Guzzle
+normalizes many of these options across different handlers, there are times
+when you need to set custom cURL options. This can be accomplished by passing
+an array keyed by allow-listed integer `CURLOPT_*` constants in the **curl**
+key of a request. Raw cURL options outside the built-in cURL handlers'
+allow-list are deprecated. The special `body_as_string` key is also recognized
+by Guzzle's cURL handler.
 
-For example, let's say you need to customize the outgoing network interface used with a client.
+For example, let's say you need to customize the outgoing network interface used
+with a client.
 
 ```php
 $client->request('GET', '/', [
@@ -45,7 +53,9 @@ $client->request('GET', '/', [
 ]);
 ```
 
-If you use asynchronous requests with cURL multi handler and want to tweak it, additional options can be specified as an array keyed by integer `CURLMOPT_*` constants in the **options** key of the `CurlMultiHandler` constructor.
+If you use asynchronous requests with cURL multi handler and want to tweak it,
+additional options can be specified as an array keyed by integer `CURLMOPT_*`
+constants in the **options** key of the `CurlMultiHandler` constructor.
 
 ```php
 use GuzzleHttp\Client;
@@ -60,13 +70,21 @@ $client = new Client(['handler' => HandlerStack::create(new CurlMultiHandler([
 ]))]);
 ```
 
-Custom cURL request options remain active during redirects unless Guzzle documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
+Custom cURL request options remain active during redirects unless Guzzle
+documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects)
+for cross-origin redirect credential behavior.
 
 ## How can I add custom stream context options?
 
-You can pass custom [stream context options](https://www.php.net/manual/en/context.php) using the **stream_context** key of the request option. The **stream_context** array is an associative array where each key is a PHP transport, and each value is an associative array of transport options.
+You can pass allow-listed custom
+[stream context options](https://www.php.net/manual/en/context.php) using the
+**stream_context** key of the request option. The **stream_context** array is an
+associative array where each key is a PHP transport, and each value is an
+associative array of transport options. Stream context options outside the
+built-in stream handler allow-list are deprecated.
 
-For example, let's say you need to customize the outgoing network interface used with a client and allow self-signed certificates.
+For example, let's say you need to customize the outgoing network interface used
+with a client and allow self-signed certificates.
 
 ```php
 $client->request('GET', '/', [
@@ -82,7 +100,9 @@ $client->request('GET', '/', [
 ]);
 ```
 
-Custom stream context options remain active during redirects unless Guzzle documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
+Custom stream context options remain active during redirects unless Guzzle
+documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects)
+for cross-origin redirect credential behavior.
 
 ## Why am I getting an SSL verification error?
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -356,7 +356,30 @@ None
 Constant
 No `RequestOptions` constant is defined for this handler-specific option.
 
-The array is keyed by integer or string cURL option names and values are passed to cURL after Guzzle applies request options. Raw cURL options that conflict with Guzzle-managed request handling are deprecated and will be rejected by the built-in cURL handlers in 8.0.
+Except for Guzzle's special `body_as_string` key, the array is keyed by
+integer cURL option constants and values are passed to cURL after Guzzle
+applies request options. Raw cURL options that conflict with Guzzle-managed
+request handling are deprecated.
+
+Raw cURL options outside the built-in cURL handlers' allow-list are deprecated.
+Allow-listing means Guzzle passes the option through without its own
+deprecation warning; PHP, libcurl, or the TLS backend may still reject or ignore
+an option depending on the runtime. The allow-list is limited to the following
+`CURLOPT_*` constants when they are defined by the installed PHP cURL extension:
+`CURLOPT_ADDRESS_SCOPE`, `CURLOPT_CONNECT_TO`,
+`CURLOPT_DNS_CACHE_TIMEOUT`, `CURLOPT_DNS_INTERFACE`,
+`CURLOPT_DNS_LOCAL_IP4`, `CURLOPT_DNS_LOCAL_IP6`, `CURLOPT_DNS_SERVERS`,
+`CURLOPT_DNS_SHUFFLE_ADDRESSES`, `CURLOPT_ENCODING`,
+`CURLOPT_FORBID_REUSE`, `CURLOPT_FRESH_CONNECT`,
+`CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS`, `CURLOPT_HTTPAUTH`,
+`CURLOPT_INTERFACE`, `CURLOPT_LOCALPORT`, `CURLOPT_LOCALPORTRANGE`,
+`CURLOPT_LOW_SPEED_LIMIT`, `CURLOPT_LOW_SPEED_TIME`,
+`CURLOPT_MAXAGE_CONN`, `CURLOPT_MAXCONNECTS`, `CURLOPT_MAXLIFETIME_CONN`,
+`CURLOPT_PROXYHEADER`, `CURLOPT_RESOLVE`, `CURLOPT_SSL_CIPHER_LIST`,
+`CURLOPT_SSL_EC_CURVES`, `CURLOPT_TCP_FASTOPEN`, `CURLOPT_TCP_KEEPALIVE`,
+`CURLOPT_TCP_KEEPIDLE`, `CURLOPT_TCP_KEEPINTVL`, `CURLOPT_TCP_KEEPCNT`,
+`CURLOPT_TCP_NODELAY`, `CURLOPT_TLS13_CIPHERS`,
+`CURLOPT_UNIX_SOCKET_PATH`, and `CURLOPT_USERPWD`.
 
 ```php
 $client->request('GET', '/', [
@@ -847,12 +870,12 @@ $client->request('GET', 'https://example.com', [
 
 > [!NOTE]
 > `protocols` replaces raw cURL `CURLOPT_PROTOCOLS` when restricting request
-> schemes. Starting in Guzzle 7.11, raw cURL options that conflict with
-> Guzzle-managed request handling trigger deprecation warnings. Use Guzzle
-> request options instead when configuring the request method, URI, body,
-> headers, timeouts, redirects, proxy, TLS, progress, debug output, sinks,
-> cookies, and protocols. Redirect middleware also validates redirect targets
-> with `allow_redirects.protocols` before creating each redirect request.
+> schemes. Raw cURL options that conflict with Guzzle-managed request handling
+> trigger deprecation warnings. Prefer request options when configuring the
+> request method, URI, body, headers, timeouts, redirects, proxy, TLS,
+> progress, debug output, sinks, cookies, and protocols. Redirect middleware
+> also validates redirect targets with `allow_redirects.protocols` before
+> creating each redirect request.
 
 ## proxy
 
@@ -1093,7 +1116,8 @@ while (!$body->eof()) {
 ## stream_context
 
 Summary
-PHP stream context options to merge into the context used by the built-in stream handler.
+PHP stream context options to merge into the context used by the built-in stream
+handler.
 
 Types
 - array
@@ -1104,7 +1128,24 @@ None
 Constant
 No `RequestOptions` constant is defined for this handler-specific option.
 
-This option is only supported by the built-in stream handler. Built-in cURL handlers deprecate and will reject this option in 8.0 because cURL does not use PHP stream contexts.
+This option is only supported by the built-in stream handler. Built-in cURL
+handlers deprecate this option because cURL does not use PHP stream contexts.
+
+Stream context options outside the built-in stream handler allow-list, or not
+available in the current PHP runtime, are deprecated. Allow-listing means Guzzle
+passes the option through without its own deprecation warning; PHP or OpenSSL
+may still reject or ignore an option depending on the runtime. The allow-list is
+`http.request_fulluri`, `socket.bindto`, `socket.tcp_nodelay`,
+`ssl.SNI_enabled`, `ssl.allow_self_signed`, `ssl.capath`,
+`ssl.capture_peer_cert`, `ssl.capture_peer_cert_chain`, `ssl.ciphers`,
+`ssl.disable_compression`, `ssl.max_proto_version`, `ssl.min_proto_version`,
+`ssl.no_ticket`, `ssl.peer_fingerprint`, `ssl.security_level`, and
+`ssl.verify_depth`. When available in the current PHP runtime,
+`socket.so_keepalive`, `socket.tcp_keepcnt`, `socket.tcp_keepidle`, and
+`socket.tcp_keepintvl` are also on the allow-list. Use Guzzle request options
+instead when configuring the request method, URI, body, headers, timeouts,
+redirects, proxy, TLS certificate files, TLS private keys, protocol versions,
+verification, progress, debug output, sinks, cookies, and allowed protocols.
 
 ## synchronous
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1140,12 +1140,10 @@ may still reject or ignore an option depending on the runtime. The allow-list is
 `ssl.capture_peer_cert`, `ssl.capture_peer_cert_chain`, `ssl.ciphers`,
 `ssl.disable_compression`, `ssl.max_proto_version`, `ssl.min_proto_version`,
 `ssl.no_ticket`, `ssl.peer_fingerprint`, `ssl.security_level`, and
-`ssl.verify_depth`. When available in the current PHP runtime,
-`socket.so_keepalive`, `socket.tcp_keepcnt`, `socket.tcp_keepidle`, and
-`socket.tcp_keepintvl` are also on the allow-list. Use Guzzle request options
-instead when configuring the request method, URI, body, headers, timeouts,
-redirects, proxy, TLS certificate files, TLS private keys, protocol versions,
-verification, progress, debug output, sinks, cookies, and allowed protocols.
+`ssl.verify_depth`. Use Guzzle request options instead when configuring the
+request method, URI, body, headers, timeouts, redirects, proxy, TLS certificate
+files, TLS private keys, protocol versions, verification, progress, debug
+output, sinks, cookies, and allowed protocols.
 
 ## synchronous
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -110,6 +110,7 @@ class CurlFactory implements CurlFactoryInterface
 
         self::triggerUnsupportedRequestOptionDeprecations($options);
         $this->rejectRequestLevelShareConflict($options);
+        self::triggerUnsupportedCurlOptionDeprecations($options);
         self::triggerConflictingCurlOptionDeprecations($options);
 
         $easy = new EasyHandle();
@@ -277,6 +278,35 @@ class CurlFactory implements CurlFactoryInterface
         }
     }
 
+    private static function triggerUnsupportedCurlOptionDeprecations(array $options): void
+    {
+        if (!isset($options['curl']) || !\is_array($options['curl']) || $options['curl'] === []) {
+            return;
+        }
+
+        $supportedOptions = self::supportedCurlOptions();
+        $conflictingOptions = self::conflictingCurlOptions();
+
+        foreach ($options['curl'] as $option => $_) {
+            if (
+                !\is_int($option)
+                || \array_key_exists($option, $supportedOptions)
+                || \array_key_exists($option, $conflictingOptions)
+            ) {
+                continue;
+            }
+
+            \trigger_deprecation(
+                'guzzlehttp/guzzle',
+                '7.12',
+                \sprintf(
+                    'Passing %s in the "curl" request option is deprecated; guzzlehttp/guzzle 8.0 will reject raw cURL options outside the built-in cURL handlers\' allow-list.',
+                    self::formatCurlOption($option)
+                )
+            );
+        }
+    }
+
     private static function triggerUnsupportedRequestOptionDeprecations(array $options): void
     {
         if (\array_key_exists('stream_context', $options)) {
@@ -361,6 +391,72 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIESESSION', 'Guzzle cookie middleware');
 
         return $options;
+    }
+
+    /**
+     * @return array<int, true>
+     */
+    private static function supportedCurlOptions(): array
+    {
+        static $options = null;
+
+        if ($options !== null) {
+            return $options;
+        }
+
+        $options = [];
+
+        self::addSupportedCurlOption($options, 'CURLOPT_ADDRESS_SCOPE');
+        self::addSupportedCurlOption($options, 'CURLOPT_CONNECT_TO');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_CACHE_TIMEOUT');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_INTERFACE');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_LOCAL_IP4');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_LOCAL_IP6');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_SERVERS');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_SHUFFLE_ADDRESSES');
+        self::addSupportedCurlOption($options, 'CURLOPT_ENCODING');
+        self::addSupportedCurlOption($options, 'CURLOPT_FORBID_REUSE');
+        self::addSupportedCurlOption($options, 'CURLOPT_FRESH_CONNECT');
+        self::addSupportedCurlOption($options, 'CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS');
+        self::addSupportedCurlOption($options, 'CURLOPT_HTTPAUTH');
+        self::addSupportedCurlOption($options, 'CURLOPT_INTERFACE');
+        self::addSupportedCurlOption($options, 'CURLOPT_LOCALPORT');
+        self::addSupportedCurlOption($options, 'CURLOPT_LOCALPORTRANGE');
+        self::addSupportedCurlOption($options, 'CURLOPT_LOW_SPEED_LIMIT');
+        self::addSupportedCurlOption($options, 'CURLOPT_LOW_SPEED_TIME');
+        self::addSupportedCurlOption($options, 'CURLOPT_MAXAGE_CONN');
+        self::addSupportedCurlOption($options, 'CURLOPT_MAXCONNECTS');
+        self::addSupportedCurlOption($options, 'CURLOPT_MAXLIFETIME_CONN');
+        self::addSupportedCurlOption($options, 'CURLOPT_PROXYHEADER');
+        self::addSupportedCurlOption($options, 'CURLOPT_RESOLVE');
+        self::addSupportedCurlOption($options, 'CURLOPT_SSL_CIPHER_LIST');
+        self::addSupportedCurlOption($options, 'CURLOPT_SSL_EC_CURVES');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_FASTOPEN');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_KEEPALIVE');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_KEEPIDLE');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_KEEPINTVL');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_KEEPCNT');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_NODELAY');
+        self::addSupportedCurlOption($options, 'CURLOPT_TLS13_CIPHERS');
+        self::addSupportedCurlOption($options, 'CURLOPT_UNIX_SOCKET_PATH');
+        self::addSupportedCurlOption($options, 'CURLOPT_USERPWD');
+
+        return $options;
+    }
+
+    /**
+     * @param array<int, true> $options
+     */
+    private static function addSupportedCurlOption(array &$options, string $constant): void
+    {
+        if (!\defined($constant)) {
+            return;
+        }
+
+        $value = \constant($constant);
+        if (\is_int($value)) {
+            $options[$value] = true;
+        }
     }
 
     /**

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -574,7 +574,7 @@ class StreamHandler
      */
     private static function supportedStreamContextOptions(): array
     {
-        $options = [
+        return [
             'http' => [
                 'request_fulluri' => true,
             ],
@@ -598,8 +598,6 @@ class StreamHandler
                 'verify_depth' => true,
             ],
         ];
-
-        return $options;
     }
 
     private function assertTransportSharingSupported(): void

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -599,19 +599,7 @@ class StreamHandler
             ],
         ];
 
-        if (self::isPhpAtLeast('8.6.0')) {
-            $options['socket']['so_keepalive'] = true;
-            $options['socket']['tcp_keepcnt'] = true;
-            $options['socket']['tcp_keepidle'] = true;
-            $options['socket']['tcp_keepintvl'] = true;
-        }
-
         return $options;
-    }
-
-    private static function isPhpAtLeast(string $version): bool
-    {
-        return \version_compare(\PHP_VERSION, $version, '>=');
     }
 
     private function assertTransportSharingSupported(): void

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -387,6 +387,7 @@ class StreamHandler
             if (!\is_array($options['stream_context'])) {
                 throw new \InvalidArgumentException('stream_context must be an array');
             }
+            self::triggerUnsupportedStreamContextOptionDeprecations($options['stream_context']);
             $context = \array_replace_recursive($context, $options['stream_context']);
         }
 
@@ -511,6 +512,106 @@ class StreamHandler
         if (\array_key_exists('expect', $options) && $options['expect'] !== false && $request->hasHeader('Expect')) {
             \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "expect" request option to the stream handler is deprecated when it adds an Expect header; guzzlehttp/guzzle 8.0 will reject this option because the stream handler does not support Expect: 100-Continue.');
         }
+    }
+
+    private static function triggerUnsupportedStreamContextOptionDeprecations(array $streamContext): void
+    {
+        $unsupportedOptions = self::unsupportedStreamContextOptions($streamContext);
+        if ($unsupportedOptions === []) {
+            return;
+        }
+
+        \trigger_deprecation(
+            'guzzlehttp/guzzle',
+            '7.12',
+            \sprintf(
+                'Passing PHP stream context options outside the built-in stream handler allow-list to the "stream_context" request option is deprecated; guzzlehttp/guzzle 8.0 will reject stream context options outside the allow-list. Deprecated option%s: %s.',
+                \count($unsupportedOptions) === 1 ? '' : 's',
+                \implode(', ', $unsupportedOptions)
+            )
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function unsupportedStreamContextOptions(array $streamContext): array
+    {
+        $supportedOptions = self::supportedStreamContextOptions();
+        $unsupportedOptions = [];
+
+        foreach ($streamContext as $wrapper => $contextOptions) {
+            if (!\is_string($wrapper) || !isset($supportedOptions[$wrapper])) {
+                if (\is_array($contextOptions)) {
+                    foreach ($contextOptions as $option => $_) {
+                        $unsupportedOptions[] = \sprintf('stream_context.%s.%s', (string) $wrapper, (string) $option);
+                    }
+                } else {
+                    $unsupportedOptions[] = \sprintf('stream_context.%s', (string) $wrapper);
+                }
+
+                continue;
+            }
+
+            if (!\is_array($contextOptions)) {
+                $unsupportedOptions[] = \sprintf('stream_context.%s', $wrapper);
+
+                continue;
+            }
+
+            foreach ($contextOptions as $option => $_) {
+                if (!\is_string($option) || !\array_key_exists($option, $supportedOptions[$wrapper])) {
+                    $unsupportedOptions[] = \sprintf('stream_context.%s.%s', $wrapper, (string) $option);
+                }
+            }
+        }
+
+        return $unsupportedOptions;
+    }
+
+    /**
+     * @return array<string, array<string, true>>
+     */
+    private static function supportedStreamContextOptions(): array
+    {
+        $options = [
+            'http' => [
+                'request_fulluri' => true,
+            ],
+            'socket' => [
+                'bindto' => true,
+                'tcp_nodelay' => true,
+            ],
+            'ssl' => [
+                'SNI_enabled' => true,
+                'allow_self_signed' => true,
+                'capath' => true,
+                'capture_peer_cert' => true,
+                'capture_peer_cert_chain' => true,
+                'ciphers' => true,
+                'disable_compression' => true,
+                'max_proto_version' => true,
+                'min_proto_version' => true,
+                'no_ticket' => true,
+                'peer_fingerprint' => true,
+                'security_level' => true,
+                'verify_depth' => true,
+            ],
+        ];
+
+        if (self::isPhpAtLeast('8.6.0')) {
+            $options['socket']['so_keepalive'] = true;
+            $options['socket']['tcp_keepcnt'] = true;
+            $options['socket']['tcp_keepidle'] = true;
+            $options['socket']['tcp_keepintvl'] = true;
+        }
+
+        return $options;
+    }
+
+    private static function isPhpAtLeast(string $version): bool
+    {
+        return \version_compare(\PHP_VERSION, $version, '>=');
     }
 
     private function assertTransportSharingSupported(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -238,8 +238,8 @@ class CurlFactoryTest extends TestCase
         Server::enqueue([new Psr7\Response()]);
         $a = new Handler\CurlMultiHandler();
         $req = new Psr7\Request('GET', Server::$url);
-        $a($req, ['curl' => [\CURLOPT_HTTP_VERSION => \CURL_HTTP_VERSION_1_0]]);
-        self::assertEquals(\CURL_HTTP_VERSION_1_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+        $a($req, ['curl' => [\CURLOPT_LOW_SPEED_TIME => 10]]);
+        self::assertEquals(10, $_SERVER['_curl'][\CURLOPT_LOW_SPEED_TIME]);
     }
 
     public function testProtocolsOptionCanRestrictCurlProtocols()

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -786,21 +786,19 @@ class StreamHandlerTest extends TestCase
             'stream_context' => [
                 'http' => [
                     'request_fulluri' => true,
-                    'method' => 'HEAD',
                 ],
                 'socket' => [
                     'bindto' => '127.0.0.1:0',
                 ],
                 'ssl' => [
-                    'verify_peer' => false,
+                    'allow_self_signed' => true,
                 ],
             ],
         ]);
         $opts = \stream_context_get_options($res->getBody()->detach());
-        self::assertSame('HEAD', $opts['http']['method']);
         self::assertTrue($opts['http']['request_fulluri']);
         self::assertSame('127.0.0.1:0', $opts['socket']['bindto']);
-        self::assertFalse($opts['ssl']['verify_peer']);
+        self::assertTrue($opts['ssl']['allow_self_signed']);
     }
 
     public function testEnsuresThatStreamContextIsAnArray()


### PR DESCRIPTION
This deprecates raw cURL request options outside the built-in cURL handlers' allow-list while preserving existing pass-through behavior in the 7.x line. It also deprecates PHP stream context options outside the built-in stream handler allow-list, including options that are unavailable in the current PHP runtime. This gives Guzzle an intentional review point for future PHP, libcurl, and stream context option surface area instead of silently treating newly exposed options as supported.