### PR TITLE
Complete the proxy environment takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added native property types to supported public cURL handler state properties
 - Added a `string` return type to `SetCookie::__toString()`
 - Validate proxy and no-proxy option types strictly across handlers
-- Downgrade HTTP/3 requests to HTTP/2 when the proxy is resolved from environment variables
+- Downgrade HTTP/3 requests to HTTP/2 or HTTP/1.1 when the proxy is resolved from environment variables
 - Pass the request as the second argument to `on_headers` callbacks
 - Declare strict types across remaining source files
 - Reject invalid `idn_conversion`, `retries`, and built-in handler `on_stats` option values before use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - Add HTTP/3 request support to the built-in cURL handlers when PHP 8.4+ and libcurl provide HTTP/3 support
 - Add generic and structured PHPDoc annotations to client request/config option, async promise, handler, middleware, pool, and mock handler APIs
-- Add CIDR notation support for IP no-proxy rules
 - Add `ConnectTimeoutException` for connect-phase timeouts, extending `ConnectException`
 - Add `NetworkException` for no-response network failures
 - Add `NetworkTimeoutException` for no-response transport timeouts
@@ -32,8 +31,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Added parameter and return types to `SetCookie` methods
 - Added native property types to supported public cURL handler state properties
 - Added a `string` return type to `SetCookie::__toString()`
-- Normalize and validate proxy no-proxy options consistently across handlers
-- Normalize no-proxy domain matching, including trailing-dot FQDNs, and IP literal matching consistently
+- Validate proxy and no-proxy option types strictly across handlers
+- Downgrade HTTP/3 requests to HTTP/2 when the proxy is resolved from environment variables
 - Pass the request as the second argument to `on_headers` callbacks
 - Declare strict types across remaining source files
 - Reject invalid `idn_conversion`, `retries`, and built-in handler `on_stats` option values before use

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -487,8 +487,9 @@ preserved instead of removed.
 
 When a request uses HTTP/3 and a proxy is resolved from the environment, the
 request is now downgraded to HTTP/2 or HTTP/1.1 in the same way as for proxies
-configured through the `proxy` request option, since HTTP/3 cannot be carried
-over an HTTP proxy.
+configured through the `proxy` request option, since current libcurl releases
+cannot carry HTTP/3 over an HTTP proxy. A request excluded by the environment
+`no_proxy` list stays direct and keeps HTTP/3.
 
 #### Handler-Specific Option Overrides
 
@@ -785,7 +786,9 @@ pass a custom delay callable to `Middleware::retry()`.
 Use `ProxyOptions::resolve()` when implementing Guzzle-compatible proxy handling
 in a custom handler. Use `ProxyOptions::isUriInNoProxy()` when checking whether a
 request URI matches a no-proxy list. Use `ProxyOptions::isHostInNoProxy()` only
-when checking a host string directly.
+when checking a host string directly. The environment-variable fallback performed
+by the built-in cURL handlers is not part of `ProxyOptions::resolve()`; custom
+handlers that want it must implement their own environment lookup.
 
 These helpers use the same normalized no-proxy matching as the `Utils` helpers
 in Guzzle 7.12 and later: domain matching is case-insensitive and ignores a

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -478,28 +478,17 @@ timeout.
 The `proxy` request option is validated more strictly. Proxy values must be
 strings, and the `proxy['no']` value may be either an array of strings or a
 comma-delimited string such as the value from the `NO_PROXY` environment
-variable. Other values now throw `InvalidArgumentException`.
+variable. Other values now throw `InvalidArgumentException`. Guzzle 7 skips
+invalid `no` entries instead of rejecting them.
 
-No-proxy matching is normalized more consistently. Domain entries are matched
-case-insensitively, a single trailing DNS root dot is ignored for domain
-matching, exact IP literal entries compare normalized IP addresses, and
-`NO_PROXY` environment entries are trimmed with the same parser used for request
-options. Internal spaces in `NO_PROXY` entries are preserved instead of removed.
+`NO_PROXY` environment entries mapped by the client are trimmed with the same
+parser used for request options, and internal spaces in `NO_PROXY` entries are
+preserved instead of removed.
 
-Explicit proxy options also override environment no-proxy settings. If you pass
-a `proxy` request option and want to exclude hosts, provide the `no` value
-explicitly:
-
-```php
-$noProxy = getenv('NO_PROXY');
-
-$client->request('GET', '/', [
-    'proxy' => [
-        'http' => 'http://localhost:8125',
-        'no' => $noProxy === false ? '' : $noProxy,
-    ],
-]);
-```
+When a request uses HTTP/3 and a proxy is resolved from the environment, the
+request is now downgraded to HTTP/2 or HTTP/1.1 in the same way as for proxies
+configured through the `proxy` request option, since HTTP/3 cannot be carried
+over an HTTP proxy.
 
 #### Handler-Specific Option Overrides
 
@@ -798,10 +787,12 @@ in a custom handler. Use `ProxyOptions::isUriInNoProxy()` when checking whether 
 request URI matches a no-proxy list. Use `ProxyOptions::isHostInNoProxy()` only
 when checking a host string directly.
 
-These helpers use Guzzle 8's normalized no-proxy matching rather than preserving
-the old `Utils::isHostInNoProxy()` semantics. Domain matching is
-case-insensitive and ignores a single trailing DNS root dot, IP literals are
-normalized before comparison, and CIDR entries match IP literal hosts.
+These helpers use the same normalized no-proxy matching as the `Utils` helpers
+in Guzzle 7.12 and later: domain matching is case-insensitive and ignores a
+single trailing DNS root dot, IP literals are normalized before comparison, and
+CIDR entries match IP literal hosts. The remaining difference is strictness —
+the `ProxyOptions` helpers throw `InvalidArgumentException` for non-string list
+entries, where the Guzzle 7 `Utils` helpers skip them.
 
 #### Removed Type Description Helper API
 

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -236,7 +236,7 @@ A handler is responsible for applying the following request options. These reque
 
 Transport-specific options such as `curl` and `stream_context` are intended for the handlers that understand them. A non-cURL handler should reject or document how it treats cURL-specific options, and a non-stream handler should do the same for PHP stream context options.
 
