### PR TITLE
Add PSR-17 `response_factory` option and document custom PSR-7 implementation risks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add `NetworkException` for no-response network failures
 - Add `NetworkTimeoutException` for no-response transport timeouts
 - Add `ResponseTransferException`, with `ResponseTimeoutException` for response-transfer timeouts
-- Add PSR-17 `request_factory`, `stream_factory`, and `uri_factory` request options for client-created requests, request body streams, and URIs
+- Add PSR-17 `request_factory`, `response_factory`, `stream_factory`, and `uri_factory` request options
 - Add explicit `close()` lifecycle methods to the built-in cURL handlers and concrete cURL factory
 - Add `HandlerClosedException` for pending transfers rejected by `CurlMultiHandler::close()`
 - Add `ProxyOptions` for proxy option resolution

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -50,6 +50,9 @@ The PSR-17 factory request options are owned by different layers:
 
 The default handlers consume `response_factory` and `stream_factory` when constructing responses. `MockHandler` returns the responses you queue, and custom handlers are responsible for honoring these options themselves.
 
+> [!WARNING]
+> Replacing Guzzle's PSR-7 implementation through these options is an advanced feature that moves responsibility for correctness and security to your code. Guzzle validates only that each value implements the relevant PSR-17 interface — it does not validate the objects a factory returns. An implementation that does not honor the documented contracts can introduce bugs or security issues: streams that drop live `timed_out` metadata silently disable read-timeout detection, streams that do not close their resource leak file descriptors, response factories that pre-seed headers corrupt the message, and URIs that misreport scheme, host, or port can defeat the cross-origin credential stripping that protects against credential leaks on redirects. See the per-option notes under [Request Options](request-options.md) for specifics.
+
 ### Closing cURL Handlers
 
 The cURL handlers own native cURL resources. These resources are normally released automatically when the handler is garbage collected. Applications that need deterministic cleanup may call `close()` on `GuzzleHttp\Handler\CurlHandler` or `GuzzleHttp\Handler\CurlMultiHandler`. Applications that construct `GuzzleHttp\Handler\CurlFactory` directly may also call `close()` on the factory to close idle easy handles.

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -40,7 +40,7 @@ When provided no `$handler` argument, `GuzzleHttp\HandlerStack::create()` will c
 > [!IMPORTANT]
 > The handler provided to a client determines how request options are applied and utilized for each request sent by a client. For example, if you do not have a cookie middleware associated with a client, then setting the `cookies` request option will have no effect on the request.
 
-### PSR-17 factories
+### PSR-17 Factories
 
 The PSR-17 factory request options are owned by different layers:
 

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -40,6 +40,16 @@ When provided no `$handler` argument, `GuzzleHttp\HandlerStack::create()` will c
 > [!IMPORTANT]
 > The handler provided to a client determines how request options are applied and utilized for each request sent by a client. For example, if you do not have a cookie middleware associated with a client, then setting the `cookies` request option will have no effect on the request.
 
+### PSR-17 factories
+
+The PSR-17 factory request options are owned by different layers:
+
+- `request_factory` and `uri_factory` are used by the client when it builds the outgoing request and resolves URIs.
+- `response_factory` is handler-owned: the built-in cURL and stream handlers use it to create the response message (status code, reason phrase, headers, and protocol version). It should return an empty, header-less response.
+- `stream_factory` has split responsibility. The client uses it for request body creation (`body`, `form_params`, `json`) and redirect body resets, while the built-in handlers use it to wrap response body resources where practical.
+
+The default handlers consume `response_factory` and `stream_factory` when constructing responses. `MockHandler` returns the responses you queue, and custom handlers are responsible for honoring these options themselves.
+
 ### Closing cURL Handlers
 
 The cURL handlers own native cURL resources. These resources are normally released automatically when the handler is garbage collected. Applications that need deterministic cleanup may call `close()` on `GuzzleHttp\Handler\CurlHandler` or `GuzzleHttp\Handler\CurlMultiHandler`. Applications that construct `GuzzleHttp\Handler\CurlFactory` directly may also call `close()` on the factory to close idle easy handles.

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -6,8 +6,6 @@ Guzzle is an HTTP client that sends HTTP requests to a server and receives HTTP 
 
 Guzzle relies on the `guzzlehttp/psr7` Composer package for its message implementation of PSR-7.
 
-By default, Guzzle uses `GuzzleHttp\Psr7\HttpFactory` as its PSR-17 request, response, URI, and stream factory when it creates requests and responses through a client. Applications that need another PSR-7 implementation can provide PSR-17 factories with the `request_factory`, `response_factory`, `uri_factory`, and `stream_factory` request options.
-
 You can create a request using the `GuzzleHttp\Psr7\Request` class:
 
 ```php
@@ -291,11 +289,13 @@ Streams expose their capabilities using three methods: `isReadable()`, `isWritab
 
 Each stream instance has various capabilities: they can be read-only, write-only, read-write, allow arbitrary random access (seeking forwards or backwards to any location), or only allow sequential access (for example in the case of a socket or pipe).
 
-Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More information on using streams, creating streams, converting streams to PHP stream resource, and stream decorators can be found in the [Guzzle PSR-7 documentation](https://github.com/guzzle/psr7/blob/master/README.md).
+Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More information on using streams, creating streams, converting streams to PHP stream resource, and stream decorators can be found in the [Guzzle PSR-7 documentation](https://github.com/guzzle/psr7/blob/3.0/README.md).
 
 ### Creating Streams
 
 The best way to create a stream is using the `GuzzleHttp\Psr7\Utils::streamFor` method. This method accepts strings, resources returned from `fopen()`, an object that implements `__toString()`, iterators, callable arrays, closures, invokable objects, and instances of `Psr\Http\Message\StreamInterface`. Callable sources receive a suggested read length, may return fewer or more bytes, and end the stream by returning `false` or `null`. Strings remain literal body contents, even when they name a callable.
+
+Guzzle uses `GuzzleHttp\Psr7\HttpFactory` by default. As an advanced feature, applications that need a different PSR-7 implementation can supply their own PSR-17 factories through the `request_factory`, `response_factory`, `uri_factory`, and `stream_factory` request options. Guzzle only checks that each value implements the relevant interface, not that the objects it returns behave correctly, so an implementation that does not honor the contracts Guzzle relies on can introduce bugs or security issues. See each option's notes in [Request Options](request-options.md) for the specifics.
 
 When Guzzle creates request body streams from supported `body`, `form_params`, or `json` option values, the `stream_factory` request option can replace the default PSR-17 stream factory. Streams supplied directly as `Psr\Http\Message\StreamInterface` instances are used as provided, while callable and iterator bodies use Guzzle's existing stream handling.
 

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -235,7 +235,7 @@ echo $request->getUri()->getPath(); // /get
 
 The contents of the path will be automatically filtered to ensure that only allowed characters are present in the path. Any characters that are not allowed in the path will be percent-encoded according to [RFC 3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3)
 
-### Query string
+### Query String
 
 The query string of a request can be accessed using the `getQuery()` of the URI object owned by the request.
 

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -6,7 +6,7 @@ Guzzle is an HTTP client that sends HTTP requests to a server and receives HTTP 
 
 Guzzle relies on the `guzzlehttp/psr7` Composer package for its message implementation of PSR-7.
 
-By default, Guzzle uses `GuzzleHttp\Psr7\HttpFactory` as its PSR-17 request, URI, and stream factory when it creates requests through a client. Applications that need another PSR-7 implementation can provide PSR-17 factories with the `request_factory`, `uri_factory`, and `stream_factory` request options.
+By default, Guzzle uses `GuzzleHttp\Psr7\HttpFactory` as its PSR-17 request, response, URI, and stream factory when it creates requests and responses through a client. Applications that need another PSR-7 implementation can provide PSR-17 factories with the `request_factory`, `response_factory`, `uri_factory`, and `stream_factory` request options.
 
 You can create a request using the `GuzzleHttp\Psr7\Request` class:
 
@@ -298,6 +298,8 @@ Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More inform
 The best way to create a stream is using the `GuzzleHttp\Psr7\Utils::streamFor` method. This method accepts strings, resources returned from `fopen()`, an object that implements `__toString()`, iterators, callable arrays, closures, invokable objects, and instances of `Psr\Http\Message\StreamInterface`. Callable sources receive a suggested read length, may return fewer or more bytes, and end the stream by returning `false` or `null`. Strings remain literal body contents, even when they name a callable.
 
 When Guzzle creates request body streams from supported `body`, `form_params`, or `json` option values, the `stream_factory` request option can replace the default PSR-17 stream factory. Streams supplied directly as `Psr\Http\Message\StreamInterface` instances are used as provided, while callable and iterator bodies use Guzzle's existing stream handling.
+
+The built-in cURL and stream handlers also create response body streams with the configured `stream_factory` where practical: the underlying transport resource (and the default `php://temp` sink) is wrapped via `createStreamFromResource()`, while Guzzle's own decorators (`InflateStream` for content decoding, `FnStream` for caller-owned sinks) are layered on top. Content decoding wraps the same factory-created stream, since PSR-17 cannot express a decoding stream. Because the handlers read response bodies through that stream — including read-timeout detection, which inspects the underlying resource's live `timed_out` metadata — a custom factory's `createStreamFromResource()` must return a stream backed by the supplied resource that exposes its live metadata and closes the resource when the stream is closed. File-path sinks keep using `GuzzleHttp\Psr7\LazyOpenStream` so the file is not opened until first use, which PSR-17's `createStreamFromFile()` cannot express. The response message itself is created with the `response_factory` request option.
 
 ```php
 use GuzzleHttp\Psr7;

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1065,6 +1065,9 @@ This option can be set on a client or per request. It affects request-side objec
 > [!NOTE]
 > This option only affects requests created by `request()`, `requestAsync()`, and shortcut methods such as `get()` and `post()`. Requests passed to `send()`, `sendAsync()`, or `sendRequest()` are used as provided.
 
+> [!WARNING]
+> Guzzle only checks that the value implements `Psr\Http\Message\RequestFactoryInterface`; it does not validate the requests it returns. Per PSR-7 the `Host` header is derived from the request URI, and Guzzle does not recompute it afterwards, so a factory that fails to set `Host` from the URI — or that lets a caller-controlled `Host` diverge from the URI actually dialed — can cause host confusion, cache poisoning, or requests routed to an unexpected origin. Supply a request implementation you trust to follow PSR-7.
+
 ## response_factory
 
 Summary
@@ -1091,6 +1094,9 @@ This option can be set on a client or per request. The built-in cURL and stream 
 
 > [!NOTE]
 > This option is consumed by the built-in handlers when they create a response. `MockHandler` returns the responses you queue, and custom handlers are responsible for honoring this option themselves.
+
+> [!WARNING]
+> Guzzle only checks that the value implements `Psr\Http\Message\ResponseFactoryInterface`; it does not validate the responses it returns. The handlers add each parsed header to the returned response with `withAddedHeader()`, so a factory that pre-seeds headers (or returns a non-empty response) duplicates them — for example emitting two `Content-Type` or `Content-Length` values and corrupting the message. The factory should return an empty, header-less response, and must reject CR/LF in any header it sets itself, or it can re-introduce header-injection and response-splitting issues. Supply a response implementation you trust.
 
 ## retries
 
@@ -1136,6 +1142,9 @@ This option can be set on a client or per request. It is used when Guzzle conver
 > [!NOTE]
 > This option does not replace every stream. Callable and iterator request bodies use Guzzle's existing PSR-7 stream handling, multipart internals are left untouched, string path sinks open lazily, and `MockHandler` queued responses and custom handler responses are used as provided. When decoding gzip/deflate responses, the factory still wraps the underlying transport resource, but Guzzle layers its own `InflateStream` decorator on top because PSR-17 cannot express a decoding stream.
 
+> [!WARNING]
+> Guzzle only checks that the value implements `Psr\Http\Message\StreamFactoryInterface`; it does not validate the streams it returns. For responses, `createStreamFromResource()` wraps the live transport socket, so the returned stream must behave like the default `GuzzleHttp\Psr7\Stream`. It must expose the resource's **live** `timed_out` metadata: a stream that snapshots metadata, or omits the `timed_out` key, silently disables read-timeout detection, so a stalled read is reported as a successful but truncated response instead of a timeout — with no error at all for chunked or `Connection: close` bodies. It must also **close the underlying resource** when closed, or each request leaks a socket or file descriptor (including `HEAD` and `stream => true` responses, which are not drained), eventually exhausting the descriptor limit. The stream must be readable for gzip/deflate decoding, and should stream the resource rather than buffer it entirely into memory. The full contract is described under *Creating Streams* in the [PSR-7 documentation](psr7.md). Supply a stream implementation you trust.
+
 ## uri_factory
 
 Summary
@@ -1163,6 +1172,9 @@ This option can be set on a client or per request. It is used for string request
 
 > [!NOTE]
 > This option affects request-side URI creation only. It does not affect response implementations returned by handlers. `GuzzleHttp\Client::sendRequest()` still returns redirect responses as-is for PSR-18 compliance.
+
+> [!WARNING]
+> Guzzle only checks that the value implements `Psr\Http\Message\UriFactoryInterface`; it does not validate the URIs it returns. When following redirects Guzzle strips credentials by comparing the origin (scheme, host, port) of the current and redirect-target URIs: on a cross-origin redirect it removes the `Authorization` and `Cookie` headers and clears HTTP auth, and it drops `Referer` on an `https` to `http` downgrade — all by reading `getScheme()`, `getHost()`, and `getPort()` from the URI built from the `Location` header. A custom URI that misreports those, or whose getters disagree with the address actually dialed, can make a cross-origin redirect look same-origin and leak credentials to the target (the class of issue behind CVE-2022-31042, CVE-2022-31043, CVE-2022-31090, and CVE-2022-31091), or enable SSRF and protocol allow-list bypass. The default `GuzzleHttp\Psr7\Uri` lower-cases and validates the scheme and host and strips default ports; supply a URI implementation you trust.
 
 ## sink
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1065,6 +1065,33 @@ This option can be set on a client or per request. It affects request-side objec
 > [!NOTE]
 > This option only affects requests created by `request()`, `requestAsync()`, and shortcut methods such as `get()` and `post()`. Requests passed to `send()`, `sendAsync()`, or `sendRequest()` are used as provided.
 
+## response_factory
+
+Summary
+PSR-17 response factory used by the built-in handlers when creating the response message.
+
+Types
+`Psr\Http\Message\ResponseFactoryInterface`
+
+Default
+`GuzzleHttp\Psr7\HttpFactory`
+
+Constant
+`GuzzleHttp\RequestOptions::RESPONSE_FACTORY`
+
+```php
+$factory = new \GuzzleHttp\Psr7\HttpFactory();
+
+$client->request('GET', '/get', [
+    'response_factory' => $factory,
+]);
+```
+
+This option can be set on a client or per request. The built-in cURL and stream handlers build the response message (status code, reason phrase, headers, and protocol version) with this factory, and create the response body stream with the configured `stream_factory` where practical. The factory should return an empty, header-less response, because the handlers apply the parsed status line, headers, and body themselves.
+
+> [!NOTE]
+> This option is consumed by the built-in handlers when they create a response. `MockHandler` returns the responses you queue, and custom handlers are responsible for honoring this option themselves.
+
 ## retries
 
 Summary
@@ -1084,7 +1111,7 @@ The retry middleware initializes this option to `0` before the first attempt and
 ## stream_factory
 
 Summary
-PSR-17 stream factory used when Guzzle creates request body streams.
+PSR-17 stream factory used when Guzzle creates request body streams and, for the built-in handlers, response body streams where practical.
 
 Types
 `Psr\Http\Message\StreamFactoryInterface`
@@ -1104,10 +1131,10 @@ $client->request('POST', '/post', [
 ]);
 ```
 
-This option can be set on a client or per request. It is used when Guzzle converts supported `body`, `form_params`, or `json` request option values into `Psr\Http\Message\StreamInterface` instances, and when redirect handling resets a request body. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
+This option can be set on a client or per request. It is used when Guzzle converts supported `body`, `form_params`, or `json` request option values into `Psr\Http\Message\StreamInterface` instances, when redirect handling resets a request body, and by the built-in cURL and stream handlers when they wrap response body resources where practical. Request bodies that already implement `Psr\Http\Message\StreamInterface` are used as provided.
 
 > [!NOTE]
-> This option affects request-side body stream creation only. It does not affect response body implementations returned by handlers, response sinks, callable or iterator bodies, or multipart internals.
+> This option does not replace every stream. Callable and iterator request bodies use Guzzle's existing PSR-7 stream handling, multipart internals are left untouched, string path sinks open lazily, and `MockHandler` queued responses and custom handler responses are used as provided. When decoding gzip/deflate responses, the factory still wraps the underlying transport resource, but Guzzle layers its own `InflateStream` decorator on top because PSR-17 cannot express a decoding stream.
 
 ## uri_factory
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -15,6 +15,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\HttpFactory;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
@@ -117,6 +118,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -167,7 +169,12 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $config[RequestOptions::STREAM_FACTORY] = $factory;
         }
 
+        if (!isset($config[RequestOptions::RESPONSE_FACTORY])) {
+            $config[RequestOptions::RESPONSE_FACTORY] = $factory;
+        }
+
         self::requireRequestFactory($config[RequestOptions::REQUEST_FACTORY]);
+        self::requireResponseFactory($config[RequestOptions::RESPONSE_FACTORY]);
         self::requireStreamFactory($config[RequestOptions::STREAM_FACTORY]);
         $uriFactory = self::requireUriFactory($config[RequestOptions::URI_FACTORY]);
 
@@ -235,6 +242,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -322,6 +330,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -425,6 +434,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -540,6 +550,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -610,6 +621,22 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                 '%s must be an instance of %s',
                 RequestOptions::REQUEST_FACTORY,
                 RequestFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    /**
+     * @param mixed $factory
+     */
+    private static function requireResponseFactory($factory): ResponseFactoryInterface
+    {
+        if (!$factory instanceof ResponseFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::RESPONSE_FACTORY,
+                ResponseFactoryInterface::class
             ));
         }
 
