### PR TITLE
Deprecate Utils describeType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated raw cURL request options outside the built-in cURL handlers' allow-list
 - Deprecated PHP stream context options outside the built-in stream handler allow-list
 - Deprecated passing `ntlm` as a built-in `auth` type
+- Deprecated `Utils::describeType()`
 
 ### Fixed
 

--- a/src/Handler/CurlShareHandleState.php
+++ b/src/Handler/CurlShareHandleState.php
@@ -3,7 +3,6 @@
 namespace GuzzleHttp\Handler;
 
 use GuzzleHttp\TransportSharing;
-use GuzzleHttp\Utils;
 
 /**
  * @internal
@@ -70,7 +69,7 @@ final class CurlShareHandleState
         throw new \InvalidArgumentException(\sprintf(
             'The "%s" option must be null or a GuzzleHttp\\TransportSharing::* constant; received %s.',
             $option,
-            Utils::describeType($sharing)
+            \get_debug_type($sharing)
         ));
     }
 

--- a/src/Handler/MockHandler.php
+++ b/src/Handler/MockHandler.php
@@ -7,7 +7,6 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\TransferStats;
-use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -160,7 +159,7 @@ class MockHandler implements \Countable
             ) {
                 $this->queue[] = $value;
             } else {
-                throw new \TypeError('Expected a Response, Promise, Throwable or callable. Found '.Utils::describeType($value));
+                throw new \TypeError('Expected a Response, Promise, Throwable or callable. Found '.\get_debug_type($value));
             }
         }
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -21,9 +21,18 @@ final class Utils
      *
      * @return string Returns a string containing the type of the variable and
      *                if a class is provided, the class name.
+     *
+     * @deprecated Utils::describeType() will be removed in guzzlehttp/guzzle:8.0. Use get_debug_type() instead.
      */
     public static function describeType($input): string
     {
+        \trigger_deprecation(
+            'guzzlehttp/guzzle',
+            '7.12',
+            '%s() is deprecated and will be removed in 8.0. Use get_debug_type() instead.',
+            __METHOD__
+        );
+
         switch (\gettype($input)) {
             case 'object':
                 return 'object('.\get_class($input).')';
@@ -550,7 +559,7 @@ EOT
                 'guzzlehttp/guzzle',
                 '7.11',
                 'Passing %s as the "idn_conversion" request option is deprecated; guzzlehttp/guzzle 8.0 will reject values that are not true, false, null, or an integer IDNA_* bitmask.',
-                self::describeType($value)
+                \get_debug_type($value)
             );
 
             return (int) $value;

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,7 +11,7 @@ namespace GuzzleHttp;
  * @return string Returns a string containing the type of the variable and
  *                if a class is provided, the class name.
  *
- * @deprecated describe_type will be removed in guzzlehttp/guzzle:8.0. Use Utils::describeType instead.
+ * @deprecated describe_type will be removed in guzzlehttp/guzzle:8.0. Use get_debug_type() instead.
  */
 function describe_type($input): string
 {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -15,44 +15,6 @@ class UtilsTest extends TestCase
         return [['get'], ['head'], ['delete']];
     }
 
-    public static function typeProvider()
-    {
-        return [
-            ['foo', 'string(3) "foo"'],
-            [true, 'bool(true)'],
-            [false, 'bool(false)'],
-            [10, 'int(10)'],
-            [1.0, 'float(1)'],
-            [new StrClass(), 'object(GuzzleHttp\Test\StrClass)'],
-            [['foo'], 'array(1)'],
-        ];
-    }
-
-    /**
-     * @dataProvider typeProvider
-     */
-    public function testDescribesType($input, $output)
-    {
-        /**
-         * Output may not match if Xdebug is loaded and overloading var_dump().
-         *
-         * @see https://xdebug.org/docs/display#overload_var_dump
-         */
-        if (extension_loaded('xdebug')) {
-            $originalOverload = ini_get('xdebug.overload_var_dump');
-            ini_set('xdebug.overload_var_dump', 0);
-        }
-
-        try {
-            self::assertSame($output, Utils::describeType($input));
-            self::assertSame($output, GuzzleHttp\describe_type($input));
-        } finally {
-            if (extension_loaded('xdebug')) {
-                ini_set('xdebug.overload_var_dump', $originalOverload);
-            }
-        }
-    }
-
     public function testParsesHeadersFromLines()
     {
         $lines = [


### PR DESCRIPTION
This deprecates Utils::describeType before its removal in Guzzle 8. Guzzle's own diagnostics now use get_debug_type directly, while the existing deprecated describe_type helper continues to delegate to Utils::describeType for compatibility.