### PR TITLE
Fail closed on proxy schemes the handler cannot execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Validate proxy and no-proxy option types strictly across handlers
 - Match leading-dot no-proxy entries against the bare domain and split string no-proxy lists on whitespace
 - Treat a matching proxy `no` entry as final even without a scheme-specific proxy entry
+- Validate proxy URLs in the built-in handlers and reject malformed or unsupported ones up front
 - Downgrade HTTP/3 requests to HTTP/2 or HTTP/1.1 when the proxy is resolved from environment variables
 - Pass the request as the second argument to `on_headers` callbacks
 - Declare strict types across remaining source files

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -511,6 +511,22 @@ no longer fall back to an environment proxy for it. The `no` list is also
 validated in that case. Guzzle 7 ignores the `no` list entirely unless the
 array selects a proxy for the request scheme.
 
+#### Proxy URL Validation
+
+The stream handler now throws `InvalidArgumentException` for any proxy URL
+whose scheme it cannot execute: `https://`, SOCKS (`socks4://`, `socks4a://`,
+`socks5://`, `socks5h://`), and anything other than `http://` or a raw PHP
+transport such as `tcp://`, `ssl://`, or `tls://`. Guzzle 7 passed these to
+PHP, which failed later with an "unable to find the socket transport" error.
+The cURL handlers reject a `proxy` URL whose scheme libcurl cannot use as a
+proxy with the same exception. Raw PHP transport values still pass through the
+stream wrapper unchanged.
+
+Both handlers also reject a malformed proxy URL (an invalid host, an
+out-of-range port, or leading junk before the scheme) up front with the same
+`InvalidArgumentException`, instead of passing it to libcurl or PHP to fail on
+later.
+
 #### Handler-Specific Option Overrides
 
 Handler-specific overrides remain available for finer transport control when

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "guzzlehttp/psr7": "^3.0@dev",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "symfony/polyfill-php80": "^1.24"
+        "symfony/polyfill-php80": "^1.25"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -983,7 +983,7 @@ $client->request('GET', '/', [
 ```
 
 > [!NOTE]
-> You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
+> You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`. A scheme-less value such as `"127.0.0.1:8125"` is treated as an HTTP proxy. Both built-in handlers validate the proxy URL up front and reject a malformed one (an invalid host, an out-of-range port, or leading junk before the scheme) with an `InvalidArgumentException`.
 
 ### Handler support
 
@@ -998,7 +998,9 @@ The `proxy` option — including the `no` list and its validation — means the 
 | Proxy credentials in the proxy URL | yes | yes (Basic only) |
 | Proxy resolution from environment variables | yes | no |
 
-The stream handler forwards requests through PHP's HTTP stream wrapper, which supports plain HTTP proxying only: it cannot establish CONNECT tunnels, so "https" requests through a proxy fail with a connection error, and SOCKS proxies are not supported. Use a cURL handler for tunneled or SOCKS proxying. The last row is by design — only the cURL handlers resolve proxy environment variables (see below).
+The stream handler forwards requests through PHP's HTTP stream wrapper, which supports plain HTTP proxying only: it cannot establish CONNECT tunnels, so "https" requests through a proxy fail with a connection error. It rejects any proxy URL whose scheme it cannot execute, throwing an `InvalidArgumentException` before the request is sent. That covers `https://`, SOCKS (`socks4://`, `socks4a://`, `socks5://`, `socks5h://`), and anything other than `http://` or a raw PHP transport such as `tcp://`, `ssl://`, or `tls://`. The last row is by design, since only the cURL handlers resolve proxy environment variables (see below).
+
+HTTPS proxies (an `https://` proxy URL, where the connection to the proxy itself is encrypted) require libcurl 7.52.0 or newer built with HTTPS-proxy support. When libcurl lacks that support, it mishandles such a proxy: versions before 7.50.2 silently downgrade it to a plaintext HTTP proxy, and later versions fail at connect time with a cryptic error. To avoid both outcomes, the cURL handlers reject the request up front. They also reject any `proxy` URL whose scheme libcurl cannot use as a proxy, with an `InvalidArgumentException`.
 
 ### Proxy environment variables
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1753,6 +1753,25 @@ final class CurlFactory implements CurlFactoryInterface
         $proxy = self::resolveProxySelection($easy->request->getUri(), $options['proxy'] ?? null);
         $selectedProxy = $proxy->getProxy();
         if ($selectedProxy !== null) {
+            if ($selectedProxy !== '') {
+                // Validate the whole proxy URL up front (ProxyOptions leans on
+                // Psr7\Uri), so a malformed proxy fails the same way on every
+                // handler, then check the scheme against what libcurl can use.
+                $scheme = ProxyOptions::proxyScheme($selectedProxy);
+
+                if (!\in_array($scheme, ['http', 'https', 'socks4', 'socks4a', 'socks5', 'socks5h'], true)) {
+                    throw new InvalidArgumentException(\sprintf('The "%s" proxy scheme is not supported by the cURL handler.', $scheme));
+                }
+
+                if ($scheme === 'https' && !CurlVersion::supportsHttpsProxy()) {
+                    // libcurl before 7.50.2 silently downgrades an https://
+                    // proxy to a plaintext HTTP proxy; 7.50.2 through 7.51, and
+                    // builds without HTTPS-proxy support, fail at connect time.
+                    // Fail closed before any bytes reach the wire.
+                    throw new RequestException('HTTPS proxies are not supported by the installed libcurl; libcurl 7.52.0 or newer built with HTTPS-proxy support is required.', $easy->request);
+                }
+            }
+
             $conf[\CURLOPT_PROXY] = $selectedProxy;
             $conf[\CURLOPT_NOPROXY] = '';
         } else {

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -17,6 +17,12 @@ final class CurlVersion
 
     private const TLS_13_VERSION = '7.52.0';
 
+    // curl 7.52.0 introduced HTTPS proxy support, advertised by a feature bit
+    // (a build can meet the version yet lack the feature). Earlier libcurl
+    // mishandles an https:// proxy: before 7.50.2 it silently downgrades to a
+    // plaintext HTTP proxy, and 7.50.2 through 7.51 reject it at connect time.
+    private const HTTPS_PROXY_VERSION = '7.52.0';
+
     private const HTTP_3_VERSION = '7.66.0';
 
     private const PROTOCOLS_STR_VERSION = '7.85.0';
@@ -82,6 +88,16 @@ final class CurlVersion
         }
 
         return 0 !== ((int) \constant('CURL_VERSION_HTTP3') & $versionInfo['features']);
+    }
+
+    public static function supportsHttpsProxy(): bool
+    {
+        $versionInfo = self::getVersionInfo();
+
+        return \defined('CURL_VERSION_HTTPS_PROXY')
+            && null !== $versionInfo
+            && version_compare($versionInfo['version'], self::HTTPS_PROXY_VERSION, '>=')
+            && 0 !== (\CURL_VERSION_HTTPS_PROXY & $versionInfo['features']);
     }
 
     public static function supportsHandlerSharing(): bool

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -1126,6 +1126,36 @@ final class StreamHandler
             return;
         }
 
