### PR TITLE
Refine raw handler option deprecations

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,15 +84,12 @@ associative array of transport options. Stream context options outside the
 built-in stream handler allow-list are deprecated.
 
 For example, let's say you need to customize the outgoing network interface used
-with a client and allow self-signed certificates.
+with a client.
 
 ```php
 $client->request('GET', '/', [
     'stream' => true,
     'stream_context' => [
-        'ssl' => [
-            'allow_self_signed' => true
-        ],
         'socket' => [
             'bindto' => 'xxx.xxx.xxx.xxx'
         ]

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -372,14 +372,14 @@ an option depending on the runtime. The allow-list is limited to the following
 `CURLOPT_DNS_SHUFFLE_ADDRESSES`, `CURLOPT_ENCODING`,
 `CURLOPT_FORBID_REUSE`, `CURLOPT_FRESH_CONNECT`,
 `CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS`, `CURLOPT_HTTPAUTH`,
-`CURLOPT_INTERFACE`, `CURLOPT_LOCALPORT`, `CURLOPT_LOCALPORTRANGE`,
-`CURLOPT_LOW_SPEED_LIMIT`, `CURLOPT_LOW_SPEED_TIME`,
+`CURLOPT_HTTPPROXYTUNNEL`, `CURLOPT_INTERFACE`, `CURLOPT_LOCALPORT`,
+`CURLOPT_LOCALPORTRANGE`, `CURLOPT_LOW_SPEED_LIMIT`, `CURLOPT_LOW_SPEED_TIME`,
 `CURLOPT_MAXAGE_CONN`, `CURLOPT_MAXCONNECTS`, `CURLOPT_MAXLIFETIME_CONN`,
-`CURLOPT_PROXYHEADER`, `CURLOPT_RESOLVE`, `CURLOPT_SSL_CIPHER_LIST`,
-`CURLOPT_SSL_EC_CURVES`, `CURLOPT_TCP_FASTOPEN`, `CURLOPT_TCP_KEEPALIVE`,
-`CURLOPT_TCP_KEEPIDLE`, `CURLOPT_TCP_KEEPINTVL`, `CURLOPT_TCP_KEEPCNT`,
-`CURLOPT_TCP_NODELAY`, `CURLOPT_TLS13_CIPHERS`,
-`CURLOPT_UNIX_SOCKET_PATH`, and `CURLOPT_USERPWD`.
+`CURLOPT_PROXYHEADER`, `CURLOPT_PROXYTYPE`, `CURLOPT_PROXYUSERPWD`,
+`CURLOPT_RESOLVE`, `CURLOPT_SSL_CIPHER_LIST`, `CURLOPT_SSL_EC_CURVES`,
+`CURLOPT_TCP_FASTOPEN`, `CURLOPT_TCP_KEEPALIVE`, `CURLOPT_TCP_KEEPIDLE`,
+`CURLOPT_TCP_KEEPINTVL`, `CURLOPT_TCP_KEEPCNT`, `CURLOPT_TCP_NODELAY`,
+`CURLOPT_TLS13_CIPHERS`, `CURLOPT_UNIX_SOCKET_PATH`, and `CURLOPT_USERPWD`.
 
 ```php
 $client->request('GET', '/', [
@@ -1136,14 +1136,15 @@ available in the current PHP runtime, are deprecated. Allow-listing means Guzzle
 passes the option through without its own deprecation warning; PHP or OpenSSL
 may still reject or ignore an option depending on the runtime. The allow-list is
 `http.request_fulluri`, `socket.bindto`, `socket.tcp_nodelay`,
-`ssl.SNI_enabled`, `ssl.allow_self_signed`, `ssl.capath`,
-`ssl.capture_peer_cert`, `ssl.capture_peer_cert_chain`, `ssl.ciphers`,
-`ssl.disable_compression`, `ssl.max_proto_version`, `ssl.min_proto_version`,
-`ssl.no_ticket`, `ssl.peer_fingerprint`, `ssl.security_level`, and
-`ssl.verify_depth`. Use Guzzle request options instead when configuring the
-request method, URI, body, headers, timeouts, redirects, proxy, TLS certificate
-files, TLS private keys, protocol versions, verification, progress, debug
-output, sinks, cookies, and allowed protocols.
+`ssl.SNI_enabled`, `ssl.capture_peer_cert`, `ssl.capture_peer_cert_chain`,
+`ssl.ciphers`, `ssl.disable_compression`, `ssl.no_ticket`,
+`ssl.peer_fingerprint`, `ssl.security_level`, and `ssl.verify_depth`. Use
+Guzzle request options instead when configuring the request method, URI, body,
+headers, timeouts, redirects, proxy, TLS certificate files, TLS private keys,
+protocol versions, verification, progress, debug output, sinks, cookies, and
+allowed protocols. TLS protocol versions are managed through the
+`crypto_method` request option, and TLS verification is managed through the
+`verify` request option.
 
 ## synchronous
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -348,8 +348,6 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_HEADERFUNCTION', 'the "on_headers" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_WRITEFUNCTION', 'the "sink" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_FILE', 'the "sink" request option');
-        self::addConflictingCurlOption($options, 'CURLOPT_RETURNTRANSFER', null);
-        self::addConflictingCurlOption($options, 'CURLOPT_HEADER', null);
         self::addConflictingCurlOption($options, 'CURLOPT_TIMEOUT', 'the "timeout" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_TIMEOUT_MS', 'the "timeout" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_CONNECTTIMEOUT', 'the "connect_timeout" request option');
@@ -369,7 +367,6 @@ class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_REDIR_PROTOCOLS_STR', 'the "allow_redirects" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_PROTOCOLS', 'the "protocols" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_PROTOCOLS_STR', 'the "protocols" request option');
-        self::addConflictingCurlOption($options, 'CURLOPT_HTTP09_ALLOWED', null);
         self::addConflictingCurlOption($options, 'CURLOPT_HTTP_VERSION', 'the request protocol version');
         self::addConflictingCurlOption($options, 'CURLOPT_IPRESOLVE', 'the "force_ip_resolve" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_SSL_VERIFYPEER', 'the "verify" request option');
@@ -427,7 +424,10 @@ class CurlFactory implements CurlFactoryInterface
         self::addSupportedCurlOption($options, 'CURLOPT_MAXAGE_CONN');
         self::addSupportedCurlOption($options, 'CURLOPT_MAXCONNECTS');
         self::addSupportedCurlOption($options, 'CURLOPT_MAXLIFETIME_CONN');
+        self::addSupportedCurlOption($options, 'CURLOPT_HTTPPROXYTUNNEL');
         self::addSupportedCurlOption($options, 'CURLOPT_PROXYHEADER');
+        self::addSupportedCurlOption($options, 'CURLOPT_PROXYTYPE');
+        self::addSupportedCurlOption($options, 'CURLOPT_PROXYUSERPWD');
         self::addSupportedCurlOption($options, 'CURLOPT_RESOLVE');
         self::addSupportedCurlOption($options, 'CURLOPT_SSL_CIPHER_LIST');
         self::addSupportedCurlOption($options, 'CURLOPT_SSL_EC_CURVES');

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -387,6 +387,7 @@ class StreamHandler
             if (!\is_array($options['stream_context'])) {
                 throw new \InvalidArgumentException('stream_context must be an array');
             }
+            self::triggerConflictingStreamContextOptionDeprecations($options['stream_context']);
             self::triggerUnsupportedStreamContextOptionDeprecations($options['stream_context']);
             $context = \array_replace_recursive($context, $options['stream_context']);
         }
@@ -514,6 +515,34 @@ class StreamHandler
         }
     }
 
