### PR TITLE
Move Basic and Digest auth to middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add `HandlerClosedException` for pending transfers rejected by `CurlMultiHandler::close()`
 - Add `ProxyOptions` for proxy option resolution
 - Add `ResponseException` for request failures with responses
+- Add auth middleware for built-in Basic and Digest authentication
 
 ### Changed
 
@@ -43,6 +44,9 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Treat only `null` as an omitted path or name when clearing cookies
 - Validate malformed `auth` request option arrays
 - Stop forwarding the generic `auth` request option when following cross-origin redirects
+- Move built-in Basic and Digest authentication handling to the default auth middleware
+- Stop implementing Digest authentication through cURL HTTP authentication options
+- Remove first-class NTLM authentication from the `auth` request option
 - Reject invalid `HandlerStack::remove()` arguments
 - Require `Pool` request collections to be iterable
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -92,6 +92,60 @@ platform.
 Applications that set this header manually should send one valid non-negative
 decimal length or omit it and let Guzzle prepare the body headers.
 
+#### Auth Request Option Changes
+
+Digest authentication is no longer implemented with cURL `CURLOPT_HTTPAUTH` and
+`CURLOPT_USERPWD`. Guzzle supports legacy Digest challenges without `qop` and
+challenges with `qop=auth`; `auth-int` is not supported. Legacy NTLM
+authentication is no longer a built-in `auth` type. If NTLM is still required,
+configure cURL HTTP authentication options directly with a cURL handler:
+
+```php
+$client->request('GET', '/', [
+    'curl' => [
+        CURLOPT_HTTPAUTH => CURLAUTH_NTLM,
+        CURLOPT_USERPWD => 'username:password',
+    ],
+]);
+```
+
+Built-in Basic and Digest authentication continue to work for clients using
+Guzzle's default handler or `GuzzleHttp\HandlerStack::create($handler)`, but
+they are now applied by the default auth middleware instead of while the client
+constructs the request. If you pass a raw custom handler directly to `Client`,
+remove default middleware, or build a handler stack manually, Basic and Digest
+authentication will only be applied when your stack includes
+`Middleware::auth()`. Unknown auth type strings are left in the request options
+for custom middleware or custom handlers.
+
+Guzzle also validates non-empty auth arrays before applying them: indexes `0`
+and `1` must be username and password strings, and index `2`, when present, must
+be a string or `null`. Invalid auth arrays that previously emitted warnings,
+coerced values, or did nothing now throw
+`GuzzleHttp\Exception\InvalidArgumentException`.
+
+```php
+// Valid:
+$client->request('GET', '/', [
+    'auth' => ['username', 'password', 'basic'],
+]);
+
+// Invalid in 8.0:
+$client->request('GET', '/', [
+    'auth' => ['username'],
+]);
+```
+
+Guzzle 8 also no longer forwards the generic `auth` request option when
+automatic redirects cross origin. Guzzle already removed the `Authorization` and
+`Cookie` headers and cURL HTTP authentication options on cross-origin redirects;
+this now also applies to handler-visible `auth` state.
+
+Same-origin redirects continue to preserve `auth`. If an application or custom
+handler intentionally reused `auth` across redirected origins, disable automatic
+redirects or handle redirects manually so each origin receives explicit
+credentials.
+
 #### Exception Hierarchy and Classification
 
 Some Guzzle 8.0 exception changes add intermediate classes, while others
@@ -444,40 +498,6 @@ $client->request('GET', '/', [
     ],
 ]);
 ```
-
-#### Auth Option Validation
-
-The `auth` request option now validates array values before applying them. Auth
-arrays must contain username and password strings at indexes `0` and `1`. If an
-auth type is provided at index `2`, it must be one of `basic`, `digest`, or
-`ntlm`.
-
-Invalid auth arrays that previously emitted warnings, coerced values, or did
-nothing now throw `GuzzleHttp\Exception\InvalidArgumentException`.
-
-```php
-// Valid:
-$client->request('GET', '/', [
-    'auth' => ['username', 'password', 'basic'],
-]);
-
-// Invalid in 8.0:
-$client->request('GET', '/', [
-    'auth' => ['username'],
-]);
-```
-
-#### Cross-Origin Redirect Auth Cleanup
-
-Guzzle 8 no longer forwards the generic `auth` request option when automatic
-redirects cross origin. Guzzle already removed the `Authorization` and `Cookie`
-headers and cURL HTTP authentication options on cross-origin redirects; this now
-also applies to handler-visible `auth` state.
-
-Same-origin redirects continue to preserve `auth`. If an application or custom
-handler intentionally reused `auth` across redirected origins, disable automatic
-redirects or handle redirects manually so each origin receives explicit
-credentials.
 
 #### Handler-Specific Option Overrides
 

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -24,16 +24,18 @@ The `create` method adds default handlers to the `HandlerStack`. When the `Handl
 
 > 1.  `http_errors` - No op when sending a request. The response status code is checked in the response processing when returning a response promise up the stack.
 > 2.  `allow_redirects` - No op when sending a request. Following redirects occurs when a response promise is being returned up the stack.
-> 3.  `cookies` - Adds cookies to requests.
-> 4.  `prepare_body` - The body of an HTTP request will be prepared (e.g., add default headers like Content-Length, Content-Type, etc.).
-> 5.  <send request with handler>
+> 3.  `auth` - Adds Basic authentication headers and handles Digest authentication challenges when the `auth` request option is set.
+> 4.  `cookies` - Adds cookies to requests.
+> 5.  `prepare_body` - The body of an HTTP request will be prepared (e.g., add default headers like Content-Length, Content-Type, etc.).
+> 6.  <send request with handler>
 
 2.  Processing response:
 
 > 1.  `prepare_body` - no op on response processing.
 > 2.  `cookies` - extracts response cookies into the cookie jar.
-> 3.  `allow_redirects` - Follows redirects.
-> 4.  `http_errors` - throws exceptions when the response status code `>=` 400.
+> 3.  `auth` - handles Digest authentication challenges before HTTP errors are raised.
+> 4.  `allow_redirects` - Follows redirects.
+> 5.  `http_errors` - throws exceptions when the response status code `>=` 400.
 
 When provided no `$handler` argument, `GuzzleHttp\HandlerStack::create()` will choose the most appropriate handler based on the extensions available on your system.
 
@@ -444,11 +446,13 @@ Request options are applied by different parts of Guzzle. A custom handler shoul
 
 | Owner | Examples | Notes |
 | --- | --- | --- |
-| Client-applied options | `base_uri`, `headers`, `body`, `form_params`, `multipart`, `json`, `query`, `version`, `idn_conversion`, basic `auth` | These options affect request construction or request mutation before the final handler sends the request. |
-| Middleware-dependent options | `allow_redirects`, `cookies`, `http_errors`, `expect` | These options require the relevant middleware, normally from `HandlerStack::create()`. |
+| Client-applied options | `base_uri`, `headers`, `body`, `form_params`, `multipart`, `json`, `query`, `version`, `idn_conversion` | These options affect request construction or request mutation before the final handler sends the request. |
+| Middleware-dependent options | `allow_redirects`, Basic and Digest `auth`, `cookies`, `http_errors`, `expect` | These options require the relevant middleware, normally from `HandlerStack::create()`. |
 | Handler-owned options | `delay`, `timeout`, `connect_timeout`, `read_timeout`, `stream`, `sink`, `verify`, `cert`, `ssl_key`, `proxy`, `force_ip_resolve`, `decode_content`, `progress`, `on_headers`, `on_stats`, `debug` | These options describe transport behavior and need explicit handler support or clear unsupported behavior. |
 