+        // Validate the whole proxy authority up front (ProxyOptions leans on
+        // Psr7\Rfc3986), so a malformed proxy fails the same way on every
+        // handler. PHP's HTTP stream wrapper can only carry HTTP over a
+        // TCP-family socket, so reject any scheme it can never execute instead
+        // of letting PHP fail with a misleading "unable to find the socket
+        // transport" error. The supported set is a scheme-less value, http, or
+        // a TCP-family transport (tcp://, ssl://, tls://, tlsv1.*) the build has.
+        $scheme = ProxyOptions::proxyScheme($proxyUri);
+
+        if ($scheme === 'https') {
+            throw new InvalidArgumentException('HTTPS proxies are not supported by the stream handler.');
+        }
+
+        if (\in_array($scheme, ['socks4', 'socks4a', 'socks5', 'socks5h'], true)) {
+            throw new InvalidArgumentException('SOCKS proxies are not supported by the stream handler.');
+        }
+
+        // Only TCP-family transports can carry HTTP; udp/unix/udg cannot, so
+        // reject them rather than install an unusable proxy.
+        $rawTransports = \array_filter(
+            \stream_get_transports(),
+            static function (string $transport): bool {
+                return $transport === 'tcp' || $transport === 'ssl' || \strncmp($transport, 'tls', 3) === 0;
+            }
+        );
+
+        if ($scheme !== 'http' && !\in_array($scheme, $rawTransports, true)) {
+            throw new InvalidArgumentException(\sprintf('The "%s" proxy scheme is not supported by the stream handler.', $scheme));
+        }
+
         $parsed = $this->parseProxy($proxyUri);
         $context['http']['proxy'] = $parsed['proxy'];
 

