### PR TITLE
Remove HandlerStack string dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Quote multipart `Content-Type` boundary parameters when required
 - Added parameter and return types to `SetCookie` methods
 - Added native property types to supported public cURL handler state properties
-- Added `string` return types to `__toString()` methods
+- Added a `string` return type to `SetCookie::__toString()`
 - Normalize and validate proxy no-proxy options consistently across handlers
 - Normalize no-proxy domain matching, including trailing-dot FQDNs, and IP literal matching consistently
 - Pass the request as the second argument to `on_headers` callbacks
@@ -97,6 +97,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Removed the deprecated `RetryMiddleware::exponentialDelay()` method
 - Removed the deprecated `RequestException::wrapException()` method
 - Removed the deprecated `Utils::describeType()` method
+- Removed `HandlerStack::__toString()`
 - Removed `RequestException::getHandlerContext()` and `ConnectException::getHandlerContext()`
 - Removed response access from `RequestException`; use `ResponseException`
 - Removed `Utils::isHostInNoProxy()`; use `ProxyOptions` helpers for Guzzle 8 no-proxy matching

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -521,7 +521,7 @@ across transports.
 Guzzle 8 adds native parameter and return types where PHP 7.4 allows. Code
 overriding affected methods must update method signatures accordingly.
 
-`HandlerStack::__toString()` and `SetCookie::__toString()` now return `string`.
+`SetCookie::__toString()` now returns `string`.
 
 `HandlerStack::remove()` now throws `TypeError` when passed a value that is
 neither a callable nor a middleware name string.
@@ -796,6 +796,10 @@ private constructors. `GuzzleHttp\Handler\Proxy` is also declared `final`.
 
 These classes only expose static members. Replace any accidental instantiation
 with static method calls or constant access.
+
+#### Removed HandlerStack String Dump
+
+`HandlerStack::__toString()` has been removed.
 
 6.0 to 7.0
 ----------

--- a/src/HandlerStack.php
+++ b/src/HandlerStack.php
@@ -83,34 +83,6 @@ class HandlerStack
     }
 
     /**
-     * Dumps a string representation of the stack.
-     */
-    public function __toString(): string
-    {
-        $depth = 0;
-        $stack = [];
-
-        if ($this->handler !== null) {
-            $stack[] = '0) Handler: '.$this->debugCallable($this->handler);
-        }
-
-        $result = '';
-        foreach (\array_reverse($this->stack) as $tuple) {
-            ++$depth;
-            $str = "{$depth}) Name: '{$tuple[1]}', ";
-            $str .= 'Function: '.$this->debugCallable($tuple[0]);
-            $result = "> {$str}\n{$result}";
-            $stack[] = $str;
-        }
-
-        foreach (\array_keys($stack) as $k) {
-            $result .= "< {$stack[$k]}\n";
-        }
-
-        return $result;
-    }
-
-    /**
      * Set the HTTP handler that actually returns a promise.
      *
      * @param callable&THandler $handler Accepts a request and array of options and returns a value expected by the stack.
@@ -270,26 +242,5 @@ class HandlerStack
             $replacement = [$this->stack[$idx], $tuple];
             \array_splice($this->stack, $idx, 1, $replacement);
         }
-    }
-
-    /**
-     * Provides a debug string for a given callable.
-     *
-     * @param callable $fn Function to write as a string.
-     */
-    private function debugCallable(callable $fn): string
-    {
-        if (\is_string($fn)) {
-            return "callable({$fn})";
-        }
-
-        if (\is_array($fn)) {
-            return \is_string($fn[0])
-                ? "callable({$fn[0]}::{$fn[1]})"
-                : "callable(['".\get_class($fn[0])."', '{$fn[1]}'])";
-        }
-
-        /** @var callable&object $fn */
-        return 'callable('.\spl_object_hash($fn).')';
     }
 }

--- a/tests/HandlerStackTest.php
+++ b/tests/HandlerStackTest.php
@@ -135,27 +135,6 @@ class HandlerStackTest extends TestCase
         self::assertSame([], $meths[0]);
     }
 