-Handlers that support the `proxy` option should use `GuzzleHttp\ProxyOptions::resolve()` unless they intentionally document different proxy selection semantics. The returned `GuzzleHttp\ProxySelection` identifies the selected proxy string, no-proxy bypasses, and explicit proxy-disable cases. The handler is still responsible for applying that selection to its transport.
+Handlers that support the `proxy` option should use `GuzzleHttp\ProxyOptions::resolve()` unless they intentionally document different proxy selection semantics. The returned `GuzzleHttp\ProxySelection` identifies the selected proxy string, no-proxy bypasses, and explicit proxy-disable cases. The handler is still responsible for applying that selection to its transport. The environment-variable fallback performed by the built-in cURL handlers is not part of the helper; handlers that want it must implement their own environment lookup.
 
 First-party handlers should not silently ignore documented handler-owned options that users reasonably expect to affect transport behavior. They should implement the option, reject the request with a clear exception when the option is present, or document a deliberate no-op where the option has no meaningful transport equivalent. Custom handlers should follow the same pattern where practical.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -382,6 +382,8 @@ Defines the proxy to use when sending requests using the "https" protocol.
 `NO_PROXY`
 Defines hosts and IP rules for which a proxy should not be used. See the [`proxy` option](request-options.md#proxy).
 
+In addition to the uppercase variables above, which a `GuzzleHttp\Client` maps into a default for the `proxy` request option, the cURL handlers resolve the standard lowercase `http_proxy`, `https_proxy`, and `no_proxy` variables (and their uppercase variants, except `HTTP_PROXY`) plus the `all_proxy`/`ALL_PROXY` fallbacks — with the same lookup semantics libcurl uses — whenever the `proxy` request option makes no decision for a request. libcurl itself never reads the environment: Guzzle always configures the proxy options explicitly. See [proxy environment variables](request-options.md#proxy-environment-variables) for the full lookup order and the Windows caveats.
+
 ### Relevant INI Settings
 
 Guzzle can utilize PHP ini settings when configuring clients.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -920,7 +920,7 @@ Pass an associative array to specify HTTP proxies for specific URI schemes (i.e.
 > [!NOTE]
 > Guzzle will automatically populate this value with your environment's `NO_PROXY` environment variable. However, when providing a `proxy` request option, it is up to you to provide the `no` value from the `NO_PROXY` environment variable.
 
-Custom handlers can use `GuzzleHttp\ProxyOptions::resolve()` to apply Guzzle-compatible proxy selection. The helper resolves the documented `proxy` request option shape, including scheme-specific proxy entries and `no` exclusion rules. Handlers remain responsible for translating the selected proxy string into their transport-specific configuration.
+Custom handlers can use `GuzzleHttp\ProxyOptions::resolve()` to apply Guzzle-compatible proxy selection. The helper resolves the documented `proxy` request option shape, including scheme-specific proxy entries and `no` exclusion rules. Handlers remain responsible for translating the selected proxy string into their transport-specific configuration. The environment-variable fallback performed by the built-in cURL handlers is not part of this helper; custom handlers that want it must implement their own environment lookup.
 
 ```php
 use GuzzleHttp\ProxyOptions;
@@ -952,27 +952,28 @@ $client->request('GET', '/', [
 
 The cURL handlers always configure libcurl's proxy options explicitly, so libcurl never reads proxy environment variables itself. When the `proxy` request option makes a decision for a request — a string proxy, or an array whose key matches the request scheme (including a `no` list match) — that decision is final, and proxy environment variables are ignored for the request. In particular, the `no_proxy`/`NO_PROXY` environment variables do not bypass an explicitly configured proxy; add the hosts to the option's `no` list instead.
 
-When the `proxy` request option makes no decision for a request, the cURL handlers resolve the proxy from the environment with the same lookup conventions libcurl uses:
+When the `proxy` request option makes no decision for a request, the cURL handlers resolve the proxy from the environment with the same lookup semantics libcurl uses:
 
 1. The lowercase scheme-specific variable, e.g. `https_proxy` for an "https" request. For "http" requests, the uppercase `HTTP_PROXY` variant is never read (see <https://httpoxy.org>, and the Windows note below); for other schemes the uppercase variant is read when the lowercase one is not set.
 2. `all_proxy`, then `ALL_PROXY`.
 
-The first variable with a non-empty value ends the lookup; variables set to an empty string are treated as unset, matching libcurl. When an environment proxy is found, the `no_proxy` (or `NO_PROXY`) environment variable is matched against the request by Guzzle, using the same rules as the option's `no` list (including CIDR ranges); a match disables the proxy for the request.
+The first variable with a non-empty value ends the lookup; variables set to an empty string are treated as unset, matching libcurl. When an environment proxy is found, the `no_proxy` (or `NO_PROXY`) environment variable is matched against the request by Guzzle. The value is tokenized the way libcurl tokenizes it — entries may be separated by commas or whitespace, and a single leading dot is ignored, so `.example.com` bypasses `example.com` and its subdomains — and each entry is then matched using the same rules as the option's `no` list (including CIDR ranges); a match disables the proxy for the request.
 
-Only the real process environment is consulted, matching libcurl: values injected per-request by the SAPI (e.g. `fastcgi_param` or `SetEnv`) are not read. On Windows, environment variable names are case-insensitive, so the lowercase-only protection for `HTTP_PROXY` is not possible; outside the CLI SAPI on Windows, proxy environment variables are therefore not resolved at all, and the `proxy` request option must be used instead.
+Only the real process environment is consulted, matching libcurl: values injected per-request by the SAPI (e.g. `fastcgi_param` or `SetEnv`) are not read by this handler-level resolution. On Windows, environment variable names are case-insensitive, so the lowercase-only protection for `HTTP_PROXY` is not possible; outside the CLI SAPI on Windows, proxy environment variables are therefore not resolved at all, and the `proxy` request option must be used instead.
 
-Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps the uppercase `HTTP_PROXY` (CLI SAPI only), `HTTPS_PROXY`, and `NO_PROXY` environment variables into a default for the `proxy` request option. See [Environment Variables](quick-start.md#environment-variables).
+Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps the uppercase `HTTP_PROXY` (CLI SAPI only), `HTTPS_PROXY`, and `NO_PROXY` environment variables into a default for the `proxy` request option. The client mapping reads `$_SERVER` first, so it does honor SAPI-provided values such as those set with `fastcgi_param` or `SetEnv`. See [Environment Variables](quick-start.md#environment-variables).
 
 > [!NOTE]
 > When sending HTTPS requests, or requests explicitly tunneled with
 > `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy,
-> libcurl versions before 8.20.0 could reuse an existing proxy tunnel even
-> after proxy credentials changed. Guzzle avoids that reuse on affected libcurl
-> versions when the proxy URL is configured through the `proxy` option or
-> resolved from the environment, including cURL proxy credential options
-> supplied through the `curl` request option. Raw `CURLOPT_PROXY` is rejected;
-> use the `proxy` request option for the proxy URL. Custom proxy authentication
-> sent with `CURLOPT_PROXYHEADER`
+> libcurl versions before 8.19.0 could reuse an existing proxy tunnel even
+> after proxy credentials changed, and 8.19.0 still contains related proxy
+> credential leak flaws that were fixed in 8.20.0. Guzzle therefore avoids
+> tunnel reuse on libcurl versions older than 8.20.0 when the proxy URL is
+> configured through the `proxy` option or resolved from the environment,
+> including cURL proxy credential options supplied through the `curl` request
+> option. Raw `CURLOPT_PROXY` is rejected; use the `proxy` request option for
+> the proxy URL. Custom proxy authentication sent with `CURLOPT_PROXYHEADER`
 > also avoids tunnel reuse because libcurl does not include those header values
 > in its connection matching. Fixed libcurl versions keep normal connection
 > reuse behavior for proxy URL and cURL proxy credential options. Advanced
@@ -1478,6 +1479,6 @@ HTTP/2 uses libcurl's `CURL_HTTP_VERSION_2_0`. HTTP/3 uses libcurl's `CURL_HTTP_
 
 HTTP/3 support requires PHP to expose cURL's HTTP/3 constants, runtime libcurl 7.66.0 or higher, and runtime libcurl reporting the `CURL_VERSION_HTTP3` feature. A libcurl version number is not enough by itself: libcurl must also be built with HTTP/3 and QUIC support, commonly through an HTTP/3 backend such as ngtcp2 with nghttp3 or quiche.
 
-A request configured with `version => 3.0` must pass HTTP/3 support checks even if it uses a proxy. If a proxy is actually selected, Guzzle does not try HTTP/3 through the proxy; it sends the transfer as HTTP/2 when available, otherwise HTTP/1.1. A matching proxy `no` rule makes the request direct, so HTTP/3 can still be attempted.
+A request configured with `version => 3.0` must pass HTTP/3 support checks even if it uses a proxy. If a proxy is actually selected — whether through the `proxy` option or resolved from the environment — Guzzle does not try HTTP/3 through the proxy; it sends the transfer as HTTP/2 when available, otherwise HTTP/1.1. A matching proxy `no` rule or environment `no_proxy` entry makes the request direct, so HTTP/3 can still be attempted.
 
 For HTTPS cURL requests, Guzzle sets a minimum of TLS 1.2 by default. That minimum also applies when HTTP/2 or HTTP/3 is requested, because cURL may fall back to a TLS-based HTTP/1.1 or HTTP/2 connection. If you set `crypto_method` to TLS 1.3, Guzzle keeps that stricter setting when the cURL stack exposes TLS 1.3 configuration. Raw `CURLOPT_SSLVERSION` values passed through the `curl` option are rejected because TLS version handling is managed by Guzzle.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -948,15 +948,31 @@ $client->request('GET', '/', [
 > [!NOTE]
 > You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
 
+### Proxy environment variables
+
+The cURL handlers always configure libcurl's proxy options explicitly, so libcurl never reads proxy environment variables itself. When the `proxy` request option makes a decision for a request — a string proxy, or an array whose key matches the request scheme (including a `no` list match) — that decision is final, and proxy environment variables are ignored for the request. In particular, the `no_proxy`/`NO_PROXY` environment variables do not bypass an explicitly configured proxy; add the hosts to the option's `no` list instead.
+
+When the `proxy` request option makes no decision for a request, the cURL handlers resolve the proxy from the environment with the same lookup conventions libcurl uses:
+
+1. The lowercase scheme-specific variable, e.g. `https_proxy` for an "https" request. For "http" requests, the uppercase `HTTP_PROXY` variant is never read (see <https://httpoxy.org>, and the Windows note below); for other schemes the uppercase variant is read when the lowercase one is not set.
+2. `all_proxy`, then `ALL_PROXY`.
+
+The first variable with a non-empty value ends the lookup; variables set to an empty string are treated as unset, matching libcurl. When an environment proxy is found, the `no_proxy` (or `NO_PROXY`) environment variable is matched against the request by Guzzle, using the same rules as the option's `no` list (including CIDR ranges); a match disables the proxy for the request.
+
+Only the real process environment is consulted, matching libcurl: values injected per-request by the SAPI (e.g. `fastcgi_param` or `SetEnv`) are not read. On Windows, environment variable names are case-insensitive, so the lowercase-only protection for `HTTP_PROXY` is not possible; outside the CLI SAPI on Windows, proxy environment variables are therefore not resolved at all, and the `proxy` request option must be used instead.
+
+Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps the uppercase `HTTP_PROXY` (CLI SAPI only), `HTTPS_PROXY`, and `NO_PROXY` environment variables into a default for the `proxy` request option. See [Environment Variables](quick-start.md#environment-variables).
+
 > [!NOTE]
 > When sending HTTPS requests, or requests explicitly tunneled with
 > `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy,
-> libcurl versions before 8.19.0 could reuse an existing proxy tunnel even
+> libcurl versions before 8.20.0 could reuse an existing proxy tunnel even
 > after proxy credentials changed. Guzzle avoids that reuse on affected libcurl
-> versions when the proxy URL is configured through the `proxy` option,
-> including cURL proxy credential options supplied through the `curl` request
-> option. Raw `CURLOPT_PROXY` is rejected; use the `proxy` request option for
-> the proxy URL. Custom proxy authentication sent with `CURLOPT_PROXYHEADER`
+> versions when the proxy URL is configured through the `proxy` option or
+> resolved from the environment, including cURL proxy credential options
+> supplied through the `curl` request option. Raw `CURLOPT_PROXY` is rejected;
+> use the `proxy` request option for the proxy URL. Custom proxy authentication
+> sent with `CURLOPT_PROXYHEADER`
 > also avoids tunnel reuse because libcurl does not include those header values
 > in its connection matching. Fixed libcurl versions keep normal connection
 > reuse behavior for proxy URL and cURL proxy credential options. Advanced

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1128,9 +1128,9 @@ final class CurlFactory implements CurlFactoryInterface
      * Resolves the proxy selection for a request, falling back to the proxy
      * environment variables when the proxy request option makes no decision.
      *
-     * The environment no_proxy list is matched here with the same rules as
-     * the proxy option's "no" list, so behavior does not depend on the
-     * installed libcurl's matcher.
+     * The environment no_proxy list is tokenized the way libcurl tokenizes
+     * it and matched here with the same rules as the proxy option's "no"
+     * list, so behavior does not depend on the installed libcurl's matcher.
      *
      * @param mixed $proxyOption
      */
@@ -1150,7 +1150,7 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         $noProxy = ProxyEnvironment::getNoProxy();
-        if ($noProxy !== null && ProxyOptions::isUriInNoProxy($uri, ProxyOptions::normalizeNoProxy($noProxy))) {
+        if ($noProxy !== null && ProxyOptions::isUriInNoProxy($uri, ProxyEnvironment::splitNoProxy($noProxy))) {
             return ProxySelection::bypassed();
         }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -17,6 +17,7 @@ use GuzzleHttp\NonSerializableTrait;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\ProxyOptions;
+use GuzzleHttp\ProxySelection;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\Psr7\FnStream;
@@ -1124,6 +1125,40 @@ final class CurlFactory implements CurlFactoryInterface
     }
 
     /**
+     * Resolves the proxy selection for a request, falling back to the proxy
+     * environment variables when the proxy request option makes no decision.
+     *
+     * The environment no_proxy list is matched here with the same rules as
+     * the proxy option's "no" list, so behavior does not depend on the
+     * installed libcurl's matcher.
+     *
+     * @param mixed $proxyOption
+     */
+    private static function resolveProxySelection(UriInterface $uri, $proxyOption): ProxySelection
+    {
+        $selection = ProxyOptions::resolve($uri, $proxyOption);
+
+        // Any option decision (proxy, bypassed, or disabled) is final; only
+        // a none() selection leaves room for the environment.
+        if ($selection->hasProxy() || $selection->shouldDisableProxy()) {
+            return $selection;
+        }
+
+        $envProxy = ProxyEnvironment::getProxyForScheme($uri->getScheme());
+        if ($envProxy === null) {
+            return $selection;
+        }
+
+        $noProxy = ProxyEnvironment::getNoProxy();
+        if ($noProxy !== null && ProxyOptions::isUriInNoProxy($uri, ProxyOptions::normalizeNoProxy($noProxy))) {
+            return ProxySelection::bypassed();
+        }
+
+        // $envProxy is never '' (empty env values are treated as unset).
+        return ProxySelection::proxy($envProxy);
+    }
+
+    /**
      * @param array<int|string, mixed> $conf
      */
     private static function getProxyForConnectionReuse(array $conf): ?string
@@ -1307,7 +1342,7 @@ final class CurlFactory implements CurlFactoryInterface
                 throw new RequestException('HTTP/3 is not supported by this cURL installation.', $easy->request);
             }
 
-            $proxy = ProxyOptions::resolve($easy->request->getUri(), $easy->options['proxy'] ?? null);
+            $proxy = self::resolveProxySelection($easy->request->getUri(), $easy->options['proxy'] ?? null);
             $conf[\CURLOPT_HTTP_VERSION] = $proxy->hasProxy()
                 ? (CurlVersion::supportsHttp2() ? \CURL_HTTP_VERSION_2_0 : \CURL_HTTP_VERSION_1_1)
                 : (int) \constant('CURL_HTTP_VERSION_3');
@@ -1713,12 +1748,14 @@ final class CurlFactory implements CurlFactoryInterface
             $conf[\CURLOPT_NOSIGNAL] = true;
         }
 
-        $proxy = ProxyOptions::resolve($easy->request->getUri(), $options['proxy'] ?? null);
+        // Always pin CURLOPT_PROXY and CURLOPT_NOPROXY so that libcurl never
+        // falls back to reading proxy environment variables itself.
+        $proxy = self::resolveProxySelection($easy->request->getUri(), $options['proxy'] ?? null);
         $selectedProxy = $proxy->getProxy();
         if ($selectedProxy !== null) {
             $conf[\CURLOPT_PROXY] = $selectedProxy;
             $conf[\CURLOPT_NOPROXY] = '';
-        } elseif ($proxy->shouldDisableProxy()) {
+        } else {
             $conf[\CURLOPT_PROXY] = '';
             $conf[\CURLOPT_NOPROXY] = $proxy->isBypassed() ? '*' : '';
         }

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -27,6 +27,9 @@ final class CurlVersion
 
     private const CONNECTION_SHARING_VERSION = '8.20.0';
 
+    // curl 8.19.0 fixed proxy tunnel reuse after credential changes
+    // (CVE-2026-3784), but related proxy credential leak flaws were only
+    // fixed in 8.20.0, so connection reuse is trusted from 8.20.0 onwards.
     private const PROXY_CREDENTIAL_REUSE_VERSION = '8.20.0';
 
     /**

--- a/src/Handler/ProxyEnvironment.php
+++ b/src/Handler/ProxyEnvironment.php
@@ -20,9 +20,10 @@ final class ProxyEnvironment
     /**
      * Resolves the proxy to use for the given request scheme.
      *
-     * The lookup mirrors libcurl: the lowercase scheme-specific variable
-     * first, its uppercase variant next (except for "http", where uppercase
-     * HTTP_PROXY is never read), then all_proxy/ALL_PROXY.
+     * The lookup mirrors libcurl for the http and https schemes the handlers
+     * accept: the lowercase scheme-specific variable first, its uppercase
+     * variant next (except for "http", where uppercase HTTP_PROXY is never
+     * read), then all_proxy/ALL_PROXY.
      *
      * @return string|null The proxy to use; null when the environment
      *                     configures none.
@@ -63,6 +64,32 @@ final class ProxyEnvironment
         }
 
         return null;
+    }
+
+    /**
+     * Splits a no_proxy environment value into matchable entries.
+     *
+     * Mirrors libcurl's tokenization: entries may be separated by commas or
+     * blanks, and a single leading dot is ignored, so ".example.com" bypasses
+     * example.com and its subdomains exactly as a bare domain entry does.
+     *
+     * @return string[]
+     */
+    public static function splitNoProxy(string $noProxy): array
+    {
+        $entries = [];
+
+        foreach (\preg_split('/[\s,]+/', $noProxy) ?: [] as $entry) {
+            if ($entry !== '' && $entry[0] === '.') {
+                $entry = \substr($entry, 1);
+            }
+
+            if ($entry !== '') {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
     }
 
     private static function getenv(string $name): ?string

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -258,7 +258,8 @@ final class RequestOptions
      * case-insensitively. Exact IP literals are normalized before matching.
      * CIDR rules match IP literals only and are not port-specific. Custom
      * handlers can use ProxyOptions::resolve() to apply Guzzle-compatible
-     * proxy selection.
+     * proxy selection; the built-in cURL handlers' environment-variable
+     * fallback is not part of that helper.
      */
     public const PROXY = 'proxy';
 

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -763,10 +763,11 @@ class CurlFactoryTest extends TestCase
     {
         self::withProxyEnvironment(['http_proxy' => 'http://proxy.example.com:8125'], static function (): void {
             $f = new CurlFactory(3);
-            $f->create(new Psr7\Request('GET', 'http://example.com'), []);
+            $easy = $f->create(new Psr7\Request('GET', 'http://example.com'), []);
 
             self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+            self::assertSame('http://proxy.example.com:8125', $easy->effectiveProxy);
         });
     }
 
@@ -793,6 +794,7 @@ class CurlFactoryTest extends TestCase
             $f->create(new Psr7\Request('GET', 'https://example.com'), []);
 
             self::assertSame('http://lower.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         });
     }
 
@@ -805,6 +807,7 @@ class CurlFactoryTest extends TestCase
             $f->create(new Psr7\Request('GET', 'http://example.com'), []);
 
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         });
     }
 
