### PR TITLE
Harden the proxy environment takeover

### DIFF
--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -925,11 +925,33 @@ When the `proxy` request option makes no decision for a request, the cURL handle
 1. The lowercase scheme-specific variable, e.g. `https_proxy` for an "https" request. For "http" requests, the uppercase `HTTP_PROXY` variant is never read (see <https://httpoxy.org>, and the Windows note below); for other schemes the uppercase variant is read when the lowercase one is not set.
 2. `all_proxy`, then `ALL_PROXY`.
 
-The first variable with a non-empty value ends the lookup; variables set to an empty string are treated as unset, matching libcurl. When an environment proxy is found, the `no_proxy` (or `NO_PROXY`) environment variable is matched against the request by Guzzle, using the same rules as the option's `no` list (including CIDR ranges); a match disables the proxy for the request.
+The first variable with a non-empty value ends the lookup; variables set to an empty string are treated as unset, matching libcurl. When an environment proxy is found, the `no_proxy` (or `NO_PROXY`) environment variable is matched against the request by Guzzle. The value is tokenized the way libcurl tokenizes it — entries may be separated by commas or whitespace, and a single leading dot is ignored, so `.example.com` bypasses `example.com` and its subdomains — and each entry is then matched using the same rules as the option's `no` list (including CIDR ranges); a match disables the proxy for the request.
 
-Only the real process environment is consulted, matching libcurl: values injected per-request by the SAPI (e.g. `fastcgi_param` or `SetEnv`) are not read. On Windows, environment variable names are case-insensitive, so the lowercase-only protection for `HTTP_PROXY` is not possible; outside the CLI SAPI on Windows, proxy environment variables are therefore not resolved at all, and the `proxy` request option must be used instead.
+Only the real process environment is consulted, matching libcurl: values injected per-request by the SAPI (e.g. `fastcgi_param` or `SetEnv`) are not read by this handler-level resolution. On Windows, environment variable names are case-insensitive, so the lowercase-only protection for `HTTP_PROXY` is not possible; outside the CLI SAPI on Windows, proxy environment variables are therefore not resolved at all, and the `proxy` request option must be used instead.
 
-Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps the uppercase `HTTP_PROXY` (CLI SAPI only), `HTTPS_PROXY`, and `NO_PROXY` environment variables into a default for the `proxy` request option. See [Environment Variables](quickstart.md#environment-variables).
+Proxy decisions are made once per request, from the request's initial URI. If libcurl-internal redirect following is enabled with the deprecated raw `CURLOPT_FOLLOWLOCATION` cURL option, every redirect hop inherits that decision, and the environment `no_proxy` list is not re-evaluated per hop; use the `allow_redirects` option instead, which re-resolves the proxy for each hop.
+
+Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps the uppercase `HTTP_PROXY` (CLI SAPI only), `HTTPS_PROXY`, and `NO_PROXY` environment variables into a default for the `proxy` request option. The client mapping reads `$_SERVER` first, so it does honor SAPI-provided values such as those set with `fastcgi_param` or `SetEnv`. See [Environment Variables](quickstart.md#environment-variables).
+
+> [!NOTE]
+> When sending HTTPS requests, or requests explicitly tunneled with
+> `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy,
+> libcurl versions before 8.19.0 could reuse an existing proxy tunnel even
+> after proxy credentials changed, and 8.19.0 still contains related proxy
+> credential leak flaws that were fixed in 8.20.0. Guzzle therefore avoids
+> tunnel reuse on libcurl versions older than 8.20.0 when the proxy URL is
+> configured through the `proxy` option or resolved from the environment,
+> including cURL proxy credential options supplied through the `curl` request
+> option. Raw `CURLOPT_PROXY` supplied through the `curl` request option is
+> deprecated but still honored, and receives the same protection. Custom proxy
+> authentication sent with `CURLOPT_PROXYHEADER` also avoids tunnel reuse
+> because libcurl does not include those header values in its connection
+> matching. Fixed libcurl versions keep normal connection reuse behavior for
+> proxy URL and cURL proxy credential options. Advanced users can still
+> control cURL connection reuse explicitly with the `curl` request option and
+> `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`; raw `CURLOPT_PROXYTYPE`
+> is respected when deciding whether a scheme-less `proxy` option value is an
+> HTTP(S) proxy.
 
 ## query
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1174,11 +1174,12 @@ class CurlFactory implements CurlFactoryInterface
                 $proxyConf = '';
             } elseif (
                 ($noProxy = ProxyEnvironment::getNoProxy()) !== null
-                && Utils::isUriInNoProxy($easy->request->getUri(), $noProxy)
+                && Utils::isUriInNoProxy($easy->request->getUri(), ProxyEnvironment::splitNoProxy($noProxy))
             ) {
-                // The environment no_proxy list is matched here with the
-                // same rules as the proxy option's "no" list, so behavior
-                // does not depend on the installed libcurl's matcher.
+                // The environment no_proxy list is tokenized the way libcurl
+                // tokenizes it and matched here with the same rules as the
+                // proxy option's "no" list, so behavior does not depend on
+                // the installed libcurl's matcher.
                 $proxyConf = '';
                 $noProxyConf = '*';
             }

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -17,6 +17,9 @@ final class CurlVersion
 
     private const SSL_SESSION_SHARING_VERSION = '8.6.0';
 
+    // curl 8.19.0 fixed proxy tunnel reuse after credential changes
+    // (CVE-2026-3784), but related proxy credential leak flaws were only
+    // fixed in 8.20.0, so connection reuse is trusted from 8.20.0 onwards.
     private const PROXY_CREDENTIAL_REUSE_VERSION = '8.20.0';
 
     /**

--- a/src/Handler/ProxyEnvironment.php
+++ b/src/Handler/ProxyEnvironment.php
@@ -18,9 +18,10 @@ final class ProxyEnvironment
     /**
      * Resolves the proxy to use for the given request scheme.
      *
-     * The lookup mirrors libcurl: the lowercase scheme-specific variable
-     * first, its uppercase variant next (except for "http", where uppercase
-     * HTTP_PROXY is never read), then all_proxy/ALL_PROXY.
+     * The lookup mirrors libcurl for the http and https schemes the handlers
+     * accept: the lowercase scheme-specific variable first, its uppercase
+     * variant next (except for "http", where uppercase HTTP_PROXY is never
+     * read), then all_proxy/ALL_PROXY.
      *
      * @return string|null The proxy to use; null when the environment
      *                     configures none.
@@ -61,6 +62,32 @@ final class ProxyEnvironment
         }
 
         return null;
+    }
+
+    /**
+     * Splits a no_proxy environment value into matchable entries.
+     *
+     * Mirrors libcurl's tokenization: entries may be separated by commas or
+     * blanks, and a single leading dot is ignored, so ".example.com" bypasses
+     * example.com and its subdomains exactly as a bare domain entry does.
+     *
+     * @return string[]
+     */
+    public static function splitNoProxy(string $noProxy): array
+    {
+        $entries = [];
+
+        foreach (\preg_split('/[\s,]+/', $noProxy) ?: [] as $entry) {
+            if ($entry !== '' && $entry[0] === '.') {
+                $entry = \substr($entry, 1);
+            }
+
+            if ($entry !== '') {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
     }
 
     private static function getenv(string $name): ?string

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -421,10 +421,11 @@ class CurlFactoryTest extends TestCase
     {
         self::withProxyEnvironment(['http_proxy' => 'http://proxy.example.com:8125'], static function (): void {
             $f = new CurlFactory(3);
-            $f->create(new Psr7\Request('GET', 'http://example.com'), []);
+            $easy = $f->create(new Psr7\Request('GET', 'http://example.com'), []);
 
             self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertNoProxyOption('');
+            self::assertSame('http://proxy.example.com:8125', $easy->effectiveProxy);
         });
     }
 
@@ -451,6 +452,7 @@ class CurlFactoryTest extends TestCase
             $f->create(new Psr7\Request('GET', 'https://example.com'), []);
 
             self::assertSame('http://lower.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('');
         });
     }
 
@@ -463,6 +465,7 @@ class CurlFactoryTest extends TestCase
             $f->create(new Psr7\Request('GET', 'http://example.com'), []);
 
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('');
         });
     }
 
@@ -472,9 +475,11 @@ class CurlFactoryTest extends TestCase
             $f = new CurlFactory(3);
             $f->create(new Psr7\Request('GET', 'http://example.com'), []);
             self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('');
 
             $f->create(new Psr7\Request('GET', 'https://example.com'), []);
             self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('');
         });
     }
 
@@ -500,15 +505,40 @@ class CurlFactoryTest extends TestCase
         ], static function (): void {
             $f = new CurlFactory(3);
 
-            $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+            $easy = $f->create(new Psr7\Request('GET', 'https://example.com'), []);
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertNoProxyOption('*');
+            self::assertNull($easy->effectiveProxy);
 
             $f->create(new Psr7\Request('GET', 'https://10.1.2.3'), []);
             self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertNoProxyOption('*');
 
             $f->create(new Psr7\Request('GET', 'https://foo.com'), []);
+            self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('');
+        });
+    }
+
+    public function testTokenizesEnvironmentNoProxyLikeLibcurl(): void
+    {
+        self::withProxyEnvironment([
+            'https_proxy' => 'http://proxy.example.com:8125',
+            'NO_PROXY' => '.internal.test host1.test host2.test',
+        ], static function (): void {
+            $f = new CurlFactory(3);
+
+            // A leading dot is ignored, so the root domain is bypassed too.
+            $f->create(new Psr7\Request('GET', 'https://internal.test'), []);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('*');
+
+            // Blanks separate entries just like commas.
+            $f->create(new Psr7\Request('GET', 'https://host2.test'), []);
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('*');
+
+            $f->create(new Psr7\Request('GET', 'https://other.test'), []);
             self::assertSame('http://proxy.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertNoProxyOption('');
         });
@@ -547,6 +577,19 @@ class CurlFactoryTest extends TestCase
             ]);
 
             self::assertSame('http://option.example.com:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('');
+        });
+    }
+
+    public function testProxyOptionEmptyStringDisablesEnvironmentProxyResolution(): void
+    {
+        self::withProxyEnvironment(['https_proxy' => 'http://env.example.com:8125'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => '',
+            ]);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
             self::assertNoProxyOption('');
         });
     }
@@ -641,6 +684,7 @@ class CurlFactoryTest extends TestCase
         try {
             $handler(new Psr7\Request('GET', Server::$url), [
                 'proxy' => 'http://user:secret@127.0.0.1:99999999',
+                'connect_timeout' => 1,
             ])->wait();
             self::fail('Expected a transfer exception');
         } catch (\GuzzleHttp\Exception\TransferException $e) {
@@ -649,6 +693,48 @@ class CurlFactoryTest extends TestCase
                 self::assertStringContainsString('***@127.0.0.1:99999999', $e->getMessage());
             }
         }
+    }
+
+    public function testRedactsEnvironmentProxyCredentialsInCurlErrorMessages(): void
+    {
+        self::withProxyEnvironment(['http_proxy' => 'foo://user:secret@127.0.0.1:1'], static function (): void {
+            $handler = new Handler\CurlHandler();
+
+            try {
+                $handler(new Psr7\Request('GET', Server::$url), [])->wait();
+                self::fail('Expected a transfer exception');
+            } catch (\GuzzleHttp\Exception\TransferException $e) {
+                self::assertStringNotContainsString('secret', $e->getMessage());
+            }
+        });
+    }
+
+    public function testRedactsParseableProxyCredentialsIndependentlyOfCurlErrorText(): void
+    {
+        $proxy = 'http://user:secret@proxy.example.com:8125';
+        $redactedUserInfo = Psr7\Utils::redactUserInfo(new Psr7\Uri($proxy))->getUserInfo();
+
+        $redacted = self::redactProxyUserInfo('Failed to connect via '.$proxy, $proxy);
+
+        self::assertStringNotContainsString('secret', $redacted);
+        self::assertSame('Failed to connect via http://'.$redactedUserInfo.'@proxy.example.com:8125', $redacted);
+    }
+
+    public function testRedactsUnparsableProxyCredentialsIndependentlyOfCurlErrorText(): void
+    {
+        $proxy = 'http://user:secret@127.0.0.1:99999999';
+
+        $redacted = self::redactProxyUserInfo("Unsupported proxy syntax in '".$proxy."'", $proxy);
+
+        self::assertStringNotContainsString('secret', $redacted);
+        self::assertSame("Unsupported proxy syntax in 'http://***@127.0.0.1:99999999'", $redacted);
+    }
+
+    public function testLeavesCurlErrorsUntouchedForProxiesWithoutCredentials(): void
+    {
+        $error = 'Failed to connect to proxy.example.com:8125';
+
+        self::assertSame($error, self::redactProxyUserInfo($error, 'http://proxy.example.com:8125'));
     }
 
     public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
@@ -680,6 +766,58 @@ class CurlFactoryTest extends TestCase
         ]);
 
         self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testDoesNotForceFreshConnectionForCurlProxyCredentialsOnFixedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_PROXYUSERPWD => 'username:password',
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForUnauthenticatedHttpsProxy(): void
+    {
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionWhenNoProxyMatches(): void
+    {
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+            'proxy' => [
+                'https' => 'http://username:password@proxy.example.com:8080',
+                'no' => ['example.com'],
+            ],
+        ]);
+
+        self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        self::assertNoProxyOption('*');
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testAuthenticatedHttpsProxyReuseOptionsCanBeSetOnFixedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_FRESH_CONNECT => false,
+                \CURLOPT_FORBID_REUSE => false,
+            ],
+        ]);
+
+        self::assertFalse($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertFalse($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
     }
 
     public function testForcesFreshConnectionForAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
@@ -1902,6 +2040,16 @@ class CurlFactoryTest extends TestCase
         }
 
         return (int) \constant('CURLOPT_PROXYHEADER');
+    }
+
+    private static function redactProxyUserInfo(string $error, ?string $proxy): string
+    {
+        $method = new \ReflectionMethod(CurlFactory::class, 'redactProxyUserInfo');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        return $method->invoke(null, $error, $proxy);
     }
 
     private static function skipIfCurlShareIsUnavailable(): void

--- a/tests/Handler/ProxyEnvironmentTest.php
+++ b/tests/Handler/ProxyEnvironmentTest.php
@@ -141,6 +141,27 @@ class ProxyEnvironmentTest extends TestCase
         });
     }
 
+    public function testSplitsNoProxyOnCommasAndBlanks(): void
+    {
+        self::assertSame(
+            ['host1.test', 'host2.test', 'host3.test', 'host4.test'],
+            ProxyEnvironment::splitNoProxy("host1.test host2.test,host3.test ,\thost4.test")
+        );
+    }
+
+    public function testIgnoresASingleLeadingDotInNoProxyEntries(): void
+    {
+        self::assertSame(
+            ['example.com', '.foo.com'],
+            ProxyEnvironment::splitNoProxy('.example.com,..foo.com')
+        );
+    }
+
+    public function testDropsEmptyNoProxyEntries(): void
+    {
+        self::assertSame([], ProxyEnvironment::splitNoProxy(' ,, . '));
+    }
+
     private static function skipIfWindows(): void
     {
         if (\PHP_OS_FAMILY === 'Windows') {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -255,6 +255,8 @@ class UtilsTest extends TestCase
             ['http://foo.example.com:8080', ['example.com:8080'], true],
             ['http://foo.example.com:8080', ['.example.com:8080'], true],
             ['http://example.com:8080', ['.example.com:8080'], false],
+            ['http://foo.example.com:8080', ['.EXAMPLE.com:8080'], true],
+            ['http://foo.example.com:8081', ['.EXAMPLE.com:8080'], false],
             ['http://[::1]:8080', ['[::1]:8080'], true],
             ['http://[::1]:8081', ['[::1]:8080'], false],
             ['http://[::1]', ['[::1]:80'], true],


### PR DESCRIPTION
This hardens the proxy environment takeover from #3619 ahead of the 7.12.0 release, mirroring the refinements that landed on the 8.0 branch in #3620. The environment no_proxy value is now tokenized the way libcurl tokenizes it before being matched with the option engine: entries may be separated by blanks as well as commas, and a single leading dot is ignored, so `.example.com` bypasses `example.com` and its subdomains. Without this, configurations that every libcurl version honored would silently change meaning once Guzzle performs the matching itself.

The test suite gains the negative directions that were previously only asserted on the 8.0 branch, although the guarded logic is identical here: an explicitly disabled proxy option suppressing environment proxies, no forced fresh connections for unauthenticated proxies or on fixed libcurl versions, user overrides of the reuse options being honored, and a no-proxy bypass never forcing a fresh connection. The credential redaction now also has libcurl-independent unit coverage of both the parse_url path and its fallback, plus an end-to-end case for environment-resolved credentials, and the environment tests assert the full pinned state including `CURLOPT_NOPROXY`.

The proxy documentation gains the connection-reuse note that previously existed only on the 8.0 branch, adapted to Guzzle 7 where raw `CURLOPT_PROXY` is deprecated rather than rejected, and worded to distinguish the tunnel reuse flaw fixed in libcurl 8.19.0 from the related proxy credential leaks fixed in 8.20.0, which is the version the mitigation gates on. It also now documents that SAPI-injected values are only excluded from the handler-level resolution while the client mapping does read them, and that proxy decisions are made once per request, so libcurl-internal redirects enabled through the deprecated raw cURL option do not re-evaluate the environment per hop.
