### PR TITLE
Reject HTTPS proxies when libcurl lacks HTTPS-proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.12.1 - Upcoming
+
+### Fixed
+
+- Reject HTTPS proxies when the installed libcurl lacks HTTPS-proxy support
+
+
 ## 7.12.0 - 2026-06-16
 
 ### Added

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -939,6 +939,8 @@ $client->request('GET', '/', [
 > [!NOTE]
 > You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
 
+HTTPS proxies (an `https://` proxy URL, where the connection to the proxy itself is encrypted) require libcurl 7.52.0 or newer built with HTTPS-proxy support. Without it, libcurl mishandles such a proxy — versions before 7.50.2 silently downgrade it to a plaintext HTTP proxy, while 7.50.2 and later, and builds lacking the feature, fail only at connect time with a cryptic error — so the cURL handlers reject the request up front instead.
+
 ### Proxy environment variables
 
 The cURL handlers always configure libcurl's proxy options explicitly, so libcurl never reads proxy environment variables itself. When the `proxy` request option makes a decision for a request — a string proxy, or an array whose key matches the request scheme (including a `no` list match) — that decision is final, and proxy environment variables are ignored for the request. In particular, the `no_proxy`/`NO_PROXY` environment variables do not bypass an explicitly configured proxy; add the hosts to the option's `no` list instead.

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -717,6 +717,13 @@ class CurlFactory implements CurlFactoryInterface
         return \is_string($proxy) && $proxy !== '' ? $proxy : null;
     }
 
+    private static function proxyScheme(string $proxy): ?string
+    {
+        $position = \strpos($proxy, '://');
+
+        return $position === false ? null : \strtolower(\substr($proxy, 0, $position));
+    }
+
     /**
      * @return array<int|string, mixed>
      */
@@ -1025,6 +1032,16 @@ class CurlFactory implements CurlFactoryInterface
                 // the installed libcurl's matcher.
                 $proxyConf = '';
                 $noProxyConf = '*';
+            }
+        }
+
+        if (\is_string($proxyConf) && $proxyConf !== '') {
+            if (self::proxyScheme($proxyConf) === 'https' && !CurlVersion::supportsHttpsProxy()) {
+                // libcurl before 7.50.2 silently downgrades an https:// proxy
+                // to a plaintext HTTP proxy; 7.50.2 through 7.51, and builds
+                // without HTTPS-proxy support, fail at connect time. Fail
+                // closed before any bytes reach the wire.
+                throw new RequestException('HTTPS proxies are not supported by the installed libcurl; libcurl 7.52.0 or newer built with HTTPS-proxy support is required.', $easy->request);
             }
         }
 

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -13,6 +13,12 @@ final class CurlVersion
 
     private const TLS_13_VERSION = '7.52.0';
 
+    // curl 7.52.0 introduced HTTPS proxy support, advertised by a feature bit
+    // (a build can meet the version yet lack the feature). Earlier libcurl
+    // mishandles an https:// proxy: before 7.50.2 it silently downgrades to a
+    // plaintext HTTP proxy, and 7.50.2 through 7.51 reject it at connect time.
+    private const HTTPS_PROXY_VERSION = '7.52.0';
+
     private const HANDLER_SHARING_VERSION = '7.35.0';
 
     private const SSL_SESSION_SHARING_VERSION = '8.6.0';
@@ -61,6 +67,19 @@ final class CurlVersion
             && \defined('CURL_VERSION_HTTP2')
             && $versionInfo !== null
             && 0 !== (\CURL_VERSION_HTTP2 & $versionInfo['features']);
+    }
+
+    public static function supportsHttpsProxy(): bool
+    {
+        $versionInfo = self::getVersionInfo();
+
+        // CURL_VERSION_HTTPS_PROXY is not defined on every supported PHP
+        // version; fall back to the curl.h bit value.
+        $httpsProxyFeature = \defined('CURL_VERSION_HTTPS_PROXY') ? \CURL_VERSION_HTTPS_PROXY : (1 << 21);
+
+        return $versionInfo !== null
+            && \version_compare($versionInfo['version'], self::HTTPS_PROXY_VERSION, '>=')
+            && 0 !== ($httpsProxyFeature & $versionInfo['features']);
     }
 
     public static function supportsHandlerSharing(): bool

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -635,6 +635,179 @@ class CurlFactoryTest extends TestCase
         });
     }
 