@@ -1218,6 +1245,13 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             'set_headers' => [],
         ];
 
+        // Validate the response and stream factories up front. Every request
+        // yields a response, and the built-in handlers build the response body
+        // stream via the stream factory even when the request has no body, so
+        // both must be validated unconditionally.
+        self::requireResponseFactory($options[RequestOptions::RESPONSE_FACTORY] ?? new HttpFactory());
+        $streamFactory = self::requireStreamFactory($options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory());
+
         if (isset($options['headers'])) {
             if (array_keys($options['headers']) === range(0, count($options['headers']) - 1)) {
                 throw new InvalidArgumentException('The headers array must have header name as keys.');
@@ -1266,7 +1300,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($options['body'])) {
                 throw $this->invalidBody();
             }
-            $streamFactory = self::requireStreamFactory($options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory());
             $modify['body'] = self::createBodyStream($options['body'], $streamFactory);
             unset($options['body']);
         }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
@@ -82,6 +83,7 @@ interface ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -161,6 +163,7 @@ interface ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -245,6 +248,7 @@ interface ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -329,6 +333,7 @@ interface ClientInterface
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
@@ -82,6 +83,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -165,6 +167,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -251,6 +254,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -337,6 +341,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -423,6 +428,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -509,6 +515,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -595,6 +602,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -682,6 +690,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -765,6 +774,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -851,6 +861,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -937,6 +948,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -1023,6 +1035,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -1109,6 +1122,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,
@@ -1195,6 +1209,7 @@ trait ClientTrait
      *     read_timeout?: int|float,
      *     retries?: int,
      *     request_factory?: RequestFactoryInterface,
+     *     response_factory?: ResponseFactoryInterface,
      *     sink?: resource|string|StreamInterface,
      *     ssl_key?: string|array{
      *         0: string,

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -16,14 +16,18 @@ use GuzzleHttp\Exception\ResponseTransferException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\ProxyOptions;
+use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\Psr7\FnStream;
+use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -932,7 +936,7 @@ final class CurlFactory implements CurlFactoryInterface
         );
 
         if ('' !== $sanitizedError) {
-            $redactedUriString = \GuzzleHttp\Psr7\Utils::redactUserInfo($uri)->__toString();
+            $redactedUriString = Psr7\Utils::redactUserInfo($uri)->__toString();
             if ($redactedUriString !== '' && false === \strpos($sanitizedError, $redactedUriString)) {
                 $message .= \sprintf(' for %s', $redactedUriString);
             }
@@ -1029,7 +1033,7 @@ final class CurlFactory implements CurlFactoryInterface
             return $error;
         }
 
