### PR TITLE
Remove redundant sink validation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1338,14 +1338,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             unset($options['query']);
         }
 
-        // Ensure that sink is not an invalid value.
-        if (isset($options['sink'])) {
-            // TODO: Add more sink validation?
-            if (\is_bool($options['sink'])) {
-                throw new InvalidArgumentException('sink must not be a boolean');
-            }
-        }
-
         if (isset($options['version'])) {
             $modify['version'] = self::normalizeProtocolVersion($options['version']);
         }


### PR DESCRIPTION
This removes a redundant sink validation branch from Client::applyOptions. Request options are already validated centrally before transfer, including the documented sink type set, so the later boolean-only check is no longer needed.