--- a/src/ProxyOptions.php
+++ b/src/ProxyOptions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp;
 
 use GuzzleHttp\Exception\InvalidArgumentException;
+use GuzzleHttp\Psr7\Rfc3986;
 use Psr\Http\Message\UriInterface;
 
 final class ProxyOptions
@@ -54,6 +55,105 @@ final class ProxyOptions
         }
 
         return ProxySelection::proxy($schemeProxy);
+    }
+
+    /**
+     * Validate a proxy URL and return its lowercased scheme.
+     *
+     * A proxy is an authority ([userinfo@]host[:port]) with an optional scheme;
+     * a scheme-less value is an HTTP proxy. The scheme is matched anchored at the
+     * start, so leading junk before it is rejected as malformed, and the host and
+     * port grammar is delegated to Psr7\Rfc3986. The whole string is validated up
+     * front so a malformed proxy fails the same way on every handler, but the
+     * original value is what callers pin, so no normalization reaches the wire.
+     * The error message never includes the proxy, which may carry credentials.
+     *
+     * @throws InvalidArgumentException on a malformed proxy URL
+     */
+    public static function proxyScheme(string $proxy): string
+    {
+        $parts = \explode('://', $proxy, 2);
+        if (\count($parts) === 1) {
+            $scheme = 'http';
+            $authority = $proxy;
+        } else {
+            [$scheme, $authority] = $parts;
+            $scheme = \strtolower($scheme);
+            if ($scheme === '' || !Rfc3986::isValidScheme($scheme)) {
+                throw new InvalidArgumentException('Invalid proxy URL.');
+            }
+        }
+
+        if (!self::isValidProxyAuthority($authority)) {
+            throw new InvalidArgumentException('Invalid proxy URL.');
+        }
+
+        return $scheme;
+    }
+
+    /**
+     * Whether the string is a valid proxy authority: [userinfo@]host[:port].
+     *
+     * A single trailing slash is tolerated; anything else after the authority
+     * (a path, query, or fragment) is rejected. Userinfo is not policed here
+     * (the proxy handles its own credentials); host and port grammar are
+     * delegated to Psr7\Rfc3986, where a zero port is accepted and left for the
+     * transport to handle as it did before.
+     */
+    private static function isValidProxyAuthority(string $authority): bool
+    {
+        // A single trailing slash is tolerated; once removed, a proxy authority
+        // ([userinfo@]host[:port]) cannot contain a path, query, or fragment
+        // delimiter anywhere — including one before a later '@'.
+        if (\str_ends_with($authority, '/')) {
+            $authority = \substr($authority, 0, \strlen($authority) - 1);
+        }
+
+        if ($authority === '' || \strpbrk($authority, '/?#') !== false) {
+            return false;
+        }
+
+        // The host cannot contain '@', so userinfo is everything before the last
+        // one. It is not validated here. A value that is only userinfo, with
+        // nothing after the last '@', has no host and is rejected.
+        $segments = \explode('@', $authority);
+        $authority = $segments[\count($segments) - 1];
+        if ($authority === '') {
+            return false;
+        }
+
+        $port = null;
+        if (\str_starts_with($authority, '[')) {
+            $parts = \explode(']', $authority, 2);
+            if (\count($parts) !== 2) {
+                return false;
+            }
+
+            $host = $parts[0].']';
+            $remainder = $parts[1];
+            if ($remainder !== '') {
+                if (!\str_starts_with($remainder, ':')) {
+                    return false;
+                }
+
+                [, $port] = \explode(':', $remainder, 2);
+            }
+        } elseif (\strpos($authority, ':') !== false) {
+            [$host, $port] = \explode(':', $authority, 2);
+        } else {
+            $host = $authority;
+        }
+
+        // A dangling "host:" carries no port, matching the previous behavior.
+        if ($port === '') {
+            $port = null;
+        }
+
+        if ($host === '' || !Rfc3986::isValidHost($host)) {
+            return false;
+        }
+
+        return $port === null || Rfc3986::isValidPort($port);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1033,6 +1033,218 @@ class CurlFactoryTest extends TestCase
         });
     }
 
