### PR TITLE
Fix Digest auth middleware edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,9 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Support retry delay callbacks with retry count only or full retry context
 - Treat only `null` as an omitted path or name when clearing cookies
 - Validate malformed `auth` request option arrays
-- Stop forwarding the generic `auth` request option when following cross-origin redirects
 - Move built-in Basic and Digest authentication handling to the default auth middleware
-- Stop implementing Digest authentication through cURL HTTP authentication options
 - Remove first-class NTLM authentication from the `auth` request option
+- Stop forwarding the generic `auth` request option when following cross-origin redirects
 - Reject invalid `HandlerStack::remove()` arguments
 - Require `Pool` request collections to be iterable
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -95,10 +95,11 @@ decimal length or omit it and let Guzzle prepare the body headers.
 #### Auth Request Option Changes
 
 Digest authentication is no longer implemented with cURL `CURLOPT_HTTPAUTH` and
-`CURLOPT_USERPWD`. Guzzle supports legacy Digest challenges without `qop` and
-challenges with `qop=auth`; `auth-int` is not supported. Legacy NTLM
-authentication is no longer a built-in `auth` type. If NTLM is still required,
-configure cURL HTTP authentication options directly with a cURL handler:
+`CURLOPT_USERPWD`. Guzzle supports legacy non-session Digest challenges without
+`qop` and challenges with `qop=auth`; session algorithms require `qop`.
+`auth-int` is not supported. Legacy NTLM authentication is no longer a built-in
+`auth` type. If NTLM is still required, configure cURL HTTP authentication
+options directly with a cURL handler:
 
 ```php
 $client->request('GET', '/', [

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -97,9 +97,11 @@ decimal length or omit it and let Guzzle prepare the body headers.
 Digest authentication is no longer implemented with cURL `CURLOPT_HTTPAUTH` and
 `CURLOPT_USERPWD`. Guzzle supports legacy non-session Digest challenges without
 `qop` and challenges with `qop=auth`; session algorithms require `qop`.
-`auth-int` is not supported. Legacy NTLM authentication is no longer a built-in
-`auth` type. If NTLM is still required, configure cURL HTTP authentication
-options directly with a cURL handler:
+`auth-int` is not supported. To use libcurl's native Digest implementation
+instead, omit `auth` and configure cURL options directly with a cURL handler,
+including `CURLOPT_HTTPAUTH => CURLAUTH_DIGEST` and `CURLOPT_USERPWD`. The same
+direct cURL configuration is required for legacy NTLM, which is no longer a
+built-in `auth` type:
 
 ```php
 $client->request('GET', '/', [
@@ -116,8 +118,8 @@ they are now applied by the default auth middleware instead of while the client
 constructs the request. If you pass a raw custom handler directly to `Client`,
 remove default middleware, or build a handler stack manually, Basic and Digest
 authentication will only be applied when your stack includes
-`Middleware::auth()`. Unknown auth type strings are left in the request options
-for custom middleware or custom handlers.
+`GuzzleHttp\Middleware::auth()`. Unknown auth type strings are left in the
+request options for custom middleware or custom handlers.
 
 Guzzle also validates non-empty auth arrays before applying them: indexes `0`
 and `1` must be username and password strings, and index `2`, when present, must
@@ -213,7 +215,9 @@ response object is available. `ResponseTransferException` is used for
 transfer-level failures after headers, including response-aware network,
 protocol, content-decoding, partial-body, and response-body transfer failures.
 `BadResponseException` and `TooManyRedirectsException` also extend
-`ResponseException`.
+`ResponseException`; custom subclasses of those existing classes, or of
+`ClientException` and `ServerException`, must not override the now-final
+`ResponseException::__construct()`.
 
 Only this branch exposes response access: `RequestException` no longer stores
 responses, no longer accepts a response constructor argument, and no longer has
@@ -235,9 +239,7 @@ timeouts. Reading the request body stream, including size detection,
 stringification, rewind, and upload reads, is a `RequestException` before a
 response and a `ResponseException` after response headers. A slow response
 `sink` write is a `ResponseException` once a response exists, or a
-`RequestException` otherwise. Whenever the timeout comes from a PSR-7 stream,
-the original `GuzzleHttp\Psr7\Exception\TimeoutException` is available via
-`getPrevious()`.
+`RequestException` otherwise.
 
 If a handler throws `Error`, `TypeError`, or another non-`Exception` `Throwable`
 before returning a promise, `Client::sendAsync()` returns a rejected promise.

--- a/docs/contributing/exception-guidelines.md
+++ b/docs/contributing/exception-guidelines.md
@@ -62,8 +62,7 @@ stream send/connect timeout message. A timeout surfaced as a PSR-7
 `TimeoutException` from a caller stream is classified like any other failure of
 that stream: `RequestException` while reading the request body before a response,
 or `ResponseException` once a response exists. It is never a
-`NetworkTimeoutException`. The original `TimeoutException` is attached via
-`getPrevious()`.
+`NetworkTimeoutException`.
 
 Note: `ResponseException` extends `RequestException`, so it (and every subtype,
 including `ResponseTransferException` and `ResponseTimeoutException`) is a PSR-18

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -152,7 +152,7 @@ $client->request('GET', '/get', [
 ]);
 ```
 
-Supported Digest algorithms are `MD5`, `MD5-sess`, `SHA-256`, `SHA-256-sess`, and the `SHA-512-256` variants when PHP supports the `sha512/256` hash algorithm. Guzzle supports legacy challenges without `qop` and challenges with `qop=auth`. `auth-int` is not supported.
+Supported Digest algorithms are `MD5`, `MD5-sess`, `SHA-256`, `SHA-256-sess`, and the `SHA-512-256` variants when PHP supports the `sha512/256` hash algorithm. Guzzle supports legacy non-session challenges without `qop` and challenges with `qop=auth`. Session algorithms require `qop`. `auth-int` is not supported.
 
 Legacy NTLM authentication is no longer a built-in `auth` type. If it is required, configure the built-in cURL handler directly with cURL HTTP authentication options.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -120,7 +120,7 @@ If TLS client credentials are only trusted for the original origin, disable auto
 Summary
 Pass HTTP authentication parameters to use with the request. An array must contain the username in index `[0]`, the password in index `[1]`, and can optionally provide a built-in authentication type in index `[2]`. Pass `false` or `null` to disable authentication for a request. String values are passed through for custom handlers.
 
-Built-in Basic and Digest authentication are applied by `GuzzleHttp\Middleware::auth`, which is included by default when using `GuzzleHttp\HandlerStack::create()` or when the client creates its default handler. Raw custom handlers must be wrapped in `HandlerStack::create($handler)` or explicitly include `Middleware::auth()` to use built-in Basic or Digest authentication. Unrecognized array auth types are left in the request options for custom middleware or custom handlers.
+Built-in Basic and Digest authentication are applied by `GuzzleHttp\Middleware::auth()`, which is included by default when using `GuzzleHttp\HandlerStack::create()` or when the client creates its default handler. Raw custom handlers must be wrapped in `GuzzleHttp\HandlerStack::create($handler)` or explicitly include `GuzzleHttp\Middleware::auth()` to use built-in Basic or Digest authentication. Unrecognized array auth types are left in the request options for custom middleware or custom handlers.
 
 Types
 - array
@@ -154,7 +154,7 @@ $client->request('GET', '/get', [
 
 Supported Digest algorithms are `MD5`, `MD5-sess`, `SHA-256`, `SHA-256-sess`, and the `SHA-512-256` variants when PHP supports the `sha512/256` hash algorithm. Guzzle supports legacy non-session challenges without `qop` and challenges with `qop=auth`. Session algorithms require `qop`. `auth-int` is not supported.
 
-Legacy NTLM authentication is no longer a built-in `auth` type. If it is required, configure the built-in cURL handler directly with cURL HTTP authentication options.
+To use libcurl's native Digest implementation instead, omit `auth` and configure cURL options such as `CURLOPT_HTTPAUTH => CURLAUTH_DIGEST` and `CURLOPT_USERPWD` directly with a cURL handler. The same direct cURL configuration is required for legacy NTLM, which is no longer a built-in `auth` type.
 
 ```php
 $client->request('GET', '/get', [
@@ -1414,8 +1414,7 @@ Timeouts from caller-supplied PSR-7 streams are not transport timeouts. A reques
 body stream timeout while detecting size, buffering, rewinding, or reading upload
 bytes throws `GuzzleHttp\Exception\RequestException` before a response and
 `GuzzleHttp\Exception\ResponseException` after response headers. A slow response
-`sink` write also throws `ResponseException`. In every case the original
-`GuzzleHttp\Psr7\Exception\TimeoutException` is available via `getPrevious()`.
+`sink` write also throws `ResponseException`.
 
 Timeout detection is best-effort: it relies on the stream exposing PHP's
 `timed_out` metadata. The network socket Guzzle opens for the stream handler

--- a/src/Auth/DigestAuth.php
+++ b/src/Auth/DigestAuth.php
@@ -60,6 +60,10 @@ final class DigestAuth
         string $cnonce,
         string $nc = '00000001'
     ): ?string {
+        if ($challenge->algorithm['sess'] && $challenge->qop === null) {
+            return null;
+        }
+
         $uri = $request->getRequestTarget();
         if ($uri === '') {
             $uri = '/';
@@ -144,6 +148,16 @@ final class DigestAuth
 
             self::skipWhitespace($header, $offset, $length);
 
+            if (self::skipToken68Challenge($header, $offset, $length)) {
+                $challenges[] = [
+                    'scheme' => \strtolower($scheme),
+                    'params' => [],
+                    'invalid' => false,
+                ];
+
+                continue;
+            }
+
             $params = [];
             $invalid = false;
 
@@ -225,6 +239,10 @@ final class DigestAuth
             return null;
         }
 
+        if ($algorithm['sess'] && $qop === null) {
+            return null;
+        }
+
         $challenge = new DigestChallenge();
         $challenge->algorithm = $algorithm;
         $challenge->realm = $params['realm'] ?? '';
@@ -302,6 +320,35 @@ final class DigestAuth
         return $nextOffset >= $length || $header[$nextOffset] !== '=';
     }
 
+    private static function skipToken68Challenge(string $header, int &$offset, int $length): bool
+    {
+        $cursor = $offset;
+        $hasValue = false;
+        while ($cursor < $length && self::isToken68Char($header[$cursor])) {
+            $hasValue = true;
+            ++$cursor;
+        }
+
+        while ($cursor < $length && $header[$cursor] === '=') {
+            ++$cursor;
+        }
+
+        if (!$hasValue) {
+            return false;
+        }
+
+        $after = $cursor;
+        self::skipWhitespace($header, $after, $length);
+
+        if ($after < $length && $header[$after] !== ',') {
+            return false;
+        }
+
+        $offset = $after;
+
+        return true;
+    }
+
     private static function skipSeparators(string $header, int &$offset, int $length): void
     {
         while ($offset < $length) {
@@ -345,6 +392,11 @@ final class DigestAuth
     private static function isTokenChar(string $char): bool
     {
         return \strspn($char, "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz") === 1;
+    }
+
+    private static function isToken68Char(string $char): bool
+    {
+        return \strspn($char, '-._~+/0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz') === 1;
     }
 
     private static function readValue(string $header, int &$offset, int $length): ?string

--- a/src/AuthMiddleware.php
+++ b/src/AuthMiddleware.php
@@ -5,12 +5,21 @@ declare(strict_types=1);
 namespace GuzzleHttp;
 
 use GuzzleHttp\Auth\DigestAuth;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Exception\ResponseTransferException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Exception\TooManyRedirectsException;
+use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Applies built-in Basic authentication and handles Digest authentication challenges.
@@ -120,6 +129,9 @@ final class AuthMiddleware
         return ($this->nextHandler)($request->withoutHeader('Authorization'), $probeOptions)->then(
             function (ResponseInterface $response) use ($request, $options, $probeOptions, $username, $password) {
                 return $this->handleDigestResponse($request, $options, $probeOptions, $response, $username, $password);
+            },
+            static function ($reason) use ($probeOptions) {
+                return self::restoreOriginalSinkOnRejection($probeOptions, $reason);
             }
         );
     }
@@ -136,12 +148,12 @@ final class AuthMiddleware
         string $password
     ) {
         if ($response->getStatusCode() !== 401) {
-            return self::restoreOriginalSink($response, $probeOptions);
+            return self::restoreOriginalSink($request, $response, $probeOptions);
         }
 
         $challenge = DigestAuth::selectChallenge($response);
         if ($challenge === null) {
-            return self::restoreOriginalSink($response, $probeOptions);
+            return self::restoreOriginalSink($request, $response, $probeOptions);
         }
 
         $retries = $options['__guzzle_digest_retries'] ?? 0;
@@ -150,7 +162,7 @@ final class AuthMiddleware
         }
 
         if (($retries > 0 && !$challenge->stale) || $retries >= self::DIGEST_MAX_RETRIES) {
-            return self::restoreOriginalSink($response, $probeOptions);
+            return self::restoreOriginalSink($request, $response, $probeOptions);
         }
 
         try {
@@ -173,7 +185,7 @@ final class AuthMiddleware
         );
 
         if ($authorization === null) {
-            return self::restoreOriginalSink($response, $probeOptions);
+            return self::restoreOriginalSink($request, $response, $probeOptions);
         }
 
         $response->getBody()->close();
@@ -189,43 +201,157 @@ final class AuthMiddleware
         return ($this->nextHandler)($retryRequest, $downstreamOptions)->then(
             function (ResponseInterface $retryResponse) use ($retryRequest, $retryOptions, $downstreamOptions, $username, $password) {
                 return $this->handleDigestResponse($retryRequest, $retryOptions, $downstreamOptions, $retryResponse, $username, $password);
+            },
+            static function ($reason) use ($downstreamOptions) {
+                return self::restoreOriginalSinkOnRejection($downstreamOptions, $reason);
             }
         );
     }
 
     private static function withTemporarySink(array $options): array
     {
-        if (!empty($options['stream']) || !\array_key_exists('sink', $options)) {
+        if (!empty($options['stream']) || !isset($options[RequestOptions::SINK])) {
             return $options;
         }
 
-        $options['__guzzle_auth_original_sink'] = $options['sink'];
-        $options['sink'] = Psr7\Utils::tryFopen('php://temp', 'w+');
+        $streamFactory = self::requireStreamFactory(
+            $options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory()
+        );
+
+        $options['__guzzle_auth_original_sink'] = $options[RequestOptions::SINK];
+        $options[RequestOptions::SINK] = $streamFactory->createStreamFromResource(
+            Psr7\Utils::tryFopen('php://temp', 'w+')
+        );
 
         return $options;
     }
 
-    private static function restoreOriginalSink(ResponseInterface $response, array $options): ResponseInterface
-    {
+    private static function restoreOriginalSink(
+        RequestInterface $request,
+        ResponseInterface $response,
+        array $options
+    ): ResponseInterface {
         if (!\array_key_exists('__guzzle_auth_original_sink', $options)) {
             return $response;
         }
 
-        $source = $response->getBody();
-        if ($source->isSeekable()) {
-            $source->rewind();
+        try {
+            $source = $response->getBody();
+            if ($source->isSeekable()) {
+                $source->rewind();
+            }
+
+            $target = self::streamForOriginalSink($options['__guzzle_auth_original_sink']);
+
+            Psr7\Utils::copyToStream($source, $target);
+
+            if ($target->isSeekable()) {
+                $target->rewind();
+            }
+
+            return $response->withBody($target);
+        } catch (\Throwable $e) {
+            throw new ResponseException(
+                $e->getMessage() !== '' ? $e->getMessage() : 'Failed to write the response body',
+                $request,
+                $response,
+                $e
+            );
+        }
+    }
+
+    /**
+     * @param mixed $reason
+     *
+     * @return PromiseInterface<ResponseInterface, mixed>
+     */
+    private static function restoreOriginalSinkOnRejection(array $options, $reason): PromiseInterface
+    {
+        if (!$reason instanceof ResponseException || !\array_key_exists('__guzzle_auth_original_sink', $options)) {
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor($reason);
         }
 
-        $target = \is_string($options['__guzzle_auth_original_sink'])
-            ? new LazyOpenStream($options['__guzzle_auth_original_sink'], 'w+')
-            : Psr7\Utils::streamFor($options['__guzzle_auth_original_sink']);
+        try {
+            $response = self::restoreOriginalSink($reason->getRequest(), $reason->getResponse(), $options);
 
-        Psr7\Utils::copyToStream($source, $target);
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor(self::withRestoredResponse($reason, $response));
+        } catch (\Throwable $e) {
+            /** @var PromiseInterface<ResponseInterface, mixed> */
+            return P\Create::rejectionFor($e);
+        }
+    }
 
-        if ($target->isSeekable()) {
-            $target->rewind();
+    private static function withRestoredResponse(
+        ResponseException $reason,
+        ResponseInterface $response
+    ): ResponseException {
+        if ($reason instanceof ResponseTransferException) {
+            return new ResponseTransferException($reason->getMessage(), $reason->getRequest(), $response, $reason);
         }
 
-        return $response->withBody($target);
+        if ($reason instanceof TooManyRedirectsException) {
+            return new TooManyRedirectsException($reason->getMessage(), $reason->getRequest(), $response, $reason);
+        }
+
+        if ($reason instanceof ClientException) {
+            return new ClientException($reason->getMessage(), $reason->getRequest(), $response, $reason);
+        }
+
+        if ($reason instanceof ServerException) {
+            return new ServerException($reason->getMessage(), $reason->getRequest(), $response, $reason);
+        }
+
+        if ($reason instanceof BadResponseException) {
+            return new BadResponseException($reason->getMessage(), $reason->getRequest(), $response, $reason);
+        }
+
+        return new ResponseException($reason->getMessage(), $reason->getRequest(), $response, $reason);
+    }
+
+    /**
+     * @param mixed $sink
+     */
+    private static function streamForOriginalSink($sink): StreamInterface
+    {
+        if (\is_string($sink)) {
+            return new LazyOpenStream($sink, 'w+');
+        }
+
+        if (\is_resource($sink)) {
+            $stream = Psr7\Utils::streamFor($sink);
+
+            return Psr7\FnStream::decorate($stream, [
+                'close' => static function () use ($stream): void {
+                    $stream->detach();
+                },
+            ]);
+        }
+
+        if (!$sink instanceof StreamInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                'sink must be a resource, string, or %s',
+                StreamInterface::class
+            ));
+        }
+
+        return Psr7\Utils::streamFor($sink);
+    }
+
+    /**
+     * @param mixed $factory
+     */
+    private static function requireStreamFactory($factory): StreamFactoryInterface
+    {
+        if (!$factory instanceof StreamFactoryInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be an instance of %s',
+                RequestOptions::STREAM_FACTORY,
+                StreamFactoryInterface::class
+            ));
+        }
+
+        return $factory;
     }
 }

--- a/src/AuthMiddleware.php
+++ b/src/AuthMiddleware.php
@@ -163,6 +163,8 @@ final class AuthMiddleware
         try {
             Psr7\Message::rewindBody($request);
         } catch (\Throwable $e) {
+            $response = self::restoreOriginalSink($request, $response, $probeOptions);
+
             throw new ResponseException(
                 'Digest authentication failed because the request body could not be rewound',
                 $request,
@@ -288,13 +290,7 @@ final class AuthMiddleware
         }
 
         if (\is_resource($sink)) {
-            $stream = Psr7\Utils::streamFor($sink);
-
-            return Psr7\FnStream::decorate($stream, [
-                'close' => static function () use ($stream): void {
-                    $stream->detach();
-                },
-            ]);
+            return self::streamForResourceSink(Psr7\Utils::streamFor($sink));
         }
 
         if (!$sink instanceof StreamInterface) {
@@ -305,6 +301,19 @@ final class AuthMiddleware
         }
 
         return Psr7\Utils::streamFor($sink);
+    }
+
+    /**
+     * Decorates a caller-owned sink stream so that closing the response body
+     * detaches Guzzle's wrapper without closing the original PHP resource.
+     */
+    private static function streamForResourceSink(StreamInterface $stream): StreamInterface
+    {
+        return Psr7\FnStream::decorate($stream, [
+            'close' => static function () use ($stream): void {
+                $stream->detach();
+            },
+        ]);
     }
 
     /**

--- a/src/AuthMiddleware.php
+++ b/src/AuthMiddleware.php
@@ -162,7 +162,7 @@ final class AuthMiddleware
 
         try {
             Psr7\Message::rewindBody($request);
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             $response = self::restoreOriginalSink($request, $response, $probeOptions);
 
             throw new ResponseException(
@@ -247,7 +247,7 @@ final class AuthMiddleware
             }
 
             return $response->withBody($target);
-        } catch (\Throwable $e) {
+        } catch (\Exception $e) {
             throw new ResponseException(
                 $e->getMessage() !== '' ? $e->getMessage() : 'Failed to write the response body',
                 $request,
@@ -273,7 +273,7 @@ final class AuthMiddleware
             $response = self::restoreOriginalSink($reason->getRequest(), $reason->getResponse(), $options);
 
             /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor($reason->withResponse($response, $reason));
+            return P\Create::rejectionFor($reason->withResponse($response));
         } catch (\Throwable $e) {
             /** @var PromiseInterface<ResponseInterface, mixed> */
             return P\Create::rejectionFor($e);

--- a/src/AuthMiddleware.php
+++ b/src/AuthMiddleware.php
@@ -5,13 +5,8 @@ declare(strict_types=1);
 namespace GuzzleHttp;
 
 use GuzzleHttp\Auth\DigestAuth;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\ResponseException;
-use GuzzleHttp\Exception\ResponseTransferException;
-use GuzzleHttp\Exception\ServerException;
-use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\HttpFactory;
@@ -276,38 +271,11 @@ final class AuthMiddleware
             $response = self::restoreOriginalSink($reason->getRequest(), $reason->getResponse(), $options);
 
             /** @var PromiseInterface<ResponseInterface, mixed> */
-            return P\Create::rejectionFor(self::withRestoredResponse($reason, $response));
+            return P\Create::rejectionFor($reason->withResponse($response, $reason));
         } catch (\Throwable $e) {
             /** @var PromiseInterface<ResponseInterface, mixed> */
             return P\Create::rejectionFor($e);
         }