@@ -814,9 +817,11 @@ class CurlFactoryTest extends TestCase
             $f = new CurlFactory(3);
             $f->create(new Psr7\Request('GET', 'http://example.com'), []);
             self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
 
             $f->create(new Psr7\Request('GET', 'https://example.com'), []);
             self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         });
     }
 
@@ -842,15 +847,40 @@ class CurlFactoryTest extends TestCase
         ], static function (): void {
             $f = new CurlFactory(3);
 
-            $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+            $easy = $f->create(new Psr7\Request('GET', 'https://example.com'), []);
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+            self::assertNull($easy->effectiveProxy);
 
             $f->create(new Psr7\Request('GET', 'https://10.1.2.3'), []);
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
 
             $f->create(new Psr7\Request('GET', 'https://foo.com'), []);
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testTokenizesEnvironmentNoProxyLikeLibcurl(): void
+    {
+        self::withProxyEnvironment([
+            'https_proxy' => 'http://proxy.example.com:8125',
+            'NO_PROXY' => '.internal.test host1.test host2.test',
+        ], static function (): void {
+            $f = new CurlFactory(3);
+
+            // A leading dot is ignored, so the root domain is bypassed too.
+            $f->create(new Psr7\Request('GET', 'https://internal.test'), []);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+
+            // Blanks separate entries just like commas.
+            $f->create(new Psr7\Request('GET', 'https://host2.test'), []);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+
+            $f->create(new Psr7\Request('GET', 'https://other.test'), []);
             self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         });
@@ -889,6 +919,19 @@ class CurlFactoryTest extends TestCase
             ]);
 
             self::assertSame('http://option.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testProxyOptionEmptyStringDisablesEnvironmentProxyResolution(): void
+    {
+        self::withProxyEnvironment(['https_proxy' => 'http://env.example.com:8125'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => '',
+            ]);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
         });
     }
