### PR TITLE
Centralize cURL feature detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Changed
 
-- Centralized cURL feature detection and sharing floors
+- Require cURL SSL support for TLS and SSL-session detection
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ## 7.12.0 - Upcoming
 
+### Changed
+
+- Centralized cURL feature detection and sharing floors
+
 ### Deprecated
 
 - Deprecated the request-level `handler` option, which will be ignored in 8.0

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -258,10 +258,18 @@ cURL share handles to share DNS and SSL session cache state. If sharing cannot
 be configured, or if the selected handler does not support sharing, Guzzle
 continues without sharing.
 
+Guzzle only enables cURL transport sharing for libcurl versions that support the
+requested shared state safely. Handler-lifetime cURL sharing requires libcurl
+7.35.0 or newer. SSL session cache sharing requires libcurl 8.6.0 or newer. On
+older libcurl versions that still meet the handler-lifetime sharing floor,
+`TransportSharing::HANDLER_PREFER` shares DNS cache state without sharing SSL
+session cache state.
+
 `TransportSharing::HANDLER_REQUIRE` requires handler-lifetime transport
 sharing. Guzzle fails when it cannot select a cURL handler with cURL share
 support, when sharing cannot be configured, or when a request is routed to a
-handler that does not support sharing.
+handler that does not support sharing. Guzzle also fails when the installed
+libcurl version cannot safely share both DNS and SSL session cache state.
 
 Transport sharing does not share cookies. Cookies are managed by Guzzle
 middleware.

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -260,10 +260,10 @@ continues without sharing.
 
 Guzzle only enables cURL transport sharing for libcurl versions that support the
 requested shared state safely. Handler-lifetime cURL sharing requires libcurl
-7.35.0 or newer. SSL session cache sharing requires libcurl 8.6.0 or newer. On
-older libcurl versions that still meet the handler-lifetime sharing floor,
-`TransportSharing::HANDLER_PREFER` shares DNS cache state without sharing SSL
-session cache state.
+7.35.0 or newer. SSL session cache sharing requires libcurl 8.6.0 or newer and
+libcurl SSL support. On older libcurl versions that still meet the
+handler-lifetime sharing floor, `TransportSharing::HANDLER_PREFER` shares DNS
+cache state without sharing SSL session cache state.
 
 `TransportSharing::HANDLER_REQUIRE` requires handler-lifetime transport
 sharing. Guzzle fails when it cannot select a cURL handler with cURL share

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -73,18 +73,6 @@ parameters:
 			path: src/Cookie/SetCookie.php
 
 		-
-			message: '#^Cannot access offset ''features'' on array\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: src/Handler/CurlFactory.php
-
-		-
-			message: '#^Cannot access offset ''version'' on array\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Handler/CurlFactory.php
-
-		-
 			message: '#^Cannot call method getBody\(\) on Psr\\Http\\Message\\ResponseInterface\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -299,12 +287,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: src/RetryMiddleware.php
-
-		-
-			message: '#^Cannot access offset ''version'' on array\|false\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Utils.php
 
 		-
 			message: '#^Cannot cast mixed to string\.$#'

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -96,7 +96,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if ('2' === $protocolVersion || '2.0' === $protocolVersion) {
-            if (!self::supportsHttp2()) {
+            if (!CurlVersion::supportsHttp2()) {
                 throw new ConnectException('HTTP/2 is supported by the cURL handler, however libcurl is built without HTTP/2 support.', $request);
             }
         } elseif ('1.0' !== $protocolVersion && '1.1' !== $protocolVersion) {
@@ -474,42 +474,6 @@ class CurlFactory implements CurlFactoryInterface
         }
     }
 
-    private static function supportsHttp2(): bool
-    {
-        static $supportsHttp2 = null;
-
-        if (null === $supportsHttp2) {
-            $supportsHttp2 = self::supportsTls12()
-                && defined('CURL_VERSION_HTTP2')
-                && (\CURL_VERSION_HTTP2 & \curl_version()['features']);
-        }
-
-        return $supportsHttp2;
-    }
-
-    private static function supportsTls12(): bool
-    {
-        static $supportsTls12 = null;
-
-        if (null === $supportsTls12) {
-            $supportsTls12 = \CURL_SSLVERSION_TLSv1_2 & \curl_version()['features'];
-        }
-
-        return $supportsTls12;
-    }
-
-    private static function supportsTls13(): bool
-    {
-        static $supportsTls13 = null;
-
-        if (null === $supportsTls13) {
-            $supportsTls13 = defined('CURL_SSLVERSION_TLSv1_3')
-                && (\CURL_SSLVERSION_TLSv1_3 & \curl_version()['features']);
-        }
-
-        return $supportsTls13;
-    }
-
     public function release(EasyHandle $easy): void
     {
         $resource = $easy->handle;
@@ -587,7 +551,7 @@ class CurlFactory implements CurlFactoryInterface
             'error' => \curl_error($easy->handle),
             'appconnect_time' => \curl_getinfo($easy->handle, \CURLINFO_APPCONNECT_TIME),
         ] + \curl_getinfo($easy->handle);
