### PR TITLE
Add missing request option constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ## 7.12.0 - Upcoming
 
+### Added
+
+- Added `RequestOptions` constants for `curl`, `retries`, and `stream_context`
+
 ### Changed
 
 - Constrain cURL transport sharing to safe libcurl DNS and SSL session support

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -354,7 +354,7 @@ Default
 None
 
 Constant
-No `RequestOptions` constant is defined for this handler-specific option.
+`GuzzleHttp\RequestOptions::CURL`
 
 Except for Guzzle's special `body_as_string` key, the array is keyed by
 integer cURL option constants and values are passed to cURL after Guzzle
@@ -987,7 +987,7 @@ Default
 `0` when retry middleware is used
 
 Constant
-No `RequestOptions` constant is defined for this middleware-specific option.
+`GuzzleHttp\RequestOptions::RETRIES`
 
 The retry middleware initializes this option to `0` before the first attempt and increments it before each retry. Applications may seed it on a per-request basis when using the retry middleware.
 
@@ -1126,7 +1126,7 @@ Default
 None
 
 Constant
-No `RequestOptions` constant is defined for this handler-specific option.
+`GuzzleHttp\RequestOptions::STREAM_CONTEXT`
 
 This option is only supported by the built-in stream handler. Built-in cURL
 handlers deprecate this option because cURL does not use PHP stream contexts.

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -97,6 +97,11 @@ final class RequestOptions
     public const CRYPTO_METHOD = 'crypto_method';
 
     /**
+     * curl: (array) Raw cURL options to apply when using a built-in cURL handler.
+     */
+    public const CURL = 'curl';
+
+    /**
      * debug: (bool|resource) Set to true or set to a PHP stream returned by
      * fopen()  enable debug output with the HTTP handler used to send a
      * request.
@@ -271,6 +276,12 @@ final class RequestOptions
     public const STREAM = 'stream';
 
     /**
+     * stream_context: (array) PHP stream context options to merge into the
+     * context used by the built-in stream handler.
+     */
+    public const STREAM_CONTEXT = 'stream_context';
+
+    /**
      * verify: (bool|string, default=true) Describes the SSL certificate
      * verification behavior of a request. Set to true to enable SSL
      * certificate verification using the system CA bundle when available
@@ -291,6 +302,11 @@ final class RequestOptions
      * Number describing the body read timeout, for stream requests.
      */
     public const READ_TIMEOUT = 'read_timeout';
+
+    /**
+     * retries: (int) Current retry count used by the retry middleware.
+     */
+    public const RETRIES = 'retries';
 
     /**
      * version: (string|int|float) Specifies the HTTP protocol version to attempt


### PR DESCRIPTION
This adds RequestOptions constants for the documented curl, retries, and stream_context request options. It updates the request options documentation and changelog so each documented request option has a matching constant.