### PR TITLE
Add cURL sharing floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject invalid `HandlerStack::remove()` arguments
 - Require `Pool` request collections to be iterable
 - Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0
+- Restricted cURL handler and sharing support to required libcurl SSL capabilities
 - Store response cookies without a `Domain` attribute as host-only cookies
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
 - Reject malformed response protocol versions and reason phrases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Stop forwarding the generic `auth` request option when following cross-origin redirects
 - Reject invalid `HandlerStack::remove()` arguments
 - Require `Pool` request collections to be iterable
-- Raised the minimum supported libcurl version for the built-in cURL handlers to 7.34.0
-- Restricted cURL handler and sharing support to required libcurl SSL capabilities
+- Raised the built-in cURL handler floor to libcurl 7.34.0 with SSL support
 - Store response cookies without a `Domain` attribute as host-only cookies
 - Tighten invalid response handling and avoid exposing response-derived cURL stats
 - Reject malformed response protocol versions and reason phrases

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -440,10 +440,12 @@ $client->request('GET', 'https://legacy.example.com', [
 #### cURL Minimum Version
 
 Guzzle 8 requires libcurl 7.34.0 or higher when using the built-in cURL
-handlers. If the default handler stack detects an older libcurl version, it will
-not select the cURL handler automatically. Manually configured cURL handlers also
-reject requests when the linked libcurl version is lower than 7.34.0 or the PHP
-cURL extension does not expose TLS 1.2 support.
+handlers. The linked libcurl must also be built with SSL support. If the default
+handler stack detects an older libcurl version or a libcurl build without SSL
+support, it will not select the cURL handler automatically. Manually configured
+cURL handlers also reject requests when the linked libcurl version is lower than
+7.34.0, the PHP cURL extension does not expose TLS 1.2 support, or libcurl does
+not advertise SSL support.
 
 #### cURL Handler Lifecycle
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -439,13 +439,10 @@ $client->request('GET', 'https://legacy.example.com', [
 
 #### cURL Minimum Version
 
-Guzzle 8 requires libcurl 7.34.0 or higher when using the built-in cURL
-handlers. The linked libcurl must also be built with SSL support. If the default
-handler stack detects an older libcurl version or a libcurl build without SSL
-support, it will not select the cURL handler automatically. Manually configured
-cURL handlers also reject requests when the linked libcurl version is lower than
-7.34.0, the PHP cURL extension does not expose TLS 1.2 support, or libcurl does
-not advertise SSL support.
+Guzzle 8 requires libcurl 7.34.0 or higher with SSL/TLS support when using the
+built-in cURL handlers. If this requirement is not met, the default handler
+stack will not select cURL automatically, and manually configured cURL handlers
+reject requests.
 
 #### cURL Handler Lifecycle
 

--- a/docs/handlers-and-middleware.md
+++ b/docs/handlers-and-middleware.md
@@ -382,6 +382,13 @@ cURL share handles to share DNS and SSL session cache state. If sharing cannot
 be configured, or if the selected handler does not support sharing, Guzzle
 continues without sharing.
 
+Guzzle only enables cURL transport sharing for libcurl versions that support the
+requested shared state safely. Handler-lifetime cURL sharing requires libcurl
+7.35.0 or newer. SSL session cache sharing requires libcurl 8.6.0 or newer and
+libcurl SSL support. On older libcurl versions that still meet the
+handler-lifetime sharing floor, `TransportSharing::HANDLER_PREFER` shares DNS
+cache state without sharing SSL session cache state.
+
 `TransportSharing::HANDLER_REQUIRE` requires handler-lifetime transport
 sharing. Guzzle fails when it cannot select a cURL handler with cURL share
 support, when sharing cannot be configured, or when a request is routed to a
@@ -393,6 +400,13 @@ handles, which can share DNS, connection, and SSL session cache state across
 handler lifetimes. If persistent sharing is unavailable or cannot be created,
 Guzzle falls back to `TransportSharing::HANDLER_PREFER`. If handler-lifetime
 sharing is also unavailable, Guzzle continues without sharing.
+
+Persistent cURL sharing requires PHP persistent cURL share handle support and
+libcurl 8.20.0 or newer because persistent sharing includes libcurl connection
+cache state. `TransportSharing::PERSISTENT_PREFER` falls back to
+handler-lifetime sharing when persistent connection sharing is unavailable.
+`TransportSharing::PERSISTENT_REQUIRE` fails when persistent connection sharing
+is unavailable.
 
 `TransportSharing::PERSISTENT_REQUIRE` requires PHP persistent cURL share
 handles and does not fall back to handler-lifetime sharing. If persistent

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -121,7 +121,7 @@ final class CurlShareHandleState
 
         self::requireCurlConstant('CURLOPT_SHARE');
         $shareOption = self::requireCurlConstant('CURLSHOPT_SHARE');
-        $locks = self::handlerLocks();
+        $locks = self::handlerLocks($mode);
         $handle = curl_share_init();
 
         try {
@@ -160,6 +160,9 @@ final class CurlShareHandleState
 
     private static function createPersistentShare(string $mode): self
     {
+        CurlVersion::ensureConnectionSharingSupported();
+        CurlVersion::ensureSslSessionSharingSupported();
+
         if (!self::supportsPersistentShare()) {
             throw new InvalidArgumentException('The "transport_sharing" option requires persistent cURL share handle support.');
         }
@@ -181,7 +184,9 @@ final class CurlShareHandleState
 
     private static function supportsPersistentShare(): bool
     {
-        return \function_exists('curl_share_init_persistent')
+        return CurlVersion::supportsConnectionSharing()
+            && CurlVersion::supportsSslSessionSharing()
+            && \function_exists('curl_share_init_persistent')
             && \class_exists('CurlSharePersistentHandle')
             && \defined('CURL_LOCK_DATA_DNS')
             && \defined('CURL_LOCK_DATA_CONNECT')
@@ -191,12 +196,23 @@ final class CurlShareHandleState
     /**
      * @return int[]
      */
-    private static function handlerLocks(): array
+    private static function handlerLocks(string $mode): array
     {
-        return [
+        CurlVersion::ensureHandlerSharingSupported();
+
+        if ($mode === TransportSharing::HANDLER_REQUIRE) {
+            CurlVersion::ensureSslSessionSharingSupported();
+        }
+
+        $locks = [
             self::requireCurlConstant('CURL_LOCK_DATA_DNS'),
-            self::requireCurlConstant('CURL_LOCK_DATA_SSL_SESSION'),
         ];
+
+        if (CurlVersion::supportsSslSessionSharing()) {
+            $locks[] = self::requireCurlConstant('CURL_LOCK_DATA_SSL_SESSION');
+        }
+
+        return $locks;
     }
 
     /**

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -40,19 +40,20 @@ final class CurlVersion
 
     public static function supportsCurlHandler(): bool
     {
-        $version = self::get();
+        $versionInfo = self::getVersionInfo();
 
-        return self::supportsSsl()
+        return \defined('CURL_VERSION_SSL')
             && \defined('CURL_SSLVERSION_TLSv1_2')
-            && null !== $version
-            && version_compare($version, self::MIN_VERSION, '>=');
+            && null !== $versionInfo
+            && version_compare($versionInfo['version'], self::MIN_VERSION, '>=')
+            && 0 !== (\CURL_VERSION_SSL & $versionInfo['features']);
     }
 
     public static function supportsTls13(): bool
     {
         $version = self::get();
 
-        return self::supportsSsl()
+        return self::supportsCurlHandler()
             && \defined('CURL_SSLVERSION_TLSv1_3')
             && null !== $version
             && version_compare($version, self::TLS_13_VERSION, '>=');
@@ -79,7 +80,7 @@ final class CurlVersion
             return false;
         }
 
-        return self::supportsSsl()
+        return self::supportsCurlHandler()
             && 0 !== ((int) \constant('CURL_VERSION_HTTP3') & self::getInfo()['features']);
     }
 
@@ -105,7 +106,7 @@ final class CurlVersion
     {
         $version = self::get();
 
-        return self::supportsSsl()
+        return self::supportsCurlHandler()
             && null !== $version
             && version_compare($version, self::SSL_SESSION_SHARING_VERSION, '>=');
     }
@@ -178,20 +179,7 @@ final class CurlVersion
             ), $request);
         }
 
-        if (!self::supportsSsl()) {
-            throw new ConnectException('The cURL handler requires libcurl SSL support.', $request);
-        }
-
-        throw new ConnectException('The installed cURL version is not supported by the cURL handler.', $request);
-    }
-
-    private static function supportsSsl(): bool
-    {
-        $versionInfo = self::getVersionInfo();
-
-        return \defined('CURL_VERSION_SSL')
-            && null !== $versionInfo
-            && 0 !== (\CURL_VERSION_SSL & $versionInfo['features']);
+        throw new ConnectException('The cURL handler requires libcurl SSL support.', $request);
     }
 
     private static function get(): ?string

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -20,7 +21,13 @@ final class CurlVersion
 
     private const PROTOCOLS_STR_VERSION = '7.85.0';
 
-    private const PROXY_CREDENTIAL_REUSE_VERSION = '8.19.0';
+    private const HANDLER_SHARING_VERSION = '7.35.0';
+
+    private const SSL_SESSION_SHARING_VERSION = '8.6.0';
+
+    private const CONNECTION_SHARING_VERSION = '8.20.0';
+
+    private const PROXY_CREDENTIAL_REUSE_VERSION = '8.20.0';
 
     /**
      * @var array{version: string, features: int}|false|null
@@ -31,11 +38,12 @@ final class CurlVersion
     {
     }
 
-    public static function supportsTls12(): bool
+    public static function supportsCurlHandler(): bool
     {
         $version = self::get();
 
-        return \defined('CURL_SSLVERSION_TLSv1_2')
+        return self::supportsSsl()
+            && \defined('CURL_SSLVERSION_TLSv1_2')
             && null !== $version
             && version_compare($version, self::MIN_VERSION, '>=');
     }
@@ -44,15 +52,20 @@ final class CurlVersion
     {
         $version = self::get();
 
-        return \defined('CURL_SSLVERSION_TLSv1_3')
+        return self::supportsSsl()
+            && \defined('CURL_SSLVERSION_TLSv1_3')
             && null !== $version
             && version_compare($version, self::TLS_13_VERSION, '>=');
     }
 
     public static function supportsHttp2(): bool
     {
-        return self::supportsTls12()
-            && (\CURL_VERSION_HTTP2 & self::getInfo()['features']);
+        if (!\defined('CURL_VERSION_HTTP2')) {
+            return false;
+        }
+
+        return self::supportsCurlHandler()
+            && 0 !== (\CURL_VERSION_HTTP2 & self::getInfo()['features']);
     }
 
     public static function supportsHttp3(): bool
@@ -66,7 +79,63 @@ final class CurlVersion
             return false;
         }
 
-        return 0 !== ((int) \constant('CURL_VERSION_HTTP3') & self::getInfo()['features']);
+        return self::supportsSsl()
+            && 0 !== ((int) \constant('CURL_VERSION_HTTP3') & self::getInfo()['features']);
+    }
+
+    public static function supportsHandlerSharing(): bool
+    {
+        $version = self::get();
+
+        return null !== $version
+            && version_compare($version, self::HANDLER_SHARING_VERSION, '>=');
+    }
+
+    public static function ensureHandlerSharingSupported(): void
+    {
+        if (!self::supportsHandlerSharing()) {
+            throw new InvalidArgumentException(\sprintf(
+                'The "transport_sharing" option requires libcurl %s or higher for cURL share handles.',
+                self::HANDLER_SHARING_VERSION
+            ));
+        }
+    }
+
+    public static function supportsSslSessionSharing(): bool
+    {
+        $version = self::get();
+
+        return self::supportsSsl()
+            && null !== $version
+            && version_compare($version, self::SSL_SESSION_SHARING_VERSION, '>=');
+    }
+
+    public static function ensureSslSessionSharingSupported(): void
+    {
+        if (!self::supportsSslSessionSharing()) {
+            throw new InvalidArgumentException(\sprintf(
+                'The "transport_sharing" option requires libcurl %s or higher with SSL support for SSL session sharing.',
+                self::SSL_SESSION_SHARING_VERSION
+            ));
+        }
+    }
+
+    public static function supportsConnectionSharing(): bool
+    {
+        $version = self::get();
+
+        return null !== $version
+            && version_compare($version, self::CONNECTION_SHARING_VERSION, '>=');
+    }
+
+    public static function ensureConnectionSharingSupported(): void
+    {
+        if (!self::supportsConnectionSharing()) {
+            throw new InvalidArgumentException(\sprintf(
+                'The "transport_sharing" option requires libcurl %s or higher for persistent connection sharing.',
+                self::CONNECTION_SHARING_VERSION
+            ));
+        }
     }
 
     public static function supportsProxyCredentialAwareConnectionReuse(): bool
@@ -88,7 +157,7 @@ final class CurlVersion
 
     public static function ensureSupported(RequestInterface $request): void
     {
-        if (self::supportsTls12()) {
+        if (self::supportsCurlHandler()) {
             return;
         }
 
@@ -108,6 +177,21 @@ final class CurlVersion
                 self::MIN_VERSION
             ), $request);
         }
+
+        if (!self::supportsSsl()) {
+            throw new ConnectException('The cURL handler requires libcurl SSL support.', $request);
+        }
+
+        throw new ConnectException('The installed cURL version is not supported by the cURL handler.', $request);
+    }
+
+    private static function supportsSsl(): bool
+    {
+        $versionInfo = self::getVersionInfo();
+
+        return \defined('CURL_VERSION_SSL')
+            && null !== $versionInfo
+            && 0 !== (\CURL_VERSION_SSL & $versionInfo['features']);
     }
 
     private static function get(): ?string

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -53,20 +53,18 @@ final class CurlVersion
     {
         $version = self::get();
 
-        return self::supportsCurlHandler()
-            && \defined('CURL_SSLVERSION_TLSv1_3')
+        return \defined('CURL_SSLVERSION_TLSv1_3')
             && null !== $version
             && version_compare($version, self::TLS_13_VERSION, '>=');
     }
 
     public static function supportsHttp2(): bool
     {
-        if (!\defined('CURL_VERSION_HTTP2')) {
-            return false;
-        }
+        $versionInfo = self::getVersionInfo();
 
-        return self::supportsCurlHandler()
-            && 0 !== (\CURL_VERSION_HTTP2 & self::getInfo()['features']);
+        return \defined('CURL_VERSION_HTTP2')
+            && null !== $versionInfo
+            && 0 !== (\CURL_VERSION_HTTP2 & $versionInfo['features']);
     }
 
     public static function supportsHttp3(): bool
@@ -75,13 +73,12 @@ final class CurlVersion
             return false;
         }
 
-        $version = self::get();
-        if (null === $version || version_compare($version, self::HTTP_3_VERSION, '<')) {
+        $versionInfo = self::getVersionInfo();
+        if (null === $versionInfo || version_compare($versionInfo['version'], self::HTTP_3_VERSION, '<')) {
             return false;
         }
 
-        return self::supportsCurlHandler()
-            && 0 !== ((int) \constant('CURL_VERSION_HTTP3') & self::getInfo()['features']);
+        return 0 !== ((int) \constant('CURL_VERSION_HTTP3') & $versionInfo['features']);
     }
 
     public static function supportsHandlerSharing(): bool
@@ -104,11 +101,12 @@ final class CurlVersion
 
     public static function supportsSslSessionSharing(): bool
     {
-        $version = self::get();
+        $versionInfo = self::getVersionInfo();
 
-        return self::supportsCurlHandler()
-            && null !== $version
-            && version_compare($version, self::SSL_SESSION_SHARING_VERSION, '>=');
+        return \defined('CURL_VERSION_SSL')
+            && null !== $versionInfo
+            && version_compare($versionInfo['version'], self::SSL_SESSION_SHARING_VERSION, '>=')
+            && 0 !== (\CURL_VERSION_SSL & $versionInfo['features']);
     }
 
     public static function ensureSslSessionSharingSupported(): void
@@ -187,20 +185,6 @@ final class CurlVersion
         $versionInfo = self::getVersionInfo();
 
         return null === $versionInfo ? null : $versionInfo['version'];
-    }
-
-    /**
-     * @return array{version: string, features: int}
-     */
-    private static function getInfo(): array
-    {
-        $versionInfo = self::getVersionInfo();
-
-        if (null === $versionInfo) {
-            throw new \RuntimeException('Unable to determine cURL version.');
-        }
-
-        return $versionInfo;
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -103,11 +103,11 @@ final class Utils
         $sharingRequested = $sharingMode !== TransportSharing::NONE;
         $sharingRequired = \in_array($sharingMode, [TransportSharing::HANDLER_REQUIRE, TransportSharing::PERSISTENT_REQUIRE], true);
         $curlHandlerOptions = [];
-        $curlSupported = CurlVersion::supportsTls12()
+        $curlSupported = CurlVersion::supportsCurlHandler()
             && (\function_exists('curl_multi_exec') || \function_exists('curl_exec'));
 
         if ($sharingRequired && !$curlSupported) {
-            throw new \RuntimeException('Required transport sharing requires the PHP cURL extension, curl_exec() or curl_multi_exec(), and a supported libcurl version.');
+            throw new \RuntimeException('Required transport sharing requires the PHP cURL extension, curl_exec() or curl_multi_exec(), and a supported libcurl version with SSL support.');
         }
 
         if ($curlSupported) {
@@ -134,7 +134,7 @@ final class Utils
                 ? Proxy::wrapStreaming($handler, $streamHandler)
                 : $streamHandler;
         } elseif (!$handler) {
-            throw new \RuntimeException('GuzzleHttp requires a supported cURL version, the allow_url_fopen ini setting, or a custom HTTP handler.');
+            throw new \RuntimeException('GuzzleHttp requires a supported cURL version with SSL support, the allow_url_fopen ini setting, or a custom HTTP handler.');
         }
 
         return $handler;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -206,11 +206,7 @@ class ClientTest extends TestCase
                 'transport_sharing' => TransportSharing::HANDLER_PREFER,
             ]);
 
-            self::assertSame(1, $_SERVER['_curl_share_init_count']);
-            self::assertSame([
-                \CURL_LOCK_DATA_DNS,
-                \CURL_LOCK_DATA_SSL_SESSION,
-            ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+            self::assertHandlerShareWasCreated();
         } finally {
             unset($_SERVER['curl_test'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
         }
@@ -1233,7 +1229,8 @@ class ClientTest extends TestCase
             !\function_exists('curl_share_init')
             || !\function_exists('curl_share_setopt')
             || !\function_exists('curl_exec')
-            || !CurlVersion::supportsTls12()
+            || !CurlVersion::supportsCurlHandler()
+            || !CurlVersion::supportsHandlerSharing()
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }
@@ -1242,7 +1239,9 @@ class ClientTest extends TestCase
     private static function assertPersistentPreferShareWasCreated(): void
     {
         if (
-            \function_exists('curl_share_init_persistent')
+            CurlVersion::supportsConnectionSharing()
+            && CurlVersion::supportsSslSessionSharing()
+            && \function_exists('curl_share_init_persistent')
             && \class_exists('CurlSharePersistentHandle')
             && \defined('CURL_LOCK_DATA_DNS')
             && \defined('CURL_LOCK_DATA_CONNECT')
@@ -1258,11 +1257,18 @@ class ClientTest extends TestCase
             return;
         }
 
+        self::assertHandlerShareWasCreated();
+    }
+
+    private static function assertHandlerShareWasCreated(): void
+    {
+        $locks = [\CURL_LOCK_DATA_DNS];
+        if (CurlVersion::supportsSslSessionSharing()) {
+            $locks[] = \CURL_LOCK_DATA_SSL_SESSION;
+        }
+
         self::assertSame(1, $_SERVER['_curl_share_init_count']);
-        self::assertSame([
-            \CURL_LOCK_DATA_DNS,
-            \CURL_LOCK_DATA_SSL_SESSION,
-        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+        self::assertSame($locks, $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
     }
 
     public function testDoesNotOverwriteHeaderWithDefaultInRequest(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -543,7 +543,7 @@ class CurlFactoryTest extends TestCase
     {
         $previousVersionInfo = self::setCurlVersionInfo([
             'version' => '7.84.0',
-            'features' => 0,
+            'features' => self::curlSslFeature(),
         ]);
 
         try {
@@ -567,7 +567,7 @@ class CurlFactoryTest extends TestCase
 
         $previousVersionInfo = self::setCurlVersionInfo([
             'version' => '7.85.0',
-            'features' => 0,
+            'features' => self::curlSslFeature(),
         ]);
 
         try {
@@ -750,7 +750,7 @@ class CurlFactoryTest extends TestCase
 
     public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
     {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
         ]);
 
@@ -759,7 +759,7 @@ class CurlFactoryTest extends TestCase
 
     public function testDoesNotForceFreshConnectionForAuthenticatedHttpsProxyOnFixedCurlVersion(): void
     {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
         ]);
 
@@ -769,7 +769,7 @@ class CurlFactoryTest extends TestCase
 
     public function testDoesNotForceFreshConnectionForCurlProxyCredentialsOnFixedCurlVersion(): void
     {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_PROXYUSERPWD => 'username:password',
@@ -782,7 +782,7 @@ class CurlFactoryTest extends TestCase
 
     public function testForcesFreshConnectionForAuthenticatedHttpsProxyWithCurlProxyCredentialsOnAffectedCurlVersion(): void
     {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_PROXYUSERPWD => 'username:password',
@@ -819,7 +819,7 @@ class CurlFactoryTest extends TestCase
 
     public function testForcesFreshConnectionForAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
     {
-        self::createWithCurlVersion('8.18.0', 'http://example.com', [
+        self::createWithCurlVersion('8.19.0', 'http://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_HTTPPROXYTUNNEL => true,
@@ -833,7 +833,7 @@ class CurlFactoryTest extends TestCase
     {
         $proxyHeaderOption = self::proxyHeaderOption();
 
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
@@ -1810,7 +1810,7 @@ class CurlFactoryTest extends TestCase
     {
         $previousVersionInfo = self::setCurlVersionInfo([
             'version' => '7.66.0',
-            'features' => 0,
+            'features' => self::curlSslFeature(),
         ]);
 
         try {
@@ -1833,7 +1833,7 @@ class CurlFactoryTest extends TestCase
     {
         $previousVersionInfo = self::setCurlVersionInfo([
             'version' => '7.66.0',
-            'features' => 0,
+            'features' => self::curlSslFeature(),
         ]);
 
         try {
@@ -1989,7 +1989,7 @@ class CurlFactoryTest extends TestCase
     {
         $previousVersionInfo = self::setCurlVersionInfo([
             'version' => '7.66.0',
-            'features' => 0,
+            'features' => self::curlSslFeature(),
         ]);
 
         try {
@@ -4881,7 +4881,7 @@ class CurlFactoryTest extends TestCase
     {
         $previousVersionInfo = self::setCurlVersionInfo([
             'version' => $version,
-            'features' => 0,
+            'features' => self::curlSslFeature(),
         ]);
 
         try {
@@ -4934,7 +4934,7 @@ class CurlFactoryTest extends TestCase
     {
         self::requireHttp3TestConstants();
 
-        $features = (int) \constant('CURL_VERSION_HTTP3');
+        $features = (int) \constant('CURL_VERSION_HTTP3') | self::curlSslFeature();
         if ($withHttp2) {
             if (!\defined('CURL_VERSION_HTTP2')) {
                 self::markTestSkipped('CURL_VERSION_HTTP2 is not available.');
@@ -4944,6 +4944,15 @@ class CurlFactoryTest extends TestCase
         }
 
         return $features;
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is not available.');
+        }
+
+        return \CURL_VERSION_SSL;
     }
 
     public static function curlHandlerProvider(): array

--- a/tests/Handler/CurlHandlerTest.php
+++ b/tests/Handler/CurlHandlerTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlFactoryInterface;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\Handler\CurlShareHandleState;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
@@ -203,11 +204,7 @@ class CurlHandlerTest extends TestCase
             $handler(new Request('GET', Server::$url), [])->wait();
 
             self::assertArrayHasKey(\CURLOPT_SHARE, $_SERVER['_curl']);
-            self::assertSame(1, $_SERVER['_curl_share_init_count']);
-            self::assertSame([
-                \CURL_LOCK_DATA_DNS,
-                \CURL_LOCK_DATA_SSL_SESSION,
-            ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+            self::assertHandlerShareWasCreated();
         } finally {
             unset($_SERVER['curl_test'], $_SERVER['_curl'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
         }
@@ -358,6 +355,8 @@ class CurlHandlerTest extends TestCase
             !\function_exists('curl_share_init')
             || !\function_exists('curl_share_setopt')
             || !\defined('CURLOPT_SHARE')
+            || !CurlVersion::supportsCurlHandler()
+            || !CurlVersion::supportsHandlerSharing()
         ) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
@@ -366,7 +365,9 @@ class CurlHandlerTest extends TestCase
     private static function assertPersistentPreferShareWasCreated(): void
     {
         if (
-            \function_exists('curl_share_init_persistent')
+            CurlVersion::supportsConnectionSharing()
+            && CurlVersion::supportsSslSessionSharing()
+            && \function_exists('curl_share_init_persistent')
             && \class_exists('CurlSharePersistentHandle')
             && \defined('CURL_LOCK_DATA_DNS')
             && \defined('CURL_LOCK_DATA_CONNECT')
@@ -382,10 +383,17 @@ class CurlHandlerTest extends TestCase
             return;
         }
 
+        self::assertHandlerShareWasCreated();
+    }
+
+    private static function assertHandlerShareWasCreated(): void
+    {
+        $locks = [\CURL_LOCK_DATA_DNS];
+        if (CurlVersion::supportsSslSessionSharing()) {
+            $locks[] = \CURL_LOCK_DATA_SSL_SESSION;
+        }
+
         self::assertSame(1, $_SERVER['_curl_share_init_count']);
-        self::assertSame([
-            \CURL_LOCK_DATA_DNS,
-            \CURL_LOCK_DATA_SSL_SESSION,
-        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+        self::assertSame($locks, $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
     }
 }

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlFactoryInterface;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\CurlShareHandleState;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7\Request;
@@ -118,11 +119,7 @@ class CurlMultiHandlerTest extends TestCase
         $handler(new Request('GET', Server::$url), [])->wait();
 
         self::assertArrayHasKey(\CURLOPT_SHARE, $_SERVER['_curl']);
-        self::assertSame(1, $_SERVER['_curl_share_init_count']);
-        self::assertSame([
-            \CURL_LOCK_DATA_DNS,
-            \CURL_LOCK_DATA_SSL_SESSION,
-        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+        self::assertHandlerShareWasCreated();
     }
 
     public function testPersistentPreferTransportSharingOptionAppliesCurlShare(): void
@@ -840,6 +837,8 @@ class CurlMultiHandlerTest extends TestCase
             !\function_exists('curl_share_init')
             || !\function_exists('curl_share_setopt')
             || !\defined('CURLOPT_SHARE')
+            || !CurlVersion::supportsCurlHandler()
+            || !CurlVersion::supportsHandlerSharing()
         ) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
@@ -848,7 +847,9 @@ class CurlMultiHandlerTest extends TestCase
     private static function assertPersistentPreferShareWasCreated(): void
     {
         if (
-            \function_exists('curl_share_init_persistent')
+            CurlVersion::supportsConnectionSharing()
+            && CurlVersion::supportsSslSessionSharing()
+            && \function_exists('curl_share_init_persistent')
             && \class_exists('CurlSharePersistentHandle')
             && \defined('CURL_LOCK_DATA_DNS')
             && \defined('CURL_LOCK_DATA_CONNECT')
@@ -864,10 +865,17 @@ class CurlMultiHandlerTest extends TestCase
             return;
         }
 
+        self::assertHandlerShareWasCreated();
+    }
+
+    private static function assertHandlerShareWasCreated(): void
+    {
+        $locks = [\CURL_LOCK_DATA_DNS];
+        if (CurlVersion::supportsSslSessionSharing()) {
+            $locks[] = \CURL_LOCK_DATA_SSL_SESSION;
+        }
+
         self::assertSame(1, $_SERVER['_curl_share_init_count']);
-        self::assertSame([
-            \CURL_LOCK_DATA_DNS,
-            \CURL_LOCK_DATA_SSL_SESSION,
-        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
+        self::assertSame($locks, $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
     }
 }

--- a/tests/Handler/CurlShareHandleStateTest.php
+++ b/tests/Handler/CurlShareHandleStateTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlShareHandleState;
+use GuzzleHttp\Handler\CurlVersion;
 use GuzzleHttp\TransportSharing;
 use PHPUnit\Framework\TestCase;
 
@@ -15,8 +16,14 @@ use PHPUnit\Framework\TestCase;
  */
 class CurlShareHandleStateTest extends TestCase
 {
+    /**
+     * @var array{version: string, features: int}|false|null
+     */
+    private $versionInfo;
+
     public function setUp(): void
     {
+        $this->versionInfo = self::getVersionInfo();
         $_SERVER['curl_test'] = true;
         unset(
             $_SERVER['_curl_share'],
@@ -31,6 +38,7 @@ class CurlShareHandleStateTest extends TestCase
 
     public function tearDown(): void
     {
+        self::setVersionInfo($this->versionInfo);
         unset(
             $_SERVER['curl_test'],
             $_SERVER['_curl_share'],
@@ -56,6 +64,10 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerPreferCreatesShareHandleForDnsAndSslSession(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.6.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER);
 
@@ -75,6 +87,10 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerRequireCreatesShareHandleForDnsAndSslSession(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.6.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
 
@@ -83,9 +99,111 @@ class CurlShareHandleStateTest extends TestCase
         self::assertHandlerShareWasCreated();
     }
 
+    public function testHandlerPreferFallsBackToNoSharingBelowHandlerSharingFloor(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '7.34.0',
+            'features' => self::curlSslFeature(),
+        ]);
+
+        self::assertNull(CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER));
+        self::assertArrayNotHasKey('_curl_share_init_count', $_SERVER);
+    }
+
+    public function testHandlerRequireRejectsBelowHandlerSharingFloor(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '7.34.0',
+            'features' => self::curlSslFeature(),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('libcurl 7.35.0');
+
+        CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+    }
+
+    public function testHandlerPreferCreatesDnsOnlyShareHandleBelowSslSessionFloor(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.5.0',
+            'features' => self::curlSslFeature(),
+        ]);
+
+        $state = CurlShareHandleState::fromOption(TransportSharing::HANDLER_PREFER);
+
+        self::assertInstanceOf(CurlShareHandleState::class, $state);
+        self::assertSame(TransportSharing::HANDLER_PREFER, $state->mode);
+        self::assertDnsOnlyShareWasCreated();
+    }
+
+    public function testHandlerRequireRejectsBelowSslSessionFloor(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.5.0',
+            'features' => self::curlSslFeature(),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('SSL session sharing');
+
+        CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+    }
+
+    public function testHandlerRequireRejectsWhenCurlLacksSslSupport(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.6.0',
+            'features' => 0,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('SSL session sharing');
+
+        CurlShareHandleState::fromOption(TransportSharing::HANDLER_REQUIRE);
+    }
+
+    public function testPersistentPreferFallsBackToHandlerSharingBelowConnectionSharingFloor(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.19.0',
+            'features' => self::curlSslFeature(),
+        ]);
+
+        $state = CurlShareHandleState::fromOption(TransportSharing::PERSISTENT_PREFER);
+
+        self::assertInstanceOf(CurlShareHandleState::class, $state);
+        self::assertSame(TransportSharing::HANDLER_PREFER, $state->mode);
+        self::assertHandlerShareWasCreated();
+        self::assertArrayNotHasKey('_curl_share_init_persistent_count', $_SERVER);
+    }
+
+    public function testPersistentRequireRejectsBelowConnectionSharingFloor(): void
+    {
+        self::setVersionInfo([
+            'version' => '8.19.0',
+            'features' => self::curlSslFeature(),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('persistent connection sharing');
+
+        CurlShareHandleState::fromOption(TransportSharing::PERSISTENT_REQUIRE);
+    }
+
     public function testPersistentPreferFallsBackToHandlerSharingWhenPersistentSharingIsUnavailable(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         if (self::persistentCurlShareIsAvailable()) {
             $_SERVER['curl_share_init_persistent_fail'] = true;
@@ -101,6 +219,10 @@ class CurlShareHandleStateTest extends TestCase
     public function testPersistentPreferFallsBackToNoSharingWhenHandlerSharingFallbackFails(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         if (self::persistentCurlShareIsAvailable()) {
             $_SERVER['curl_share_init_persistent_fail'] = true;
@@ -112,6 +234,10 @@ class CurlShareHandleStateTest extends TestCase
 
     public function testPersistentPreferUsesPersistentSharingWhenAvailable(): void
     {
+        self::setVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
         self::skipIfPersistentCurlShareIsUnavailable();
 
         $state = CurlShareHandleState::fromOption(TransportSharing::PERSISTENT_PREFER);
@@ -124,6 +250,11 @@ class CurlShareHandleStateTest extends TestCase
 
     public function testPersistentRequireRejectsWhenPersistentSharingIsUnavailable(): void
     {
+        self::setVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
+
         if (\function_exists('curl_share_init_persistent') && \class_exists('CurlSharePersistentHandle')) {
             self::markTestSkipped('Persistent cURL share handles are available.');
         }
@@ -136,6 +267,10 @@ class CurlShareHandleStateTest extends TestCase
 
     public function testPersistentRequireRejectsWhenPersistentInitializationFails(): void
     {
+        self::setVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
         self::skipIfPersistentCurlShareIsUnavailable();
 
         $_SERVER['curl_share_init_persistent_fail'] = true;
@@ -148,6 +283,10 @@ class CurlShareHandleStateTest extends TestCase
 
     public function testPersistentRequireUsesPersistentSharingWhenAvailable(): void
     {
+        self::setVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
         self::skipIfPersistentCurlShareIsUnavailable();
 
         $state = CurlShareHandleState::fromOption(TransportSharing::PERSISTENT_REQUIRE);
@@ -220,6 +359,10 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerPreferFallsBackToNoSharingWhenShareSetupFails(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.6.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
 
@@ -229,6 +372,10 @@ class CurlShareHandleStateTest extends TestCase
     public function testHandlerRequireShareSetoptFailureThrows(): void
     {
         self::skipIfCurlShareIsUnavailable();
+        self::setVersionInfo([
+            'version' => '8.6.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         $_SERVER['curl_share_setopt_fail'] = \CURL_LOCK_DATA_DNS;
 
@@ -240,7 +387,7 @@ class CurlShareHandleStateTest extends TestCase
 
     private static function skipIfCurlShareIsUnavailable(): void
     {
-        if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt')) {
+        if (!\function_exists('curl_share_init') || !\function_exists('curl_share_setopt') || !\defined('CURLOPT_SHARE')) {
             self::markTestSkipped('cURL share handles are unavailable.');
         }
     }
@@ -259,6 +406,49 @@ class CurlShareHandleStateTest extends TestCase
             && \defined('CURL_LOCK_DATA_DNS')
             && \defined('CURL_LOCK_DATA_CONNECT')
             && \defined('CURL_LOCK_DATA_SSL_SESSION');
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is unavailable.');
+        }
+
+        return \CURL_VERSION_SSL;
+    }
+
+    /**
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function getVersionInfo()
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
+
+        return $property->getValue();
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     */
+    private static function setVersionInfo($versionInfo): void
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
+
+        $property->setValue(null, $versionInfo);
+    }
+
+    private static function assertDnsOnlyShareWasCreated(): void
+    {
+        self::assertSame(1, $_SERVER['_curl_share_init_count']);
+        self::assertSame([
+            \CURL_LOCK_DATA_DNS,
+        ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
     }
 
     private static function assertHandlerShareWasCreated(): void

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -52,42 +52,40 @@ class CurlVersionTest extends TestCase
         self::assertTrue(CurlVersion::supportsCurlHandler());
     }
 
-    public function testSupportsTls13RequiresSslFeature(): void
+    public function testSupportsTls13UsesRuntimeVersion(): void
     {
         if (!\defined('CURL_SSLVERSION_TLSv1_3')) {
             self::markTestSkipped('CURL_SSLVERSION_TLSv1_3 is not available.');
         }
-        self::requiresCurlSslConstants();
 
         self::setVersionInfo([
-            'version' => '7.52.0',
+            'version' => '7.51.0',
             'features' => 0,
         ]);
         self::assertFalse(CurlVersion::supportsTls13());
 
         self::setVersionInfo([
             'version' => '7.52.0',
-            'features' => self::curlSslFeature(),
+            'features' => 0,
         ]);
         self::assertTrue(CurlVersion::supportsTls13());
     }
 
-    public function testSupportsHttp2RequiresSslFeature(): void
+    public function testSupportsHttp2UsesHttp2Feature(): void
     {
-        self::requiresCurlSslConstants();
         if (!\defined('CURL_VERSION_HTTP2')) {
             self::markTestSkipped('CURL_VERSION_HTTP2 is not available.');
         }
 
         self::setVersionInfo([
             'version' => '7.34.0',
-            'features' => \CURL_VERSION_HTTP2,
+            'features' => 0,
         ]);
         self::assertFalse(CurlVersion::supportsHttp2());
 
         self::setVersionInfo([
             'version' => '7.34.0',
-            'features' => \CURL_VERSION_HTTP2 | self::curlSslFeature(),
+            'features' => \CURL_VERSION_HTTP2,
         ]);
         self::assertTrue(CurlVersion::supportsHttp2());
     }
@@ -126,31 +124,12 @@ class CurlVersionTest extends TestCase
     public function testSupportsHttp3WhenVersionAndFeatureAreAvailable(): void
     {
         self::requiresHttp3Constants();
-        self::requiresCurlSslFeature();
-
-        self::setVersionInfo([
-            'version' => '7.66.0',
-            'features' => self::http3Feature() | self::curlSslFeature(),
-        ]);
-
-        self::assertTrue(CurlVersion::supportsHttp3());
-    }
-
-    public function testSupportsHttp3RequiresSslFeature(): void
-    {
-        self::requiresHttp3Constants();
-        self::requiresCurlSslFeature();
 
         self::setVersionInfo([
             'version' => '7.66.0',
             'features' => self::http3Feature(),
         ]);
-        self::assertFalse(CurlVersion::supportsHttp3());
 
-        self::setVersionInfo([
-            'version' => '7.66.0',
-            'features' => self::http3Feature() | self::curlSslFeature(),
-        ]);
         self::assertTrue(CurlVersion::supportsHttp3());
     }
 

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Tests\Handler;
 
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlVersion;
+use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,6 +27,69 @@ class CurlVersionTest extends TestCase
     protected function tearDown(): void
     {
         self::setVersionInfo($this->versionInfo);
+    }
+
+    public function testSupportsCurlHandlerRequiresTls12Contract(): void
+    {
+        self::requiresCurlSslConstants();
+
+        self::setVersionInfo([
+            'version' => '7.33.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertFalse(CurlVersion::supportsCurlHandler());
+
+        self::setVersionInfo([
+            'version' => '7.34.0',
+            'features' => 0,
+        ]);
+        self::assertFalse(CurlVersion::supportsCurlHandler());
+
+        self::setVersionInfo([
+            'version' => '7.34.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertTrue(CurlVersion::supportsCurlHandler());
+    }
+
+    public function testSupportsTls13RequiresSslFeature(): void
+    {
+        if (!\defined('CURL_SSLVERSION_TLSv1_3')) {
+            self::markTestSkipped('CURL_SSLVERSION_TLSv1_3 is not available.');
+        }
+        self::requiresCurlSslConstants();
+
+        self::setVersionInfo([
+            'version' => '7.52.0',
+            'features' => 0,
+        ]);
+        self::assertFalse(CurlVersion::supportsTls13());
+
+        self::setVersionInfo([
+            'version' => '7.52.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertTrue(CurlVersion::supportsTls13());
+    }
+
+    public function testSupportsHttp2RequiresSslFeature(): void
+    {
+        self::requiresCurlSslConstants();
+        if (!\defined('CURL_VERSION_HTTP2')) {
+            self::markTestSkipped('CURL_VERSION_HTTP2 is not available.');
+        }
+
+        self::setVersionInfo([
+            'version' => '7.34.0',
+            'features' => \CURL_VERSION_HTTP2,
+        ]);
+        self::assertFalse(CurlVersion::supportsHttp2());
+
+        self::setVersionInfo([
+            'version' => '7.34.0',
+            'features' => \CURL_VERSION_HTTP2 | self::curlSslFeature(),
+        ]);
+        self::assertTrue(CurlVersion::supportsHttp2());
     }
 
     public function testSupportsHttp3ReturnsFalseWhenVersionInfoIsUnavailable(): void
@@ -61,13 +126,111 @@ class CurlVersionTest extends TestCase
     public function testSupportsHttp3WhenVersionAndFeatureAreAvailable(): void
     {
         self::requiresHttp3Constants();
+        self::requiresCurlSslFeature();
+
+        self::setVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3Feature() | self::curlSslFeature(),
+        ]);
+
+        self::assertTrue(CurlVersion::supportsHttp3());
+    }
+
+    public function testSupportsHttp3RequiresSslFeature(): void
+    {
+        self::requiresHttp3Constants();
+        self::requiresCurlSslFeature();
 
         self::setVersionInfo([
             'version' => '7.66.0',
             'features' => self::http3Feature(),
         ]);
+        self::assertFalse(CurlVersion::supportsHttp3());
 
+        self::setVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3Feature() | self::curlSslFeature(),
+        ]);
         self::assertTrue(CurlVersion::supportsHttp3());
+    }
+
+    public function testSupportsTransportSharingUsesSharingFloors(): void
+    {
+        self::requiresCurlSslFeature();
+
+        self::setVersionInfo([
+            'version' => '7.34.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertFalse(CurlVersion::supportsHandlerSharing());
+        self::assertFalse(CurlVersion::supportsSslSessionSharing());
+        self::assertFalse(CurlVersion::supportsConnectionSharing());
+
+        self::setVersionInfo([
+            'version' => '7.35.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertTrue(CurlVersion::supportsHandlerSharing());
+        self::assertFalse(CurlVersion::supportsSslSessionSharing());
+        self::assertFalse(CurlVersion::supportsConnectionSharing());
+
+        self::setVersionInfo([
+            'version' => '8.6.0',
+            'features' => 0,
+        ]);
+        self::assertTrue(CurlVersion::supportsHandlerSharing());
+        self::assertFalse(CurlVersion::supportsSslSessionSharing());
+        self::assertFalse(CurlVersion::supportsConnectionSharing());
+
+        self::setVersionInfo([
+            'version' => '8.6.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertTrue(CurlVersion::supportsHandlerSharing());
+        self::assertTrue(CurlVersion::supportsSslSessionSharing());
+        self::assertFalse(CurlVersion::supportsConnectionSharing());
+
+        self::setVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertTrue(CurlVersion::supportsHandlerSharing());
+        self::assertTrue(CurlVersion::supportsSslSessionSharing());
+        self::assertTrue(CurlVersion::supportsConnectionSharing());
+    }
+
+    public function testSupportsProxyCredentialAwareConnectionReuseUsesSafeVersion(): void
+    {
+        self::requiresCurlSslFeature();
+
+        self::setVersionInfo([
+            'version' => '8.19.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertFalse(CurlVersion::supportsProxyCredentialAwareConnectionReuse());
+
+        self::setVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
+        self::assertTrue(CurlVersion::supportsProxyCredentialAwareConnectionReuse());
+    }
+
+    public function testEnsureSupportedRejectsCurlWithoutSslSupport(): void
+    {
+        if (!\defined('CURL_SSLVERSION_TLSv1_2')) {
+            self::markTestSkipped('CURL_SSLVERSION_TLSv1_2 is not available.');
+        }
+
+        self::setVersionInfo([
+            'version' => '7.34.0',
+            'features' => 0,
+        ]);
+
+        $this->expectException(ConnectException::class);
+        $this->expectExceptionMessage('SSL support');
+
+        CurlVersion::ensureSupported(new Request('GET', 'http://example.com'));
     }
 
     public function testSupportsProtocolsStrReturnsFalseWhenVersionInfoIsUnavailable(): void
@@ -108,6 +271,22 @@ class CurlVersionTest extends TestCase
         }
     }
 
+    private static function requiresCurlSslConstants(): void
+    {
+        if (!\defined('CURL_SSLVERSION_TLSv1_2')) {
+            self::markTestSkipped('CURL_SSLVERSION_TLSv1_2 is not available.');
+        }
+
+        self::requiresCurlSslFeature();
+    }
+
+    private static function requiresCurlSslFeature(): void
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is not available.');
+        }
+    }
+
     private static function requiresProtocolsStrConstant(): void
     {
         if (!\defined('CURLOPT_PROTOCOLS_STR')) {
@@ -118,6 +297,13 @@ class CurlVersionTest extends TestCase
     private static function http3Feature(): int
     {
         return (int) \constant('CURL_VERSION_HTTP3');
+    }
+
+    private static function curlSslFeature(): int
+    {
+        self::requiresCurlSslFeature();
+
+        return \CURL_VERSION_SSL;
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -90,6 +90,10 @@ class UtilsTest extends TestCase
     public function testChooseHandlerAcceptsPreferredTransportSharing(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '8.6.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -104,6 +108,7 @@ class UtilsTest extends TestCase
                 \CURL_LOCK_DATA_SSL_SESSION,
             ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
         } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
             unset($_SERVER['curl_test'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
         }
     }
@@ -111,6 +116,10 @@ class UtilsTest extends TestCase
     public function testChooseHandlerAcceptsRequiredTransportSharing(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '8.6.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
@@ -125,6 +134,7 @@ class UtilsTest extends TestCase
                 \CURL_LOCK_DATA_SSL_SESSION,
             ], $_SERVER['_curl_share'][\CURLSHOPT_SHARE]);
         } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
             unset($_SERVER['curl_test'], $_SERVER['_curl_share'], $_SERVER['_curl_share_init_count']);
         }
     }
@@ -132,6 +142,10 @@ class UtilsTest extends TestCase
     public function testChooseHandlerAcceptsPersistentPreferTransportSharing(): void
     {
         self::skipIfDefaultCurlHandlerIsUnavailable();
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '8.20.0',
+            'features' => self::curlSslFeature(),
+        ]);
 
         $_SERVER['curl_test'] = true;
         unset($_SERVER['_curl_share_init_count'], $_SERVER['_curl_share_init_persistent_count']);
@@ -141,6 +155,7 @@ class UtilsTest extends TestCase
 
             self::assertIsCallable($handler);
         } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
             unset($_SERVER['curl_test'], $_SERVER['_curl_share_init_count'], $_SERVER['_curl_share_init_persistent_count']);
         }
     }
@@ -257,10 +272,38 @@ class UtilsTest extends TestCase
             !\function_exists('curl_share_init')
             || !\function_exists('curl_share_setopt')
             || !\function_exists('curl_exec')
-            || !CurlVersion::supportsTls12()
+            || !CurlVersion::supportsCurlHandler()
+            || !CurlVersion::supportsHandlerSharing()
         ) {
             self::markTestSkipped('Default cURL handler with share handles is unavailable.');
         }
+    }
+
+    private static function curlSslFeature(): int
+    {
+        if (!\defined('CURL_VERSION_SSL')) {
+            self::markTestSkipped('CURL_VERSION_SSL is not available.');
+        }
+
+        return \CURL_VERSION_SSL;
+    }
+
+    /**
+     * @param array{version: string, features: int}|false|null $versionInfo
+     *
+     * @return array{version: string, features: int}|false|null
+     */
+    private static function setCurlVersionInfo($versionInfo)
+    {
+        $property = new \ReflectionProperty(CurlVersion::class, 'versionInfo');
+        if (\PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
+
+        $previousVersionInfo = $property->getValue();
+        $property->setValue(null, $versionInfo);
+
+        return $previousVersionInfo;
     }
 }
 


### PR DESCRIPTION
Guzzle now treats libcurl SSL support as part of the cURL handler capability checks in Guzzle 8. Transport sharing now uses cURL version and feature floors for DNS, SSL session, and persistent connection cache sharing. Persistent sharing falls back when connection sharing is unavailable unless it was explicitly required.