+    public static function unsupportedHttpsProxyCurlVersionProvider(): array
+    {
+        return [
+            ['7.21.2'],
+            ['7.50.0'],
+            ['7.51.0'],
+            ['7.52.0'],
+            ['7.61.0'],
+        ];
+    }
+
+    /**
+     * @dataProvider unsupportedHttpsProxyCurlVersionProvider
+     */
+    public function testRejectsHttpsProxyWhenLibcurlLacksSupport(string $version): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => $version, 'features' => 0]);
+
+        try {
+            $this->expectException(RequestException::class);
+            $this->expectExceptionMessage('HTTPS proxies are not supported by the installed libcurl; libcurl 7.52.0 or newer built with HTTPS-proxy support is required.');
+
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => 'https://proxy.example.com:3128',
+            ]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public static function rejectedHttpsProxyOptionProvider(): array
+    {
+        return [
+            ['HTTPS://proxy.example.com:3128'],
+            [['https' => 'https://proxy.example.com:3128']],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedHttpsProxyOptionProvider
+     *
+     * @param string|array $proxy
+     */
+    public function testRejectsHttpsProxyFormsWhenLibcurlLacksSupport($proxy): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => 0]);
+
+        try {
+            $this->expectException(RequestException::class);
+            $this->expectExceptionMessage('HTTPS proxies are not supported by the installed libcurl');
+
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), ['proxy' => $proxy]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public static function rejectedHttpsProxyEnvironmentProvider(): array
+    {
+        return [
+            [['https_proxy' => 'https://proxy.example.com:3128']],
+            [['HTTPS_PROXY' => 'https://proxy.example.com:3128']],
+            [['all_proxy' => 'https://proxy.example.com:3128']],
+            [['ALL_PROXY' => 'https://proxy.example.com:3128']],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedHttpsProxyEnvironmentProvider
+     */
+    public function testRejectsEnvironmentHttpsProxyWhenLibcurlLacksSupport(array $env): void
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('HTTPS proxies are not supported by the installed libcurl');
+
+        self::withProxyEnvironment($env, static function (): void {
+            $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => 0]);
+
+            try {
+                $f = new CurlFactory(3);
+                $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+            } finally {
+                self::setCurlVersionInfo($previousVersionInfo);
+            }
+        });
+    }
+
+    public static function unaffectedProxyOptionProvider(): array
+    {
+        return [
+            ['http://proxy.example.com:3128'],
+            ['127.0.0.1:8125'],
+            ['socks5://proxy.example.com:1080'],
+            [''],
+        ];
+    }
+
+    /**
+     * @dataProvider unaffectedProxyOptionProvider
+     */
+    public function testDoesNotRejectNonHttpsProxiesOnOldLibcurl(string $proxy): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => 0]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), ['proxy' => $proxy]);
+
+            self::assertSame($proxy, $_SERVER['_curl'][\CURLOPT_PROXY]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testAllowsHttpsProxyWhenLibcurlSupportsIt(): void
+    {
+        $httpsProxyFeature = \defined('CURL_VERSION_HTTPS_PROXY') ? \CURL_VERSION_HTTPS_PROXY : (1 << 21);
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.52.0', 'features' => $httpsProxyFeature]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => 'https://proxy.example.com:3128',
+            ]);
+
+            self::assertSame('https://proxy.example.com:3128', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testDoesNotRejectBypassedHttpsProxyOnOldLibcurl(): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => 0]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => [
+                    'https' => 'https://proxy.example.com:3128',
+                    'no' => ['example.com'],
+                ],
+            ]);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertNoProxyOption('*');
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testDoesNotRejectBypassedEnvironmentHttpsProxyOnOldLibcurl(): void
+    {
+        self::withProxyEnvironment([
+            'https_proxy' => 'https://proxy.example.com:3128',
+            'NO_PROXY' => 'example.com',
+        ], static function (): void {
+            $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => 0]);
+
+            try {
+                $f = new CurlFactory(3);
+                $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+
+                self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+                self::assertNoProxyOption('*');
+            } finally {
+                self::setCurlVersionInfo($previousVersionInfo);
+            }
+        });
+    }
+
     public function testRedactsProxyCredentialsInCurlErrorMessages(): void
     {
         $handler = new Handler\CurlHandler();

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -99,6 +99,28 @@ class CurlVersionTest extends TestCase
         }
     }
 
+    public function testSupportsHttpsProxyUsesMinimumVersionAndFeature(): void
+    {
+        $httpsProxyFeature = \defined('CURL_VERSION_HTTPS_PROXY') ? \CURL_VERSION_HTTPS_PROXY : (1 << 21);
+
+        $previous = self::setCurlVersionInfo(['version' => '7.51.0', 'features' => $httpsProxyFeature]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsHttpsProxy());
+
+            self::setCurlVersionInfo(['version' => '7.52.0', 'features' => 0]);
+            self::assertFalse(CurlVersion::supportsHttpsProxy());
+
+            self::setCurlVersionInfo(['version' => '7.52.0', 'features' => $httpsProxyFeature]);
+            self::assertTrue(CurlVersion::supportsHttpsProxy());
+
+            self::setCurlVersionInfo(false);
+            self::assertFalse(CurlVersion::supportsHttpsProxy());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
     public function testSupportsTransportSharingUsesSharingFloors(): void
     {
         if (!\defined('CURL_VERSION_SSL')) {


### PR DESCRIPTION
libcurl gained HTTPS proxy support in 7.52.0, advertised by a feature bit. Older or feature-less libcurl builds cannot establish TLS to an `https://` proxy: before 7.50.2 they silently treat that proxy as a plaintext `http://` proxy, while 7.50.2 through 7.51.x and newer builds without the feature fail only at connect time.

On the 7.12 branch this change is limited to the cURL handlers. After Guzzle resolves the effective proxy from the `proxy` option or the process environment, and after configured `no` lists and environment `no_proxy`/`NO_PROXY` bypasses have been applied, an effective `https://` proxy is rejected up front with a `RequestException` unless `CurlVersion` reports both libcurl 7.52.0 or newer and HTTPS-proxy feature support. The scheme check trims leading whitespace and matches case-insensitively so spellings old libcurl would mishandle are caught before `CURLOPT_PROXY` is pinned.

Requests with no proxy, an empty or bypassed proxy, an `http://` or SOCKS proxy, or a libcurl build with working HTTPS-proxy support are unchanged. The stream handler is not changed on this branch. The request options documentation and changelog describe the libcurl requirement and the earlier exception.
