### PR TITLE
Fix PSR-7 README link

### DIFF
--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -287,7 +287,7 @@ Streams expose their capabilities using three methods: `isReadable()`, `isWritab
 
 Each stream instance has various capabilities: they can be read-only, write-only, read-write, allow arbitrary random access (seeking forwards or backwards to any location), or only allow sequential access (for example in the case of a socket or pipe).
 
-Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More information on using streams, creating streams, converting streams to PHP stream resource, and stream decorators can be found in the [Guzzle PSR-7 documentation](https://github.com/guzzle/psr7/blob/master/README.md).
+Guzzle uses the `guzzlehttp/psr7` package to provide stream support. More information on using streams, creating streams, converting streams to PHP stream resource, and stream decorators can be found in the [Guzzle PSR-7 documentation](https://github.com/guzzle/psr7/blob/2.11/README.md).
 
 ### Creating Streams
 


### PR DESCRIPTION
The link to the Guzzle PSR-7 documentation in the streams section pointed at the package README on the `master` branch, which no longer exists. This updates it to the `2.11` branch, matching the `guzzlehttp/psr7: ^2.11` dependency used on this branch.