+    public static function unsupportedHttpsProxyCurlVersionProvider(): array
+    {
+        return [
+            ['7.34.0'],
+            ['7.50.0'],
+            ['7.51.0'],
+            ['7.52.0'],
+            ['7.61.0'],
+        ];
+    }
+
+    /**
+     * @dataProvider unsupportedHttpsProxyCurlVersionProvider
+     */
+    public function testRejectsHttpsProxyWhenLibcurlLacksSupport(string $version): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => $version, 'features' => self::curlSslFeature()]);
+
+        try {
+            $this->expectException(RequestException::class);
+            $this->expectExceptionMessage('HTTPS proxies are not supported by the installed libcurl; libcurl 7.52.0 or newer built with HTTPS-proxy support is required.');
+
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => 'https://proxy.example.com:3128',
+            ]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public static function rejectedHttpsProxyOptionProvider(): array
+    {
+        return [
+            ['HTTPS://proxy.example.com:3128'],
+            [['https' => 'https://proxy.example.com:3128']],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedHttpsProxyOptionProvider
+     *
+     * @param string|array $proxy
+     */
+    public function testRejectsHttpsProxyFormsWhenLibcurlLacksSupport($proxy): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => self::curlSslFeature()]);
+
+        try {
+            $this->expectException(RequestException::class);
+            $this->expectExceptionMessage('HTTPS proxies are not supported by the installed libcurl');
+
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), ['proxy' => $proxy]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public static function rejectedHttpsProxyEnvironmentProvider(): array
+    {
+        return [
+            [['https_proxy' => 'https://proxy.example.com:3128']],
+            [['HTTPS_PROXY' => 'https://proxy.example.com:3128']],
+            [['all_proxy' => 'https://proxy.example.com:3128']],
+            [['ALL_PROXY' => 'https://proxy.example.com:3128']],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedHttpsProxyEnvironmentProvider
+     */
+    public function testRejectsEnvironmentHttpsProxyWhenLibcurlLacksSupport(array $env): void
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('HTTPS proxies are not supported by the installed libcurl');
+
+        self::withProxyEnvironment($env, static function (): void {
+            $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => self::curlSslFeature()]);
+
+            try {
+                $f = new CurlFactory(3);
+                $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+            } finally {
+                self::setCurlVersionInfo($previousVersionInfo);
+            }
+        });
+    }
+
+    public static function unaffectedProxyOptionProvider(): array
+    {
+        return [
+            ['http://proxy.example.com:3128'],
+            ['127.0.0.1:8125'],
+            ['socks5://proxy.example.com:1080'],
+        ];
+    }
+
+    /**
+     * @dataProvider unaffectedProxyOptionProvider
+     */
+    public function testDoesNotRejectNonHttpsProxiesOnOldLibcurl(string $proxy): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => self::curlSslFeature()]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), ['proxy' => $proxy]);
+
+            self::assertSame($proxy, $_SERVER['_curl'][\CURLOPT_PROXY]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public static function rejectedCurlProxySchemeProvider(): array
+    {
+        return [
+            ['ftp://proxy.example.com:21'],
+            ['gopher://proxy.example.com:70'],
+            ['ws://proxy.example.com:80'],
+            ['tcp://proxy.example.com:8125'],
+            ['ssl://proxy.example.com:8125'],
+            ['tls://proxy.example.com:8125'],
+            ['socks6://proxy.example.com:1080'],
+            ['htps://proxy.example.com:3128'],
+            [['https' => 'ftp://proxy.example.com:21']],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedCurlProxySchemeProvider
+     *
+     * @param string|array $proxy
+     */
+    public function testRejectsUnsupportedCurlProxySchemes($proxy): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('proxy scheme is not supported by the cURL handler');
+
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), ['proxy' => $proxy]);
+    }
+
+    public function testRejectsEnvironmentUnsupportedCurlProxyScheme(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('proxy scheme is not supported by the cURL handler');
+
+        self::withProxyEnvironment(['https_proxy' => 'ftp://proxy.example.com:21'], static function (): void {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+        });
+    }
+
+    public function testAllowsHttpsProxyWhenLibcurlSupportsIt(): void
+    {
+        $httpsProxyFeature = \defined('CURL_VERSION_HTTPS_PROXY') ? \CURL_VERSION_HTTPS_PROXY : (1 << 21);
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.52.0', 'features' => self::curlSslFeature() | $httpsProxyFeature]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => 'https://proxy.example.com:3128',
+            ]);
+
+            self::assertSame('https://proxy.example.com:3128', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testDoesNotRejectBypassedHttpsProxyOnOldLibcurl(): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => self::curlSslFeature()]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => [
+                    'https' => 'https://proxy.example.com:3128',
+                    'no' => ['example.com'],
+                ],
+            ]);
+
+            self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+            self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testDoesNotRejectBypassedEnvironmentHttpsProxyOnOldLibcurl(): void
+    {
+        self::withProxyEnvironment([
+            'https_proxy' => 'https://proxy.example.com:3128',
+            'NO_PROXY' => 'example.com',
+        ], static function (): void {
+            $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.50.0', 'features' => self::curlSslFeature()]);
+
+            try {
+                $f = new CurlFactory(3);
+                $f->create(new Psr7\Request('GET', 'https://example.com'), []);
+
+                self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+                self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
+            } finally {
+                self::setCurlVersionInfo($previousVersionInfo);
+            }
+        });
+    }
+
     public function testForcesFreshConnectionForEnvironmentCredentialedProxyOnAffectedCurlVersion(): void
     {
         self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
@@ -1052,59 +1264,80 @@ class CurlFactoryTest extends TestCase
         });
     }
 