-    }
-
-    private static function withRestoredResponse(
-        ResponseException $reason,
-        ResponseInterface $response
-    ): ResponseException {
-        if ($reason instanceof ResponseTransferException) {
-            return new ResponseTransferException($reason->getMessage(), $reason->getRequest(), $response, $reason);
-        }
-
-        if ($reason instanceof TooManyRedirectsException) {
-            return new TooManyRedirectsException($reason->getMessage(), $reason->getRequest(), $response, $reason);
-        }
-
-        if ($reason instanceof ClientException) {
-            return new ClientException($reason->getMessage(), $reason->getRequest(), $response, $reason);
-        }
-
-        if ($reason instanceof ServerException) {
-            return new ServerException($reason->getMessage(), $reason->getRequest(), $response, $reason);
-        }
-
-        if ($reason instanceof BadResponseException) {
-            return new BadResponseException($reason->getMessage(), $reason->getRequest(), $response, $reason);
-        }
-
-        return new ResponseException($reason->getMessage(), $reason->getRequest(), $response, $reason);
     }
 
     /**

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -14,7 +14,7 @@ class ResponseException extends RequestException
 {
     private ResponseInterface $response;
 
-    public function __construct(
+    final public function __construct(
         string $message,
         RequestInterface $request,
         ResponseInterface $response,
@@ -22,6 +22,28 @@ class ResponseException extends RequestException
     ) {
         parent::__construct($message, $request, $response->getStatusCode(), $previous);
         $this->response = $response;
+    }
+
+    /**
+     * Return a new exception instance with an updated response.
+     *
+     * @param \Throwable|null $previous Previous exception, or the current
+     *                                  previous exception when omitted.
+     *
+     * @return static
+     */
+    public function withResponse(ResponseInterface $response, ?\Throwable $previous = null): self
+    {
+        if ($response->getStatusCode() !== $this->response->getStatusCode()) {
+            throw new \InvalidArgumentException('Cannot replace response with a different status code.');
+        }
+
+        return new static(
+            $this->getMessage(),
+            $this->getRequest(),
+            $response,
+            $previous ?? $this->getPrevious()
+        );
     }
 
     /**

--- a/tests/Auth/DigestAuthTest.php
+++ b/tests/Auth/DigestAuthTest.php
@@ -88,6 +88,28 @@ class DigestAuthTest extends TestCase
         self::assertSame('auth', $challenge->qop);
     }
 
+    /**
+     * @dataProvider token68ChallengeProvider
+     */
+    public function testSkipsToken68ChallengeAndUsesLaterDigest(string $prefix): void
+    {
+        $challenge = DigestAuth::selectChallenge(new Response(401, [
+            'WWW-Authenticate' => $prefix.', Digest realm="good", nonce="n", qop="auth"',
+        ]));
+
+        self::assertNotNull($challenge);
+        self::assertSame('good', $challenge->realm);
+        self::assertSame('n', $challenge->nonce);
+        self::assertSame('auth', $challenge->qop);
+    }
+
+    public static function token68ChallengeProvider(): iterable
+    {
+        yield 'basic padding' => ['Basic dGVzdA=='];
+        yield 'negotiate slash padding' => ['Negotiate abc/def+ghi=='];
+        yield 'unknown token68 chars' => ['Newauth a+b/c_~=='];
+    }
+
     public function testSkipsInvalidChallengeAndUsesLaterValidChallenge(): void
     {
         $challenge = DigestAuth::selectChallenge(new Response(401, [
@@ -106,5 +128,35 @@ class DigestAuthTest extends TestCase
         ]));
 
         self::assertNull($challenge);
+    }
+
+    /**
+     * @dataProvider sessAlgorithmProvider
+     */
+    public function testSessAlgorithmWithoutQopIsUnsupported(string $algorithm): void
+    {
+        $challenge = DigestAuth::selectChallenge(new Response(401, [
+            'WWW-Authenticate' => \sprintf('Digest realm="r", nonce="n", algorithm=%s', $algorithm),
+        ]));
+
+        self::assertNull($challenge);
+    }
+
+    public static function sessAlgorithmProvider(): iterable
+    {
+        yield 'MD5-sess' => ['MD5-sess'];
+        yield 'SHA-256-sess' => ['SHA-256-sess'];
+        yield 'SHA-512-256-sess' => ['SHA-512-256-sess'];
+    }
+
+    public function testSkipsSessWithoutQopAndUsesLaterValidDigest(): void
+    {
+        $challenge = DigestAuth::selectChallenge(new Response(401, [
+            'WWW-Authenticate' => 'Digest realm="bad", nonce="one", algorithm=MD5-sess, Digest realm="good", nonce="two", algorithm=MD5',
+        ]));
+
+        self::assertNotNull($challenge);
+        self::assertSame('good', $challenge->realm);
+        self::assertSame('two', $challenge->nonce);
     }
 }