-        $redactedUriString = \GuzzleHttp\Psr7\Utils::redactUserInfo($baseUri)->__toString();
+        $redactedUriString = Psr7\Utils::redactUserInfo($baseUri)->__toString();
 
         return str_replace($baseUriString, $redactedUriString, $error);
     }
@@ -1443,22 +1447,32 @@ final class CurlFactory implements CurlFactoryInterface
     }
 
     /**
-     * Creates a response body stream for a caller-owned sink resource.
-     *
-     * Closing the response body must detach Guzzle's wrapper without closing
-     * the original PHP resource.
-     *
-     * @param resource $resource
+     * Decorates a caller-owned sink stream so that closing the response body
+     * detaches Guzzle's wrapper without closing the original PHP resource.
      */
-    private static function streamForResourceSink($resource): StreamInterface
+    private static function streamForResourceSink(StreamInterface $stream): StreamInterface
     {
-        $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
-
         return FnStream::decorate($stream, [
             'close' => static function () use ($stream): void {
                 $stream->detach();
             },
         ]);
+    }
+
+    /**
+     * @param mixed $factory
+     */
+    private static function requireStreamFactory($factory): StreamFactoryInterface
+    {
+        if (!$factory instanceof StreamFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::STREAM_FACTORY,
+                StreamFactoryInterface::class
+            ));
+        }
+
+        return $factory;
     }
 
     private function applyHandlerOptions(EasyHandle $easy, array &$conf): void
@@ -1511,16 +1525,18 @@ final class CurlFactory implements CurlFactoryInterface
             }
         }
 
+        $streamFactory = self::requireStreamFactory($options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory());
         $hasSink = isset($options['sink']);
         if (!$hasSink) {
             // Use a default temp stream if no sink was set.
-            $options['sink'] = \GuzzleHttp\Psr7\Utils::tryFopen('php://temp', 'w+');
+            $options['sink'] = Psr7\Utils::tryFopen('php://temp', 'w+');
         }
         $sink = $options['sink'];
-        if ($hasSink && \is_resource($sink)) {
-            $sink = self::streamForResourceSink($sink);
+        if (\is_resource($sink)) {
+            $sinkStream = $streamFactory->createStreamFromResource($sink);
+            $sink = $hasSink ? self::streamForResourceSink($sinkStream) : $sinkStream;
         } elseif (!\is_string($sink)) {
-            $sink = \GuzzleHttp\Psr7\Utils::streamFor($sink);
+            $sink = Psr7\Utils::streamFor($sink);
         } elseif (!\is_dir(\dirname($sink))) {
             // Ensure that the directory exists before failing in curl.
             throw new RequestException(\sprintf('Directory %s does not exist for sink value of %s', \dirname($sink), $sink), $easy->request);

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Handler;
 
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Psr7\Exception\TimeoutException;
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -144,14 +147,31 @@ final class EasyHandle
             }
         }
 
-        // Attach a response to the easy handle with the parsed headers.
-        $this->response = new Response(
-            $status,
-            $headers,
-            $this->sink,
-            $ver,
-            $reason
-        );
+        // Attach a response to the easy handle with the parsed headers. Any
+        // exception propagates to the caller (CurlFactory), which records it as
+        // the createResponseException — do not catch it here.
+        $responseFactory = self::requireResponseFactory($this->options[RequestOptions::RESPONSE_FACTORY] ?? new HttpFactory());
+        $response = $responseFactory->createResponse($status, $reason ?? '')->withProtocolVersion($ver);
+        foreach ($headers as $name => $value) {
+            $response = $response->withAddedHeader((string) $name, $value);
+        }
+        $this->response = $response->withBody($this->sink);
+    }
+
+    /**
+     * @param mixed $factory
+     */
+    private static function requireResponseFactory($factory): ResponseFactoryInterface
+    {
+        if (!$factory instanceof ResponseFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::RESPONSE_FACTORY,
+                ResponseFactoryInterface::class
+            ));
+        }
+
+        return $factory;
     }
 
     /**

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -19,11 +19,14 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\ProxyOptions;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Exception\TimeoutException;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -276,8 +279,14 @@ final class StreamHandler
             return $this->rejectResponseCreation($options, $request, $startTime, $e);
         }
 
-        [$stream, $headers] = $this->checkDecode($options, $headers, $stream);
-        $stream = Psr7\Utils::streamFor($stream);
+        $streamFactory = self::requireStreamFactory($options[RequestOptions::STREAM_FACTORY] ?? new Psr7\HttpFactory());
+        $responseFactory = self::requireResponseFactory($options[RequestOptions::RESPONSE_FACTORY] ?? new Psr7\HttpFactory());
+
+        // Wrap the transport resource with the configured stream factory before
+        // optional content decoding layers an InflateStream on top.
+        $stream = $streamFactory->createStreamFromResource($stream);
+        [$stream, $headers] = self::checkDecode($options, $headers, $stream);
+
         $sink = $stream;
 
         if ($request->getMethod() !== 'HEAD') {
@@ -285,7 +294,11 @@ final class StreamHandler
         }
 
         try {
-            $response = new Psr7\Response($status, $headers, $sink, $ver, $reason);
+            $response = $responseFactory->createResponse($status, $reason ?? '')->withProtocolVersion($ver);
+            foreach ($headers as $name => $value) {
+                $response = $response->withAddedHeader((string) $name, $value);
+            }
+            $response = $response->withBody($sink);
         } catch (\Throwable $e) {
             return $this->rejectResponseCreation($options, $request, $startTime, $e);
         }
@@ -349,28 +362,29 @@ final class StreamHandler
             return $stream;
         }
 
+        $streamFactory = self::requireStreamFactory($options[RequestOptions::STREAM_FACTORY] ?? new Psr7\HttpFactory());
         $hasSink = isset($options['sink']);
         $sink = $hasSink ? $options['sink'] : Psr7\Utils::tryFopen('php://temp', 'r+');
 
-        if ($hasSink && \is_resource($sink)) {
-            return self::streamForResourceSink($sink);
+        if (\is_string($sink)) {
+            return new Psr7\LazyOpenStream($sink, 'w+');
         }
 
-        return \is_string($sink) ? new Psr7\LazyOpenStream($sink, 'w+') : Psr7\Utils::streamFor($sink);
+        if (!\is_resource($sink)) {
+            return Psr7\Utils::streamFor($sink);
+        }
+
+        $sinkStream = $streamFactory->createStreamFromResource($sink);
+
+        return $hasSink ? self::streamForResourceSink($sinkStream) : $sinkStream;
     }
 
     /**
-     * Creates a response body stream for a caller-owned sink resource.
-     *
-     * Closing the response body must detach Guzzle's wrapper without closing
-     * the original PHP resource.
-     *
-     * @param resource $resource
+     * Decorates a caller-owned sink stream so that closing the response body
+     * detaches Guzzle's wrapper without closing the original PHP resource.
      */