@@ -971,6 +1014,7 @@ class CurlFactoryTest extends TestCase
         try {
             $handler(new Psr7\Request('GET', Server::$url), [
                 'proxy' => 'http://user:secret@127.0.0.1:99999999',
+                'connect_timeout' => 1,
             ])->wait();
             self::fail('Expected a transfer exception');
         } catch (\GuzzleHttp\Exception\TransferException $e) {
@@ -979,6 +1023,48 @@ class CurlFactoryTest extends TestCase
                 self::assertStringContainsString('***@127.0.0.1:99999999', $e->getMessage());
             }
         }
+    }
+
+    public function testRedactsEnvironmentProxyCredentialsInCurlErrorMessages(): void
+    {
+        self::withProxyEnvironment(['http_proxy' => 'foo://user:secret@127.0.0.1:1'], static function (): void {
+            $handler = new Handler\CurlHandler();
+
+            try {
+                $handler(new Psr7\Request('GET', Server::$url), [])->wait();
+                self::fail('Expected a transfer exception');
+            } catch (\GuzzleHttp\Exception\TransferException $e) {
+                self::assertStringNotContainsString('secret', $e->getMessage());
+            }
+        });
+    }
+
+    public function testRedactsParseableProxyCredentialsIndependentlyOfCurlErrorText(): void
+    {
+        $proxy = 'http://user:secret@proxy.example.com:8125';
+        $redactedUserInfo = Psr7\Utils::redactUserInfo(new Psr7\Uri($proxy))->getUserInfo();
+
+        $redacted = self::redactProxyUserInfo('Failed to connect via '.$proxy, $proxy);
+
+        self::assertStringNotContainsString('secret', $redacted);
+        self::assertSame('Failed to connect via http://'.$redactedUserInfo.'@proxy.example.com:8125', $redacted);
+    }
+
+    public function testRedactsUnparsableProxyCredentialsIndependentlyOfCurlErrorText(): void
+    {
+        $proxy = 'http://user:secret@127.0.0.1:99999999';
+
+        $redacted = self::redactProxyUserInfo("Unsupported proxy syntax in '".$proxy."'", $proxy);
+
+        self::assertStringNotContainsString('secret', $redacted);
+        self::assertSame("Unsupported proxy syntax in 'http://***@127.0.0.1:99999999'", $redacted);
+    }
+
+    public function testLeavesCurlErrorsUntouchedForProxiesWithoutCredentials(): void
+    {
+        $error = 'Failed to connect to proxy.example.com:8125';
+
+        self::assertSame($error, self::redactProxyUserInfo($error, 'http://proxy.example.com:8125'));
     }
 
     public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
