### PR TITLE
Prevent proxy tunnel reuse overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers
-- Avoid stale authenticated proxy tunnels on affected libcurl versions
+- Prevent raw cURL reuse options from reusing authenticated proxy tunnels on affected libcurl versions
 - Allow built-in cURL handler `progress` callbacks to abort transfers with truthy return values
 - Normalize built-in handler `progress` callback arguments to integer byte counts
 - Reject built-in cURL `progress` throwables with `ResponseException` when a response exists, otherwise `RequestException`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers
-- Prevent raw cURL reuse options from reusing authenticated proxy tunnels on affected libcurl versions
+- Prevent raw cURL reuse options from overriding authenticated proxy tunnel isolation
 - Allow built-in cURL handler `progress` callbacks to abort transfers with truthy return values
 - Normalize built-in handler `progress` callback arguments to integer byte counts
 - Reject built-in cURL `progress` throwables with `ResponseException` when a response exists, otherwise `RequestException`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Treat request method names case-sensitively in built-in handler and redirect method-specific behavior
 - Treat PHP resources passed as `sink` as caller-owned in the built-in cURL and stream handlers
 - Use the configured PSR-17 URI factory when parsing redirect `Location` headers
-- Prevent raw cURL reuse options from overriding authenticated proxy tunnel isolation
+- Avoid stale authenticated proxy tunnels on affected libcurl versions
 - Allow built-in cURL handler `progress` callbacks to abort transfers with truthy return values
 - Normalize built-in handler `progress` callback arguments to integer byte counts
 - Reject built-in cURL `progress` throwables with `ResponseException` when a response exists, otherwise `RequestException`

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -205,6 +205,8 @@ final class CurlFactory implements CurlFactoryInterface
             $conf = \array_replace($conf, $options['curl']);
         }
 