-    private static function streamForResourceSink($resource): StreamInterface
+    private static function streamForResourceSink(StreamInterface $stream): StreamInterface
     {
-        $stream = Psr7\Utils::streamFor($resource);
-
         return Psr7\FnStream::decorate($stream, [
             'close' => static function () use ($stream): void {
                 $stream->detach();
@@ -379,9 +393,38 @@ final class StreamHandler
     }
 
     /**
-     * @param resource $stream
+     * @param mixed $factory
      */
-    private function checkDecode(array $options, array $headers, $stream): array
+    private static function requireStreamFactory($factory): StreamFactoryInterface
+    {
+        if (!$factory instanceof StreamFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::STREAM_FACTORY,
+                StreamFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    /**
+     * @param mixed $factory
+     */
+    private static function requireResponseFactory($factory): ResponseFactoryInterface
+    {
+        if (!$factory instanceof ResponseFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::RESPONSE_FACTORY,
+                ResponseFactoryInterface::class
+            ));
+        }
+
+        return $factory;
+    }
+
+    private static function checkDecode(array $options, array $headers, StreamInterface $stream): array
     {
         // Automatically decode responses when instructed.
         if (!empty($options['decode_content'])) {
@@ -389,7 +432,7 @@ final class StreamHandler
             if (isset($normalizedKeys['content-encoding'])) {
                 $encoding = $headers[$normalizedKeys['content-encoding']];
                 if ($encoding[0] === 'gzip' || $encoding[0] === 'deflate') {
-                    $stream = new Psr7\InflateStream(Psr7\Utils::streamFor($stream));
+                    $stream = new Psr7\InflateStream($stream);
                     $headers['x-encoded-content-encoding'] = $headers[$normalizedKeys['content-encoding']];
 
                     // Remove content-encoding header

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
@@ -96,6 +97,7 @@ class Pool implements PromisorInterface
      *         read_timeout?: int|float,
      *         retries?: int,
      *         request_factory?: RequestFactoryInterface,
+     *         response_factory?: ResponseFactoryInterface,
      *         sink?: resource|string|StreamInterface,
      *         ssl_key?: string|array{
      *             0: string,
@@ -220,6 +222,7 @@ class Pool implements PromisorInterface
      *         read_timeout?: int|float,
      *         retries?: int,
      *         request_factory?: RequestFactoryInterface,
+     *         response_factory?: ResponseFactoryInterface,
      *         sink?: resource|string|StreamInterface,
      *         ssl_key?: string|array{
      *             0: string,

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -273,9 +273,17 @@ final class RequestOptions
     /**
      * stream_factory: (Psr\Http\Message\StreamFactoryInterface) PSR-17
      * stream factory used when creating request body streams from body,
-     * form_params, and json request options.
+     * form_params, and json request options, and when the built-in handlers
+     * create response body streams.
      */
     public const STREAM_FACTORY = 'stream_factory';
+
+    /**
+     * response_factory: (Psr\Http\Message\ResponseFactoryInterface) PSR-17
+     * response factory used by the built-in handlers when creating the
+     * response message.
+     */
+    public const RESPONSE_FACTORY = 'response_factory';
 
     /**
      * sink: (resource|string|StreamInterface) Where the data of the

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -27,6 +27,7 @@ use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
@@ -409,6 +410,8 @@ class ClientTest extends TestCase
         self::assertInstanceOf(UriFactoryInterface::class, $config[RequestOptions::URI_FACTORY]);
         self::assertArrayHasKey(RequestOptions::STREAM_FACTORY, $config);
         self::assertInstanceOf(StreamFactoryInterface::class, $config[RequestOptions::STREAM_FACTORY]);
+        self::assertArrayHasKey(RequestOptions::RESPONSE_FACTORY, $config);
+        self::assertInstanceOf(ResponseFactoryInterface::class, $config[RequestOptions::RESPONSE_FACTORY]);
     }
 
     public function testRequestUsesConfiguredRequestAndUriFactories(): void
@@ -885,6 +888,53 @@ class ClientTest extends TestCase
         self::assertSame([], $factory->streamCalls());
     }
 
+    public function testResponseFactoryIsForwardedToHandler(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::RESPONSE_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path');
+
+        self::assertSame($factory, $mock->getLastOptions()[RequestOptions::RESPONSE_FACTORY]);
+    }
+
+    public function testPerRequestResponseFactoryOverridesClientResponseFactory(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $clientFactory = new ClientTestFactory();
+        $requestFactory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::RESPONSE_FACTORY => $clientFactory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path', [
+            RequestOptions::RESPONSE_FACTORY => $requestFactory,
+        ]);
+
+        self::assertSame($requestFactory, $mock->getLastOptions()[RequestOptions::RESPONSE_FACTORY]);
+    }
+
+    public function testNullPerRequestResponseFactoryRemovesClientDefaultBeforeHandler(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $factory = new ClientTestFactory();
+        $client = new Client([
+            'handler' => $mock,
+            RequestOptions::RESPONSE_FACTORY => $factory,
+        ]);
+
+        $client->request('GET', 'http://example.com/path', [
+            RequestOptions::RESPONSE_FACTORY => null,
+        ]);
+
+        self::assertArrayNotHasKey(RequestOptions::RESPONSE_FACTORY, $mock->getLastOptions());
+    }
+
     public function testCallableBodyFallsBackToGuzzleStreamHandling(): void
     {
         $mock = new MockHandler([new Response()]);
@@ -1022,6 +1072,16 @@ class ClientTest extends TestCase
         ]);
     }
 
+    public function testInvalidResponseFactoryIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('response_factory must be an instance of Psr\\Http\\Message\\ResponseFactoryInterface');
+
+        new Client([
+            RequestOptions::RESPONSE_FACTORY => new \stdClass(),
+        ]);
+    }
+
     public function testInvalidPerRequestRequestFactoryIsRejected(): void
     {
         $client = new Client([
@@ -1062,6 +1122,68 @@ class ClientTest extends TestCase
         $client->request('POST', 'http://example.com', [
             RequestOptions::BODY => 'payload',
             RequestOptions::STREAM_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidPerRequestResponseFactoryIsRejected(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('response_factory must be an instance of Psr\\Http\\Message\\ResponseFactoryInterface');
+
+        // A body-less GET must still reject an invalid per-request response
+        // factory: response factory validation is unconditional because every
+        // request yields a response.
+        $client->request('GET', 'http://example.com', [
+            RequestOptions::RESPONSE_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testInvalidPerRequestStreamFactoryIsRejectedForBodylessRequest(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
+
+        // A body-less GET must still reject an invalid per-request stream
+        // factory: the built-in handlers use it for the response body stream,
+        // so its validation is unconditional rather than body-gated.
+        $client->request('GET', 'http://example.com', [
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testSendRejectsInvalidPerRequestStreamFactory(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stream_factory must be an instance of Psr\\Http\\Message\\StreamFactoryInterface');
+
+        $client->send(new Request('GET', 'http://example.com'), [
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
+        ]);
+    }
+
+    public function testSendRejectsInvalidPerRequestResponseFactory(): void
+    {
+        $client = new Client([
+            'handler' => new MockHandler([new Response()]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('response_factory must be an instance of Psr\\Http\\Message\\ResponseFactoryInterface');
+
+        $client->send(new Request('GET', 'http://example.com'), [
+            RequestOptions::RESPONSE_FACTORY => new \stdClass(),
         ]);
     }
 
@@ -2467,7 +2589,11 @@ final class ClientTestAlternateStream extends Psr7\Stream
 {
 }
 
-final class ClientTestFactory implements RequestFactoryInterface, StreamFactoryInterface, UriFactoryInterface
+final class ClientTestResponse extends Response
+{
+}
+
+final class ClientTestFactory implements RequestFactoryInterface, ResponseFactoryInterface, StreamFactoryInterface, UriFactoryInterface
 {
     /** @var class-string<Request> */
     private $requestClass;
@@ -2477,6 +2603,9 @@ final class ClientTestFactory implements RequestFactoryInterface, StreamFactoryI
 
     /** @var class-string<Psr7\Stream> */
     private $streamClass;
+
+    /** @var class-string<Response> */
+    private $responseClass;
 
     /** @var array<int, array{0: string, 1: mixed}> */
     private $requestCalls = [];
@@ -2490,19 +2619,25 @@ final class ClientTestFactory implements RequestFactoryInterface, StreamFactoryI
     /** @var int */
     private $streamResourceCalls = 0;
 
+    /** @var array<int, array{0: int, 1: string}> */
+    private $responseCalls = [];
+
     /**
      * @param class-string<Request>     $requestClass
      * @param class-string<Uri>         $uriClass
      * @param class-string<Psr7\Stream> $streamClass
+     * @param class-string<Response>    $responseClass
      */
     public function __construct(
         string $requestClass = ClientTestRequest::class,
         string $uriClass = ClientTestUri::class,
-        string $streamClass = ClientTestStream::class
+        string $streamClass = ClientTestStream::class,
+        string $responseClass = ClientTestResponse::class
     ) {
         $this->requestClass = $requestClass;
         $this->uriClass = $uriClass;
         $this->streamClass = $streamClass;
+        $this->responseClass = $responseClass;
     }
 
     public function createRequest(string $method, $uri): RequestInterface
@@ -2550,6 +2685,15 @@ final class ClientTestFactory implements RequestFactoryInterface, StreamFactoryI
         return new $class($resource);
     }
 
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+    {
+        $this->responseCalls[] = [$code, $reasonPhrase];
+
+        $class = $this->responseClass;
+
+        return new $class($code, [], null, '1.1', $reasonPhrase);
+    }
+
     /**
      * @return array<int, array{0: string, 1: mixed}>
      */
@@ -2577,5 +2721,13 @@ final class ClientTestFactory implements RequestFactoryInterface, StreamFactoryI
     public function streamResourceCalls(): int
     {
         return $this->streamResourceCalls;
+    }
+
+    /**
+     * @return array<int, array{0: int, 1: string}>
+     */
+    public function responseCalls(): array
+    {
+        return $this->responseCalls;
     }
 }

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -14,7 +14,11 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Server\Server;
+use GuzzleHttp\Tests\Psr17SpyFactory;
+use GuzzleHttp\Tests\SpyResponse;
+use GuzzleHttp\Tests\SpyStream;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
@@ -51,6 +55,27 @@ class CurlHandlerTest extends TestCase
         } catch (\Throwable $e) {
             $this->assertStringNotContainsString('secretPass', $e->getMessage());
         }
+    }
+
+    public function testResponseMessageAndBodyAreBuiltViaConfiguredFactories(): void
+    {
+        Server::flush();
+        Server::enqueue([new Response(200, ['Foo' => 'Bar'], 'hi there')]);
+        $handler = new CurlHandler();
+        $factory = new Psr17SpyFactory();
+
+        $response = $handler(new Request('GET', Server::$url), [
+            RequestOptions::STREAM_FACTORY => $factory,
+            RequestOptions::RESPONSE_FACTORY => $factory,
+        ])->wait();
+
+        self::assertInstanceOf(SpyResponse::class, $response);
+        self::assertInstanceOf(SpyStream::class, $response->getBody());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('Bar', $response->getHeaderLine('Foo'));
+        self::assertSame('hi there', (string) $response->getBody());
+        self::assertSame(1, $factory->createResponseCalls);
+        self::assertGreaterThanOrEqual(1, $factory->createStreamFromResourceCalls);
     }
 
     public function testReusesHandles(): void

--- a/tests/Handler/EasyHandleTest.php
+++ b/tests/Handler/EasyHandleTest.php
@@ -6,7 +6,12 @@ namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Tests\Psr17SpyFactory;
+use GuzzleHttp\Tests\SpyResponse;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @covers \GuzzleHttp\Handler\EasyHandle
@@ -84,5 +89,67 @@ class EasyHandleTest extends TestCase
         self::assertFalse($easy->response->hasHeader('Content-Length'));
         self::assertSame('gzip', $easy->response->getHeaderLine('x-encoded-content-encoding'));
         self::assertSame('3', $easy->response->getHeaderLine('x-encoded-content-length'));
+    }
+
+    public function testCreateResponseIsBuiltViaConfiguredResponseFactory(): void
+    {
+        $factory = new Psr17SpyFactory();
+        $easy = new EasyHandle();
+        $easy->sink = Psr7\Utils::streamFor('hi');
+        $easy->headers = ['HTTP/1.1 200 OK', 'Foo: Bar'];
+        $easy->options = [RequestOptions::RESPONSE_FACTORY => $factory];
+
+        $easy->createResponse();
+
+        self::assertInstanceOf(SpyResponse::class, $easy->response);
+        self::assertSame(1, $factory->createResponseCalls);
+        self::assertSame(200, $easy->response->getStatusCode());
+        self::assertSame('Bar', $easy->response->getHeaderLine('Foo'));
+        self::assertSame('hi', (string) $easy->response->getBody());
+    }
+
+    public function testCreateResponsePreservesMixedCaseDuplicateHeaders(): void
+    {
+        $easy = new EasyHandle();
+        $easy->sink = Psr7\Utils::streamFor('');
+        $easy->headers = ['HTTP/1.1 200 OK', 'Set-Cookie: a=1', 'set-cookie: b=2'];
+
+        $easy->createResponse();
+
+        self::assertNotNull($easy->response);
+        self::assertSame(['a=1', 'b=2'], $easy->response->getHeader('Set-Cookie'));
+    }
+
+    public function testCreateResponsePropagatesResponseFactoryExceptions(): void
+    {
+        $easy = new EasyHandle();
+        $easy->sink = Psr7\Utils::streamFor('');
+        $easy->headers = ['HTTP/1.1 200 OK'];
+        $easy->options = [
+            RequestOptions::RESPONSE_FACTORY => new class implements ResponseFactoryInterface {
+                public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+                {
+                    throw new \RuntimeException('factory failed');
+                }
+            },
+        ];
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('factory failed');
+
+        $easy->createResponse();
+    }
+
+    public function testCreateResponseRejectsInvalidResponseFactory(): void
+    {
+        $easy = new EasyHandle();
+        $easy->sink = Psr7\Utils::streamFor('');
+        $easy->headers = ['HTTP/1.1 200 OK'];
+        $easy->options = [RequestOptions::RESPONSE_FACTORY => new \stdClass()];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('response_factory must be an instance of Psr\\Http\\Message\\ResponseFactoryInterface');
+
+        $easy->createResponse();
     }
 }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -17,6 +17,9 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Server\Server;
+use GuzzleHttp\Tests\Psr17SpyFactory;
+use GuzzleHttp\Tests\SpyResponse;
+use GuzzleHttp\Tests\SpyStream;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
@@ -2800,6 +2803,225 @@ class StreamHandlerTest extends TestCase
                 RequestOptions::STREAM => true,
             ]
         )->wait();
+    }
+
+    public function testResponseMessageIsBuiltViaResponseFactory(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', 'http://example.com');
+        $factory = new Psr17SpyFactory();
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 201 Created',
+            'Foo: Bar',
+        ]);
+
+        /** @var ResponseInterface $response */
+        $response = $this->invokeStreamHandlerCreateResponse(
+            $handler,
+            $request,
+            [RequestOptions::RESPONSE_FACTORY => $factory],
+            Psr7\Utils::streamFor('body')
+        )->wait();
+
+        self::assertInstanceOf(SpyResponse::class, $response);
+        self::assertSame(1, $factory->createResponseCalls);
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('Created', $response->getReasonPhrase());
+        self::assertSame('Bar', $response->getHeaderLine('Foo'));
+        self::assertSame('1.1', $response->getProtocolVersion());
+        self::assertSame('body', (string) $response->getBody());
+    }
+
+    public function testResponsePreservesMixedCaseDuplicateHeaders(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', 'http://example.com');
+
+        // Different-case duplicates are kept as separate keys by parseHeaders;
+        // the response must merge them (withAddedHeader), not drop one.
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Set-Cookie: a=1',
+            'set-cookie: b=2',
+        ]);
+
+        /** @var ResponseInterface $response */
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor(''))->wait();
+
+        self::assertSame(['a=1', 'b=2'], $response->getHeader('Set-Cookie'));
+        self::assertSame('a=1, b=2', $response->getHeaderLine('Set-Cookie'));
+    }
+
+    public function testResponseAppliesDefaultReasonPhraseForAbsentReason(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', 'http://example.com');
+
+        $this->setStreamHandlerLastHeaders($handler, ['HTTP/1.1 200']);
+        /** @var ResponseInterface $ok */
+        $ok = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor(''))->wait();
+        self::assertSame('OK', $ok->getReasonPhrase());
+
+        $unknown = new StreamHandler();
+        $this->setStreamHandlerLastHeaders($unknown, ['HTTP/1.1 599']);
+        /** @var ResponseInterface $unknownResponse */
+        $unknownResponse = $this->invokeStreamHandlerCreateResponse($unknown, $request, [], Psr7\Utils::streamFor(''))->wait();
+        self::assertSame(599, $unknownResponse->getStatusCode());
+        self::assertSame('', $unknownResponse->getReasonPhrase());
+    }
+
+    public function testResponsePreservesProtocolVersion(): void
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', 'http://example.com');
+
+        $this->setStreamHandlerLastHeaders($handler, ['HTTP/1.0 200 OK']);
+        /** @var ResponseInterface $response */
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [], Psr7\Utils::streamFor(''))->wait();
+
+        self::assertSame('1.0', $response->getProtocolVersion());
+    }
+
+    public function testResponseBodyIsBuiltViaStreamFactory(): void
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $factory = new Psr17SpyFactory();
+
+        $response = $handler(new Request('GET', Server::$url), [
+            RequestOptions::STREAM_FACTORY => $factory,
+            RequestOptions::RESPONSE_FACTORY => $factory,
+        ])->wait();
+
+        self::assertInstanceOf(SpyResponse::class, $response);
+        self::assertInstanceOf(SpyStream::class, $response->getBody());
+        self::assertSame('hi there', (string) $response->getBody());
+        self::assertGreaterThanOrEqual(1, $factory->createStreamFromResourceCalls);
+    }
+
+    public function testStreamOptionBodyIsBuiltViaStreamFactory(): void
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $factory = new Psr17SpyFactory();
+
+        $response = $handler(new Request('GET', Server::$url), [
+            RequestOptions::STREAM => true,
+            RequestOptions::STREAM_FACTORY => $factory,
+            RequestOptions::RESPONSE_FACTORY => $factory,
+        ])->wait();
+
+        self::assertInstanceOf(SpyStream::class, $response->getBody());
+        self::assertSame('hi there', (string) $response->getBody());
+        // The stream option short-circuits sink creation, so only the body
+        // source is wrapped by the stream factory.
+        self::assertSame(1, $factory->createStreamFromResourceCalls);
+    }
+
+    public function testGzipDecodeRoutesBodySourceThroughStreamFactory(): void
+    {
+        $gzip = \gzencode('decoded');
+        self::assertIsString($gzip);
+
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        \fwrite($resource, $gzip);
+        \rewind($resource);
+
+        $handler = new StreamHandler();
+        $request = new Request('GET', 'http://example.com');
+        $factory = new Psr17SpyFactory();
+
+        $this->setStreamHandlerLastHeaders($handler, [
+            'HTTP/1.1 200 OK',
+            'Content-Encoding: gzip',
+        ]);
+
+        /** @var ResponseInterface $response */
+        $response = $this->invokeStreamHandlerCreateResponse($handler, $request, [
+            RequestOptions::STREAM => true,
+            RequestOptions::DECODE_CONTENT => true,
+            RequestOptions::STREAM_FACTORY => $factory,
+        ], $resource)->wait();
+
+        self::assertSame('decoded', (string) $response->getBody());
+        // The transport resource is wrapped via the stream factory once, up
+        // front; the decode path then layers an InflateStream over that stream.
+        self::assertSame(1, $factory->createStreamFromResourceCalls);
+
+        // A non-decoded streamed body source is wrapped exactly the same way.
+        $plainResource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        \fwrite($plainResource, 'plain');
+        \rewind($plainResource);
+
+        $plainHandler = new StreamHandler();
+        $this->setStreamHandlerLastHeaders($plainHandler, ['HTTP/1.1 200 OK']);
+        $plainFactory = new Psr17SpyFactory();
+
+        /** @var ResponseInterface $plainResponse */
+        $plainResponse = $this->invokeStreamHandlerCreateResponse($plainHandler, $request, [
+            RequestOptions::STREAM => true,
+            RequestOptions::STREAM_FACTORY => $plainFactory,
+        ], $plainResource)->wait();
+
+        self::assertInstanceOf(SpyStream::class, $plainResponse->getBody());
+        self::assertSame('plain', (string) $plainResponse->getBody());
+        self::assertSame(1, $plainFactory->createStreamFromResourceCalls);
+    }
+
+    public function testCallerResourceSinkIsNotClosedWhenBodyClosesWithCustomStreamFactory(): void
+    {
+        $this->queueRes();
+        $handler = new StreamHandler();
+        $factory = new Psr17SpyFactory();
+        $sink = Psr7\Utils::tryFopen('php://temp', 'r+');
+
+        $response = $handler(new Request('GET', Server::$url), [
+            RequestOptions::SINK => $sink,
+            RequestOptions::STREAM_FACTORY => $factory,
+            RequestOptions::RESPONSE_FACTORY => $factory,
+        ])->wait();
+
+        self::assertSame('hi there', (string) $response->getBody());
+        self::assertGreaterThanOrEqual(1, $factory->createStreamFromResourceCalls);
+
+        // Closing the response body must detach the caller's resource without
+        // closing it (the FnStream close => detach contract).
+        $response->getBody()->close();
+        self::assertIsResource($sink);
+        \fclose($sink);
+    }
+
+    public function testFilePathSinkUsesLazyOpenStreamWithCustomStreamFactory(): void
+    {
+        $tmpfname = \tempnam(\sys_get_temp_dir(), 'guzzle-sink');
+        self::assertIsString($tmpfname);
+
+        $body = null;
+        try {
+            $this->queueRes();
+            $handler = new StreamHandler();
+            $factory = new Psr17SpyFactory();
+
+            $response = $handler(new Request('GET', Server::$url), [
+                RequestOptions::SINK => $tmpfname,
+                RequestOptions::STREAM_FACTORY => $factory,
+                RequestOptions::RESPONSE_FACTORY => $factory,
+            ])->wait();
+
+            $body = $response->getBody();
+            // String path sinks keep lazy open semantics and must not be routed
+            // through the stream factory.
+            self::assertInstanceOf(Psr7\LazyOpenStream::class, $body);
+            self::assertNotInstanceOf(SpyStream::class, $body);
+            self::assertSame($tmpfname, $body->getMetadata('uri'));
+            self::assertSame('hi there', (string) $body);
+        } finally {
+            if ($body !== null) {
+                $body->close();
+            }
+            @\unlink($tmpfname);
+        }
     }
 
     private static function requestWithProtocolVersion(string $protocolVersion): RequestInterface