@@ -2200,12 +2286,15 @@ class CurlFactoryTest extends TestCase
                 'https_proxy' => 'http://proxy.example.com:8080',
                 'NO_PROXY' => 'example.com',
             ], static function (): void {
-                $factory = new CurlFactory(3);
-                $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), []);
+                // Asserted on the default conf, like the other keep-HTTP/3
+                // tests: applying CURL_HTTP_VERSION_3 to a real handle fails
+                // on libcurl builds without HTTP/3 support.
+                $conf = self::getDefaultCurlConf(
+                    new Psr7\Request('GET', 'https://example.com', [], null, '3.0'),
+                    []
+                );
 
-                self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
-                self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
-                self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+                self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $conf[\CURLOPT_HTTP_VERSION]);
             });
         } finally {
             self::setCurlVersionInfo($previousVersionInfo);
@@ -5254,6 +5343,16 @@ class CurlFactoryTest extends TestCase
         }
 
         return $method->invoke($factory, $easy);
+    }
+
+    private static function redactProxyUserInfo(string $error, ?string $proxy): string
+    {
+        $method = new \ReflectionMethod(CurlFactory::class, 'redactProxyUserInfo');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        return $method->invoke(null, $error, $proxy);
     }
 
     private static function requireHttp3TestConstants(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -748,6 +748,239 @@ class CurlFactoryTest extends TestCase
         $this->checkNoProxyForHost('http://[fe80::1]', ['fd00::/8'], true);
     }
 
