### PR TITLE
Remove Utils describeType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Removed `RedirectMiddleware::$defaultSettings`; use `RedirectMiddleware::DEFAULT_SETTINGS`
 - Removed the deprecated `RetryMiddleware::exponentialDelay()` method
 - Removed the deprecated `RequestException::wrapException()` method
+- Removed the deprecated `Utils::describeType()` method
 - Removed `RequestException::getHandlerContext()` and `ConnectException::getHandlerContext()`
 - Removed response access from `RequestException`; use `ResponseException`
 - Removed `Utils::isHostInNoProxy()`; use `ProxyOptions` helpers for Guzzle 8 no-proxy matching

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -783,6 +783,10 @@ the old `Utils::isHostInNoProxy()` semantics. Domain matching is
 case-insensitive and ignores a single trailing DNS root dot, IP literals are
 normalized before comparison, and CIDR entries match IP literal hosts.
 
+#### Removed Type Description Helper API
+
+`Utils::describeType()` has been removed. Use PHP's `get_debug_type()` instead.
+
 #### Non-instantiable Utility Classes
 
 Static utility and constant classes such as `GuzzleHttp\Middleware`,

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -23,32 +23,6 @@ final class Utils
     }
 
     /**
-     * Debug function used to describe the provided value type and class.
-     *
-     * @param mixed $input
-     *
-     * @return string Returns a string containing the type of the variable and
-     *                if a class is provided, the class name.
-     */
-    public static function describeType($input): string
-    {
-        switch (\gettype($input)) {
-            case 'object':
-                return 'object('.\get_class($input).')';
-            case 'array':
-                return 'array('.\count($input).')';
-            default:
-                \ob_start();
-                \var_dump($input);
-                // normalize float vs double
-                /** @var string $varDumpContent */
-                $varDumpContent = \ob_get_clean();
-
-                return \str_replace('double(', 'float(', \rtrim($varDumpContent));
-        }
-    }
-
-    /**
      * Parses an array of header lines into an associative array of headers.
      *
      * @param iterable $lines Header lines array of strings in the following


### PR DESCRIPTION
This removes the deprecated Utils::describeType method from the 8.0 branch. The remaining Guzzle diagnostics already use get_debug_type directly, so the helper is no longer needed.