-Some options have split responsibilities. Basic `auth` adds an `Authorization` header before the handler runs, while digest and NTLM authentication are implemented through cURL options by Guzzle's built-in cURL handlers. The `expect` option is used by the body preparation middleware to add `Expect: 100-Continue`, but the transport still determines whether the protocol workflow is supported. The `decode_content` option can affect the `Accept-Encoding` request header, but response decoding is handled by the transport. Redirect middleware validates redirect targets with `allow_redirects.protocols`, but the handler is still responsible for enforcing which schemes it can send.
+Some options have split responsibilities. Basic and Digest `auth` are applied by the auth middleware. Legacy NTLM authentication is not a built-in `auth` type; configure cURL HTTP authentication options directly if it is required. The `expect` option is used by the body preparation middleware to add `Expect: 100-Continue`, but the transport still determines whether the protocol workflow is supported. The `decode_content` option can affect the `Accept-Encoding` request header, but response decoding is handled by the transport. Redirect middleware validates redirect targets with `allow_redirects.protocols`, but the handler is still responsible for enforcing which schemes it can send.
+
+Raw custom handlers do not receive Basic or Digest authentication automatically. Wrap custom handlers with `HandlerStack::create($handler)` or add `Middleware::auth()` to a custom stack when those built-in authentication types are needed.
 
 ### Handler-Owned Transfer Options
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -120,6 +120,8 @@ If TLS client credentials are only trusted for the original origin, disable auto
 Summary
 Pass HTTP authentication parameters to use with the request. An array must contain the username in index `[0]`, the password in index `[1]`, and can optionally provide a built-in authentication type in index `[2]`. Pass `false` or `null` to disable authentication for a request. String values are passed through for custom handlers.
 
+Built-in Basic and Digest authentication are applied by `GuzzleHttp\Middleware::auth`, which is included by default when using `GuzzleHttp\HandlerStack::create()` or when the client creates its default handler. Raw custom handlers must be wrapped in `HandlerStack::create($handler)` or explicitly include `Middleware::auth()` to use built-in Basic or Digest authentication. Unrecognized array auth types are left in the request options for custom middleware or custom handlers.
+
 Types
 - array
 - string
