### PR TITLE
Fix non-finite float coercion warnings on PHP 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.11.2 - Upcoming
+
+### Fixed
+
+- Fixed non-finite float values emitting coercion warnings on PHP 8.5
+
+
 ## 7.11.1 - 2026-06-07
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -841,7 +841,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
                     .'x-www-form-urlencoded requests, and the multipart '
                     .'option to send multipart/form-data requests.');
             }
-            $options['body'] = \http_build_query($options['form_params'], '', '&');
+            $options['body'] = \http_build_query(self::normalizeNonFiniteFloats($options['form_params']), '', '&');
             unset($options['form_params']);
             // Ensure that we don't have the header in different case and set the new value.
             $options['_conditional'] = Psr7\Utils::caselessRemove(['Content-Type'], $options['_conditional']);
@@ -902,7 +902,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         if (isset($options['query'])) {
             $value = $options['query'];
             if (\is_array($value)) {
-                $value = \http_build_query($value, '', '&', \PHP_QUERY_RFC3986);
+                $value = \http_build_query(self::normalizeNonFiniteFloats($value), '', '&', \PHP_QUERY_RFC3986);
             }
             if (!\is_string($value)) {
                 throw new InvalidArgumentException('query must be a string or array');
@@ -970,6 +970,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
                 foreach ($value as $index => $item) {
                     if ($item === null || (!\is_string($item) && \is_scalar($item))) {
+                        if (\is_float($item) && !\is_finite($item)) {
+                            $item = \is_nan($item) ? 'NAN' : ($item > 0 ? 'INF' : '-INF');
+                        }
                         $value[$index] = (string) $item;
                     }
                 }
@@ -980,11 +983,31 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             }
 
             if ($value === null || (!\is_string($value) && \is_scalar($value))) {
+                if (\is_float($value) && !\is_finite($value)) {
+                    $value = \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+                }
                 $headers[$name] = (string) $value;
             }
         }
 
         return $droppedHeaderNames;
+    }
+
+    /**
+     * Converts non-finite floats in the array to the strings PHP coerces
+     * them to, as implicit coercion of NAN emits a warning on PHP 8.5.
+     */
+    private static function normalizeNonFiniteFloats(array $values): array
+    {
+        foreach ($values as $key => $value) {
+            if (\is_array($value)) {
+                $values[$key] = self::normalizeNonFiniteFloats($value);
+            } elseif (\is_float($value) && !\is_finite($value)) {
+                $values[$key] = \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+            }
+        }
+
+        return $values;
     }
 
     /**


### PR DESCRIPTION
PHP 8.5 emits a warning whenever a NAN float is implicitly coerced to a string. The `query` and `form_params` options pass their arrays straight to `http_build_query()`, and non-string scalar header option values are cast with a plain string cast, so a non-finite float value now triggers the warning at each of these sites. This converts non-finite floats to their string forms explicitly beforehand, preserving the existing output on all PHP versions.