-    public function testRedactsProxyCredentialsInCurlErrorMessages(): void
+    public function testRejectingUnsupportedProxySchemeDoesNotLeakCredentials(): void
     {
-        $handler = new Handler\CurlHandler();
+        $f = new CurlFactory(3);
 
         try {
-            $handler(new Psr7\Request('GET', Server::$url), [
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
                 'proxy' => 'foo://user:secret@127.0.0.1:1',
-            ])->wait();
-            self::fail('Expected a transfer exception');
-        } catch (\GuzzleHttp\Exception\TransferException $e) {
+            ]);
+            self::fail('Expected an InvalidArgumentException');
+        } catch (\InvalidArgumentException $e) {
             self::assertStringNotContainsString('secret', $e->getMessage());
-            if (\strpos($e->getMessage(), 'foo://') !== false) {
-                // The redacted form follows the installed psr7 version:
-                // 'user:***' on psr7 2, '***' on psr7 3.
-                $redactedUserInfo = Psr7\Utils::redactUserInfo(
-                    new Psr7\Uri('foo://user:secret@127.0.0.1:1')
-                )->getUserInfo();
-
-                self::assertStringContainsString('foo://'.$redactedUserInfo.'@127.0.0.1:1', $e->getMessage());
-            }
         }
     }
 
-    public function testRedactsProxyCredentialsWhenProxyDefeatsUrlParsing(): void
+    public function testRejectsMalformedProxyUrlWithoutLeakingCredentials(): void
     {
-        $handler = new Handler\CurlHandler();
+        $f = new CurlFactory(3);
 
         try {
-            $handler(new Psr7\Request('GET', Server::$url), [
+            $f->create(new Psr7\Request('GET', 'https://example.com'), [
                 'proxy' => 'http://user:secret@127.0.0.1:99999999',
-                'connect_timeout' => 1,
-            ])->wait();
-            self::fail('Expected a transfer exception');
-        } catch (\GuzzleHttp\Exception\TransferException $e) {
+            ]);
+            self::fail('Expected an InvalidArgumentException');
+        } catch (\InvalidArgumentException $e) {
             self::assertStringNotContainsString('secret', $e->getMessage());
-            if (\strpos($e->getMessage(), '127.0.0.1:99999999') !== false) {
-                self::assertStringContainsString('***@127.0.0.1:99999999', $e->getMessage());
-            }
         }
     }
 
