### PR TITLE
Align auth deprecations with Guzzle 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated the request-level `handler` option, which will be ignored in 8.0
 - Deprecated raw cURL request options outside the built-in cURL handlers' allow-list
 - Deprecated PHP stream context options outside the built-in stream handler allow-list
+- Deprecated passing `ntlm` as a built-in `auth` type
 
 
 ## 7.11.1 - 2026-06-07

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -163,7 +163,7 @@ $client->request('GET', '/get', [
 ```
 
 > [!NOTE]
-> This is currently only supported when using the cURL handler.
+> This is currently only supported when using the cURL handler. The `ntlm` auth type is deprecated. Configure NTLM with cURL HTTP authentication options instead.
 
 ## body
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -908,6 +908,11 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     $options['curl'][\CURLOPT_USERPWD] = "$value[0]:$value[1]";
                     break;
                 case 'ntlm':
+                    \trigger_deprecation(
+                        'guzzlehttp/guzzle',
+                        '7.12',
+                        'Passing "ntlm" as the built-in auth type is deprecated; guzzlehttp/guzzle 8.0 will no longer apply NTLM through the "auth" request option. Configure NTLM with cURL HTTP authentication options instead.'
+                    );
                     $options['curl'][\CURLOPT_HTTPAUTH] = \CURLAUTH_NTLM;
                     $options['curl'][\CURLOPT_USERPWD] = "$value[0]:$value[1]";
                     break;

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -506,10 +506,6 @@ class StreamHandler
             \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "curl" request option to the stream handler is deprecated; guzzlehttp/guzzle 8.0 will reject this option because the stream handler ignores cURL options.');
         }
 
-        if (self::usesDigestAuth($options)) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing digest authentication to the stream handler is deprecated; guzzlehttp/guzzle 8.0 will reject digest authentication with the stream handler because it is only supported by cURL handlers.');
-        }
-
         if (\array_key_exists('expect', $options) && $options['expect'] !== false && $request->hasHeader('Expect')) {
             \trigger_deprecation('guzzlehttp/guzzle', '7.11', 'Passing the "expect" request option to the stream handler is deprecated when it adds an Expect header; guzzlehttp/guzzle 8.0 will reject this option because the stream handler does not support Expect: 100-Continue.');
         }
@@ -696,13 +692,6 @@ class StreamHandler
             && \count($options['curl']) === 2
             && isset($options['curl'][\CURLOPT_HTTPAUTH], $options['curl'][\CURLOPT_USERPWD])
             && $options['curl'][\CURLOPT_HTTPAUTH] === $httpAuth;
-    }
-
-    private static function usesDigestAuth(array $options): bool
-    {
-        return isset($options['auth'][2])
-            && \is_string($options['auth'][2])
-            && \strtolower($options['auth'][2]) === 'digest';
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -641,18 +641,6 @@ class ClientTest extends TestCase
         ], $last['curl']);
     }
 
-    public function testAuthCanBeArrayForNtlmAuth()
-    {
-        $mock = new MockHandler([new Response()]);
-        $client = new Client(['handler' => $mock]);
-        $client->get('http://foo.com', ['auth' => ['a', 'b', 'ntlm']]);
-        $last = $mock->getLastOptions();
-        self::assertSame([
-            \CURLOPT_HTTPAUTH => 8,
-            \CURLOPT_USERPWD => 'a:b',
-        ], $last['curl']);
-    }
-
     public function testCanAddFormParams()
     {
         $mock = new MockHandler([new Response()]);

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -296,7 +296,6 @@ class RedirectMiddlewareTest extends TestCase
 
     /**
      * @testWith ["digest"]
-     *           ["ntlm"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossHost($auth)
     {
@@ -326,7 +325,6 @@ class RedirectMiddlewareTest extends TestCase
 
     /**
      * @testWith ["digest"]
-     *           ["ntlm"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossPort($auth)
     {
@@ -356,7 +354,6 @@ class RedirectMiddlewareTest extends TestCase
 
     /**
      * @testWith ["digest"]
-     *           ["ntlm"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossScheme($auth)
     {
@@ -386,7 +383,6 @@ class RedirectMiddlewareTest extends TestCase
 
     /**
      * @testWith ["digest"]
-     *           ["ntlm"]
      */
     public function testRemoveCurlAuthorizationOptionsOnRedirectCrossSchemeSamePort($auth)
     {
@@ -416,7 +412,6 @@ class RedirectMiddlewareTest extends TestCase
 
     /**
      * @testWith ["digest"]
-     *           ["ntlm"]
      */
     public function testNotRemoveCurlAuthorizationOptionsOnRedirect($auth)
     {


### PR DESCRIPTION
This updates the 7.12 auth migration path by deprecating first-class NTLM through the auth request option and pointing users to cURL HTTP authentication options instead. It also removes the stream-handler Digest deprecation because Digest authentication is no longer planned to be rejected by the stream handler in Guzzle 8.