+    public function testPinsProxyOptionsWhenNoProxyIsConfigured(): void
+    {
+        self::withProxyEnvironment([], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', Server::$url), []);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testResolvesLowercaseProxyEnvironmentVariable(): void
+    {
+        self::withProxyEnvironment(['http_proxy' => 'http://proxy.example.com:8125'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'http://example.com'), []);
+
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testResolvesUppercaseHttpsProxyEnvironmentVariable(): void
+    {
+        self::withProxyEnvironment(['HTTPS_PROXY' => 'http://proxy.example.com:8125'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testLowercaseProxyEnvironmentVariableTakesPrecedence(): void
+    {
+        self::skipIfWindows();
+
+        self::withProxyEnvironment([
+            'https_proxy' => 'http://lower.example.com:8125',
+            'HTTPS_PROXY' => 'http://upper.example.com:8125',
+        ], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+
+            self::assertSame('http://lower.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        });
+    }
+
+    public function testNeverReadsUppercaseHttpProxyEnvironmentVariable(): void
+    {
+        self::skipIfWindows();
+
+        self::withProxyEnvironment(['HTTP_PROXY' => 'http://proxy.example.com:8125'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'http://example.com'), []);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        });
+    }
+
+    public function testResolvesAllProxyEnvironmentVariableForAnyScheme(): void
+    {
+        self::withProxyEnvironment(['ALL_PROXY' => 'http://proxy.example.com:8125'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'http://example.com'), []);
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+
+            $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        });
+    }
+
+    public function testTreatsEmptyProxyEnvironmentVariableAsUnset(): void
+    {
+        self::withProxyEnvironment([
+            'https_proxy' => '',
+            'ALL_PROXY' => 'http://proxy.example.com:8125',
+        ], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testMatchesEnvironmentNoProxyAgainstTheRequest(): void
+    {
+        self::withProxyEnvironment([
+            'https_proxy' => 'http://proxy.example.com:8125',
+            'NO_PROXY' => '10.0.0.0/8,example.com, .internal',
+        ], static function (): void {
+            $f = new CurlFactory(3);
+
+            $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+
+            $f->create(new Psr7\Request('GET', 'https://10.1.2.3'), []);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+
+            $f->create(new Psr7\Request('GET', 'https://foo.com'), []);
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testLowercaseNoProxyEnvironmentVariableTakesPrecedence(): void
+    {
+        self::skipIfWindows();
+
+        self::withProxyEnvironment([
+            'https_proxy' => 'http://proxy.example.com:8125',
+            'no_proxy' => 'lower.example.com',
+            'NO_PROXY' => 'upper.example.com',
+        ], static function (): void {
+            $f = new CurlFactory(3);
+
+            $f->create(new Psr7\Request('GET', 'https://lower.example.com'), []);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+
+            $f->create(new Psr7\Request('GET', 'https://upper.example.com'), []);
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testProxyOptionDisablesEnvironmentProxyResolution(): void
+    {
+        self::withProxyEnvironment([
+            'https_proxy' => 'http://env.example.com:8125',
+            'NO_PROXY' => 'example.com',
+        ], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => 'http://option.example.com:8125',
+            ]);
+
+            self::assertSame('http://option.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testNoProxyMatchIsNotReProxiedFromEnvironment(): void
+    {
+        self::withProxyEnvironment(['http_proxy' => 'http://env.example.com:8125'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'http://internal.example.com'), [
+                'proxy' => [
+                    'http' => 'http://option.example.com:8125',
+                    'no' => ['internal.example.com'],
+                ],
+            ]);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testFallsBackToEnvironmentWhenSchemeIsNotConfigured(): void
+    {
+        self::withProxyEnvironment(['https_proxy' => 'http://env.example.com:8125'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => ['http' => 'http://option.example.com:8125'],
+            ]);
+
+            self::assertSame('http://env.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        });
+    }
+
+    public function testForcesFreshConnectionForEnvironmentCredentialedProxyOnAffectedCurlVersion(): void
+    {
+        self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
+            self::createWithCurlVersion('8.19.0', 'https://example.com', []);
+
+            self::assertAuthenticatedProxyConnectionReuseOptions();
+        });
+    }
+
+    public function testDoesNotForceFreshConnectionForEnvironmentCredentialedProxyOnFixedCurlVersion(): void
+    {
+        self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
+            self::createWithCurlVersion('8.20.0', 'https://example.com', []);
+
+            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        });
+    }
+
+    public function testRedactsProxyCredentialsInCurlErrorMessages(): void
+    {
+        $handler = new Handler\CurlHandler();
+
+        try {
+            $handler(new Psr7\Request('GET', Server::$url), [
+                'proxy' => 'foo://user:secret@127.0.0.1:1',
+            ])->wait();
+            self::fail('Expected a transfer exception');
+        } catch (\GuzzleHttp\Exception\TransferException $e) {
+            self::assertStringNotContainsString('secret', $e->getMessage());
+            if (\strpos($e->getMessage(), 'foo://') !== false) {
+                // The redacted form follows the installed psr7 version:
+                // 'user:***' on psr7 2, '***' on psr7 3.
+                $redactedUserInfo = Psr7\Utils::redactUserInfo(
+                    new Psr7\Uri('foo://user:secret@127.0.0.1:1')
+                )->getUserInfo();
+
+                self::assertStringContainsString('foo://'.$redactedUserInfo.'@127.0.0.1:1', $e->getMessage());
+            }
+        }
+    }
+
+    public function testRedactsProxyCredentialsWhenProxyDefeatsUrlParsing(): void
+    {
+        $handler = new Handler\CurlHandler();
+
+        try {
+            $handler(new Psr7\Request('GET', Server::$url), [
+                'proxy' => 'http://user:secret@127.0.0.1:99999999',
+            ])->wait();
+            self::fail('Expected a transfer exception');
+        } catch (\GuzzleHttp\Exception\TransferException $e) {
+            self::assertStringNotContainsString('secret', $e->getMessage());
+            if (\strpos($e->getMessage(), '127.0.0.1:99999999') !== false) {
+                self::assertStringContainsString('***@127.0.0.1:99999999', $e->getMessage());
+            }
+        }
+    }
+
     public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
     {
         self::createWithCurlVersion('8.19.0', 'https://example.com', [
@@ -1925,6 +2158,55 @@ class CurlFactoryTest extends TestCase
             self::assertSame('http://proxy.example.com:8080', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
             self::assertSame(\CURL_HTTP_VERSION_2_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testHttp3WithEnvironmentProxyFallsBackToHttp2WhenSupported(): void
+    {
+        self::requireHttp3TestConstants();
+
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3FeatureMask(true),
+        ]);
+
+        try {
+            self::withProxyEnvironment(['https_proxy' => 'http://proxy.example.com:8080'], static function (): void {
+                $factory = new CurlFactory(3);
+                $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), []);
+
+                self::assertSame('http://proxy.example.com:8080', $_SERVER['_curl'][\CURLOPT_PROXY]);
+                self::assertSame('', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+                self::assertSame(\CURL_HTTP_VERSION_2_0, $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+            });
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testHttp3IsKeptWhenEnvironmentNoProxyExcludesTheTarget(): void
+    {
+        self::requireHttp3TestConstants();
+
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => '7.66.0',
+            'features' => self::http3FeatureMask(true),
+        ]);
+
+        try {
+            self::withProxyEnvironment([
+                'https_proxy' => 'http://proxy.example.com:8080',
+                'NO_PROXY' => 'example.com',
+            ], static function (): void {
+                $factory = new CurlFactory(3);
+                $factory->create(new Psr7\Request('GET', 'https://example.com', [], null, '3.0'), []);
+
+                self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+                self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+                self::assertSame((int) \constant('CURL_HTTP_VERSION_3'), $_SERVER['_curl'][\CURLOPT_HTTP_VERSION]);
+            });
         } finally {
             self::setCurlVersionInfo($previousVersionInfo);
         }
@@ -4843,6 +5125,45 @@ class CurlFactoryTest extends TestCase
             );
             self::assertNotInstanceOf(ResponseException::class, $e);
             self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
+        }
+    }
+
+    private static function skipIfWindows(): void
+    {
+        if (\PHP_OS_FAMILY === 'Windows') {
+            self::markTestSkipped('Environment variables are case-insensitive on Windows.');
+        }
+    }
+
+    /**
+     * Runs the callback with only the given proxy environment variables set,
+     * restoring the process environment afterwards.
+     *
+     * @param array<string, string> $env
+     */
+    private static function withProxyEnvironment(array $env, callable $test): void
+    {
+        $names = ['http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY', 'all_proxy', 'ALL_PROXY', 'no_proxy', 'NO_PROXY'];
+        $previous = [];
+        foreach ($names as $name) {
+            $previous[$name] = \getenv($name, true);
+            \putenv($name);
+        }
+        foreach ($env as $name => $value) {
+            \putenv($name.'='.$value);
+        }
+
+        try {
+            $test();
+        } finally {
+            foreach ($names as $name) {
+                \putenv($name);
+            }
+            foreach ($previous as $name => $value) {
+                if ($value !== false) {
+                    \putenv($name.'='.$value);
+                }
+            }
         }
     }
 

--- a/tests/Handler/EasyHandleTest.php
+++ b/tests/Handler/EasyHandleTest.php
@@ -28,6 +28,13 @@ class EasyHandleTest extends TestCase
         $easy->handle;
     }
 
+    public function testEffectiveProxyDefaultsToNull(): void
+    {
+        $easy = new EasyHandle();
+
+        self::assertNull($easy->effectiveProxy);
+    }
+
     public function testCreateResponseIgnoresInterim1xxResponses(): void
     {
         $easy = new EasyHandle();

--- a/tests/Handler/ProxyEnvironmentTest.php
+++ b/tests/Handler/ProxyEnvironmentTest.php
@@ -143,6 +143,27 @@ class ProxyEnvironmentTest extends TestCase
         });
     }
 
+    public function testSplitsNoProxyOnCommasAndBlanks(): void
+    {
+        self::assertSame(
+            ['host1.test', 'host2.test', 'host3.test', 'host4.test'],
+            ProxyEnvironment::splitNoProxy("host1.test host2.test,host3.test ,\thost4.test")
+        );
+    }
+
+    public function testIgnoresASingleLeadingDotInNoProxyEntries(): void
+    {
+        self::assertSame(
+            ['example.com', '.foo.com'],
+            ProxyEnvironment::splitNoProxy('.example.com,..foo.com')
+        );
+    }
+
+    public function testDropsEmptyNoProxyEntries(): void
+    {
+        self::assertSame([], ProxyEnvironment::splitNoProxy(' ,, . '));
+    }
+
     private static function skipIfWindows(): void
     {
         if (\PHP_OS_FAMILY === 'Windows') {


### PR DESCRIPTION
This completes the proxy environment variable takeover from #3619 on the 8.0 branch. The merge from 7.12 brought over the environment resolver, but proxy resolution still went through `ProxyOptions::resolve()` alone, which leaves libcurl's own environment reading live whenever the `proxy` request option makes no decision for a request. The cURL factory now routes both of its resolution call sites through a private helper that falls back to the environment in exactly that case, matching the environment `no_proxy` list with `ProxyOptions`' own rules and collapsing the result into the existing `ProxySelection` states. The environment `no_proxy` value is tokenized the way libcurl tokenizes it, so entries separated by blanks as well as commas keep working and a leading dot also bypasses the bare domain, while the entries themselves are matched with the option engine. The public option-resolution API is unchanged and never learns about the environment, and `CURLOPT_PROXY` and `CURLOPT_NOPROXY` are now pinned on every request, so libcurl reads no proxy environment variables at all.

Because the HTTP/3 downgrade decision shares the same helper, requests negotiating HTTP/3 are now downgraded to HTTP/2 or HTTP/1.1 when the proxy comes from the environment. Previously Guzzle kept requesting HTTP/3 while libcurl proxied the request and silently negotiated HTTP/2 or HTTP/1.1 itself, or failed outright on older HTTP/3 builds, so the downgrade is now explicit and consistent with option-configured proxies. A request whose target is excluded by the environment no_proxy list keeps HTTP/3, since it is pinned to connect directly.

The changelog and upgrade guide are also re-baselined against Guzzle 7.12: CIDR no-proxy support, the normalized no-proxy matching, and the option-over-environment precedence ship in 7.12.0 and are no longer differences in 8.0, while the stricter proxy option validation and the preserved internal spaces in client-mapped `NO_PROXY` values remain 8.0 changes. The proxy documentation gains the environment variable section from 7.12, and the connection-reuse note now distinguishes the proxy tunnel reuse flaw fixed in libcurl 8.19.0 from the related proxy credential leaks fixed in 8.20.0, which is the version Guzzle's mitigation gates on.