-    public function testRedactsEnvironmentProxyCredentialsInCurlErrorMessages(): void
+    public function testRejectsMalformedEnvironmentProxyUrlWithoutLeakingCredentials(): void
     {
-        self::withProxyEnvironment(['http_proxy' => 'foo://user:secret@127.0.0.1:1'], static function (): void {
-            $handler = new Handler\CurlHandler();
+        self::withProxyEnvironment(['http_proxy' => 'http://user:secret@127.0.0.1:99999999'], static function (): void {
+            $f = new CurlFactory(3);
 
             try {
-                $handler(new Psr7\Request('GET', Server::$url), [])->wait();
-                self::fail('Expected a transfer exception');
-            } catch (\GuzzleHttp\Exception\TransferException $e) {
+                $f->create(new Psr7\Request('GET', 'http://example.com'), []);
+                self::fail('Expected an InvalidArgumentException');
+            } catch (\InvalidArgumentException $e) {
                 self::assertStringNotContainsString('secret', $e->getMessage());
             }
         });
+    }
+
+    public static function malformedProxyUrlProvider(): array
+    {
+        return [
+            ['http://exa mple.com:3128'],          // space in host
+            ['http://127.0.0.1:99999999'],         // port out of range
+            ['127.0.0.1:99999999'],                // scheme-less, port out of range
+            ["\u{00A0}https://proxy.example.com:3128"], // leading junk before the scheme
+            [' https://proxy.example.com:3128'],   // leading space before the scheme
+            [' 127.0.0.1:8125'],                   // leading space, scheme-less
+        ];
+    }
+
+    /**
+     * @dataProvider malformedProxyUrlProvider
+     */
+    public function testRejectsMalformedProxyUrls(string $proxy): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid proxy URL');
+
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), ['proxy' => $proxy]);
+    }
+
+    public function testAcceptsSchemeLessProxyWithCredentials(): void
+    {
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'proxy' => 'user:pass@127.0.0.1:8125',
+        ]);
+
+        self::assertSame('user:pass@127.0.0.1:8125', $_SERVER['_curl'][\CURLOPT_PROXY]);
     }
 
     public function testRedactsParseableProxyCredentialsIndependentlyOfCurlErrorText(): void

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -133,6 +133,34 @@ class CurlVersionTest extends TestCase
         self::assertTrue(CurlVersion::supportsHttp3());
     }
 
+    public function testSupportsHttpsProxyUsesMinimumVersionAndFeature(): void
+    {
+        if (!\defined('CURL_VERSION_HTTPS_PROXY')) {
+            self::markTestSkipped('CURL_VERSION_HTTPS_PROXY is not available.');
+        }
+
+        self::setVersionInfo([
+            'version' => '7.51.0',
+            'features' => \CURL_VERSION_HTTPS_PROXY,
+        ]);
+        self::assertFalse(CurlVersion::supportsHttpsProxy());
+
+        self::setVersionInfo([
+            'version' => '7.52.0',
+            'features' => 0,
+        ]);
+        self::assertFalse(CurlVersion::supportsHttpsProxy());
+
+        self::setVersionInfo([
+            'version' => '7.52.0',
+            'features' => \CURL_VERSION_HTTPS_PROXY,
+        ]);
+        self::assertTrue(CurlVersion::supportsHttpsProxy());
+
+        self::setVersionInfo(false);
+        self::assertFalse(CurlVersion::supportsHttpsProxy());
+    }
+
     public function testSupportsTransportSharingUsesSharingFloors(): void
     {
         self::requiresCurlSslFeature();

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Tests\Handler;
 
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Exception\ResponseTimeoutException;
@@ -1131,6 +1132,23 @@ class StreamHandlerTest extends TestCase
         return $context;
     }
 