-        $ctx[self::CURL_VERSION_STR] = self::getCurlVersion();
+        $ctx[self::CURL_VERSION_STR] = CurlVersion::getVersion() ?? '';
         $factory->release($easy);
 
         // Retry when nothing is present or when curl failed to rewind.
@@ -596,17 +560,6 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         return self::createRejection($easy, $ctx);
-    }
-
-    private static function getCurlVersion(): string
-    {
-        static $curlVersion = null;
-
-        if (null === $curlVersion) {
-            $curlVersion = \curl_version()['version'];
-        }
-
-        return $curlVersion;
     }
 
     private static function createRejection(EasyHandle $easy, array $ctx): PromiseInterface
@@ -988,7 +941,7 @@ class CurlFactory implements CurlFactoryInterface
                 ) {
                     $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
                 } elseif (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $options['crypto_method']) {
-                    if (!self::supportsTls13()) {
+                    if (!CurlVersion::supportsTls13()) {
                         throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
                     }
                     $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;
@@ -1000,12 +953,12 @@ class CurlFactory implements CurlFactoryInterface
             } elseif (\STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT === $options['crypto_method']) {
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_1;
             } elseif (\STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT === $options['crypto_method']) {
-                if (!self::supportsTls12()) {
+                if (!CurlVersion::supportsTls12()) {
                     throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.2 not supported by your version of cURL');
                 }
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_2;
             } elseif (defined('STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT') && \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT === $options['crypto_method']) {
-                if (!self::supportsTls13()) {
+                if (!CurlVersion::supportsTls13()) {
                     throw new \InvalidArgumentException('Invalid crypto_method request option: TLS 1.3 not supported by your version of cURL');
                 }
                 $conf[\CURLOPT_SSLVERSION] = \CURL_SSLVERSION_TLSv1_3;

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -108,7 +108,7 @@ final class CurlShareHandleState
 
         self::requireCurlConstant('CURLOPT_SHARE');
         $shareOption = self::requireCurlConstant('CURLSHOPT_SHARE');
-        $locks = self::handlerLocks();
+        $locks = self::handlerLocks($mode);
         $handle = curl_share_init();
 
         try {
@@ -135,12 +135,23 @@ final class CurlShareHandleState
     /**
      * @return int[]
      */
-    private static function handlerLocks(): array
+    private static function handlerLocks(string $mode): array
     {
-        return [
+        CurlVersion::ensureHandlerSharingSupported();
+
+        if ($mode === TransportSharing::HANDLER_REQUIRE) {
+            CurlVersion::ensureSslSessionSharingSupported();
+        }
+
+        $locks = [
             self::requireCurlConstant('CURL_LOCK_DATA_DNS'),
-            self::requireCurlConstant('CURL_LOCK_DATA_SSL_SESSION'),
         ];
+
+        if (CurlVersion::supportsSslSessionSharing()) {
+            $locks[] = self::requireCurlConstant('CURL_LOCK_DATA_SSL_SESSION');
+        }
+
+        return $locks;
     }
 
     private static function requireCurlConstant(string $constant): int

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace GuzzleHttp\Handler;
+
+/**
+ * @internal
+ */
+final class CurlVersion
+{
+    private const MIN_VERSION = '7.21.2';
+
+    private const TLS_12_VERSION = '7.34.0';
+
+    private const TLS_13_VERSION = '7.52.0';
+
+    private const HANDLER_SHARING_VERSION = '7.35.0';
+
+    private const SSL_SESSION_SHARING_VERSION = '8.6.0';
+
+    /**
+     * @var array{version: string, features: int}|false|null
+     */
+    private static $versionInfo;
+
+    private function __construct()
+    {
+    }
+
+    public static function supportsCurlHandler(): bool
+    {
+        $version = self::getVersion();
+
+        return $version !== null && \version_compare($version, self::MIN_VERSION, '>=');
+    }
+
+    public static function supportsTls12(): bool
+    {
+        $version = self::getVersion();
+
+        return \defined('CURL_SSLVERSION_TLSv1_2')
+            && $version !== null
+            && \version_compare($version, self::TLS_12_VERSION, '>=');
+    }
+
+    public static function supportsTls13(): bool
+    {
+        $version = self::getVersion();
+
+        return \defined('CURL_SSLVERSION_TLSv1_3')
+            && $version !== null
+            && \version_compare($version, self::TLS_13_VERSION, '>=');
+    }
+
+    public static function supportsHttp2(): bool
+    {
+        $versionInfo = self::getVersionInfo();
+
+        return self::supportsTls12()
+            && \defined('CURL_VERSION_HTTP2')
+            && $versionInfo !== null
+            && 0 !== (\CURL_VERSION_HTTP2 & $versionInfo['features']);
+    }
+
+    public static function supportsHandlerSharing(): bool
+    {
+        $version = self::getVersion();
+
+        return $version !== null && \version_compare($version, self::HANDLER_SHARING_VERSION, '>=');
+    }
+
+    public static function ensureHandlerSharingSupported(): void
+    {
+        if (!self::supportsHandlerSharing()) {
+            throw new \InvalidArgumentException(\sprintf(
+                'The "transport_sharing" option requires libcurl %s or higher for cURL share handles.',
+                self::HANDLER_SHARING_VERSION
+            ));
+        }
+    }
+
+    public static function supportsSslSessionSharing(): bool
+    {
+        $version = self::getVersion();
+
+        return $version !== null && \version_compare($version, self::SSL_SESSION_SHARING_VERSION, '>=');
+    }
+
+    public static function ensureSslSessionSharingSupported(): void
+    {
+        if (!self::supportsSslSessionSharing()) {
+            throw new \InvalidArgumentException(\sprintf(
+                'The "transport_sharing" option requires libcurl %s or higher for SSL session sharing.',
+                self::SSL_SESSION_SHARING_VERSION
+            ));
+        }
+    }
+
+    public static function getVersion(): ?string
+    {
+        $versionInfo = self::getVersionInfo();
+
+        return $versionInfo === null ? null : $versionInfo['version'];
+    }
+
+    /**
+     * @return array{version: string, features: int}|null
+     */
+    private static function getVersionInfo(): ?array
+    {
+        if (self::$versionInfo === null) {
+            if (!\function_exists('curl_version')) {
+                self::$versionInfo = false;
+            } else {
+                $versionInfo = \curl_version();
+                self::$versionInfo = \is_array($versionInfo)
+                    && isset($versionInfo['version'], $versionInfo['features'])
+                    && \is_string($versionInfo['version'])
+                    && \is_int($versionInfo['features'])
+                        ? [
+                            'version' => $versionInfo['version'],
+                            'features' => $versionInfo['features'],
+                        ]
+                        : false;
+            }
+        }
+
+        return self::$versionInfo === false ? null : self::$versionInfo;
+    }
+}

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -37,7 +37,8 @@ final class CurlVersion
     {
         $version = self::getVersion();
 
-        return \defined('CURL_SSLVERSION_TLSv1_2')
+        return self::supportsSsl()
+            && \defined('CURL_SSLVERSION_TLSv1_2')
             && $version !== null
             && \version_compare($version, self::TLS_12_VERSION, '>=');
     }
@@ -46,7 +47,8 @@ final class CurlVersion
     {
         $version = self::getVersion();
 
-        return \defined('CURL_SSLVERSION_TLSv1_3')
+        return self::supportsSsl()
+            && \defined('CURL_SSLVERSION_TLSv1_3')
             && $version !== null
             && \version_compare($version, self::TLS_13_VERSION, '>=');
     }
@@ -82,17 +84,28 @@ final class CurlVersion
     {
         $version = self::getVersion();
 
-        return $version !== null && \version_compare($version, self::SSL_SESSION_SHARING_VERSION, '>=');
+        return self::supportsSsl()
+            && $version !== null
+            && \version_compare($version, self::SSL_SESSION_SHARING_VERSION, '>=');
     }
 
     public static function ensureSslSessionSharingSupported(): void
     {
         if (!self::supportsSslSessionSharing()) {
             throw new \InvalidArgumentException(\sprintf(
-                'The "transport_sharing" option requires libcurl %s or higher for SSL session sharing.',
+                'The "transport_sharing" option requires libcurl %s or higher with SSL support for SSL session sharing.',
                 self::SSL_SESSION_SHARING_VERSION
             ));
         }
+    }
+
+    private static function supportsSsl(): bool
+    {
+        $versionInfo = self::getVersionInfo();
+
+        return \defined('CURL_VERSION_SSL')
+            && $versionInfo !== null
+            && 0 !== (\CURL_VERSION_SSL & $versionInfo['features']);
     }
 
     public static function getVersion(): ?string

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\CurlShareHandleState;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\Proxy;
 use GuzzleHttp\Handler\StreamHandler;
 use Psr\Http\Message\RequestInterface;
@@ -95,8 +96,7 @@ final class Utils
         $sharingRequired = $sharingMode === TransportSharing::HANDLER_REQUIRE;
         $curlHandlerOptions = [];
         $curlSupported = \defined('CURLOPT_CUSTOMREQUEST')
-            && \function_exists('curl_version')
-            && version_compare(curl_version()['version'], '7.21.2') >= 0
+            && CurlVersion::supportsCurlHandler()
             && (\function_exists('curl_multi_exec') || \function_exists('curl_exec'));
 
         if ($sharingRequired && !$curlSupported) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -185,7 +185,7 @@ class ClientTest extends TestCase
     public function testHandlerPreferTransportSharingCreatesDefaultShareHandle(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -354,6 +354,15 @@ class ClientTest extends TestCase
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is unavailable.');
+        }
+
+        return \CURL_VERSION_SSL;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -364,7 +364,9 @@ class ClientTest extends TestCase
     private static function setCurlVersionInfo($versionInfo)
     {
         $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $previousVersionInfo = $property->getValue();
         $property->setValue(null, $versionInfo);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -184,6 +185,7 @@ class ClientTest extends TestCase
     public function testHandlerPreferTransportSharingCreatesDefaultShareHandle(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -199,6 +201,7 @@ class ClientTest extends TestCase
                 \CURL_LOCK_DATA_SSL_SESSION,
             ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
         } finally {
+            self::setCurlVersionInfo($previous);
             unset($_SERVER['curl_test'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
         }
     }
@@ -347,11 +350,26 @@ class ClientTest extends TestCase
             !\function_exists('curl_share_init')
             || !\function_exists('curl_share_setopt')
             || !\function_exists('curl_exec')
-            || !\function_exists('curl_version')
-            || version_compare(curl_version()['version'], '7.21.2') < 0
+            || !CurlVersion::supportsCurlHandler()
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        $property->setAccessible(true);
+
+        $previousVersionInfo = $property->getValue();
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
     }
 
     public function testDoesNotOverwriteHeaderWithDefaultInRequest()

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler;
 use GuzzleHttp\Handler\CurlFactory;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7;
@@ -466,9 +467,15 @@ class CurlFactoryTest extends TestCase
 
     public function testAddsCryptoMethodTls12()
     {
+        $previous = self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
         $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', Server::$url), ['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT]);
-        self::assertEquals(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+
+        try {
+            $f->create(new Psr7\Request('GET', Server::$url), ['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT]);
+            self::assertEquals(\CURL_SSLVERSION_TLSv1_2, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
     }
 
     /**
@@ -476,9 +483,19 @@ class CurlFactoryTest extends TestCase
      */
     public function testAddsCryptoMethodTls13()
     {
+        if (!\defined('CURL_SSLVERSION_TLSv1_3')) {
+            self::markTestSkipped('CURL_SSLVERSION_TLSv1_3 is unavailable.');
+        }
+
+        $previous = self::setCurlVersionInfo(['version' => '7.52.0', 'features' => 0]);
         $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', Server::$url), ['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]);
-        self::assertEquals(\CURL_SSLVERSION_TLSv1_3, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+
+        try {
+            $f->create(new Psr7\Request('GET', Server::$url), ['crypto_method' => \STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT]);
+            self::assertEquals(\CURL_SSLVERSION_TLSv1_3, $_SERVER['_curl'][\CURLOPT_SSLVERSION]);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
     }
 
     public function testValidatesSslKey()
@@ -1436,5 +1453,21 @@ class CurlFactoryTest extends TestCase
         if (!\function_exists('curl_share_init') || !\defined('CURLOPT_SHARE')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        $property->setAccessible(true);
+
+        $previousVersionInfo = $property->getValue();
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
     }
 }

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -467,7 +467,7 @@ class CurlFactoryTest extends TestCase
 
     public function testAddsCryptoMethodTls12()
     {
-        $previous = self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '7.34.0', 'features' => self::curlSslFeature()]);
         $f = new CurlFactory(3);
 
         try {
@@ -487,7 +487,7 @@ class CurlFactoryTest extends TestCase
             self::markTestSkipped('CURL_SSLVERSION_TLSv1_3 is unavailable.');
         }
 
-        $previous = self::setCurlVersionInfo(['version' => '7.52.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '7.52.0', 'features' => self::curlSslFeature()]);
         $f = new CurlFactory(3);
 
         try {
@@ -1453,6 +1453,15 @@ class CurlFactoryTest extends TestCase
         if (!\function_exists('curl_share_init') || !\defined('CURLOPT_SHARE')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is unavailable.');
+        }
+
+        return \CURL_VERSION_SSL;
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1463,7 +1463,9 @@ class CurlFactoryTest extends TestCase
     private static function setCurlVersionInfo($versionInfo)
     {
         $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $previousVersionInfo = $property->getValue();
         $property->setValue(null, $versionInfo);

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -163,7 +163,9 @@ class CurlHandlerTest extends TestCase
     private static function setCurlVersionInfo($versionInfo)
     {
         $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $previousVersionInfo = $property->getValue();
         $property->setValue(null, $versionInfo);

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -5,6 +5,7 @@ namespace GuzzleHttp\Tests\Handler;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlHandler;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -72,6 +73,7 @@ class CurlHandlerTest extends TestCase
     public function testTransportSharingOptionAppliesCurlShare(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -92,6 +94,7 @@ class CurlHandlerTest extends TestCase
                 \CURL_LOCK_DATA_SSL_SESSION,
             ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
         } finally {
+            self::setCurlVersionInfo($previous);
             unset($_SERVER['curl_test'], $_SERVER['_curl'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
         }
     }
@@ -150,5 +153,21 @@ class CurlHandlerTest extends TestCase
         if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt') || !\defined('CURLOPT_SHARE')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        $property->setAccessible(true);
+
+        $previousVersionInfo = $property->getValue();
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
     }
 }

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -73,7 +73,7 @@ class CurlHandlerTest extends TestCase
     public function testTransportSharingOptionAppliesCurlShare(): void
     {
         self::skipIfCurlShareIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -153,6 +153,15 @@ class CurlHandlerTest extends TestCase
         if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt') || !\defined('CURLOPT_SHARE')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is unavailable.');
+        }
+
+        return \CURL_VERSION_SSL;
     }
 
     /**

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -5,6 +5,7 @@ namespace GuzzleHttp\Tests\Handler;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -65,22 +66,27 @@ class CurlMultiHandlerTest extends TestCase
     public function testTransportSharingOptionAppliesCurlShare(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
-        Server::flush();
-        Server::enqueue([new Response(200)]);
+        try {
+            Server::flush();
+            Server::enqueue([new Response(200)]);
 
-        $handler = new CurlMultiHandler([
-            'transport_sharing' => TransportSharing::HANDLER_PREFER,
-        ]);
+            $handler = new CurlMultiHandler([
+                'transport_sharing' => TransportSharing::HANDLER_PREFER,
+            ]);
 
-        $handler(new Request('GET', Server::$url), [])->wait();
+            $handler(new Request('GET', Server::$url), [])->wait();
 
-        self::assertArrayHasKey(\CURLOPT_SHARE, $_SERVER['_curl']);
-        self::assertSame(1, $_SERVER['_curl_share_init_count']);
-        self::assertSame([
-            \CURL_LOCK_DATA_DNS,
-            \CURL_LOCK_DATA_SSL_SESSION,
-        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+            self::assertArrayHasKey(\CURLOPT_SHARE, $_SERVER['_curl']);
+            self::assertSame(1, $_SERVER['_curl_share_init_count']);
+            self::assertSame([
+                \CURL_LOCK_DATA_DNS,
+                \CURL_LOCK_DATA_SSL_SESSION,
+            ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
     }
 
     public function testPreferredTransportSharingCanBeUsedWithCustomFactory(): void
@@ -340,5 +346,21 @@ class CurlMultiHandlerTest extends TestCase
         if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt') || !\defined('CURLOPT_SHARE')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        $property->setAccessible(true);
+
+        $previousVersionInfo = $property->getValue();
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
     }
 }

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -66,7 +66,7 @@ class CurlMultiHandlerTest extends TestCase
     public function testTransportSharingOptionAppliesCurlShare(): void
     {
         self::skipIfCurlShareIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         try {
             Server::flush();
@@ -346,6 +346,15 @@ class CurlMultiHandlerTest extends TestCase
         if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt') || !\defined('CURLOPT_SHARE')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is unavailable.');
+        }
+
+        return \CURL_VERSION_SSL;
     }
 
     /**

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -356,7 +356,9 @@ class CurlMultiHandlerTest extends TestCase
     private static function setCurlVersionInfo($versionInfo)
     {
         $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $previousVersionInfo = $property->getValue();
         $property->setValue(null, $versionInfo);

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlShareHandleState;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\TransportSharing;
 use PHPUnit\Framework\TestCase;
 
@@ -48,35 +49,107 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerPreferCreatesShareHandleForDnsAndSslSession(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
-        $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER);
+        try {
+            $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER);
 
-        self::assertInstanceOf(CurlShareHandleState::class, $state);
-        self::assertSame(TransportSharing::HANDLER_PREFER, $state->mode);
-        self::assertSame(1, $_SERVER['_curl_share_init_count']);
-        self::assertSame([
-            \CURL_LOCK_DATA_DNS,
-            \CURL_LOCK_DATA_SSL_SESSION,
-        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+            self::assertInstanceOf(CurlShareHandleState::class, $state);
+            self::assertSame(TransportSharing::HANDLER_PREFER, $state->mode);
+            self::assertSame(1, $_SERVER['_curl_share_init_count']);
+            self::assertSame([
+                \CURL_LOCK_DATA_DNS,
+                \CURL_LOCK_DATA_SSL_SESSION,
+            ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
 
-        if (\defined('CURL_LOCK_DATA_CONNECT')) {
-            self::assertNotContains(\constant('CURL_LOCK_DATA_CONNECT'), $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+            if (\defined('CURL_LOCK_DATA_CONNECT')) {
+                self::assertNotContains(\constant('CURL_LOCK_DATA_CONNECT'), $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+            }
+        } finally {
+            self::setCurlVersionInfo($previous);
         }
     }
 
     public function testHandlerRequireCreatesShareHandleForDnsAndSslSession(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
-        $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+        try {
+            $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
 
-        self::assertInstanceOf(CurlShareHandleState::class, $state);
-        self::assertSame(TransportSharing::HANDLER_REQUIRE, $state->mode);
-        self::assertSame(1, $_SERVER['_curl_share_init_count']);
-        self::assertSame([
-            \CURL_LOCK_DATA_DNS,
-            \CURL_LOCK_DATA_SSL_SESSION,
-        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+            self::assertInstanceOf(CurlShareHandleState::class, $state);
+            self::assertSame(TransportSharing::HANDLER_REQUIRE, $state->mode);
+            self::assertSame(1, $_SERVER['_curl_share_init_count']);
+            self::assertSame([
+                \CURL_LOCK_DATA_DNS,
+                \CURL_LOCK_DATA_SSL_SESSION,
+            ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testHandlerPreferFallsBackToNoSharingBelowMinimumCurlVersion(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
+
+        try {
+            self::assertNull(CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER));
+            self::assertArrayNotHasKey('_curl_share_init_count', $_SERVER);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testHandlerRequireRejectsBelowMinimumCurlVersion(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('libcurl 7.35.0');
+
+            CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testHandlerPreferCreatesDnsOnlyShareHandleBelowSslSessionFloor(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.5.0', 'features' => 0]);
+
+        try {
+            $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER);
+
+            self::assertInstanceOf(CurlShareHandleState::class, $state);
+            self::assertSame(TransportSharing::HANDLER_PREFER, $state->mode);
+            self::assertSame(1, $_SERVER['_curl_share_init_count']);
+            self::assertSame([
+                \CURL_LOCK_DATA_DNS,
+            ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testHandlerRequireRejectsBelowSslSessionFloor(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.5.0', 'features' => 0]);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('SSL session sharing');
+
+            CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
     }
 
     /**
@@ -133,22 +206,32 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerPreferFallsBackToNoSharingWhenShareSetupFails(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
-        $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
+        try {
+            $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
 
-        self::assertNull(CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER));
+            self::assertNull(CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER));
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
     }
 
     public function testHandlerRequireShareSetoptFailureThrows(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
-        $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
+        try {
+            $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to configure cURL share handle');
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Unable to configure cURL share handle');
 
-        CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+            CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
     }
 
     private static function skipIfCurlShareIsUnavailable(): void
@@ -156,5 +239,21 @@ class CurlShareHandleStateTest extends TestCase
         if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        $property->setAccessible(true);
+
+        $previousVersionInfo = $property->getValue();
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
     }
 }

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -49,7 +49,7 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerPreferCreatesShareHandleForDnsAndSslSession(): void
     {
         self::skipIfCurlShareIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         try {
             $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER);
@@ -73,7 +73,7 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerRequireCreatesShareHandleForDnsAndSslSession(): void
     {
         self::skipIfCurlShareIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         try {
             $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
@@ -121,7 +121,7 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerPreferCreatesDnsOnlyShareHandleBelowSslSessionFloor(): void
     {
         self::skipIfCurlShareIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.5.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.5.0', 'features' => self::curlSslFeature()]);
 
         try {
             $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER);
@@ -140,7 +140,22 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerRequireRejectsBelowSslSessionFloor(): void
     {
         self::skipIfCurlShareIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.5.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.5.0', 'features' => self::curlSslFeature()]);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('SSL session sharing');
+
+            CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testHandlerRequireRejectsWhenCurlLacksSslSupport(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
         try {
             $this->expectException(\InvalidArgumentException::class);
@@ -206,7 +221,7 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerPreferFallsBackToNoSharingWhenShareSetupFails(): void
     {
         self::skipIfCurlShareIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         try {
             $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
@@ -220,7 +235,7 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerRequireShareSetoptFailureThrows(): void
     {
         self::skipIfCurlShareIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         try {
             $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
@@ -239,6 +254,15 @@ class CurlShareHandleStateTest extends TestCase
         if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is unavailable.');
+        }
+
+        return \CURL_VERSION_SSL;
     }
 
     /**

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -249,7 +249,9 @@ class CurlShareHandleStateTest extends TestCase
     private static function setCurlVersionInfo($versionInfo)
     {
         $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $previousVersionInfo = $property->getValue();
         $property->setValue(null, $versionInfo);

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -26,16 +26,19 @@ class CurlVersionTest extends TestCase
 
     public function testSupportsTls12UsesMinimumVersion(): void
     {
-        if (!\defined('CURL_SSLVERSION_TLSv1_2')) {
-            self::markTestSkipped('CURL_SSLVERSION_TLSv1_2 is unavailable.');
+        if (!\defined('CURL_SSLVERSION_TLSv1_2') || !\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('TLS 1.2 cURL constants are unavailable.');
         }
 
-        $previous = self::setCurlVersionInfo(['version' => '7.33.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '7.33.0', 'features' => \CURL_VERSION_SSL]);
 
         try {
             self::assertFalse(CurlVersion::supportsTls12());
 
             self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
+            self::assertFalse(CurlVersion::supportsTls12());
+
+            self::setCurlVersionInfo(['version' => '7.34.0', 'features' => \CURL_VERSION_SSL]);
             self::assertTrue(CurlVersion::supportsTls12());
         } finally {
             self::setCurlVersionInfo($previous);
@@ -44,16 +47,19 @@ class CurlVersionTest extends TestCase
 
     public function testSupportsTls13UsesMinimumVersion(): void
     {
-        if (!\defined('CURL_SSLVERSION_TLSv1_3')) {
-            self::markTestSkipped('CURL_SSLVERSION_TLSv1_3 is unavailable.');
+        if (!\defined('CURL_SSLVERSION_TLSv1_3') || !\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('TLS 1.3 cURL constants are unavailable.');
         }
 
-        $previous = self::setCurlVersionInfo(['version' => '7.51.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '7.51.0', 'features' => \CURL_VERSION_SSL]);
 
         try {
             self::assertFalse(CurlVersion::supportsTls13());
 
             self::setCurlVersionInfo(['version' => '7.52.0', 'features' => 0]);
+            self::assertFalse(CurlVersion::supportsTls13());
+
+            self::setCurlVersionInfo(['version' => '7.52.0', 'features' => \CURL_VERSION_SSL]);
             self::assertTrue(CurlVersion::supportsTls13());
         } finally {
             self::setCurlVersionInfo($previous);
@@ -62,7 +68,7 @@ class CurlVersionTest extends TestCase
 
     public function testSupportsHttp2RequiresTls12AndHttp2Feature(): void
     {
-        if (!\defined('CURL_SSLVERSION_TLSv1_2') || !\defined('CURL_VERSION_HTTP2')) {
+        if (!\defined('CURL_SSLVERSION_TLSv1_2') || !\defined('CURL_VERSION_HTTP2') || !\defined('CURL_VERSION_SSL')) {
             self::markTestSkipped('HTTP/2 cURL constants are unavailable.');
         }
 
@@ -81,6 +87,12 @@ class CurlVersionTest extends TestCase
                 'version' => '7.34.0',
                 'features' => \CURL_VERSION_HTTP2,
             ]);
+            self::assertFalse(CurlVersion::supportsHttp2());
+
+            self::setCurlVersionInfo([
+                'version' => '7.34.0',
+                'features' => \CURL_VERSION_HTTP2 | \CURL_VERSION_SSL,
+            ]);
             self::assertTrue(CurlVersion::supportsHttp2());
         } finally {
             self::setCurlVersionInfo($previous);
@@ -89,16 +101,24 @@ class CurlVersionTest extends TestCase
 
     public function testSupportsTransportSharingUsesSharingFloors(): void
     {
-        $previous = self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is unavailable.');
+        }
+
+        $previous = self::setCurlVersionInfo(['version' => '7.34.0', 'features' => \CURL_VERSION_SSL]);
 
         try {
             self::assertFalse(CurlVersion::supportsHandlerSharing());
 
-            self::setCurlVersionInfo(['version' => '7.35.0', 'features' => 0]);
+            self::setCurlVersionInfo(['version' => '7.35.0', 'features' => \CURL_VERSION_SSL]);
             self::assertTrue(CurlVersion::supportsHandlerSharing());
             self::assertFalse(CurlVersion::supportsSslSessionSharing());
 
             self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsHandlerSharing());
+            self::assertFalse(CurlVersion::supportsSslSessionSharing());
+
+            self::setCurlVersionInfo(['version' => '8.6.0', 'features' => \CURL_VERSION_SSL]);
             self::assertTrue(CurlVersion::supportsHandlerSharing());
             self::assertTrue(CurlVersion::supportsSslSessionSharing());
         } finally {

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace GuzzleHttp\Tests\Handler;
+
+use GuzzleHttp\Handler\CurlVersion;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Handler\CurlVersion
+ */
+class CurlVersionTest extends TestCase
+{
+    public function testSupportsCurlHandlerUsesMinimumVersion(): void
+    {
+        $previous = self::setCurlVersionInfo(['version' => '7.21.1', 'features' => 0]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsCurlHandler());
+
+            self::setCurlVersionInfo(['version' => '7.21.2', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsCurlHandler());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testSupportsTls12UsesMinimumVersion(): void
+    {
+        if (!\defined('CURL_SSLVERSION_TLSv1_2')) {
+            self::markTestSkipped('CURL_SSLVERSION_TLSv1_2 is unavailable.');
+        }
+
+        $previous = self::setCurlVersionInfo(['version' => '7.33.0', 'features' => 0]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsTls12());
+
+            self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsTls12());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testSupportsTls13UsesMinimumVersion(): void
+    {
+        if (!\defined('CURL_SSLVERSION_TLSv1_3')) {
+            self::markTestSkipped('CURL_SSLVERSION_TLSv1_3 is unavailable.');
+        }
+
+        $previous = self::setCurlVersionInfo(['version' => '7.51.0', 'features' => 0]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsTls13());
+
+            self::setCurlVersionInfo(['version' => '7.52.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsTls13());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testSupportsHttp2RequiresTls12AndHttp2Feature(): void
+    {
+        if (!\defined('CURL_SSLVERSION_TLSv1_2') || !\defined('CURL_VERSION_HTTP2')) {
+            self::markTestSkipped('HTTP/2 cURL constants are unavailable.');
+        }
+
+        $previous = self::setCurlVersionInfo([
+            'version' => '7.33.0',
+            'features' => \CURL_VERSION_HTTP2,
+        ]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsHttp2());
+
+            self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
+            self::assertFalse(CurlVersion::supportsHttp2());
+
+            self::setCurlVersionInfo([
+                'version' => '7.34.0',
+                'features' => \CURL_VERSION_HTTP2,
+            ]);
+            self::assertTrue(CurlVersion::supportsHttp2());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testSupportsTransportSharingUsesSharingFloors(): void
+    {
+        $previous = self::setCurlVersionInfo(['version' => '7.34.0', 'features' => 0]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsHandlerSharing());
+
+            self::setCurlVersionInfo(['version' => '7.35.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsHandlerSharing());
+            self::assertFalse(CurlVersion::supportsSslSessionSharing());
+
+            self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsHandlerSharing());
+            self::assertTrue(CurlVersion::supportsSslSessionSharing());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    public function testGetVersionReturnsNullWhenVersionIsUnavailable(): void
+    {
+        $previous = self::setCurlVersionInfo(false);
+
+        try {
+            self::assertNull(CurlVersion::getVersion());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        $property->setAccessible(true);
+
+        $previousVersionInfo = $property->getValue();
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
+    }
+}

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -125,7 +125,9 @@ class CurlVersionTest extends TestCase
     private static function setCurlVersionInfo($versionInfo)
     {
         $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $previousVersionInfo = $property->getValue();
         $property->setValue(null, $versionInfo);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -90,7 +90,7 @@ class UtilsTest extends TestCase
     public function testChooseHandlerAcceptsPreferredTransportSharing(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -113,7 +113,7 @@ class UtilsTest extends TestCase
     public function testChooseHandlerAcceptsRequiredTransportSharing(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
-        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => self::curlSslFeature()]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -359,6 +359,15 @@ class UtilsTest extends TestCase
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is unavailable.');
+        }
+
+        return \CURL_VERSION_SSL;
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -3,6 +3,7 @@
 namespace GuzzleHttp\Test;
 
 use GuzzleHttp;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\TransportSharing;
 use GuzzleHttp\Utils;
 use PHPUnit\Framework\TestCase;
@@ -89,6 +90,7 @@ class UtilsTest extends TestCase
     public function testChooseHandlerAcceptsPreferredTransportSharing(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -103,6 +105,7 @@ class UtilsTest extends TestCase
                 \CURL_LOCK_DATA_SSL_SESSION,
             ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
         } finally {
+            self::setCurlVersionInfo($previous);
             unset($_SERVER['curl_test'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
         }
     }
@@ -110,6 +113,7 @@ class UtilsTest extends TestCase
     public function testChooseHandlerAcceptsRequiredTransportSharing(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
+        $previous = self::setCurlVersionInfo(['version' => '8.6.0', 'features' => 0]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -124,6 +128,7 @@ class UtilsTest extends TestCase
                 \CURL_LOCK_DATA_SSL_SESSION,
             ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
         } finally {
+            self::setCurlVersionInfo($previous);
             unset($_SERVER['curl_test'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
         }
     }
@@ -350,11 +355,26 @@ class UtilsTest extends TestCase
             !\function_exists('curl_share_init')
             || !\function_exists('curl_share_setopt')
             || !\function_exists('curl_exec')
-            || !\function_exists('curl_version')
-            || version_compare(curl_version()['version'], '7.21.2') < 0
+            || !CurlVersion::supportsCurlHandler()
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        $property->setAccessible(true);
+
+        $previousVersionInfo = $property->getValue();
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
     }
 }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -369,7 +369,9 @@ class UtilsTest extends TestCase
     private static function setCurlVersionInfo($versionInfo)
     {
         $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
-        $property->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         $previousVersionInfo = $property->getValue();
         $property->setValue(null, $versionInfo);


### PR DESCRIPTION
This centralizes cURL version and feature detection in an internal CurlVersion helper. It moves HTTP/2 and TLS capability checks onto that helper while preserving the existing cURL handler minimum version. It also limits cURL transport sharing to libcurl versions that can safely share the requested DNS and SSL session state, so preferred sharing can fall back and required sharing fails when the full sharing contract cannot be met.