--- a/tests/AuthMiddlewareTest.php
+++ b/tests/AuthMiddlewareTest.php
@@ -13,6 +13,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -188,6 +189,121 @@ class AuthMiddlewareTest extends TestCase
             ]);
 
             self::assertSame('ok', \file_get_contents($sink));
+        } finally {
+            if (\file_exists($sink)) {
+                \unlink($sink);
+            }
+        }
+    }
+
+    public function testDigestTemporarySinkUsesConfiguredStreamFactory(): void
+    {
+        $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
+        self::assertIsString($sink);
+
+        try {
+            $factory = new Psr17SpyFactory();
+            $mock = new MockHandler([
+                new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth"'], 'challenge'),
+                new Response(200, [], 'ok'),
+            ]);
+            $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+            $response = $client->get('http://example.com', [
+                'auth' => ['a', 'b', 'digest'],
+                RequestOptions::SINK => $sink,
+                RequestOptions::STREAM_FACTORY => $factory,
+            ]);
+
+            self::assertSame(200, $response->getStatusCode());
+            self::assertSame(2, $factory->createStreamFromResourceCalls);
+            self::assertSame('ok', \file_get_contents($sink));
+        } finally {
+            if (\file_exists($sink)) {
+                \unlink($sink);
+            }
+        }
+    }
+
+    public function testDigestRestoredResourceSinkDetachesOnClose(): void
+    {
+        $sink = Psr7\Utils::tryFopen('php://temp', 'w+');
+
+        try {
+            $mock = new MockHandler([
+                new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth"'], 'challenge'),
+                new Response(200, [], 'ok'),
+            ]);
+            $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+            $response = $client->get('http://example.com', [
+                'auth' => ['a', 'b', 'digest'],
+                RequestOptions::SINK => $sink,
+            ]);
+
+            self::assertSame('ok', (string) $response->getBody());
+
+            $response->getBody()->close();
+
+            self::assertIsResource($sink);
+        } finally {
+            if (\is_resource($sink)) {
+                \fclose($sink);
+            }
+        }
+    }
+
+    public function testDigestSinkRestoreFailureRejectsWithResponseException(): void
+    {
+        $sink = \sys_get_temp_dir().'/guzzle-auth-missing-'.\bin2hex(\random_bytes(4)).'/error.txt';
+        $mock = new MockHandler([
+            new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth"']),
+            new Response(200, [], 'ok'),
+        ]);
+        $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+        try {
+            $client->get('http://example.com', [
+                'auth' => ['a', 'b', 'digest'],
+                RequestOptions::SINK => $sink,
+            ]);
+
+            self::fail('Expected ResponseException.');
+        } catch (ResponseException $e) {
+            self::assertSame(200, $e->getResponse()->getStatusCode());
+        }
+    }
+
+    public function testDigestRestoresOriginalSinkOnResponseException(): void
+    {
+        $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
+        self::assertIsString($sink);
+
+        try {
+            $mock = new MockHandler([
+                static function (RequestInterface $request): ResponseException {
+                    return new ResponseException(
+                        'response failed',
+                        $request,
+                        new Response(500, [], 'failed')
+                    );
+                },
+            ]);
+            $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+            try {
+                $client->get('http://example.com', [
+                    'auth' => ['a', 'b', 'digest'],
+                    RequestOptions::SINK => $sink,
+                ]);
+
+                self::fail('Expected ResponseException.');
+            } catch (ResponseException $e) {
+                self::assertSame('response failed', $e->getMessage());
+                self::assertSame(500, $e->getResponse()->getStatusCode());
+                self::assertSame('failed', \file_get_contents($sink));
+                self::assertSame('failed', (string) $e->getResponse()->getBody());
+            }
         } finally {
             if (\file_exists($sink)) {
                 \unlink($sink);

--- a/tests/AuthMiddlewareTest.php
+++ b/tests/AuthMiddlewareTest.php
@@ -212,6 +212,43 @@ class AuthMiddlewareTest extends TestCase
         }
     }
 
+    public function testDigestBodyRewindErrorPropagates(): void
+    {
+        $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
+        self::assertIsString($sink);
+
+        try {
+            $previous = new \Error('cannot rewind');
+            $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('data'), [
+                'tell' => static function (): int {
+                    return 4;
+                },
+                'rewind' => static function () use ($previous): void {
+                    throw $previous;
+                },
+            ]);
+            $mock = new MockHandler([
+                new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth"'], 'challenge'),
+            ]);
+            $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+            try {
+                $client->send(new Request('POST', 'http://example.com', [], $body), [
+                    'auth' => ['a', 'b', 'digest'],
+                    'sink' => $sink,
+                ]);
+
+                self::fail('Expected Error.');
+            } catch (\Error $e) {
+                self::assertSame($previous, $e);
+            }
+        } finally {
+            if (\file_exists($sink)) {
+                \unlink($sink);
+            }
+        }
+    }
+
     public function testDigestDoesNotWriteChallengeBodyToUserSink(): void
     {
         $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
@@ -315,6 +352,31 @@ class AuthMiddlewareTest extends TestCase
         }
     }
 