--- a/tests/Psr17SpyFactory.php
+++ b/tests/Psr17SpyFactory.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests;
+
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * A spy PSR-17 stream + response factory used by the handler tests to assert
+ * that the built-in handlers create response body streams via the configured
+ * stream factory and the response message via the configured response factory.
+ *
+ * Streams are returned as {@see SpyStream} and responses as {@see SpyResponse}
+ * so tests can assert on the concrete type, and the call counters let tests
+ * verify which code path created (or skipped creating) a stream.
+ */
+final class Psr17SpyFactory implements StreamFactoryInterface, ResponseFactoryInterface
+{
+    /** @var int */
+    public $createStreamCalls = 0;
+
+    /** @var int */
+    public $createStreamFromResourceCalls = 0;
+
+    /** @var int */
+    public $createStreamFromFileCalls = 0;
+
+    /** @var int */
+    public $createResponseCalls = 0;
+
+    public function createStream(string $content = ''): StreamInterface
+    {
+        ++$this->createStreamCalls;
+
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        if ($content !== '') {
+            \fwrite($resource, $content);
+            \rewind($resource);
+        }
+
+        return new SpyStream($resource);
+    }
+
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+    {
+        ++$this->createStreamFromFileCalls;
+
+        return new SpyStream(Psr7\Utils::tryFopen($filename, $mode));
+    }
+
+    /**
+     * @param resource $resource
+     */
+    public function createStreamFromResource($resource): StreamInterface
+    {
+        ++$this->createStreamFromResourceCalls;
+
+        return new SpyStream($resource);
+    }
+
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+    {
+        ++$this->createResponseCalls;
+
+        return new SpyResponse($code, [], null, '1.1', $reasonPhrase);
+    }
+}
+
+final class SpyStream extends Stream
+{
+}
+
+final class SpyResponse extends Response
+{
+}