+    /**
+     * @param mixed $value
+     */
+    private function applyProxyOption(string $uri, array $context, $value): array
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', $uri);
+        $method = new \ReflectionMethod(StreamHandler::class, 'applyProxyOption');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $method->invokeArgs($handler, [$request, &$context, $value]);
+
+        return $context;
+    }
+
     private function matchesStreamHandlerError(string $method, string $message): bool
     {
         $reflection = new \ReflectionMethod(StreamHandler::class, $method);
@@ -1217,6 +1235,78 @@ class StreamHandlerTest extends TestCase
         $opts = \stream_context_get_options($res->getBody()->detach());
 
         self::assertArrayNotHasKey('proxy', $opts['http']);
+    }
+
+    public static function rejectedProxySchemeProvider(): array
+    {
+        $https = 'HTTPS proxies are not supported by the stream handler.';
+        $socks = 'SOCKS proxies are not supported by the stream handler.';
+        $generic = static function (string $scheme): string {
+            return \sprintf('The "%s" proxy scheme is not supported by the stream handler.', $scheme);
+        };
+
+        return [
+            ['https://proxy.example.com:3128', $https],
+            ['HTTPS://proxy.example.com:3128', $https],
+            ['socks4://proxy.example.com:1080', $socks],
+            ['socks4a://proxy.example.com:1080', $socks],
+            ['socks5://proxy.example.com:1080', $socks],
+            ['socks5h://proxy.example.com:1080', $socks],
+            [['http' => 'socks5://proxy.example.com:1080'], $socks],
+            ['ftp://proxy.example.com:21', $generic('ftp')],
+            ['ws://proxy.example.com:80', $generic('ws')],
+            ['gopher://proxy.example.com:70', $generic('gopher')],
+            ['socks6://proxy.example.com:1080', $generic('socks6')],
+            ['htps://proxy.example.com:3128', $generic('htps')],
+            ['udp://127.0.0.1:8125', $generic('udp')],
+            [['http' => 'ftp://proxy.example.com:21'], $generic('ftp')],
+        ];
+    }
+
+    /**
+     * @dataProvider rejectedProxySchemeProvider
+     *
+     * @param string|array $proxy
+     */
+    public function testRejectsUnsupportedProxySchemes($proxy, string $message): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        $context = [];
+        $this->applyProxyOption('http://example.com', $context, $proxy);
+    }
+
+    public function testPassesRawTransportProxySchemesThrough(): void
+    {
+        foreach (['tcp://127.0.0.1:8125', 'ssl://127.0.0.1:8125', 'tls://127.0.0.1:8125'] as $proxy) {
+            $context = [];
+            $result = $this->applyProxyOption('http://example.com', $context, $proxy);
+
+            self::assertSame($proxy, $result['http']['proxy']);
+        }
+    }
+
+    public static function malformedProxyUrlProvider(): array
+    {
+        return [
+            ['http://exa mple.com:3128'],               // space in host
+            ['127.0.0.1:99999999'],                     // scheme-less, port out of range
+            [' https://proxy.example.com:3128'],        // leading space before the scheme
+            ["\u{00A0}https://proxy.example.com:3128"], // leading non-breaking space
+        ];
+    }
+
+    /**
+     * @dataProvider malformedProxyUrlProvider
+     */
+    public function testRejectsMalformedProxyUrl(string $proxy): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid proxy URL');
+
+        $context = [];
+        $this->applyProxyOption('http://example.com', $context, $proxy);
     }
 
     public function testUsesProxy(): void

--- a/tests/ProxyOptionsTest.php
+++ b/tests/ProxyOptionsTest.php
@@ -334,4 +334,69 @@ class ProxyOptionsTest extends TestCase
 
         ProxyOptions::isHostInNoProxy('', []);
     }