+    public function testDigestSinkRestoreErrorPropagates(): void
+    {
+        $previous = new \Error('sink bug');
+        $sink = Psr7\FnStream::decorate(Psr7\Utils::streamFor(), [
+            'write' => static function (string $data) use ($previous): int {
+                throw $previous;
+            },
+        ]);
+        $mock = new MockHandler([
+            new Response(200, [], 'ok'),
+        ]);
+        $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+        try {
+            $client->get('http://example.com', [
+                'auth' => ['a', 'b', 'digest'],
+                'sink' => $sink,
+            ]);
+
+            self::fail('Expected Error.');
+        } catch (\Error $e) {
+            self::assertSame($previous, $e);
+        }
+    }
+
     public function testDigestRestoresOriginalSinkOnResponseException(): void
     {
         $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
@@ -358,12 +420,14 @@ class AuthMiddlewareTest extends TestCase
         self::assertIsString($sink);
 
         try {
+            $previous = new \RuntimeException('timeout cause');
             $mock = new MockHandler([
-                static function (RequestInterface $request): ResponseTimeoutException {
+                static function (RequestInterface $request) use ($previous): ResponseTimeoutException {
                     return new ResponseTimeoutException(
                         'response timed out',
                         $request,
-                        new Response(200, [], 'partial')
+                        new Response(200, [], 'partial'),
+                        $previous
                     );
                 },
             ]);
@@ -379,7 +443,7 @@ class AuthMiddlewareTest extends TestCase
             } catch (ResponseTimeoutException $e) {
                 self::assertSame('response timed out', $e->getMessage());
                 self::assertSame(200, $e->getResponse()->getStatusCode());
-                self::assertInstanceOf(ResponseTimeoutException::class, $e->getPrevious());
+                self::assertSame($previous, $e->getPrevious());
                 self::assertSame('partial', \file_get_contents($sink));
                 self::assertSame('partial', (string) $e->getResponse()->getBody());
             }

--- a/tests/AuthMiddlewareTest.php
+++ b/tests/AuthMiddlewareTest.php
@@ -14,7 +14,6 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -172,6 +171,47 @@ class AuthMiddlewareTest extends TestCase
         }
     }
 