+    private static function triggerConflictingStreamContextOptionDeprecations(array $streamContext): void
+    {
+        $conflictingOptions = self::conflictingStreamContextOptions();
+
+        foreach ($streamContext as $wrapper => $contextOptions) {
+            if (!\is_string($wrapper) || !isset($conflictingOptions[$wrapper]) || !\is_array($contextOptions)) {
+                continue;
+            }
+
+            foreach ($contextOptions as $option => $_) {
+                if (!\is_string($option) || !\array_key_exists($option, $conflictingOptions[$wrapper])) {
+                    continue;
+                }
+
+                \trigger_deprecation(
+                    'guzzlehttp/guzzle',
+                    '7.12',
+                    \sprintf(
+                        'Passing stream_context.%s.%s in the "stream_context" request option is deprecated; guzzlehttp/guzzle 8.0 will reject this option because it conflicts with Guzzle-managed request handling. Use %s instead.',
+                        $wrapper,
+                        $option,
+                        $conflictingOptions[$wrapper][$option]
+                    )
+                );
+            }
+        }
+    }
+
     private static function triggerUnsupportedStreamContextOptionDeprecations(array $streamContext): void
     {
         $unsupportedOptions = self::unsupportedStreamContextOptions($streamContext);
@@ -538,12 +567,17 @@ class StreamHandler
     private static function unsupportedStreamContextOptions(array $streamContext): array
     {
         $supportedOptions = self::supportedStreamContextOptions();
+        $conflictingOptions = self::conflictingStreamContextOptions();
         $unsupportedOptions = [];
 
         foreach ($streamContext as $wrapper => $contextOptions) {
             if (!\is_string($wrapper) || !isset($supportedOptions[$wrapper])) {
                 if (\is_array($contextOptions)) {
                     foreach ($contextOptions as $option => $_) {
+                        if (\is_string($wrapper) && \is_string($option) && isset($conflictingOptions[$wrapper]) && \array_key_exists($option, $conflictingOptions[$wrapper])) {
+                            continue;
+                        }
+
                         $unsupportedOptions[] = \sprintf('stream_context.%s.%s', (string) $wrapper, (string) $option);
                     }
                 } else {
@@ -560,6 +594,10 @@ class StreamHandler
             }
 
             foreach ($contextOptions as $option => $_) {
+                if (\is_string($option) && isset($conflictingOptions[$wrapper]) && \array_key_exists($option, $conflictingOptions[$wrapper])) {
+                    continue;
+                }
+
                 if (!\is_string($option) || !\array_key_exists($option, $supportedOptions[$wrapper])) {
                     $unsupportedOptions[] = \sprintf('stream_context.%s.%s', $wrapper, (string) $option);
                 }
@@ -584,18 +622,46 @@ class StreamHandler
             ],
             'ssl' => [
                 'SNI_enabled' => true,
-                'allow_self_signed' => true,
-                'capath' => true,
                 'capture_peer_cert' => true,
                 'capture_peer_cert_chain' => true,
                 'ciphers' => true,
                 'disable_compression' => true,
-                'max_proto_version' => true,
-                'min_proto_version' => true,
                 'no_ticket' => true,
                 'peer_fingerprint' => true,
                 'security_level' => true,
                 'verify_depth' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private static function conflictingStreamContextOptions(): array
+    {
+        return [
+            'http' => [
+                'content' => 'the request body',
+                'follow_location' => 'the "allow_redirects" request option',
+                'header' => 'the request headers',
+                'max_redirects' => 'the "allow_redirects" request option',
+                'method' => 'the request method',
+                'protocol_version' => 'the request protocol version',
+                'proxy' => 'the "proxy" request option',
+                'timeout' => 'the "timeout" request option',
+            ],
+            'ssl' => [
+                'allow_self_signed' => 'the "verify" request option',
+                'cafile' => 'the "verify" request option',
+                'capath' => 'the "verify" request option',
+                'crypto_method' => 'the "crypto_method" request option',
+                'local_cert' => 'the "cert" request option',
+                'local_pk' => 'the "ssl_key" request option',
+                'min_proto_version' => 'the "crypto_method" request option',
+                'passphrase' => 'the "cert" or "ssl_key" request option',
+                'peer_name' => 'the request URI',
+                'verify_peer' => 'the "verify" request option',
+                'verify_peer_name' => 'the "verify" request option',
             ],
         ];
     }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -791,14 +791,14 @@ class StreamHandlerTest extends TestCase
                     'bindto' => '127.0.0.1:0',
                 ],
                 'ssl' => [
-                    'allow_self_signed' => true,
+                    'ciphers' => 'DEFAULT',
                 ],
             ],
         ]);
         $opts = \stream_context_get_options($res->getBody()->detach());
         self::assertTrue($opts['http']['request_fulluri']);
         self::assertSame('127.0.0.1:0', $opts['socket']['bindto']);
-        self::assertTrue($opts['ssl']['allow_self_signed']);
+        self::assertSame('DEFAULT', $opts['ssl']['ciphers']);
     }
 
     public function testEnsuresThatStreamContextIsAnArray()


### PR DESCRIPTION
This refines the raw handler option deprecations by allow-listing cURL proxy options that existing Guzzle behavior already accounts for and by moving options without replacement guidance to the generic unsupported-option deprecation path. It also gives PHP stream context options that overlap Guzzle-managed request handling their own replacement-oriented deprecation messages.