### PR TITLE
Reject unsupported raw handler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject invalid `idn_conversion`, `retries`, and built-in handler `on_stats` option values before use
 - Reject invalid `SetCookie` constructor field types instead of coercing them
 - Reject malformed, conflicting, or unrepresentable request `Content-Length` values in built-in handlers
-- Reject conflicting raw cURL request options, including request-level `CURLOPT_SHARE`
+- Reject raw cURL request options outside the built-in cURL handlers' allow-list
+- Reject PHP stream context options outside the built-in stream handler allow-list
 - Reject selected request options ignored by incompatible built-in handlers
 - Support retry delay callbacks with retry count only or full retry context
 - Treat only `null` as an omitted path or name when clearing cookies

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,9 +30,17 @@ $response = $promise->wait();
 
 ## How can I add custom cURL options?
 
-cURL offers a huge number of [customizable options](https://www.php.net/curl_setopt). While Guzzle normalizes many of these options across different handlers, there are times when you need to set custom cURL options. This can be accomplished by passing an array keyed by integer `CURLOPT_*` constants in the **curl** key of a request. The special `body_as_string` key is also recognized by Guzzle's cURL handler.
+cURL offers a huge number of
+[customizable options](https://www.php.net/curl_setopt). While Guzzle
+normalizes many of these options across different handlers, there are times
+when you need to set custom cURL options. This can be accomplished by passing
+an array keyed by allow-listed integer `CURLOPT_*` constants in the **curl**
+key of a request. Raw cURL options outside the built-in cURL handlers'
+allow-list are rejected. The special `body_as_string` key is also recognized
+by Guzzle's cURL handler.
 
-For example, let's say you need to customize the outgoing network interface used with a client.
+For example, let's say you need to customize the outgoing network interface used
+with a client.
 
 ```php
 $client->request('GET', '/', [
@@ -42,7 +50,9 @@ $client->request('GET', '/', [
 ]);
 ```
 
-If you use asynchronous requests with cURL multi handler and want to tweak it, additional options can be specified as an array keyed by integer `CURLMOPT_*` constants in the **options** key of the `CurlMultiHandler` constructor.
+If you use asynchronous requests with cURL multi handler and want to tweak it,
+additional options can be specified as an array keyed by integer `CURLMOPT_*`
+constants in the **options** key of the `CurlMultiHandler` constructor.
 
 ```php
 use GuzzleHttp\Client;
@@ -57,7 +67,9 @@ $client = new Client(['handler' => HandlerStack::create(new CurlMultiHandler([
 ]))]);
 ```
 
-Custom cURL request options remain active during redirects unless Guzzle documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
+Custom cURL request options remain active during redirects unless Guzzle
+documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects)
+for cross-origin redirect credential behavior.
 
 Callbacks supplied directly through the `curl` request option are passed to PHP's cURL extension as low-level callbacks. Guzzle does not normalize exception or abort behavior for raw cURL callbacks. Prefer Guzzle's `progress`, `on_headers`, and `on_stats` request options when you want Guzzle's documented callback semantics.
 
@@ -84,17 +96,20 @@ After a cURL handler has been closed, it cannot be reused. `Client` and `Handler
 
 ## How can I add custom stream context options?
 
-You can pass custom [stream context options](https://www.php.net/manual/en/context.php) using the **stream_context** key of the request option. The **stream_context** array is an associative array where each key is a PHP transport, and each value is an associative array of transport options.
+You can pass allow-listed custom
+[stream context options](https://www.php.net/manual/en/context.php) using the
+**stream_context** key of the request option. The **stream_context** array is an
+associative array where each key is a PHP transport, and each value is an
+associative array of transport options. Stream context options outside the
+built-in stream handler allow-list are rejected.
 
-For example, let's say you need to customize the outgoing network interface used with a client and allow self-signed certificates.
+For example, let's say you need to customize the outgoing network interface used
+with a client.
 
 ```php
 $client->request('GET', '/', [
     'stream' => true,
     'stream_context' => [
-        'ssl' => [
-            'allow_self_signed' => true
-        ],
         'socket' => [
             'bindto' => 'xxx.xxx.xxx.xxx'
         ]
@@ -102,7 +117,9 @@ $client->request('GET', '/', [
 ]);
 ```
 
-Custom stream context options remain active during redirects unless Guzzle documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
+Custom stream context options remain active during redirects unless Guzzle
+documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects)
+for cross-origin redirect credential behavior.
 
 ## Why am I getting an SSL verification error?
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -356,7 +356,30 @@ None
 Constant
 No `RequestOptions` constant is defined for this handler-specific option.
 
-The array is keyed by integer or string cURL option names and values are passed to cURL after Guzzle applies request options. Raw cURL options that conflict with Guzzle-managed request handling are rejected by the built-in cURL handlers.
+Except for Guzzle's special `body_as_string` key, the array is keyed by integer
+cURL option constants and values are passed to cURL after Guzzle applies request
+options. Raw cURL options that conflict with Guzzle-managed request handling are
+rejected by the built-in cURL handlers.
+
+Raw cURL options outside the built-in cURL handlers' allow-list are rejected.
+Allow-listing means Guzzle passes the option through; PHP, libcurl, or the TLS
+backend may still reject or ignore an option depending on the runtime. The
+allow-list is limited to the following `CURLOPT_*` constants when they are
+defined by the installed PHP cURL extension: `CURLOPT_ADDRESS_SCOPE`,
+`CURLOPT_CONNECT_TO`, `CURLOPT_DNS_CACHE_TIMEOUT`,
+`CURLOPT_DNS_INTERFACE`, `CURLOPT_DNS_LOCAL_IP4`,
+`CURLOPT_DNS_LOCAL_IP6`, `CURLOPT_DNS_SERVERS`,
+`CURLOPT_DNS_SHUFFLE_ADDRESSES`, `CURLOPT_ENCODING`,
+`CURLOPT_FORBID_REUSE`, `CURLOPT_FRESH_CONNECT`,
+`CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS`, `CURLOPT_HTTPAUTH`,
+`CURLOPT_HTTPPROXYTUNNEL`, `CURLOPT_INTERFACE`, `CURLOPT_LOCALPORT`,
+`CURLOPT_LOCALPORTRANGE`, `CURLOPT_LOW_SPEED_LIMIT`, `CURLOPT_LOW_SPEED_TIME`,
+`CURLOPT_MAXAGE_CONN`, `CURLOPT_MAXCONNECTS`, `CURLOPT_MAXLIFETIME_CONN`,
+`CURLOPT_PROXYHEADER`, `CURLOPT_PROXYTYPE`, `CURLOPT_PROXYUSERPWD`,
+`CURLOPT_RESOLVE`, `CURLOPT_SSL_CIPHER_LIST`, `CURLOPT_SSL_EC_CURVES`,
+`CURLOPT_TCP_FASTOPEN`, `CURLOPT_TCP_KEEPALIVE`, `CURLOPT_TCP_KEEPIDLE`,
+`CURLOPT_TCP_KEEPINTVL`, `CURLOPT_TCP_KEEPCNT`, `CURLOPT_TCP_NODELAY`,
+`CURLOPT_TLS13_CIPHERS`, `CURLOPT_UNIX_SOCKET_PATH`, and `CURLOPT_USERPWD`.
 
 ```php
 $client->request('GET', '/', [
@@ -1256,7 +1279,22 @@ None
 Constant
 No `RequestOptions` constant is defined for this handler-specific option.
 
-This option is only supported by the built-in stream handler. Built-in cURL handlers reject this option because cURL does not use PHP stream contexts.
+This option is only supported by the built-in stream handler. Built-in cURL
+handlers reject this option because cURL does not use PHP stream contexts.
+
+Stream context options outside the built-in stream handler allow-list, or not
+available in the current PHP runtime, are rejected. Allow-listing means Guzzle
+passes the option through; PHP or OpenSSL may still reject or ignore an option
+depending on the runtime. The allow-list is `http.request_fulluri`,
+`socket.bindto`, `socket.tcp_nodelay`, `ssl.SNI_enabled`,
+`ssl.capture_peer_cert`, `ssl.capture_peer_cert_chain`, `ssl.ciphers`,
+`ssl.disable_compression`, `ssl.no_ticket`, `ssl.peer_fingerprint`,
+`ssl.security_level`, and `ssl.verify_depth`. Use Guzzle request options
+instead when configuring the request method, URI, body, headers, timeouts,
+redirects, proxy, TLS certificate files, TLS private keys, protocol versions,
+verification, progress, debug output, sinks, cookies, and allowed protocols.
+TLS protocol versions are managed through the `crypto_method` request option,
+and TLS verification is managed through the `verify` request option.
 
 ## synchronous
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -179,6 +179,7 @@ final class CurlFactory implements CurlFactoryInterface
         self::assertOnStatsCallable($options);
         $this->rejectRequestLevelShareConflict($options);
         $this->rejectPersistentRequireConnectionReuseConflicts($options);
+        self::rejectUnsupportedCurlOptions($options);
         self::rejectConflictingCurlOptions($options);
 
         $contentLength = self::requestContentLength($request);
@@ -360,6 +361,31 @@ final class CurlFactory implements CurlFactoryInterface
         }
     }
 
+    private static function rejectUnsupportedCurlOptions(array $options): void
+    {
+        if (!isset($options['curl']) || !\is_array($options['curl']) || $options['curl'] === []) {
+            return;
+        }
+
+        $supportedOptions = self::supportedCurlOptions();
+        $conflictingOptions = self::conflictingCurlOptions();
+
+        foreach ($options['curl'] as $option => $_) {
+            if (
+                !\is_int($option)
+                || \array_key_exists($option, $supportedOptions)
+                || \array_key_exists($option, $conflictingOptions)
+            ) {
+                continue;
+            }
+
+            throw new InvalidArgumentException(\sprintf(
+                'Passing %s in the "curl" request option is not supported because it is outside the built-in cURL handlers\' allow-list.',
+                self::formatCurlOption($option)
+            ));
+        }
+    }
+
     private static function rejectUnsupportedRequestOptions(array $options): void
     {
         if (\array_key_exists('stream_context', $options)) {
@@ -408,8 +434,6 @@ final class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_HEADERFUNCTION', 'the "on_headers" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_WRITEFUNCTION', 'the "sink" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_FILE', 'the "sink" request option');
-        self::addConflictingCurlOption($options, 'CURLOPT_RETURNTRANSFER', null);
-        self::addConflictingCurlOption($options, 'CURLOPT_HEADER', null);
         self::addConflictingCurlOption($options, 'CURLOPT_TIMEOUT', 'the "timeout" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_TIMEOUT_MS', 'the "timeout" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_CONNECTTIMEOUT', 'the "connect_timeout" request option');
@@ -429,7 +453,6 @@ final class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_REDIR_PROTOCOLS_STR', 'the "allow_redirects" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_PROTOCOLS', 'the "protocols" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_PROTOCOLS_STR', 'the "protocols" request option');
-        self::addConflictingCurlOption($options, 'CURLOPT_HTTP09_ALLOWED', null);
         self::addConflictingCurlOption($options, 'CURLOPT_HTTP_VERSION', 'the request protocol version');
         self::addConflictingCurlOption($options, 'CURLOPT_IPRESOLVE', 'the "force_ip_resolve" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_SSL_VERIFYPEER', 'the "verify" request option');
@@ -451,6 +474,75 @@ final class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_COOKIESESSION', 'Guzzle cookie middleware');
 
         return $options;
+    }
+
+    /**
+     * @return array<int, true>
+     */
+    private static function supportedCurlOptions(): array
+    {
+        static $options = null;
+
+        if ($options !== null) {
+            return $options;
+        }
+
+        $options = [];
+
+        self::addSupportedCurlOption($options, 'CURLOPT_ADDRESS_SCOPE');
+        self::addSupportedCurlOption($options, 'CURLOPT_CONNECT_TO');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_CACHE_TIMEOUT');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_INTERFACE');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_LOCAL_IP4');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_LOCAL_IP6');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_SERVERS');
+        self::addSupportedCurlOption($options, 'CURLOPT_DNS_SHUFFLE_ADDRESSES');
+        self::addSupportedCurlOption($options, 'CURLOPT_ENCODING');
+        self::addSupportedCurlOption($options, 'CURLOPT_FORBID_REUSE');
+        self::addSupportedCurlOption($options, 'CURLOPT_FRESH_CONNECT');
+        self::addSupportedCurlOption($options, 'CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS');
+        self::addSupportedCurlOption($options, 'CURLOPT_HTTPAUTH');
+        self::addSupportedCurlOption($options, 'CURLOPT_INTERFACE');
+        self::addSupportedCurlOption($options, 'CURLOPT_LOCALPORT');
+        self::addSupportedCurlOption($options, 'CURLOPT_LOCALPORTRANGE');
+        self::addSupportedCurlOption($options, 'CURLOPT_LOW_SPEED_LIMIT');
+        self::addSupportedCurlOption($options, 'CURLOPT_LOW_SPEED_TIME');
+        self::addSupportedCurlOption($options, 'CURLOPT_MAXAGE_CONN');
+        self::addSupportedCurlOption($options, 'CURLOPT_MAXCONNECTS');
+        self::addSupportedCurlOption($options, 'CURLOPT_MAXLIFETIME_CONN');
+        self::addSupportedCurlOption($options, 'CURLOPT_HTTPPROXYTUNNEL');
+        self::addSupportedCurlOption($options, 'CURLOPT_PROXYHEADER');
+        self::addSupportedCurlOption($options, 'CURLOPT_PROXYTYPE');
+        self::addSupportedCurlOption($options, 'CURLOPT_PROXYUSERPWD');
+        self::addSupportedCurlOption($options, 'CURLOPT_RESOLVE');
+        self::addSupportedCurlOption($options, 'CURLOPT_SSL_CIPHER_LIST');
+        self::addSupportedCurlOption($options, 'CURLOPT_SSL_EC_CURVES');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_FASTOPEN');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_KEEPALIVE');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_KEEPIDLE');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_KEEPINTVL');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_KEEPCNT');
+        self::addSupportedCurlOption($options, 'CURLOPT_TCP_NODELAY');
+        self::addSupportedCurlOption($options, 'CURLOPT_TLS13_CIPHERS');
+        self::addSupportedCurlOption($options, 'CURLOPT_UNIX_SOCKET_PATH');
+        self::addSupportedCurlOption($options, 'CURLOPT_USERPWD');
+
+        return $options;
+    }
+
+    /**
+     * @param array<int, true> $options
+     */
+    private static function addSupportedCurlOption(array &$options, string $constant): void
+    {
+        if (!\defined($constant)) {
+            return;
+        }
+
+        $value = \constant($constant);
+        if (\is_int($value)) {
+            $options[$value] = true;
+        }
     }
 
     /**

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -664,6 +664,8 @@ final class StreamHandler
             if (!\is_array($streamContext)) {
                 throw new InvalidArgumentException('stream_context must be an array');
             }
+            self::rejectConflictingStreamContextOptions($streamContext);
+            self::rejectUnsupportedStreamContextOptions($streamContext);
             $context = \array_replace_recursive($context, $streamContext);
 
             $sslContext = $streamContext['ssl'] ?? null;
@@ -862,6 +864,149 @@ final class StreamHandler
         if (\array_key_exists('expect', $options) && $options['expect'] !== false && $request->hasHeader('Expect')) {
             throw new InvalidArgumentException('Passing the "expect" request option to the stream handler is not supported when it adds an Expect header because the stream handler does not support Expect: 100-Continue.');
         }
+    }
+
+    private static function rejectConflictingStreamContextOptions(array $streamContext): void
+    {
+        $conflictingOptions = self::conflictingStreamContextOptions();
+
+        foreach ($streamContext as $wrapper => $contextOptions) {
+            if (!\is_string($wrapper) || !isset($conflictingOptions[$wrapper]) || !\is_array($contextOptions)) {
+                continue;
+            }
+
+            foreach ($contextOptions as $option => $_) {
+                if (!\is_string($option) || !\array_key_exists($option, $conflictingOptions[$wrapper])) {
+                    continue;
+                }
+
+                $replacement = $conflictingOptions[$wrapper][$option];
+                if ($replacement !== null) {
+                    throw new InvalidArgumentException(\sprintf(
+                        'Passing stream_context.%s.%s in the "stream_context" request option is not supported because it conflicts with Guzzle-managed request handling. Use %s instead.',
+                        $wrapper,
+                        $option,
+                        $replacement
+                    ));
+                }
+
+                throw new InvalidArgumentException(\sprintf(
+                    'Passing stream_context.%s.%s in the "stream_context" request option is not supported because it conflicts with Guzzle-managed stream handler internals.',
+                    $wrapper,
+                    $option
+                ));
+            }
+        }
+    }
+
+    private static function rejectUnsupportedStreamContextOptions(array $streamContext): void
+    {
+        $unsupportedOptions = self::unsupportedStreamContextOptions($streamContext);
+        if ($unsupportedOptions === []) {
+            return;
+        }
+
+        throw new InvalidArgumentException(\sprintf(
+            'Passing PHP stream context options outside the built-in stream handler allow-list to the "stream_context" request option is not supported. Unsupported option%s: %s.',
+            \count($unsupportedOptions) === 1 ? '' : 's',
+            \implode(', ', $unsupportedOptions)
+        ));
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function unsupportedStreamContextOptions(array $streamContext): array
+    {
+        $supportedOptions = self::supportedStreamContextOptions();
+        $unsupportedOptions = [];
+
+        foreach ($streamContext as $wrapper => $contextOptions) {
+            if (!\is_string($wrapper) || !isset($supportedOptions[$wrapper])) {
+                if (\is_array($contextOptions)) {
+                    foreach ($contextOptions as $option => $_) {
+                        $unsupportedOptions[] = \sprintf('stream_context.%s.%s', (string) $wrapper, (string) $option);
+                    }
+                } else {
+                    $unsupportedOptions[] = \sprintf('stream_context.%s', (string) $wrapper);
+                }
+
+                continue;
+            }
+
+            if (!\is_array($contextOptions)) {
+                $unsupportedOptions[] = \sprintf('stream_context.%s', $wrapper);
+
+                continue;
+            }
+
+            foreach ($contextOptions as $option => $_) {
+                if (!\is_string($option) || !\array_key_exists($option, $supportedOptions[$wrapper])) {
+                    $unsupportedOptions[] = \sprintf('stream_context.%s.%s', $wrapper, (string) $option);
+                }
+            }
+        }
+
+        return $unsupportedOptions;
+    }
+
+    /**
+     * @return array<string, array<string, true>>
+     */
+    private static function supportedStreamContextOptions(): array
+    {
+        return [
+            'http' => [
+                'request_fulluri' => true,
+            ],
+            'socket' => [
+                'bindto' => true,
+                'tcp_nodelay' => true,
+            ],
+            'ssl' => [
+                'SNI_enabled' => true,
+                'capture_peer_cert' => true,
+                'capture_peer_cert_chain' => true,
+                'ciphers' => true,
+                'disable_compression' => true,
+                'no_ticket' => true,
+                'peer_fingerprint' => true,
+                'security_level' => true,
+                'verify_depth' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, string|null>>
+     */
+    private static function conflictingStreamContextOptions(): array
+    {
+        return [
+            'http' => [
+                'content' => 'the request body',
+                'follow_location' => 'the "allow_redirects" request option',
+                'header' => 'the request headers',
+                'max_redirects' => 'the "allow_redirects" request option',
+                'method' => 'the request method',
+                'protocol_version' => 'the request protocol version',
+                'proxy' => 'the "proxy" request option',
+                'timeout' => 'the "timeout" request option',
+            ],
+            'ssl' => [
+                'allow_self_signed' => 'the "verify" request option',
+                'cafile' => 'the "verify" request option',
+                'capath' => 'the "verify" request option',
+                'crypto_method' => 'the "crypto_method" request option',
+                'local_cert' => 'the "cert" request option',
+                'local_pk' => 'the "ssl_key" request option',
+                'min_proto_version' => 'the "crypto_method" request option',
+                'passphrase' => 'the "cert" or "ssl_key" request option',
+                'peer_name' => 'the request URI',
+                'verify_peer' => 'the "verify" request option',
+                'verify_peer_name' => 'the "verify" request option',
+            ],
+        ];
     }
 
     private function assertTransportSharingSupported(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -291,6 +291,21 @@ class CurlFactoryTest extends TestCase
         new CurlFactory(3, TransportSharing::HANDLER_PREFER, false);
     }
 
+    public function testRejectsUnsupportedCurlOption(): void
+    {
+        $option = 999999;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage((string) $option);
+        $this->expectExceptionMessage('outside the built-in cURL handlers\' allow-list');
+
+        (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+            'curl' => [
+                $option => true,
+            ],
+        ]);
+    }
+
     public function testPersistentRequireRejectsFreshConnect(): void
     {
         self::skipIfCurlShareIsUnavailable();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1345,31 +1345,48 @@ class StreamHandlerTest extends TestCase
         self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_3, $opts['ssl']['min_proto_version']);
     }
 
-    public function testStreamContextTlsMinimumOverridesCryptoMethod(): void
+    /**
+     * @dataProvider conflictingStreamContextProvider
+     *
+     * @param mixed $value
+     */
+    public function testRejectsConflictingStreamContextOptions(string $wrapper, string $option, $value, ?string $replacement): void
     {
-        $res = $this->getSendResult([
-            'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_context.'.$wrapper.'.'.$option);
+        $this->expectExceptionMessage('conflicts with Guzzle-managed');
+        if ($replacement !== null) {
+            $this->expectExceptionMessage($replacement);
+        }
+
+        $this->getSendResult([
             'stream_context' => [
-                'ssl' => ['min_proto_version' => \STREAM_CRYPTO_PROTO_TLSv1_0],
+                $wrapper => [$option => $value],
             ],
         ]);
-        $opts = \stream_context_get_options($res->getBody()->detach());
-
-        self::assertSame(\STREAM_CRYPTO_PROTO_TLSv1_0, $opts['ssl']['min_proto_version']);
     }
 
-    public function testStreamContextCryptoMethodOverridesCryptoMethod(): void
+    public static function conflictingStreamContextProvider(): iterable
     {
-        $res = $this->getSendResult([
-            'crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
-            'stream_context' => [
-                'ssl' => ['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT],
-            ],
-        ]);
-        $opts = \stream_context_get_options($res->getBody()->detach());
-
-        self::assertSame(\STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT, $opts['ssl']['crypto_method']);
-        self::assertArrayNotHasKey('min_proto_version', $opts['ssl']);
+        yield 'http content' => ['http', 'content', 'body', 'request body'];
+        yield 'http follow location' => ['http', 'follow_location', 1, 'allow_redirects'];
+        yield 'http header' => ['http', 'header', 'X-Test: 1', 'request headers'];
+        yield 'http max redirects' => ['http', 'max_redirects', 5, 'allow_redirects'];
+        yield 'http method' => ['http', 'method', 'POST', 'request method'];
+        yield 'http protocol version' => ['http', 'protocol_version', '1.0', 'request protocol version'];
+        yield 'http proxy' => ['http', 'proxy', 'tcp://proxy.example.com:8125', 'proxy'];
+        yield 'http timeout' => ['http', 'timeout', 1, 'timeout'];
+        yield 'ssl allow self signed' => ['ssl', 'allow_self_signed', true, 'verify'];
+        yield 'ssl cafile' => ['ssl', 'cafile', __FILE__, 'verify'];
+        yield 'ssl capath' => ['ssl', 'capath', __DIR__, 'verify'];
+        yield 'ssl crypto method' => ['ssl', 'crypto_method', \STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT, 'crypto_method'];
+        yield 'ssl local cert' => ['ssl', 'local_cert', __FILE__, 'cert'];
+        yield 'ssl local pk' => ['ssl', 'local_pk', __FILE__, 'ssl_key'];
+        yield 'ssl min protocol version' => ['ssl', 'min_proto_version', \STREAM_CRYPTO_PROTO_TLSv1_0, 'crypto_method'];
+        yield 'ssl passphrase' => ['ssl', 'passphrase', 'secret', 'cert'];
+        yield 'ssl peer name' => ['ssl', 'peer_name', 'example.com', 'request URI'];
+        yield 'ssl verify peer' => ['ssl', 'verify_peer', false, 'verify'];
+        yield 'ssl verify peer name' => ['ssl', 'verify_peer_name', false, 'verify'];
     }
 
     public function testCanSetPasswordWhenSettingCert(): void
@@ -1632,21 +1649,45 @@ class StreamHandlerTest extends TestCase
             'stream_context' => [
                 'http' => [
                     'request_fulluri' => true,
-                    'method' => 'HEAD',
                 ],
                 'socket' => [
                     'bindto' => '127.0.0.1:0',
                 ],
                 'ssl' => [
-                    'verify_peer' => false,
+                    'ciphers' => 'DEFAULT',
                 ],
             ],
         ]);
         $opts = \stream_context_get_options($res->getBody()->detach());
-        self::assertSame('HEAD', $opts['http']['method']);
         self::assertTrue($opts['http']['request_fulluri']);
         self::assertSame('127.0.0.1:0', $opts['socket']['bindto']);
-        self::assertFalse($opts['ssl']['verify_peer']);
+        self::assertSame('DEFAULT', $opts['ssl']['ciphers']);
+    }
+
+    public function testRejectsUnsupportedStreamContextOptions(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_context.http.unknown_option');
+        $this->expectExceptionMessage('stream_context.http.ignore_errors');
+        $this->expectExceptionMessage('stream_context.ssl.max_proto_version');
+        $this->expectExceptionMessage('stream_context.ssl.SNI_server_name');
+        $this->expectExceptionMessage('stream_context.custom.foo');
+
+        $this->getSendResult([
+            'stream_context' => [
+                'http' => [
+                    'ignore_errors' => true,
+                    'unknown_option' => true,
+                ],
+                'ssl' => [
+                    'max_proto_version' => \STREAM_CRYPTO_PROTO_TLSv1_2,
+                    'SNI_server_name' => 'example.com',
+                ],
+                'custom' => [
+                    'foo' => true,
+                ],
+            ],
+        ]);
     }
 
     public function testEnsuresThatStreamContextIsAnArray(): void


### PR DESCRIPTION
This rejects raw cURL request options outside the built-in cURL handlers' allow-list and rejects PHP stream context options outside the built-in stream handler allow-list. It also treats raw stream context TLS version controls as conflicting with Guzzle-managed TLS version handling, matching the existing cURL behavior for raw CURLOPT_SSLVERSION.