@@ -142,7 +144,7 @@ $client->request('GET', '/get', ['auth' => ['username', 'password']]);
 ```
 
 digest
-Use [digest authentication](http://www.ietf.org/rfc/rfc2069.txt) (must be supported by the HTTP handler).
+Use [digest authentication](https://www.rfc-editor.org/rfc/rfc7616.html) through Guzzle's auth middleware. Digest authentication sends an initial unauthenticated request, processes a `WWW-Authenticate: Digest ...` challenge, then retries with an `Authorization: Digest ...` header.
 
 ```php
 $client->request('GET', '/get', [
@@ -150,20 +152,18 @@ $client->request('GET', '/get', [
 ]);
 ```
 
-> [!NOTE]
-> This is currently only supported when using the cURL handler, but creating a replacement that can be used with any HTTP handler is planned.
+Supported Digest algorithms are `MD5`, `MD5-sess`, `SHA-256`, `SHA-256-sess`, and the `SHA-512-256` variants when PHP supports the `sha512/256` hash algorithm. Guzzle supports legacy challenges without `qop` and challenges with `qop=auth`. `auth-int` is not supported.
 
-ntlm
-Use [Microsoft NTLM authentication](https://msdn.microsoft.com/en-us/library/windows/desktop/aa378749(v=vs.85).aspx) (must be supported by the HTTP handler).
+Legacy NTLM authentication is no longer a built-in `auth` type. If it is required, configure the built-in cURL handler directly with cURL HTTP authentication options.
 
 ```php
 $client->request('GET', '/get', [
-    'auth' => ['username', 'password', 'ntlm']
+    'curl' => [
+        CURLOPT_HTTPAUTH => CURLAUTH_NTLM,
+        CURLOPT_USERPWD => 'username:password',
+    ],
 ]);
 ```
-
-> [!NOTE]
-> This is currently only supported when using the cURL handler.
 
 ## body
 

--- a/src/Auth/DigestAuth.php
+++ b/src/Auth/DigestAuth.php
@@ -1,0 +1,392 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Auth;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @internal
+ */
+final class DigestAuth
+{
+    /**
+     * @var array<string, array{hash: string, sess: bool, rank: int, header: string}>
+     */
+    private const ALGORITHMS = [
+        'MD5' => ['hash' => 'md5', 'sess' => false, 'rank' => 10, 'header' => 'MD5'],
+        'MD5-SESS' => ['hash' => 'md5', 'sess' => true, 'rank' => 11, 'header' => 'MD5-sess'],
+        'SHA-256' => ['hash' => 'sha256', 'sess' => false, 'rank' => 20, 'header' => 'SHA-256'],
+        'SHA-256-SESS' => ['hash' => 'sha256', 'sess' => true, 'rank' => 21, 'header' => 'SHA-256-sess'],
+        'SHA-512-256' => ['hash' => 'sha512/256', 'sess' => false, 'rank' => 30, 'header' => 'SHA-512-256'],
+        'SHA-512-256-SESS' => ['hash' => 'sha512/256', 'sess' => true, 'rank' => 31, 'header' => 'SHA-512-256-sess'],
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function selectChallenge(ResponseInterface $response): ?DigestChallenge
+    {
+        $selected = null;
+
+        foreach ($response->getHeader('WWW-Authenticate') as $header) {
+            foreach (self::parseAuthenticateHeader($header) as $challenge) {
+                if ($challenge['scheme'] !== 'digest' || $challenge['invalid']) {
+                    continue;
+                }
+
+                $digest = self::createChallenge($challenge['params']);
+                if ($digest === null) {
+                    continue;
+                }
+
+                if ($selected === null || $digest->algorithm['rank'] > $selected->algorithm['rank']) {
+                    $selected = $digest;
+                }
+            }
+        }
+
+        return $selected;
+    }
+
+    public static function authorizationHeader(
+        RequestInterface $request,
+        DigestChallenge $challenge,
+        string $username,
+        string $password,
+        string $cnonce,
+        string $nc = '00000001'
+    ): ?string {
+        $uri = $request->getRequestTarget();
+        if ($uri === '') {
+            $uri = '/';
+        }
+
+        foreach ([$username, $challenge->realm, $challenge->nonce, $uri, $cnonce] as $value) {
+            if (!self::isHeaderSafe($value)) {
+                return null;
+            }
+        }
+
+        if ($challenge->opaque !== null && !self::isHeaderSafe($challenge->opaque)) {
+            return null;
+        }
+
+        $hash = $challenge->algorithm['hash'];
+        $ha1 = \hash($hash, $username.':'.$challenge->realm.':'.$password);
+
+        if ($challenge->algorithm['sess']) {
+            $ha1 = \hash($hash, $ha1.':'.$challenge->nonce.':'.$cnonce);
+        }
+
+        $ha2 = \hash($hash, $request->getMethod().':'.$uri);
+        $response = $challenge->qop === null
+            ? \hash($hash, $ha1.':'.$challenge->nonce.':'.$ha2)
+            : \hash($hash, $ha1.':'.$challenge->nonce.':'.$nc.':'.$cnonce.':'.$challenge->qop.':'.$ha2);
+
+        if ($challenge->userhash) {
+            $headerUsername = \hash($hash, $username.':'.$challenge->realm);
+            if ($headerUsername === false) {
+                return null;
+            }
+        } else {
+            $headerUsername = $username;
+        }
+
+        $parts = [
+            'username='.self::quote($headerUsername),
+            'realm='.self::quote($challenge->realm),
+            'nonce='.self::quote($challenge->nonce),
+            'uri='.self::quote($uri),
+            'response='.self::quote($response),
+            'algorithm='.$challenge->algorithm['header'],
+        ];
+
+        if ($challenge->opaque !== null) {
+            $parts[] = 'opaque='.self::quote($challenge->opaque);
+        }
+
+        if ($challenge->qop !== null) {
+            $parts[] = 'qop='.$challenge->qop;
+            $parts[] = 'nc='.$nc;
+            $parts[] = 'cnonce='.self::quote($cnonce);
+        }
+
+        if ($challenge->userhash) {
+            $parts[] = 'userhash=true';
+        }
+
+        return 'Digest '.\implode(', ', $parts);
+    }
+
+    /**
+     * @return list<array{scheme: string, params: array<string, string>, invalid: bool}>
+     */
+    public static function parseAuthenticateHeader(string $header): array
+    {
+        $length = \strlen($header);
+        $offset = 0;
+        $challenges = [];
+
+        while (true) {
+            self::skipSeparators($header, $offset, $length);
+            if ($offset >= $length) {
+                break;
+            }
+
+            $scheme = self::readToken($header, $offset, $length);
+            if ($scheme === null) {
+                break;
+            }
+
+            self::skipWhitespace($header, $offset, $length);
+
+            $params = [];
+            $invalid = false;
+
+            while ($offset < $length) {
+                self::skipWhitespace($header, $offset, $length);
+
+                if ($offset < $length && $header[$offset] === ',') {
+                    if (self::commaStartsNextChallenge($header, $offset + 1, $length)) {
+                        ++$offset;
+                        break;
+                    }
+
+                    ++$offset;
+                    continue;
+                }
+
+                $name = self::readToken($header, $offset, $length);
+                if ($name === null) {
+                    break;
+                }
+
+                self::skipWhitespace($header, $offset, $length);
+                if ($offset >= $length || $header[$offset] !== '=') {
+                    break;
+                }
+
+                ++$offset;
+                self::skipWhitespace($header, $offset, $length);
+
+                $value = self::readValue($header, $offset, $length);
+                if ($value === null) {
+                    $invalid = true;
+                    break;
+                }
+
+                $lowerName = \strtolower($name);
+                if (\array_key_exists($lowerName, $params)) {
+                    $invalid = true;
+                }
+
+                $params[$lowerName] = $value;
+
+                self::skipWhitespace($header, $offset, $length);
+                if ($offset >= $length || $header[$offset] !== ',') {
+                    break;
+                }
+            }
+
+            $challenges[] = [
+                'scheme' => \strtolower($scheme),
+                'params' => $params,
+                'invalid' => $invalid,
+            ];
+        }
+
+        return $challenges;
+    }
+
+    /**
+     * @param array<string, string> $params
+     */
+    private static function createChallenge(array $params): ?DigestChallenge
+    {
+        if (!isset($params['nonce']) || $params['nonce'] === '') {
+            return null;
+        }
+
+        if (isset($params['charset']) && \strcasecmp($params['charset'], 'UTF-8') !== 0) {
+            return null;
+        }
+
+        $algorithm = self::algorithm($params['algorithm'] ?? null);
+        if ($algorithm === null) {
+            return null;
+        }
+
+        $qop = self::selectQop($params['qop'] ?? null);
+        if ($qop === false) {
+            return null;
+        }
+
+        $challenge = new DigestChallenge();
+        $challenge->algorithm = $algorithm;
+        $challenge->realm = $params['realm'] ?? '';
+        $challenge->nonce = $params['nonce'];
+        $challenge->opaque = $params['opaque'] ?? null;
+        $challenge->qop = $qop;
+        $challenge->stale = isset($params['stale']) && \strcasecmp($params['stale'], 'true') === 0;
+        $challenge->userhash = isset($params['userhash']) && \strcasecmp($params['userhash'], 'true') === 0;
+
+        return $challenge;
+    }
+
+    /**
+     * @return array{name: string, hash: string, sess: bool, rank: int, header: string}|null
+     */
+    private static function algorithm(?string $algorithm): ?array
+    {
+        $name = \strtoupper($algorithm ?? 'MD5');
+
+        if (!isset(self::ALGORITHMS[$name])) {
+            return null;
+        }
+
+        $mapped = self::ALGORITHMS[$name];
+        if (!\in_array($mapped['hash'], \hash_algos(), true)) {
+            return null;
+        }
+
+        return ['name' => $name] + $mapped;
+    }
+
+    /**
+     * @return string|false|null
+     */
+    private static function selectQop(?string $qop)
+    {
+        if ($qop === null) {
+            return null;
+        }
+
+        $tokens = \array_map(
+            static function (string $token): string {
+                return \strtolower(\trim($token));
+            },
+            \explode(',', $qop)
+        );
+
+        return \in_array('auth', $tokens, true) ? 'auth' : false;
+    }
+
+    private static function quote(string $value): string
+    {
+        return '"'.\strtr($value, [
+            '\\' => '\\\\',
+            '"' => '\\"',
+        ]).'"';
+    }
+
+    private static function isHeaderSafe(string $value): bool
+    {
+        return \strcspn($value, "\r\n\0") === \strlen($value);
+    }
+
+    private static function commaStartsNextChallenge(string $header, int $offset, int $length): bool
+    {
+        self::skipWhitespace($header, $offset, $length);
+        $nextOffset = $offset;
+        $token = self::readToken($header, $nextOffset, $length);
+        if ($token === null) {
+            return false;
+        }
+
+        self::skipWhitespace($header, $nextOffset, $length);
+
+        return $nextOffset >= $length || $header[$nextOffset] !== '=';
+    }
+
+    private static function skipSeparators(string $header, int &$offset, int $length): void
+    {
+        while ($offset < $length) {
+            $char = $header[$offset];
+            if ($char !== ',' && !self::isWhitespace($char)) {
+                return;
+            }
+
+            ++$offset;
+        }
+    }
+
+    private static function skipWhitespace(string $header, int &$offset, int $length): void
+    {
+        while ($offset < $length && self::isWhitespace($header[$offset])) {
+            ++$offset;
+        }
+    }
+
+    private static function isWhitespace(string $char): bool
+    {
+        return $char === ' ' || $char === "\t";
+    }
+
+    private static function readToken(string $header, int &$offset, int $length): ?string
+    {
+        $start = $offset;
+        while ($offset < $length && self::isTokenChar($header[$offset])) {
+            ++$offset;
+        }
+
+        if ($offset === $start) {
+            return null;
+        }
+
+        $token = \substr($header, $start, $offset - $start);
+
+        return $token === false ? null : $token;
+    }
+
+    private static function isTokenChar(string $char): bool
+    {
+        return \strspn($char, "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz") === 1;
+    }
+
+    private static function readValue(string $header, int &$offset, int $length): ?string
+    {
+        if ($offset >= $length) {
+            return null;
+        }
+
+        if ($header[$offset] === '"') {
+            return self::readQuotedString($header, $offset, $length);
+        }
+
+        return self::readToken($header, $offset, $length);
+    }
+
+    private static function readQuotedString(string $header, int &$offset, int $length): ?string
+    {
+        ++$offset;
+        $value = '';
+        $escaped = false;
+
+        while ($offset < $length) {
+            $char = $header[$offset++];
+
+            if ($escaped) {
+                $value .= $char;
+                $escaped = false;
+                continue;
+            }
+
+            if ($char === '\\') {
+                $escaped = true;
+                continue;
+            }
+
+            if ($char === '"') {
+                return $value;
+            }
+
+            $value .= $char;
+        }
+
+        return null;
+    }
+}

--- a/src/Auth/DigestChallenge.php
+++ b/src/Auth/DigestChallenge.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Auth;
+
+/**
+ * @internal
+ */
+final class DigestChallenge
+{
+    /** @var array{name: string, hash: string, sess: bool, rank: int, header: string} */
+    public array $algorithm;
+
+    public string $realm = '';
+
+    public string $nonce;
+
+    public ?string $opaque = null;
+
+    public ?string $qop = null;
+
+    public bool $stale = false;
+
+    public bool $userhash = false;
+}

--- a/src/AuthMiddleware.php
+++ b/src/AuthMiddleware.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp;
+
+use GuzzleHttp\Auth\DigestAuth;
+use GuzzleHttp\Exception\InvalidArgumentException;
+use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\LazyOpenStream;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Applies built-in Basic authentication and handles Digest authentication challenges.
+ */
+final class AuthMiddleware
+{
+    private const DIGEST_MAX_RETRIES = 2;
+
+    /**
+     * @var callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>
+     */
+    private $nextHandler;
+
+    /**
+     * @var callable(): string
+     */
+    private $cnonceGenerator;
+
+    /**
+     * @param callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed> $nextHandler
+     * @param (callable(): string)|null                                                                       $cnonceGenerator
+     */
+    public function __construct(callable $nextHandler, ?callable $cnonceGenerator = null)
+    {
+        $this->nextHandler = $nextHandler;
+        $this->cnonceGenerator = $cnonceGenerator ?? static function (): string {
+            return \bin2hex(\random_bytes(16));
+        };
+    }
+
+    /**
+     * @return PromiseInterface<ResponseInterface, mixed>
+     */
+    public function __invoke(RequestInterface $request, array $options): PromiseInterface
+    {
+        $auth = $options['auth'] ?? null;
+        if ($auth === null || $auth === false || $auth === [] || \is_string($auth)) {
+            return ($this->nextHandler)($request, $options);
+        }
+
+        $normalizedAuth = self::normalizeAuth($auth);
+        if ($normalizedAuth === null) {
+            return ($this->nextHandler)($request, $options);
+        }
+
+        [$username, $password, $type] = $normalizedAuth;
+
+        if ($type === 'basic') {
+            return $this->sendBasic($request, $options, $username, $password);
+        }
+
+        return $this->sendDigest($request, $options, $username, $password);
+    }
+
+    /**
+     * @param array<array-key, mixed> $auth
+     *
+     * @return array{0: string, 1: string, 2: 'basic'|'digest'}|null
+     */
+    private static function normalizeAuth(array $auth): ?array
+    {
+        $type = 'basic';
+        if (\array_key_exists(2, $auth) && $auth[2] !== null) {
+            if (!\is_string($auth[2])) {
+                throw new InvalidArgumentException('auth type must be a string');
+            }
+
+            $type = \strtolower($auth[2]);
+        }
+
+        if (!\in_array($type, ['basic', 'digest'], true)) {
+            return null;
+        }
+
+        if (!\array_key_exists(0, $auth) || !\array_key_exists(1, $auth)) {
+            throw new InvalidArgumentException('auth must contain username and password strings');
+        }
+
+        if (!\is_string($auth[0]) || !\is_string($auth[1])) {
+            throw new InvalidArgumentException('auth must contain username and password strings');
+        }
+
+        return [$auth[0], $auth[1], $type];
+    }
+
+    /**
+     * @return PromiseInterface<ResponseInterface, mixed>
+     */
+    private function sendBasic(RequestInterface $request, array $options, string $username, string $password): PromiseInterface
+    {
+        unset($options['auth']);
+
+        return ($this->nextHandler)(
+            $request->withHeader('Authorization', 'Basic '.\base64_encode($username.':'.$password)),
+            $options
+        );
+    }
+
+    /**
+     * @return PromiseInterface<ResponseInterface, mixed>
+     */
+    private function sendDigest(RequestInterface $request, array $options, string $username, string $password): PromiseInterface
+    {
+        $probeOptions = self::withTemporarySink($options);
+        unset($probeOptions['auth']);
+
+        return ($this->nextHandler)($request->withoutHeader('Authorization'), $probeOptions)->then(
+            function (ResponseInterface $response) use ($request, $options, $probeOptions, $username, $password) {
+                return $this->handleDigestResponse($request, $options, $probeOptions, $response, $username, $password);
+            }
+        );
+    }
+
+    /**
+     * @return ResponseInterface|PromiseInterface<ResponseInterface, mixed>
+     */
+    private function handleDigestResponse(
+        RequestInterface $request,
+        array $options,
+        array $probeOptions,
+        ResponseInterface $response,
+        string $username,
+        string $password
+    ) {
+        if ($response->getStatusCode() !== 401) {
+            return self::restoreOriginalSink($response, $probeOptions);
+        }
+
+        $challenge = DigestAuth::selectChallenge($response);
+        if ($challenge === null) {
+            return self::restoreOriginalSink($response, $probeOptions);
+        }
+
+        $retries = $options['__guzzle_digest_retries'] ?? 0;
+        if (!\is_int($retries)) {
+            $retries = 0;
+        }
+
+        if (($retries > 0 && !$challenge->stale) || $retries >= self::DIGEST_MAX_RETRIES) {
+            return self::restoreOriginalSink($response, $probeOptions);
+        }
+
+        try {
+            Psr7\Message::rewindBody($request);
+        } catch (\Throwable $e) {
+            throw new ResponseException(
+                'Digest authentication failed because the request body could not be rewound',
+                $request,
+                $response,
+                $e
+            );
+        }
+
+        $authorization = DigestAuth::authorizationHeader(
+            $request,
+            $challenge,
+            $username,
+            $password,
+            ($this->cnonceGenerator)()
+        );
+
+        if ($authorization === null) {
+            return self::restoreOriginalSink($response, $probeOptions);
+        }
+
+        $response->getBody()->close();
+
+        $retryOptions = $options;
+        $retryOptions['__guzzle_digest_retries'] = $retries + 1;
+        $downstreamOptions = $retryOptions;
+        $downstreamOptions = self::withTemporarySink($downstreamOptions);
+        unset($downstreamOptions['auth']);
+
+        $retryRequest = $request->withHeader('Authorization', $authorization);
+
+        return ($this->nextHandler)($retryRequest, $downstreamOptions)->then(
+            function (ResponseInterface $retryResponse) use ($retryRequest, $retryOptions, $downstreamOptions, $username, $password) {
+                return $this->handleDigestResponse($retryRequest, $retryOptions, $downstreamOptions, $retryResponse, $username, $password);
+            }
+        );
+    }
+
+    private static function withTemporarySink(array $options): array
+    {
+        if (!empty($options['stream']) || !\array_key_exists('sink', $options)) {
+            return $options;
+        }
+
+        $options['__guzzle_auth_original_sink'] = $options['sink'];
+        $options['sink'] = Psr7\Utils::tryFopen('php://temp', 'w+');
+
+        return $options;
+    }
+
+    private static function restoreOriginalSink(ResponseInterface $response, array $options): ResponseInterface
+    {
+        if (!\array_key_exists('__guzzle_auth_original_sink', $options)) {
+            return $response;
+        }
+
+        $source = $response->getBody();
+        if ($source->isSeekable()) {
+            $source->rewind();
+        }
+
+        $target = \is_string($options['__guzzle_auth_original_sink'])
+            ? new LazyOpenStream($options['__guzzle_auth_original_sink'], 'w+')
+            : Psr7\Utils::streamFor($options['__guzzle_auth_original_sink']);
+
+        Psr7\Utils::copyToStream($source, $target);
+
+        if ($target->isSeekable()) {
+            $target->rewind();
+        }
+
+        return $response->withBody($target);
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -855,6 +855,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             self::invalidRequestOptionType('auth', 'array{0: string, 1: string, 2?: string|null}|string|false|null', $options['auth']);
         }
 
+        if (isset($options['auth']) && \is_array($options['auth']) && $options['auth'] !== []) {
+            self::assertAuthOptionTypes($options['auth']);
+        }
+
         self::assertTlsFileOptionTypes($options, 'cert');
         self::assertIfPresentAndNotString($options, 'cert_type');
         self::assertIfPresentAndNotNumber($options, 'connect_timeout');
@@ -917,6 +921,24 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         self::assertIfPresentAndNotStringArray($allowRedirects, 'protocols', true, 'allow_redirects.protocols');
         self::assertIfPresentAndNotCallable($allowRedirects, 'on_redirect', 'allow_redirects.on_redirect');
         self::assertIfPresentAndNotBool($allowRedirects, 'track_redirects', 'allow_redirects.track_redirects');
+    }
+
+    /**
+     * @param array<array-key, mixed> $auth
+     */
+    private static function assertAuthOptionTypes(array $auth): void
+    {
+        if (!\array_key_exists(0, $auth) || !\is_string($auth[0])) {
+            self::invalidRequestOptionType('auth.0', 'string', $auth[0] ?? null);
+        }
+
+        if (!\array_key_exists(1, $auth) || !\is_string($auth[1])) {
+            self::invalidRequestOptionType('auth.1', 'string', $auth[1] ?? null);
+        }
+
+        if (\array_key_exists(2, $auth) && $auth[2] !== null && !\is_string($auth[2])) {
+            self::invalidRequestOptionType('auth.2', 'string|null', $auth[2]);
+        }
     }
 
     /**
@@ -1302,49 +1324,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             }
             $modify['body'] = self::createBodyStream($options['body'], $streamFactory);
             unset($options['body']);
-        }
-
-        if (isset($options['auth']) && \is_array($options['auth']) && $options['auth'] !== []) {
-            $value = $options['auth'];
-
-            if (!\array_key_exists(0, $value) || !\array_key_exists(1, $value)) {
-                throw new InvalidArgumentException('auth must contain username and password strings');
-            }
-
-            $username = $value[0];
-            $password = $value[1];
-
-            if (!\is_string($username) || !\is_string($password)) {
-                throw new InvalidArgumentException('auth must contain username and password strings');
-            }
-
-            $type = 'basic';
-            if (\array_key_exists(2, $value) && $value[2] !== null) {
-                $type = $value[2];
-                if (!\is_string($type)) {
-                    throw new InvalidArgumentException('auth type must be a string');
-                }
-            }
-
-            switch (\strtolower($type)) {
-                case 'basic':
-                    // Ensure that we don't have the header in different case and set the new value.
-                    $modify['set_headers'] = Psr7\Utils::caselessRemove(['Authorization'], $modify['set_headers']);
-                    $modify['set_headers']['Authorization'] = 'Basic '
-                        .\base64_encode($username.':'.$password);
-                    break;
-                case 'digest':
-                    // @todo: Do not rely on curl
-                    $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_DIGEST;
-                    $options['curl'][\CURLOPT_USERPWD] = $username.':'.$password;
-                    break;
-                case 'ntlm':
-                    $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_NTLM;
-                    $options['curl'][\CURLOPT_USERPWD] = $username.':'.$password;
-                    break;
-                default:
-                    throw new InvalidArgumentException(\sprintf('Unsupported auth type "%s"', $type));
-            }
         }
 
         if (isset($options['query'])) {

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -721,11 +721,6 @@ final class StreamHandler
 
         $this->addDefaultTlsMinimum($request, $context);
 
-        // Microsoft NTLM authentication only supported with curl handler
-        if (isset($options['auth'][2]) && 'ntlm' === $options['auth'][2]) {
-            throw new InvalidArgumentException('Microsoft NTLM authentication only supported with curl handler');
-        }
-
         $uri = $this->resolveHost($request, $options);
 
         $contextResource = $this->createResource(
@@ -897,13 +892,8 @@ final class StreamHandler
             \array_key_exists('curl', $options)
             && $options['curl'] !== null
             && $options['curl'] !== []
-            && !self::isCurlOptionGeneratedByAuth($options)
         ) {
             throw new InvalidArgumentException('Passing the "curl" request option to the stream handler is not supported because the stream handler ignores cURL options.');
-        }
-
-        if (self::usesDigestAuth($options)) {
-            throw new InvalidArgumentException('Digest authentication is not supported by the stream handler because it is only supported by cURL handlers.');
         }
 
         if (\array_key_exists('expect', $options) && $options['expect'] !== false && $request->hasHeader('Expect')) {
@@ -1064,38 +1054,6 @@ final class StreamHandler
         if ($this->transportSharingMode === TransportSharing::HANDLER_REQUIRE) {
             throw new InvalidArgumentException('The "transport_sharing" option requires transport sharing, but the stream handler does not support it.');
         }
-    }
-
-    private static function isCurlOptionGeneratedByAuth(array $options): bool
-    {
-        if (!isset($options['curl']) || !\is_array($options['curl']) || !isset($options['auth'][2]) || !\is_string($options['auth'][2])) {
-            return false;
-        }
-
-        if (!\defined('CURLOPT_HTTPAUTH') || !\defined('CURLOPT_USERPWD')) {
-            return false;
-        }
-
-        $type = \strtolower($options['auth'][2]);
-        if ($type === 'digest') {
-            $httpAuth = \defined('CURLAUTH_DIGEST') ? \constant('CURLAUTH_DIGEST') : null;
-        } elseif ($type === 'ntlm') {
-            $httpAuth = \defined('CURLAUTH_NTLM') ? \constant('CURLAUTH_NTLM') : null;
-        } else {
-            return false;
-        }
-
-        return $httpAuth !== null
-            && \count($options['curl']) === 2
-            && isset($options['curl'][\CURLOPT_HTTPAUTH], $options['curl'][\CURLOPT_USERPWD])
-            && $options['curl'][\CURLOPT_HTTPAUTH] === $httpAuth;
-    }
-
-    private static function usesDigestAuth(array $options): bool
-    {
-        return isset($options['auth'][2])
-            && \is_string($options['auth'][2])
-            && \strtolower($options['auth'][2]) === 'digest';
     }
 
     /**

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -38,8 +38,8 @@ class HandlerStack
      *
      * The returned handler will wrap the provided handler or use the most
      * appropriate default handler for your system. The returned HandlerStack has
-     * support for cookies, redirects, HTTP error exceptions, and preparing a body
-     * before sending.
+     * support for authentication, cookies, redirects, HTTP error exceptions,
+     * and preparing a body before sending.
      *
      * The returned handler stack can be passed to a client in the "handler"
      * option.
@@ -55,6 +55,7 @@ class HandlerStack
         $stack = new self($handler ?: Utils::chooseHandler());
         $stack->push(Middleware::httpErrors(), 'http_errors');
         $stack->push(Middleware::redirect(), 'allow_redirects');
+        $stack->push(Middleware::auth(), 'auth');
         $stack->push(Middleware::cookies(), 'cookies');
         $stack->push(Middleware::prepareBody(), 'prepare_body');
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -23,6 +23,19 @@ final class Middleware
     }
 
     /**
+     * Middleware that applies built-in Basic authentication and handles Digest
+     * authentication challenges when the "auth" request option is set.
+     *
+     * @return callable((callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)): (callable(RequestInterface, array<array-key, mixed>): PromiseInterface<ResponseInterface, mixed>)
+     */
+    public static function auth(): callable
+    {
+        return static function (callable $handler): AuthMiddleware {
+            return new AuthMiddleware($handler);
+        };
+    }
+
+    /**
      * Middleware that adds cookies to requests.
      *
      * The options array must be set to a CookieJarInterface in order to use

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -99,9 +99,9 @@ class RedirectMiddleware
 
         // Remove HTTP origin credentials if URI is cross-origin.
         if (Psr7\UriComparator::isCrossOrigin($request->getUri(), $nextRequest->getUri())) {
-            unset($options['auth']);
+            unset($options['auth'], $options['__guzzle_digest_retries']);
 
-            if (defined('\CURLOPT_HTTPAUTH')) {
+            if (defined('\CURLOPT_HTTPAUTH') && defined('\CURLOPT_USERPWD')) {
                 unset(
                     $options['curl'][\CURLOPT_HTTPAUTH],
                     $options['curl'][\CURLOPT_USERPWD]

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -53,7 +53,9 @@ final class RequestOptions
      * The array must contain the username in index [0], the password in index
      * [1], and you can optionally provide a built-in authentication type in
      * index [2]. Pass false or null to disable authentication for a request.
-     * String values are passed through for custom handlers.
+     * Built-in Basic and Digest authentication are applied by the auth
+     * middleware, normally from HandlerStack::create(). String values are
+     * passed through for custom handlers.
      */
     public const AUTH = 'auth';
 

--- a/tests/Auth/DigestAuthTest.php
+++ b/tests/Auth/DigestAuthTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Auth;
+
+use GuzzleHttp\Auth\DigestAuth;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class DigestAuthTest extends TestCase
+{
+    /**
+     * @dataProvider algorithmProvider
+     */
+    public function testGeneratesDigestAuthorizationHeader(string $algorithm, string $hashAlgorithm, string $expectedResponse): void
+    {
+        if (!\in_array($hashAlgorithm, \hash_algos(), true)) {
+            self::markTestSkipped(\sprintf('Hash algorithm for %s is not available.', $algorithm));
+        }
+
+        $challenge = DigestAuth::selectChallenge(new Response(401, [
+            'WWW-Authenticate' => \sprintf(
+                'Digest realm="testrealm@host.com", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", qop="auth", algorithm=%s',
+                $algorithm
+            ),
+        ]));
+
+        self::assertNotNull($challenge);
+
+        $header = DigestAuth::authorizationHeader(
+            new Request('GET', 'http://example.com/dir/index.html'),
+            $challenge,
+            'Mufasa',
+            'Circle Of Life',
+            '0a4f113b'
+        );
+
+        self::assertNotNull($header);
+        self::assertStringContainsString('response="'.$expectedResponse.'"', $header);
+        self::assertStringContainsString('qop=auth', $header);
+        self::assertStringContainsString('nc=00000001', $header);
+        self::assertStringContainsString('cnonce="0a4f113b"', $header);
+    }
+
+    public static function algorithmProvider(): iterable
+    {
+        yield 'MD5' => ['MD5', 'md5', '6629fae49393a05397450978507c4ef1'];
+        yield 'MD5-sess' => ['MD5-sess', 'md5', '8e3825c57e897f5a0dec6c2d4e5059d0'];
+        yield 'SHA-256' => ['SHA-256', 'sha256', '5abdd07184ba512a22c53f41470e5eea7dcaa3a93a59b630c13dfe0a5dc6e38b'];
+        yield 'SHA-256-sess' => ['SHA-256-sess', 'sha256', 'b8822e12417cb7750f4e2b8515f0dcf25b7dd26993e80bee1426201446a7f59b'];
+        yield 'SHA-512-256' => ['SHA-512-256', 'sha512/256', 'f23c08ec7334a881f8286e68450ddbd9f0cd91c41481f0e1433604da8113c6dc'];
+        yield 'SHA-512-256-sess' => ['SHA-512-256-sess', 'sha512/256', '0d21f0db3ec5cda5b850c0afa3bc29b4a3c5a6191959ff1baf511d4b38eb6b1e'];
+    }
+
+    public function testGeneratesLegacyDigestAuthorizationHeaderWithoutQop(): void
+    {
+        $challenge = DigestAuth::selectChallenge(new Response(401, [
+            'WWW-Authenticate' => 'Digest realm="testrealm@host.com", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093"',
+        ]));
+
+        self::assertNotNull($challenge);
+
+        $header = DigestAuth::authorizationHeader(
+            new Request('GET', 'http://example.com/dir/index.html'),
+            $challenge,
+            'Mufasa',
+            'Circle Of Life',
+            '0a4f113b'
+        );
+
+        self::assertNotNull($header);
+        self::assertStringContainsString('response="670fd8c2df070c60b045671b8b24ff02"', $header);
+        self::assertStringNotContainsString('qop=', $header);
+        self::assertStringNotContainsString('nc=', $header);
+        self::assertStringNotContainsString('cnonce=', $header);
+    }
+
+    public function testParsesQuotedCommasAndEscapes(): void
+    {
+        $challenge = DigestAuth::selectChallenge(new Response(401, [
+            'WWW-Authenticate' => 'Basic realm="basic", Digest realm="a,b\"c", nonce="n", qop="auth,auth-int"',
+        ]));
+
+        self::assertNotNull($challenge);
+        self::assertSame('a,b"c', $challenge->realm);
+        self::assertSame('auth', $challenge->qop);
+    }
+
+    public function testSkipsInvalidChallengeAndUsesLaterValidChallenge(): void
+    {
+        $challenge = DigestAuth::selectChallenge(new Response(401, [
+            'WWW-Authenticate' => 'Digest realm="bad", nonce="one", nonce="two", Digest realm="good", nonce="three"',
+        ]));
+
+        self::assertNotNull($challenge);
+        self::assertSame('good', $challenge->realm);
+        self::assertSame('three', $challenge->nonce);
+    }
+
+    public function testAuthIntOnlyChallengeIsUnsupported(): void
+    {
+        $challenge = DigestAuth::selectChallenge(new Response(401, [
+            'WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth-int"',
+        ]));
+
+        self::assertNull($challenge);
+    }
+}

--- a/tests/AuthMiddlewareTest.php
+++ b/tests/AuthMiddlewareTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests;
+
+use GuzzleHttp\AuthMiddleware;
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class AuthMiddlewareTest extends TestCase
+{
+    /**
+     * @dataProvider basicAuthProvider
+     */
+    public function testAppliesBasicAuth(array $auth): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $client->get('http://example.com', ['auth' => $auth]);
+
+        self::assertSame('Basic YTpi', $mock->getLastRequest()->getHeaderLine('Authorization'));
+        self::assertArrayNotHasKey('auth', $mock->getLastOptions());
+    }
+
+    public static function basicAuthProvider(): iterable
+    {
+        yield 'implicit' => [['a', 'b']];
+        yield 'explicit' => [['a', 'b', 'basic']];
+        yield 'mixed case' => [['a', 'b', 'BaSiC']];
+        yield 'null type' => [['a', 'b', null]];
+    }
+
+    public function testBasicAuthReplacesExistingAuthorizationHeader(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $client->get('http://example.com', [
+            'auth' => ['a', 'b'],
+            'headers' => ['authorization' => 'Bearer token'],
+        ]);
+
+        self::assertSame('Basic YTpi', $mock->getLastRequest()->getHeaderLine('Authorization'));
+    }
+
+    public function testCustomAuthStringPassesThrough(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $client->get('http://example.com', ['auth' => 'custom']);
+
+        self::assertFalse($mock->getLastRequest()->hasHeader('Authorization'));
+        self::assertSame('custom', $mock->getLastOptions()['auth']);
+    }
+
+    public function testHandlesDigestChallenge(): void
+    {
+        $requests = [];
+        $mock = new MockHandler([
+            static function (RequestInterface $request) use (&$requests): ResponseInterface {
+                $requests[] = $request;
+
+                return new Response(401, [
+                    'WWW-Authenticate' => 'Digest realm="testrealm@host.com", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", qop="auth"',
+                ]);
+            },
+            static function (RequestInterface $request) use (&$requests): ResponseInterface {
+                $requests[] = $request;
+
+                return new Response(200);
+            },
+        ]);
+        $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+        $response = $client->get('http://example.com/dir/index.html', [
+            'auth' => ['Mufasa', 'Circle Of Life', 'digest'],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(2, $requests);
+        self::assertFalse($requests[0]->hasHeader('Authorization'));
+        self::assertStringContainsString('Digest ', $requests[1]->getHeaderLine('Authorization'));
+        self::assertStringContainsString('response="6629fae49393a05397450978507c4ef1"', $requests[1]->getHeaderLine('Authorization'));
+    }
+
+    public function testDigestAuthIntOnlyChallengeDoesNotRetry(): void
+    {
+        $mock = new MockHandler([
+            new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth-int"']),
+            new Response(200),
+        ]);
+        $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+        $response = $client->get('http://example.com', [
+            'auth' => ['a', 'b', 'digest'],
+            'http_errors' => false,
+        ]);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertCount(1, $mock);
+    }
+
+    public function testDigestStaleChallengeRetriesOnceMore(): void
+    {
+        $requests = [];
+        $mock = new MockHandler([
+            static function (RequestInterface $request) use (&$requests): ResponseInterface {
+                $requests[] = $request;
+
+                return new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="one", qop="auth"']);
+            },
+            static function (RequestInterface $request) use (&$requests): ResponseInterface {
+                $requests[] = $request;
+
+                return new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="two", qop="auth", stale=true']);
+            },
+            static function (RequestInterface $request) use (&$requests): ResponseInterface {
+                $requests[] = $request;
+
+                return new Response(200);
+            },
+        ]);
+        $cnonces = ['first', 'second'];
+        $client = new Client(['handler' => self::handlerWithAuth($mock, static function () use (&$cnonces): string {
+            return (string) \array_shift($cnonces);
+        })]);
+
+        $response = $client->get('http://example.com', ['auth' => ['a', 'b', 'digest']]);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertCount(3, $requests);
+        self::assertStringContainsString('nonce="one"', $requests[1]->getHeaderLine('Authorization'));
+        self::assertStringContainsString('nonce="two"', $requests[2]->getHeaderLine('Authorization'));
+    }
+
+    public function testDigestBodyRewindFailureRejects(): void
+    {
+        $previous = new \RuntimeException('cannot rewind');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            'tell' => static function (): int {
+                return 4;
+            },
+            'rewind' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+        $mock = new MockHandler([
+            new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth"']),
+        ]);
+        $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+        try {
+            $client->send(new Request('POST', 'http://example.com', [], $body), ['auth' => ['a', 'b', 'digest']]);
+            self::fail('Expected ResponseException.');
+        } catch (ResponseException $e) {
+            self::assertSame('Digest authentication failed because the request body could not be rewound', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        }
+    }
+
+    public function testDigestDoesNotWriteChallengeBodyToUserSink(): void
+    {
+        $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
+        self::assertIsString($sink);
+
+        try {
+            $mock = new MockHandler([
+                new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth"'], 'challenge'),
+                new Response(200, [], 'ok'),
+            ]);
+            $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+            $client->get('http://example.com', [
+                'auth' => ['a', 'b', 'digest'],
+                'sink' => $sink,
+            ]);
+
+            self::assertSame('ok', \file_get_contents($sink));
+        } finally {
+            if (\file_exists($sink)) {
+                \unlink($sink);
+            }
+        }
+    }
+
+    public function testCookiesFromDigestChallengeAreSentOnRetry(): void
+    {
+        $mock = new MockHandler([
+            new Response(401, [
+                'WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth"',
+                'Set-Cookie' => 'foo=bar; Domain=example.com',
+            ]),
+            static function (RequestInterface $request): ResponseInterface {
+                self::assertSame('foo=bar', $request->getHeaderLine('Cookie'));
+
+                return new Response(200);
+            },
+        ]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+
+        $response = $client->get('http://example.com', [
+            'auth' => ['a', 'b', 'digest'],
+            'cookies' => new CookieJar(),
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * @param (callable(): string)|null $cnonceGenerator
+     */
+    private static function handlerWithAuth(MockHandler $mock, ?callable $cnonceGenerator = null): HandlerStack
+    {
+        $stack = new HandlerStack($mock);
+        $stack->push(static function (callable $handler) use ($cnonceGenerator): AuthMiddleware {
+            return new AuthMiddleware($handler, $cnonceGenerator ?? static function (): string {
+                return '0a4f113b';
+            });
+        }, 'auth');
+
+        return $stack;
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1771,7 +1771,7 @@ class ClientTest extends TestCase
     public function testAuthCanBeArrayForBasicAuth(): void
     {
         $mock = new MockHandler([new Response()]);
-        $client = new Client(['handler' => $mock]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
         $client->get('http://foo.com', ['auth' => ['a', 'b']]);
         $last = $mock->getLastRequest();
         self::assertSame('Basic YTpi', $last->getHeaderLine('Authorization'));
@@ -1780,7 +1780,7 @@ class ClientTest extends TestCase
     public function testAuthCanBeArrayForExplicitBasicAuth(): void
     {
         $mock = new MockHandler([new Response()]);
-        $client = new Client(['handler' => $mock]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
         $client->get('http://foo.com', ['auth' => ['a', 'b', 'basic']]);
 
         $last = $mock->getLastRequest();
@@ -1790,7 +1790,7 @@ class ClientTest extends TestCase
     public function testAuthCanUseNullTypeForDefaultBasicAuth(): void
     {
         $mock = new MockHandler([new Response()]);
-        $client = new Client(['handler' => $mock]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
         $client->get('http://foo.com', ['auth' => ['a', 'b', null]]);
 
         $last = $mock->getLastRequest();
@@ -1803,22 +1803,29 @@ class ClientTest extends TestCase
         $client = new Client(['handler' => $mock]);
         $client->get('http://foo.com', ['auth' => ['a', 'b', 'digest']]);
         $last = $mock->getLastOptions();
-        self::assertSame([
-            \CURLOPT_HTTPAUTH => 2,
-            \CURLOPT_USERPWD => 'a:b',
-        ], $last['curl']);
+        self::assertSame(['a', 'b', 'digest'], $last['auth']);
+        self::assertArrayNotHasKey('curl', $last);
     }
 
-    public function testAuthCanBeArrayForNtlmAuth(): void
+    public function testUnknownArrayAuthTypePassesThroughForCustomMiddleware(): void
     {
         $mock = new MockHandler([new Response()]);
-        $client = new Client(['handler' => $mock]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
+        $client->get('http://foo.com', ['auth' => ['a', 'b', 'custom']]);
+
+        self::assertSame(['a', 'b', 'custom'], $mock->getLastOptions()['auth']);
+        self::assertFalse($mock->getLastRequest()->hasHeader('Authorization'));
+    }
+
+    public function testLegacyNtlmAuthTypePassesThroughForCustomMiddleware(): void
+    {
+        $mock = new MockHandler([new Response()]);
+        $client = new Client(['handler' => HandlerStack::create($mock)]);
         $client->get('http://foo.com', ['auth' => ['a', 'b', 'ntlm']]);
-        $last = $mock->getLastOptions();
-        self::assertSame([
-            \CURLOPT_HTTPAUTH => 8,
-            \CURLOPT_USERPWD => 'a:b',
-        ], $last['curl']);
+
+        self::assertSame(['a', 'b', 'ntlm'], $mock->getLastOptions()['auth']);
+        self::assertFalse($mock->getLastRequest()->hasHeader('Authorization'));
+        self::assertArrayNotHasKey('curl', $mock->getLastOptions());
     }
 
     /**
@@ -1843,7 +1850,6 @@ class ClientTest extends TestCase
             [['user', ['pass']]],
             [['user', 'pass', 1]],
             [['user', 'pass', []]],
-            [['user', 'pass', 'unknown']],
         ];
     }
 

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -2600,16 +2600,19 @@ class StreamHandlerTest extends TestCase
         ]);
     }
 
-    public function testStreamRejectsDigestAuth(): void
+    public function testStreamHandlerDoesNotRejectDigestAuthOption(): void
     {
+        Server::flush();
+        Server::enqueue([new Response(200)]);
+
         $handler = new StreamHandler();
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Digest authentication');
-
-        $handler(new Request('GET', Server::$url), [
+        $response = $handler(new Request('GET', Server::$url), [
             'auth' => ['user', 'pass', 'digest'],
-        ]);
+        ])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertFalse(Server::received()[0]->hasHeader('Authorization'));
     }
 
     public function testStreamRejectsExpectOptionWhenHeaderIsPresent(): void

--- a/tests/HandlerStackTest.php
+++ b/tests/HandlerStackTest.php
@@ -219,6 +219,18 @@ class HandlerStackTest extends TestCase
         self::assertSame('foo=bar', $lastRequest->getHeaderLine('Cookie'));
     }
 
+    public function testDefaultStackIncludesAuthMiddlewareInOrder(): void
+    {
+        $stack = HandlerStack::create(new MockHandler([new Response()]));
+        $lines = \explode("\n", (string) $stack);
+
+        self::assertStringContainsString("< 1) Name: 'prepare_body'", $lines[6]);
+        self::assertStringContainsString("< 2) Name: 'cookies'", $lines[7]);
+        self::assertStringContainsString("< 3) Name: 'auth'", $lines[8]);
+        self::assertStringContainsString("< 4) Name: 'allow_redirects'", $lines[9]);
+        self::assertStringContainsString("< 5) Name: 'http_errors'", $lines[10]);
+    }
+
     /**
      * @return array{0: array<int, array{string, string}>, 1: callable, 2: callable, 3: callable, 4: callable}
      */

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -632,13 +632,9 @@ class RedirectMiddlewareTest extends TestCase
         self::assertTrue($call);
     }
 
-    /**
-     * @testWith ["digest"]
-     *           ["ntlm"]
-     */
-    public function testRemoveCurlAuthorizationOptionsOnRedirectCrossHost(string $auth): void
+    public function testRemoveCurlAuthorizationOptionsOnRedirectCrossHost(): void
     {
-        if (!defined('\CURLOPT_HTTPAUTH')) {
+        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_USERPWD') || !defined('\CURLAUTH_NTLM')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -659,16 +655,12 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('http://example.com?a=b', ['curl' => self::curlNtlmAuthOptions()]);
     }
 
-    /**
-     * @testWith ["digest"]
-     *           ["ntlm"]
-     */
-    public function testRemoveCurlAuthorizationOptionsOnRedirectCrossPort(string $auth): void
+    public function testRemoveCurlAuthorizationOptionsOnRedirectCrossPort(): void
     {
-        if (!defined('\CURLOPT_HTTPAUTH')) {
+        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_USERPWD') || !defined('\CURLAUTH_NTLM')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -689,16 +681,12 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('http://example.com?a=b', ['curl' => self::curlNtlmAuthOptions()]);
     }
 
-    /**
-     * @testWith ["digest"]
-     *           ["ntlm"]
-     */
-    public function testRemoveCurlAuthorizationOptionsOnRedirectCrossScheme(string $auth): void
+    public function testRemoveCurlAuthorizationOptionsOnRedirectCrossScheme(): void
     {
-        if (!defined('\CURLOPT_HTTPAUTH')) {
+        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_USERPWD') || !defined('\CURLAUTH_NTLM')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -719,16 +707,12 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('https://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('https://example.com?a=b', ['curl' => self::curlNtlmAuthOptions()]);
     }
 
-    /**
-     * @testWith ["digest"]
-     *           ["ntlm"]
-     */
-    public function testRemoveCurlAuthorizationOptionsOnRedirectCrossSchemeSamePort(string $auth): void
+    public function testRemoveCurlAuthorizationOptionsOnRedirectCrossSchemeSamePort(): void
     {
-        if (!defined('\CURLOPT_HTTPAUTH')) {
+        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_USERPWD') || !defined('\CURLAUTH_NTLM')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -749,16 +733,12 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('https://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('https://example.com?a=b', ['curl' => self::curlNtlmAuthOptions()]);
     }
 
-    /**
-     * @testWith ["digest"]
-     *           ["ntlm"]
-     */
-    public function testNotRemoveCurlAuthorizationOptionsOnRedirect(string $auth): void
+    public function testNotRemoveCurlAuthorizationOptionsOnRedirect(): void
     {
-        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_USERPWD')) {
+        if (!defined('\CURLOPT_HTTPAUTH') || !defined('\CURLOPT_USERPWD') || !defined('\CURLAUTH_NTLM')) {
             self::markTestSkipped('ext-curl is required for this test');
         }
 
@@ -779,7 +759,15 @@ class RedirectMiddlewareTest extends TestCase
         ]);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        $client->get('http://example.com?a=b', ['auth' => ['testuser', 'testpass', $auth]]);
+        $client->get('http://example.com?a=b', ['curl' => self::curlNtlmAuthOptions()]);
+    }
+
+    private static function curlNtlmAuthOptions(): array
+    {
+        return [
+            \CURLOPT_HTTPAUTH => \CURLAUTH_NTLM,
+            \CURLOPT_USERPWD => 'testuser:testpass',
+        ];
     }
 
     /**
@@ -787,7 +775,7 @@ class RedirectMiddlewareTest extends TestCase
      */
     public function testAuthOptionTreatmentOnRedirect(string $originalUri, string $targetUri, bool $isCrossOrigin): void
     {
-        $auth = ['testuser', 'testpass'];
+        $auth = 'custom';
 
         $mock = new MockHandler([
             new Response(302, ['Location' => $targetUri]),


### PR DESCRIPTION
This moves built-in Basic and Digest authentication out of client request construction and into Guzzle's default auth middleware, so Digest is no longer implemented through cURL-specific authentication options. Basic and Digest continue to work for clients using the default handler stack, while custom stacks can opt in with Middleware::auth(). Unknown auth type strings remain available for custom middleware or handlers, and legacy NTLM is no longer a built-in auth type.