### PR DESCRIPTION
This adds a `response_factory` request option that accepts a PSR-17 `ResponseFactoryInterface` and is used by the built-in cURL and stream handlers to create the response message, including its status code, reason phrase, headers, and protocol version. The option defaults to the bundled `HttpFactory` and is validated both when the client is constructed and on each request before it is handed to the handler, so an invalid factory is rejected early with a clear exception rather than failing later inside a handler.

Alongside the new option, the built-in handlers now route response body stream creation through the configured `stream_factory`. The transport resource is wrapped through the factory before any content-decoding layer is applied, so the decode path and the non-decode path both go through the same abstraction, and caller-owned sink resources are wrapped through the factory and decorated so that closing the response body detaches Guzzle's wrapper without closing the underlying resource. The cURL factory and the stream handler share the same sink handling so their behaviour stays consistent.

The client now validates the response and stream factories unconditionally before a request is transferred. Previously the stream factory was only validated inside the request body branch, which meant an invalid per-request stream factory on a request without a body would surface as a low-level error deep inside a handler instead of a descriptive exception.

Now that all four PSR-17 factory options are available, the documentation is expanded to make clear that supplying your own PSR-7 implementation is an advanced feature that moves responsibility for correctness and security to your code. Guzzle only checks that each value implements the relevant interface, not that the objects it returns behave correctly, so each option now documents the contracts it depends on and the consequences of breaking them. A response body stream must expose the transport resource's live timeout metadata or read-timeout detection silently degrades into truncated responses, and it must close the underlying resource or each request leaks a socket. A response factory that pre-seeds headers corrupts the message, a request factory must derive the Host header from the URI, and a URI implementation must report the scheme, host, and port correctly or it can defeat the cross-origin credential stripping that protects redirects against leaking the Authorization and Cookie headers.
