### PR TITLE
Use debug type for request body errors

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -724,7 +724,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             return Psr7\Utils::streamFor($body);
         }
 
-        throw new InvalidArgumentException('Invalid resource type: '.\gettype($body));
+        throw new InvalidArgumentException(\sprintf(
+            'Passing %s to request option "body" is invalid; expected resource|string|null|int|float|bool|StreamInterface|callable&object|Iterator|Stringable.',
+            \get_debug_type($body)
+        ));
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1458,6 +1458,11 @@ class ClientTest extends TestCase
             'Passing bool to request option "auth" is invalid; expected array{0: string, 1: string, 2?: string|null}|string|false|null.',
         ];
 
+        yield 'body' => [
+            ['body' => new \stdClass()],
+            'Passing stdClass to request option "body" is invalid; expected resource|string|null|int|float|bool|StreamInterface|callable&object|Iterator|Stringable.',
+        ];
+
         yield 'cert password' => [
             ['cert' => ['cert.pem', new \stdClass()]],
             'Passing stdClass to request option "cert.1" is invalid; expected string|null.',


### PR DESCRIPTION
This updates the invalid body request option error to use the same request option diagnostic format as the rest of the client validation. The message now reports the value type with get_debug_type and names the supported body value types.