+        $this->forceFreshConnectionForAuthenticatedProxy($request, $conf);
+
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
         if ($this->shareHandle !== null) {
             if (!\defined('CURLOPT_SHARE')) {
@@ -1038,9 +1040,45 @@ final class CurlFactory implements CurlFactoryInterface
         return str_replace($baseUriString, $redactedUriString, $error);
     }
 
-    private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy, array $options): bool
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private function forceFreshConnectionForAuthenticatedProxy(RequestInterface $request, array &$conf): void
     {
-        if (!self::usesProxyTunnel($request, $options) || !self::isHttpProxyForConnectionReuse($proxy, $options)) {
+        $proxy = self::getProxyForConnectionReuse($conf);
+
+        if ($proxy === null || !self::requiresFreshConnectionForAuthenticatedProxy($request, $proxy, $conf)) {
+            return;
+        }
+
+        if ($this->shareMode === TransportSharing::PERSISTENT_REQUIRE) {
+            throw new InvalidArgumentException('Persistent cURL sharing is required, but this request requires a fresh proxy tunnel connection.');
+        }
+
+        $conf[\CURLOPT_FRESH_CONNECT] = true;
+        $conf[\CURLOPT_FORBID_REUSE] = true;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function getProxyForConnectionReuse(array $conf): ?string
+    {
+        if (!\array_key_exists(\CURLOPT_PROXY, $conf)) {
+            return null;
+        }
+
+        $proxy = $conf[\CURLOPT_PROXY];
+
+        return \is_string($proxy) && $proxy !== '' ? $proxy : null;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy, array $conf): bool
+    {
+        if (!self::usesProxyTunnel($request, $conf) || !self::isHttpProxyForConnectionReuse($proxy, $conf)) {
             return false;
         }
 
@@ -1050,7 +1088,7 @@ final class CurlFactory implements CurlFactoryInterface
             return false;
         }
 
-        if (self::hasCurlProxyAuthorizationHeader($options)) {
+        if (self::hasCurlProxyAuthorizationHeader($conf)) {
             return true;
         }
 
@@ -1058,32 +1096,27 @@ final class CurlFactory implements CurlFactoryInterface
             && (
                 \array_key_exists('user', $proxyParts)
                 || \array_key_exists('pass', $proxyParts)
-                || self::hasCurlProxyCredentials($options)
+                || self::hasCurlProxyCredentials($conf)
             );
     }
 
-    private static function usesProxyTunnel(RequestInterface $request, array $options): bool
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function usesProxyTunnel(RequestInterface $request, array $conf): bool
     {
         return 'https' === $request->getUri()->getScheme()
             || (
-                isset($options['curl'])
-                && \array_key_exists(\CURLOPT_HTTPPROXYTUNNEL, $options['curl'])
-                && (bool) $options['curl'][\CURLOPT_HTTPPROXYTUNNEL]
+                \defined('CURLOPT_HTTPPROXYTUNNEL')
+                && \array_key_exists((int) \constant('CURLOPT_HTTPPROXYTUNNEL'), $conf)
+                && (bool) $conf[(int) \constant('CURLOPT_HTTPPROXYTUNNEL')]
             );
     }
 
-    private static function getEffectiveProxyForConnectionReuse(?string $selectedProxy, array $options): ?string
-    {
-        if (!isset($options['curl']) || !\array_key_exists(\CURLOPT_PROXY, $options['curl'])) {
-            return $selectedProxy;
-        }
-
-        $proxy = $options['curl'][\CURLOPT_PROXY];
-
-        return \is_string($proxy) && $proxy !== '' ? $proxy : null;
-    }
-
-    private static function isHttpProxyForConnectionReuse(string $proxy, array $options): bool
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function isHttpProxyForConnectionReuse(string $proxy, array $conf): bool
     {
         if (\strpos($proxy, '://') !== false) {
             $proxyParts = \parse_url($proxy);
@@ -1096,7 +1129,7 @@ final class CurlFactory implements CurlFactoryInterface
             return $proxyScheme === 'http' || $proxyScheme === 'https';
         }
 
-        return !self::isSocksProxyType($options['curl'][\CURLOPT_PROXYTYPE] ?? null);
+        return !self::isSocksProxyType($conf[\CURLOPT_PROXYTYPE] ?? null);
     }
 
     /**
@@ -1123,28 +1156,35 @@ final class CurlFactory implements CurlFactoryInterface
         return false;
     }
 
-    private static function hasCurlProxyCredentials(array $options): bool
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlProxyCredentials(array $conf): bool
     {
-        return isset($options['curl'])
-            && (
-                \array_key_exists(\CURLOPT_PROXYUSERPWD, $options['curl'])
-                || \array_key_exists(\CURLOPT_PROXYUSERNAME, $options['curl'])
-                || \array_key_exists(\CURLOPT_PROXYPASSWORD, $options['curl'])
-            );
+        foreach (['CURLOPT_PROXYUSERPWD', 'CURLOPT_PROXYUSERNAME', 'CURLOPT_PROXYPASSWORD'] as $option) {
+            if (\defined($option) && \array_key_exists((int) \constant($option), $conf)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    private static function hasCurlProxyAuthorizationHeader(array $options): bool
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlProxyAuthorizationHeader(array $conf): bool
     {
         if (!\defined('CURLOPT_PROXYHEADER')) {
             return false;
         }
 
         $option = (int) \constant('CURLOPT_PROXYHEADER');
-        if (!isset($options['curl']) || !\array_key_exists($option, $options['curl'])) {
+        if (!\array_key_exists($option, $conf)) {
             return false;
         }
 
-        $headers = $options['curl'][$option];
+        $headers = $conf[$option];
         if (!\is_array($headers)) {
             return false;
         }
@@ -1617,16 +1657,6 @@ final class CurlFactory implements CurlFactoryInterface
         } elseif ($proxy->shouldDisableProxy()) {
             $conf[\CURLOPT_PROXY] = '';
             $conf[\CURLOPT_NOPROXY] = $proxy->isBypassed() ? '*' : '';
-        }
-
-        $proxyForConnectionReuse = self::getEffectiveProxyForConnectionReuse($selectedProxy, $options);
-        if ($proxyForConnectionReuse !== null && self::requiresFreshConnectionForAuthenticatedProxy($easy->request, $proxyForConnectionReuse, $options)) {
-            if ($this->shareMode === TransportSharing::PERSISTENT_REQUIRE) {
-                throw new InvalidArgumentException('Persistent cURL sharing is required, but this request requires a fresh proxy tunnel connection.');
-            }
-
-            $conf[\CURLOPT_FRESH_CONNECT] = true;
-            $conf[\CURLOPT_FORBID_REUSE] = true;
         }
 
         $cryptoMethod = $options['crypto_method'] ?? null;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -968,10 +968,22 @@ class CurlFactoryTest extends TestCase
         self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
     }
 
-    public function testAuthenticatedHttpsProxyReuseOptionsCanBeOverridden(): void
+    public function testAuthenticatedHttpsProxyReuseOptionsCannotBeOverriddenOnAffectedCurlVersion(): void
     {
-        $f = new CurlFactory(3);
-        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_FRESH_CONNECT => false,
+                \CURLOPT_FORBID_REUSE => false,
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testAuthenticatedHttpsProxyReuseOptionsCanBeSetOnFixedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_FRESH_CONNECT => false,

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -829,7 +829,7 @@ class CurlFactoryTest extends TestCase
         self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
-    public function testForcesFreshConnectionForProxyAuthorizationProxyHeaderOnFixedCurlVersion(): void
+    public function testProxyAuthorizationProxyHeaderReuseOptionsCannotBeOverriddenOnFixedCurlVersion(): void
     {
         $proxyHeaderOption = self::proxyHeaderOption();
 
@@ -837,6 +837,8 @@ class CurlFactoryTest extends TestCase
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+                \CURLOPT_FRESH_CONNECT => false,
+                \CURLOPT_FORBID_REUSE => false,
             ],
         ]);
 


### PR DESCRIPTION
This tightens the authenticated proxy tunnel reuse mitigation in the built-in cURL handler. It applies the mitigation after request-level cURL options are merged, so raw reuse options cannot override authenticated proxy tunnel isolation. It preserves the existing persistent sharing rejection when a required persistent share would conflict with a fresh proxy tunnel connection.