-    public function testCanPrintMiddleware(): void
-    {
-        $meths = $this->getFunctions();
-        $builder = new HandlerStack();
-        $builder->setHandler($meths[1]);
-        $builder->push($meths[2], 'a');
-        $builder->push([__CLASS__, 'foo']);
-        $builder->push([$this, 'bar']);
-        $builder->push(__CLASS__.'::foo');
-        $lines = \explode("\n", (string) $builder);
-        self::assertStringContainsString("> 4) Name: 'a', Function: callable(", $lines[0]);
-        self::assertStringContainsString("> 3) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[1]);
-        self::assertStringContainsString("> 2) Name: '', Function: callable(['GuzzleHttp\\Tests\\HandlerStackTest', 'bar'])", $lines[2]);
-        self::assertStringContainsString("> 1) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[3]);
-        self::assertStringContainsString('< 0) Handler: callable(', $lines[4]);
-        self::assertStringContainsString("< 1) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[5]);
-        self::assertStringContainsString("< 2) Name: '', Function: callable(['GuzzleHttp\\Tests\\HandlerStackTest', 'bar'])", $lines[6]);
-        self::assertStringContainsString("< 3) Name: '', Function: callable(GuzzleHttp\\Tests\\HandlerStackTest::foo)", $lines[7]);
-        self::assertStringContainsString("< 4) Name: 'a', Function: callable(", $lines[8]);
-    }
-
     public function testCanAddBeforeByName(): void
     {
         $meths = $this->getFunctions();
@@ -165,11 +144,13 @@ class HandlerStackTest extends TestCase
         $builder->before('foo', $meths[3], 'baz');
         $builder->before('baz', $meths[4], 'bar');
         $builder->before('baz', $meths[4], 'qux');
-        $lines = \explode("\n", (string) $builder);
-        self::assertStringContainsString('> 4) Name: \'bar\'', $lines[0]);
-        self::assertStringContainsString('> 3) Name: \'qux\'', $lines[1]);
-        self::assertStringContainsString('> 2) Name: \'baz\'', $lines[2]);
-        self::assertStringContainsString('> 1) Name: \'foo\'', $lines[3]);
+
+        $composed = $builder->resolve();
+        self::assertSame('Hello - test3321', $composed('test'));
+        self::assertSame(
+            [['c', 'test'], ['c', 'test3'], ['b', 'test33'], ['a', 'test332']],
+            $meths[0]
+        );
     }
 
     public function testEnsuresHandlerExistsByName(): void
@@ -190,11 +171,13 @@ class HandlerStackTest extends TestCase
         $builder->push($meths[3], 'b');
         $builder->after('a', $meths[4], 'c');
         $builder->after('b', $meths[4], 'd');
-        $lines = \explode("\n", (string) $builder);
-        self::assertStringContainsString('4) Name: \'a\'', $lines[0]);
-        self::assertStringContainsString('3) Name: \'c\'', $lines[1]);
-        self::assertStringContainsString('2) Name: \'b\'', $lines[2]);
-        self::assertStringContainsString('1) Name: \'d\'', $lines[3]);
+
+        $composed = $builder->resolve();
+        self::assertSame('Hello - test1323', $composed('test'));
+        self::assertSame(
+            [['a', 'test'], ['c', 'test1'], ['b', 'test13'], ['c', 'test132']],
+            $meths[0]
+        );
     }
 
     public function testPicksUpCookiesFromRedirects(): void
@@ -217,18 +200,6 @@ class HandlerStackTest extends TestCase
         $lastRequest = $mock->getLastRequest();
         self::assertSame('http://foo.com/baz', (string) $lastRequest->getUri());
         self::assertSame('foo=bar', $lastRequest->getHeaderLine('Cookie'));
-    }
-
-    public function testDefaultStackIncludesAuthMiddlewareInOrder(): void
-    {
-        $stack = HandlerStack::create(new MockHandler([new Response()]));
-        $lines = \explode("\n", (string) $stack);
-
-        self::assertStringContainsString("< 1) Name: 'prepare_body'", $lines[6]);
-        self::assertStringContainsString("< 2) Name: 'cookies'", $lines[7]);
-        self::assertStringContainsString("< 3) Name: 'auth'", $lines[8]);
-        self::assertStringContainsString("< 4) Name: 'allow_redirects'", $lines[9]);
-        self::assertStringContainsString("< 5) Name: 'http_errors'", $lines[10]);
     }
 
     /**


### PR DESCRIPTION
This removes HandlerStack::__toString() and its private callable formatting helper from the 8.0 branch. The remaining HandlerStack tests assert middleware insertion order through composed handler behavior rather than through the debug string representation.