### PR TITLE
Prevent authenticated proxy tunnel reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fix cURL TLS and HTTP/2 capability detection using libcurl feature checks
+- Prevent reuse of authenticated proxy tunnel connections on libcurl versions older than 8.20.0
 
 
 ## 7.11.1 - 2026-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Changed
 
 - Constrain cURL transport sharing to safe libcurl DNS and SSL session support
+- Prevent authenticated proxy tunnel reuse on libcurl versions older than 8.20.0
 
 ### Deprecated
 
@@ -19,7 +20,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Fix cURL TLS and HTTP/2 capability detection using libcurl feature checks
-- Prevent reuse of authenticated proxy tunnel connections on libcurl versions older than 8.20.0
 
 
 ## 7.11.1 - 2026-06-07

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -127,6 +127,8 @@ class CurlFactory implements CurlFactoryInterface
             $conf = \array_replace($conf, $options['curl']);
         }
 
+        self::forceFreshConnectionForAuthenticatedProxy($request, $conf);
+
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
         if ($this->shareHandle !== null) {
             if (!\defined('CURLOPT_SHARE')) {
@@ -640,6 +642,174 @@ class CurlFactory implements CurlFactoryInterface
         $redactedUriString = \GuzzleHttp\Psr7\Utils::redactUserInfo($baseUri)->__toString();
 
         return str_replace($baseUriString, $redactedUriString, $error);
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function forceFreshConnectionForAuthenticatedProxy(RequestInterface $request, array &$conf): void
+    {
+        $proxy = self::getProxyForConnectionReuse($conf);
+
+        if ($proxy === null || !self::requiresFreshConnectionForAuthenticatedProxy($request, $proxy, $conf)) {
+            return;
+        }
+
+        $conf[\CURLOPT_FRESH_CONNECT] = true;
+        $conf[\CURLOPT_FORBID_REUSE] = true;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function getProxyForConnectionReuse(array $conf): ?string
+    {
+        if (!\array_key_exists(\CURLOPT_PROXY, $conf)) {
+            return null;
+        }
+
+        $proxy = $conf[\CURLOPT_PROXY];
+
+        return \is_string($proxy) && $proxy !== '' ? $proxy : null;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy, array $conf): bool
+    {
+        if (!self::usesProxyTunnel($request, $conf) || !self::isHttpProxyForConnectionReuse($proxy, $conf)) {
+            return false;
+        }
+
+        $proxyForParsing = \strpos($proxy, '://') === false ? 'http://'.$proxy : $proxy;
+        $proxyParts = \parse_url($proxyForParsing);
+
+        if (!\is_array($proxyParts)) {
+            return false;
+        }
+
+        if (self::hasCurlProxyAuthorizationHeader($conf)) {
+            return true;
+        }
+
+        return !CurlVersion::supportsProxyCredentialAwareConnectionReuse()
+            && (
+                \array_key_exists('user', $proxyParts)
+                || \array_key_exists('pass', $proxyParts)
+                || self::hasCurlProxyCredentials($conf)
+            );
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function usesProxyTunnel(RequestInterface $request, array $conf): bool
+    {
+        return 'https' === $request->getUri()->getScheme()
+            || (
+                \defined('CURLOPT_HTTPPROXYTUNNEL')
+                && \array_key_exists((int) \constant('CURLOPT_HTTPPROXYTUNNEL'), $conf)
+                && (bool) $conf[(int) \constant('CURLOPT_HTTPPROXYTUNNEL')]
+            );
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function isHttpProxyForConnectionReuse(string $proxy, array $conf): bool
+    {
+        if (\strpos($proxy, '://') !== false) {
+            $proxyParts = \parse_url($proxy);
+
+            if (!\is_array($proxyParts) || !isset($proxyParts['scheme'])) {
+                return false;
+            }
+
+            $proxyScheme = \strtolower($proxyParts['scheme']);
+
+            return $proxyScheme === 'http' || $proxyScheme === 'https';
+        }
+
+        return !self::isSocksProxyType($conf[\CURLOPT_PROXYTYPE] ?? null);
+    }
+
+    /**
+     * @param mixed $proxyType
+     */
+    private static function isSocksProxyType($proxyType): bool
+    {
+        if (!\is_int($proxyType)) {
+            return false;
+        }
+
+        foreach ([
+            'CURLPROXY_SOCKS4' => 4,
+            'CURLPROXY_SOCKS5' => 5,
+            'CURLPROXY_SOCKS4A' => 6,
+            'CURLPROXY_SOCKS5_HOSTNAME' => 7,
+        ] as $name => $fallback) {
+            $value = \defined($name) ? (int) \constant($name) : $fallback;
+            if ($proxyType === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlProxyCredentials(array $conf): bool
+    {
+        foreach (['CURLOPT_PROXYUSERPWD', 'CURLOPT_PROXYUSERNAME', 'CURLOPT_PROXYPASSWORD'] as $option) {
+            if (\defined($option) && \array_key_exists((int) \constant($option), $conf)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlProxyAuthorizationHeader(array $conf): bool
+    {
+        if (!\defined('CURLOPT_PROXYHEADER')) {
+            return false;
+        }
+
+        $option = (int) \constant('CURLOPT_PROXYHEADER');
+        if (!\array_key_exists($option, $conf)) {
+            return false;
+        }
+
+        $headers = $conf[$option];
+        if (!\is_array($headers)) {
+            return false;
+        }
+
+        foreach ($headers as $header) {
+            if (!\is_string($header)) {
+                continue;
+            }
+
+            $parts = \explode(':', $header, 2);
+            if (\count($parts) !== 2) {
+                continue;
+            }
+
+            if (
+                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
+                && \trim($parts[1]) !== ''
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -17,6 +17,8 @@ final class CurlVersion
 
     private const SSL_SESSION_SHARING_VERSION = '8.6.0';
 
+    private const PROXY_CREDENTIAL_REUSE_VERSION = '8.20.0';
+
     /**
      * @var array{version: string, features: int}|false|null
      */
@@ -97,6 +99,14 @@ final class CurlVersion
                 self::SSL_SESSION_SHARING_VERSION
             ));
         }
+    }
+
+    public static function supportsProxyCredentialAwareConnectionReuse(): bool
+    {
+        $version = self::getVersion();
+
+        return $version !== null
+            && \version_compare($version, self::PROXY_CREDENTIAL_REUSE_VERSION, '>=');
     }
 
     private static function supportsSsl(): bool

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -402,6 +402,130 @@ class CurlFactoryTest extends TestCase
         $this->checkNoProxyForHost('http://127.0.0.1', ['127.0.0.*'], true);
     }
 
+    public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedHttpsProxyOnFixedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testForcesFreshConnectionForCurlProxyCredentialsOnAffectedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_PROXYUSERPWD => 'username:password',
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testForcesFreshConnectionForAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
+    {
+        if (!\defined('CURLOPT_HTTPPROXYTUNNEL')) {
+            self::markTestSkipped('CURLOPT_HTTPPROXYTUNNEL is not available.');
+        }
+
+        self::createWithCurlVersion('8.19.0', 'http://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_HTTPPROXYTUNNEL => true,
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testForcesFreshConnectionForProxyAuthorizationProxyHeaderOnFixedCurlVersion(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testDoesNotForceFreshConnectionForUnrelatedProxyHeader(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['X-Proxy-Header: value'],
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForEmptyProxyAuthorizationProxyHeader(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['Proxy-Authorization:'],
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'http://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedSocksProxy(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'socks5://username:password@proxy.example.com:1080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testAuthenticatedHttpsProxyReuseOptionsCannotBeOverriddenOnAffectedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_FRESH_CONNECT => false,
+                \CURLOPT_FORBID_REUSE => false,
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
     private function checkNoProxyForHost($url, $noProxy, $assertUseProxy)
     {
         $f = new CurlFactory(3);
@@ -1446,6 +1570,39 @@ class CurlFactoryTest extends TestCase
         }, null, CurlFactory::class);
 
         return $readHandles($factory);
+    }
+
+    private static function assertAuthenticatedProxyConnectionReuseOptions(): void
+    {
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    /**
+     * @param array<int|string, mixed> $options
+     */
+    private static function createWithCurlVersion(string $version, string $uri, array $options): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => 0,
+        ]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', $uri), $options);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    private static function proxyHeaderOption(): int
+    {
+        if (!\defined('CURLOPT_PROXYHEADER')) {
+            self::markTestSkipped('CURLOPT_PROXYHEADER is not available.');
+        }
+
+        return (int) \constant('CURLOPT_PROXYHEADER');
     }
 
     private static function skipIfCurlShareIsUnavailable(): void

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -126,6 +126,20 @@ class CurlVersionTest extends TestCase
         }
     }
 
+    public function testSupportsProxyCredentialAwareConnectionReuseUsesSafeVersion(): void
+    {
+        $previous = self::setCurlVersionInfo(['version' => '8.19.0', 'features' => 0]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsProxyCredentialAwareConnectionReuse());
+
+            self::setCurlVersionInfo(['version' => '8.20.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsProxyCredentialAwareConnectionReuse());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
     public function testGetVersionReturnsNullWhenVersionIsUnavailable(): void
     {
         $previous = self::setCurlVersionInfo(false);


### PR DESCRIPTION
This backports the authenticated proxy tunnel connection reuse mitigation to 7.12. It treats libcurl 8.20.0 as the safe floor for proxy credential-aware reuse and forces fresh, non-reused connections for authenticated HTTP proxy tunnels on older libcurl versions. It also treats explicit Proxy-Authorization proxy headers as requiring fresh proxy tunnel connections because libcurl cannot safely reason about those credentials.