### PR TITLE
Upgrade integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "require-dev": {
         "ext-curl": "*",
         "bamarni/composer-bin-plugin": "^1.8.2",
-        "guzzle/client-integration-tests": "3.0.2",
+        "guzzle/client-integration-tests": "4.0.0",
         "guzzlehttp/test-server": "^1.0@dev",
         "php-http/message-factory": "^1.1",
         "phpunit/phpunit": "^9.6.34",
@@ -81,9 +81,9 @@
             "type": "package",
             "package": {
                 "name": "guzzle/client-integration-tests",
-                "version": "v3.0.2",
+                "version": "v4.0.0",
                 "require": {
-                    "guzzlehttp/psr7": "^1.7 || ^2.0 || ^3.0@dev",
+                    "guzzlehttp/psr7": "^3.0@dev",
                     "php": "^7.4 || ^8.0",
                     "php-http/message": "^1.0 || ^2.0",
                     "phpunit/phpunit": "^9.6.34",
@@ -99,7 +99,7 @@
                 ],
                 "dist": {
                     "type": "zip",
-                    "url": "https://codeload.github.com/guzzle/client-integration-tests/zip/2c025848417c1135031fdf9c728ee53d0a7ceaee"
+                    "url": "https://codeload.github.com/guzzle/client-integration-tests/zip/85dc446e24fc0163e955439f4874e53be0df0679"
                 }
             }
         }


### PR DESCRIPTION
Uses a patched version of php-http/client-integration-tests v4.0.0.