+    public function testDigestBodyRewindFailureRestoresOriginalSink(): void
+    {
+        $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
+        self::assertIsString($sink);
+
+        try {
+            $previous = new \RuntimeException('cannot rewind');
+            $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('data'), [
+                'tell' => static function (): int {
+                    return 4;
+                },
+                'rewind' => static function () use ($previous): void {
+                    throw $previous;
+                },
+            ]);
+            $mock = new MockHandler([
+                new Response(401, ['WWW-Authenticate' => 'Digest realm="test", nonce="abc", qop="auth"'], 'challenge'),
+            ]);
+            $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+            try {
+                $client->send(new Request('POST', 'http://example.com', [], $body), [
+                    'auth' => ['a', 'b', 'digest'],
+                    'sink' => $sink,
+                ]);
+
+                self::fail('Expected ResponseException.');
+            } catch (ResponseException $e) {
+                self::assertSame('Digest authentication failed because the request body could not be rewound', $e->getMessage());
+                self::assertSame($previous, $e->getPrevious());
+                self::assertSame(401, $e->getResponse()->getStatusCode());
+                self::assertSame('challenge', \file_get_contents($sink));
+                self::assertSame('challenge', (string) $e->getResponse()->getBody());
+            }
+        } finally {
+            if (\file_exists($sink)) {
+                \unlink($sink);
+            }
+        }
+    }
+
     public function testDigestDoesNotWriteChallengeBodyToUserSink(): void
     {
         $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
@@ -212,8 +252,8 @@ class AuthMiddlewareTest extends TestCase
 
             $response = $client->get('http://example.com', [
                 'auth' => ['a', 'b', 'digest'],
-                RequestOptions::SINK => $sink,
-                RequestOptions::STREAM_FACTORY => $factory,
+                'sink' => $sink,
+                'stream_factory' => $factory,
             ]);
 
             self::assertSame(200, $response->getStatusCode());
@@ -239,7 +279,7 @@ class AuthMiddlewareTest extends TestCase
 
             $response = $client->get('http://example.com', [
                 'auth' => ['a', 'b', 'digest'],
-                RequestOptions::SINK => $sink,
+                'sink' => $sink,
             ]);
 
             self::assertSame('ok', (string) $response->getBody());
@@ -266,7 +306,7 @@ class AuthMiddlewareTest extends TestCase
         try {
             $client->get('http://example.com', [
                 'auth' => ['a', 'b', 'digest'],
-                RequestOptions::SINK => $sink,
+                'sink' => $sink,
             ]);
 
             self::fail('Expected ResponseException.');
@@ -295,7 +335,7 @@ class AuthMiddlewareTest extends TestCase
             try {
                 $client->get('http://example.com', [
                     'auth' => ['a', 'b', 'digest'],
-                    RequestOptions::SINK => $sink,
+                    'sink' => $sink,
                 ]);
 
                 self::fail('Expected ResponseException.');
@@ -332,7 +372,7 @@ class AuthMiddlewareTest extends TestCase
             try {
                 $client->get('http://example.com', [
                     'auth' => ['a', 'b', 'digest'],
-                    RequestOptions::SINK => $sink,
+                    'sink' => $sink,
                 ]);
 
                 self::fail('Expected ResponseTimeoutException.');

--- a/tests/AuthMiddlewareTest.php
+++ b/tests/AuthMiddlewareTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\AuthMiddleware;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Exception\ResponseTimeoutException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
@@ -303,6 +304,44 @@ class AuthMiddlewareTest extends TestCase
                 self::assertSame(500, $e->getResponse()->getStatusCode());
                 self::assertSame('failed', \file_get_contents($sink));
                 self::assertSame('failed', (string) $e->getResponse()->getBody());
+            }
+        } finally {
+            if (\file_exists($sink)) {
+                \unlink($sink);
+            }
+        }
+    }
+
+    public function testDigestRestoresOriginalSinkOnResponseTimeoutException(): void
+    {
+        $sink = \tempnam(\sys_get_temp_dir(), 'guzzle-auth-sink');
+        self::assertIsString($sink);
+
+        try {
+            $mock = new MockHandler([
+                static function (RequestInterface $request): ResponseTimeoutException {
+                    return new ResponseTimeoutException(
+                        'response timed out',
+                        $request,
+                        new Response(200, [], 'partial')
+                    );
+                },
+            ]);
+            $client = new Client(['handler' => self::handlerWithAuth($mock)]);
+
+            try {
+                $client->get('http://example.com', [
+                    'auth' => ['a', 'b', 'digest'],
+                    RequestOptions::SINK => $sink,
+                ]);
+
+                self::fail('Expected ResponseTimeoutException.');
+            } catch (ResponseTimeoutException $e) {
+                self::assertSame('response timed out', $e->getMessage());
+                self::assertSame(200, $e->getResponse()->getStatusCode());
+                self::assertInstanceOf(ResponseTimeoutException::class, $e->getPrevious());
+                self::assertSame('partial', \file_get_contents($sink));
+                self::assertSame('partial', (string) $e->getResponse()->getBody());
             }
         } finally {
             if (\file_exists($sink)) {

--- a/tests/Exception/ResponseExceptionTest.php
+++ b/tests/Exception/ResponseExceptionTest.php
@@ -33,4 +33,46 @@ class ResponseExceptionTest extends TestCase
         self::assertSame(418, $e->getCode());
         self::assertSame($prev, $e->getPrevious());
     }
+
+    public function testCanCreateCopyWithUpdatedResponse(): void
+    {
+        $req = new Request('GET', '/');
+        $res = new Response(418, [], 'original');
+        $newRes = new Response(418, [], 'updated');
+        $prev = new \Exception();
+        $e = new ResponseException('foo', $req, $res, $prev);
+
+        $new = $e->withResponse($newRes);
+
+        self::assertNotSame($e, $new);
+        self::assertSame($req, $new->getRequest());
+        self::assertSame($newRes, $new->getResponse());
+        self::assertSame($res, $e->getResponse());
+        self::assertSame('foo', $new->getMessage());
+        self::assertSame(418, $new->getCode());
+        self::assertSame($prev, $new->getPrevious());
+    }
+
+    public function testCanCreateCopyWithUpdatedResponseAndPreviousException(): void
+    {
+        $e = new ResponseException('foo', new Request('GET', '/'), new Response(418));
+        $newRes = new Response(418);
+        $prev = new \Exception();
+
+        $new = $e->withResponse($newRes, $prev);
+
+        self::assertSame($newRes, $new->getResponse());
+        self::assertSame(418, $new->getCode());
+        self::assertSame($prev, $new->getPrevious());
+    }
+
+    public function testCannotCreateCopyWithDifferentStatusCode(): void
+    {
+        $e = new ResponseException('foo', new Request('GET', '/'), new Response(418));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot replace response with a different status code.');
+
+        $e->withResponse(new Response(200));
+    }
 }


### PR DESCRIPTION
This fixes Digest auth middleware sink handling so middleware-owned temporary bodies use the configured stream factory, caller-owned resource sinks keep detach-on-close semantics, and response-aware failures restore original sinks consistently. It also tightens Digest challenge parsing for token68 challenges, rejects session algorithms without qop to match libcurl, and updates the related changelog and documentation wording.