+
+    public static function validProxyProvider(): array
+    {
+        return [
+            'http with port' => ['http://proxy.example.com:8080', 'http'],
+            'https' => ['https://proxy.example.com:3128', 'https'],
+            'uppercase scheme is lowercased' => ['HTTP://proxy.example.com', 'http'],
+            'socks5' => ['socks5://proxy.example.com:1080', 'socks5'],
+            'scheme-less is http' => ['127.0.0.1:8125', 'http'],
+            'scheme-less with credentials' => ['user:pass@127.0.0.1:8125', 'http'],
+            'credentials in url' => ['http://user:pass@proxy.example.com:8080', 'http'],
+            'ipv6 literal' => ['http://[::1]:8080', 'http'],
+            'zero port left to the transport' => ['http://proxy.example.com:0', 'http'],
+            'single trailing slash tolerated' => ['http://proxy.example.com:8080/', 'http'],
+            'dangling colon is no port' => ['http://proxy.example.com:', 'http'],
+            'scheme-less dangling colon is no port' => ['proxy.example.com:', 'http'],
+            'ipv6 literal without port' => ['http://[::1]', 'http'],
+        ];
+    }
+
+    /**
+     * @dataProvider validProxyProvider
+     */
+    public function testProxySchemeReturnsLowercasedSchemeForValidProxies(string $proxy, string $expected): void
+    {
+        self::assertSame($expected, ProxyOptions::proxyScheme($proxy));
+    }
+
+    public static function malformedProxyProvider(): array
+    {
+        return [
+            'leading space before scheme' => [' https://proxy.example.com:3128'],
+            'non-breaking space before scheme' => ["\u{00A0}https://proxy.example.com:3128"],
+            'space inside scheme' => ['ht tps://proxy.example.com:3128'],
+            'empty scheme' => ['://proxy.example.com:3128'],
+            'space in host' => ['http://exa mple.com:3128'],
+            'leading space, scheme-less' => [' 127.0.0.1:8125'],
+            'port out of range' => ['http://127.0.0.1:99999999'],
+            'non-numeric port' => ['http://127.0.0.1:8a'],
+            'path after authority' => ['http://proxy.example.com:8080/path'],
+            'query after authority' => ['http://proxy.example.com:8080?x=1'],
+            'fragment after authority' => ['http://proxy.example.com:8080#frag'],
+            'slash before the userinfo @' => ['http://user/path@proxy.example.com:8080'],
+            'query before the userinfo @' => ['http://user?x@proxy.example.com:8080'],
+            'hash before the userinfo @' => ['http://user#x@proxy.example.com:8080'],
+            'bare ipv6 without brackets' => ['http://::1:8080'],
+            'empty string' => [''],
+            'userinfo only, empty authority' => ['http://user@'],
+            'at sign then empty authority' => ['http://@'],
+            'scheme-less userinfo only' => ['user@'],
+            'bare at sign' => ['@'],
+            'unclosed ipv6 bracket' => ['http://[::1:8080'],
+        ];
+    }
+
+    /**
+     * @dataProvider malformedProxyProvider
+     */
+    public function testProxySchemeRejectsMalformedProxies(string $proxy): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid proxy URL.');
+
+        ProxyOptions::proxyScheme($proxy);
+    }
 }


### PR DESCRIPTION
This carries the cURL-handler HTTPS-proxy capability check into 8.0, where proxy selection already goes through Guzzle's proxy resolver. After `resolveProxySelection()` selects a proxy and applies bypass rules, the cURL handler rejects an effective `https://` proxy before pinning `CURLOPT_PROXY` unless the installed libcurl is 7.52.0 or newer and advertises HTTPS-proxy support. Disabled and bypassed proxies are unaffected.

This PR also changes the stream handler, which is the part not covered by the 7.12 branch. The stream handler uses PHP's HTTP stream wrapper, which can only perform plain HTTP proxying. It now rejects `https://` and SOCKS proxy URLs with an `InvalidArgumentException` that names the unsupported handler capability, instead of passing those values to PHP and failing later with a misleading socket-transport error. Raw PHP transport values such as `tcp://`, `ssl://`, and `tls://` still pass through unchanged.

Requests using `http://` proxies, no proxy, bypassed proxies, or cURL handlers with working HTTPS-proxy support are unchanged. The request options documentation, upgrade guide, and changelog describe the new behavior.
