### PR TITLE
Section proxy tunnel connection reuse by credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 ### Changed
 
-- Prevent authenticated proxy tunnel reuse on libcurl versions older than 8.20.0
+- Section proxy tunnel connection reuse by credential so distinct credentials never share a tunnel
 
 
 ## 7.12.1 - Upcoming

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -960,21 +960,32 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 
 > [!NOTE]
 > When sending HTTPS requests, or requests explicitly tunneled with
-> `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy,
-> libcurl versions before 8.19.0 could reuse an existing proxy tunnel even
-> after proxy credentials changed, and 8.19.0 still contains related proxy
-> credential leak flaws that were fixed in 8.20.0. Guzzle therefore avoids
-> tunnel reuse on libcurl versions older than 8.20.0 when the proxy URL is
-> configured through the `proxy` option or resolved from the environment,
-> including cURL proxy credential options supplied through the `curl` request
-> option. Raw `CURLOPT_PROXY` supplied through the `curl` request option is
-> deprecated but still honored, and receives the same protection. Custom proxy
-> authentication sent with `CURLOPT_PROXYHEADER` also avoids tunnel reuse
-> because libcurl does not include those header values in its connection
-> matching. Fixed libcurl versions keep normal connection reuse behavior for
-> proxy URL and cURL proxy credential options. Advanced users can still
-> control cURL connection reuse explicitly with the `curl` request option and
-> `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
+> `CURLOPT_HTTPPROXYTUNNEL`, through an HTTP or HTTPS proxy, libcurl versions
+> before 8.19.0 could reuse an existing proxy tunnel even after proxy
+> credentials changed, and 8.19.0 still contains related proxy credential leak
+> flaws that were fixed in 8.20.0. Guzzle therefore sections proxy tunnel
+> connection reuse by the proxy credentials in effect: requests with the same
+> credentials reuse a pooled tunnel, while a change of proxy credentials (from
+> the `proxy` option, the environment, or cURL proxy credential options
+> supplied through the `curl` request option) is isolated onto its own
+> connections. Anonymous tunnels are sectioned apart from authenticated ones,
+> so an unauthenticated request never rides an authenticated tunnel. Raw
+> `CURLOPT_PROXY` supplied through the `curl` request option is deprecated but
+> still honored and participates in the same sectioning. Custom proxy
+> authentication sent with `CURLOPT_PROXYHEADER` is always sectioned because
+> libcurl cannot key connection reuse on those header values. On libcurl 8.20.0
+> and newer, credential sectioning for option-supplied credentials is left to
+> libcurl's own credential-aware connection matching.
+>
+> Sectioning has a cost in mixed workloads: changing the proxy credentials in
+> use discards the idle pooled connections held for the previous credentials,
+> which also drops unrelated direct keep-alive connections pooled alongside
+> them, and alternating anonymous and authenticated traffic through the same
+> proxy repeats that cost on each switch. Advanced users can still control cURL
+> connection reuse explicitly with the `curl` request option and
+> `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`; raw `CURLOPT_PROXYTYPE` is
+> respected when deciding whether a scheme-less `proxy` option value is an
+> HTTP(S) proxy.
 
 ## query
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -157,6 +157,12 @@ parameters:
 			path: src/Handler/CurlMultiHandler.php
 
 		-
+			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Handler/CurlMultiHandler.php
+
+		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_add_handle expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 2
@@ -165,7 +171,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_close expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Handler/CurlMultiHandler.php
 
 		-
@@ -201,7 +207,7 @@ parameters:
 		-
 			message: '#^Property GuzzleHttp\\Handler\\CurlMultiHandler\:\:\$_mh \(CurlMultiHandle\|resource\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
-			count: 1
+			count: 2
 			path: src/Handler/CurlMultiHandler.php
 
 		-

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -532,10 +532,9 @@ class CurlFactory implements CurlFactoryInterface
             $this->poolMayHoldTunnels = true;
         }
 
-        // Remove all callback functions as they can hold onto references
-        // and are not cleaned up by curl_reset. Using curl_setopt_array
-        // does not work for some reason, so removing each one
-        // individually.
+        // Remove all callback functions as they can hold onto references and
+        // are not cleaned up by curl_reset. Using curl_setopt_array does not
+        // work for some reason, so removing each one individually.
         \curl_setopt($resource, \CURLOPT_HEADERFUNCTION, null);
         \curl_setopt($resource, \CURLOPT_READFUNCTION, null);
         \curl_setopt($resource, \CURLOPT_WRITEFUNCTION, null);
@@ -803,11 +802,10 @@ class CurlFactory implements CurlFactoryInterface
             return true;
         }
 
-        // A proxy client certificate or TLS-SRP authenticates the client to an
-        // HTTPS proxy at the TLS layer; libcurl's connection matcher ignored
-        // TLS-SRP before 7.83.1 (CVE-2022-27782), so an old build can reuse a
-        // tunnel across those identities. Force a fresh one, as the non-share
-        // signature path always does.
+        // A proxy client certificate or TLS-SRP authenticates the client to the
+        // HTTPS proxy at the TLS layer; libcurl ignored TLS-SRP before 7.83.1
+        // (CVE-2022-27782), so an old build can reuse a tunnel across those
+        // identities. Force a fresh one, as the non-share signature path does.
         if (
             !CurlVersion::supportsProxyTlsCredentialAwareConnectionReuse()
             && self::hasCurlProxyTlsCredentials($conf)

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -36,6 +36,17 @@ class CurlFactory implements CurlFactoryInterface
     private $handles = [];
 
     /**
+     * @var string|null Owner signature of the proxy tunnels that pooled idle
+     *                  handles may still hold
+     */
+    private $proxyTunnelOwner;
+
+    /**
+     * @var bool Whether an in-domain handle has been pooled since the last purge
+     */
+    private $poolMayHoldTunnels = false;
+
+    /**
      * @var int Total number of idle handles to keep in cache
      */
     private $maxHandles;
@@ -129,7 +140,25 @@ class CurlFactory implements CurlFactoryInterface
             $conf = \array_replace($conf, $options['curl']);
         }
 
-        self::forceFreshConnectionForAuthenticatedProxy($request, $conf);
+        if ($this->shareHandle !== null) {
+            // Conservative blanket mode: a configured share handle hides the
+            // pooled connections' provenance, so sectioned reuse cannot reason
+            // about them.
+            self::forceFreshConnectionForAuthenticatedProxy($request, $conf);
+        } else {
+            $signature = self::proxyTunnelSignature($request, $conf);
+            $easy->proxyTunnelSignature = $signature;
+            if ($signature !== null && $signature !== $this->proxyTunnelOwner) {
+                if ($this->poolMayHoldTunnels) {
+                    // Pooled idle handles may hold a different owner's tunnel.
+                    $this->discardIdleHandles();
+                    $this->poolMayHoldTunnels = false;
+                }
+                // The first in-domain owner latches without purging: the pool
+                // provably holds no in-domain tunnel yet.
+                $this->proxyTunnelOwner = $signature;
+            }
+        }
 
         $easy->effectiveProxy = self::getEffectiveProxy($conf);
 
@@ -484,22 +513,35 @@ class CurlFactory implements CurlFactoryInterface
         $resource = $easy->handle;
         unset($easy->handle);
 
-        if (\count($this->handles) >= $this->maxHandles) {
+        if (
+            \count($this->handles) >= $this->maxHandles
+            || ($easy->proxyTunnelSignature !== null && $easy->proxyTunnelSignature !== $this->proxyTunnelOwner)
+        ) {
+            // Pool is full, or this handle belongs to a superseded tunnel
+            // owner (an async create/release overlap can hand a stale-owner
+            // handle back after a purge) - drop it instead of pooling it.
             if (PHP_VERSION_ID < 80000) {
                 \curl_close($resource);
             }
-        } else {
-            // Remove all callback functions as they can hold onto references
-            // and are not cleaned up by curl_reset. Using curl_setopt_array
-            // does not work for some reason, so removing each one
-            // individually.
-            \curl_setopt($resource, \CURLOPT_HEADERFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_READFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_WRITEFUNCTION, null);
-            \curl_setopt($resource, \CURLOPT_PROGRESSFUNCTION, null);
-            \curl_reset($resource);
-            $this->handles[] = $resource;
+
+            return;
         }
+
+        if ($easy->proxyTunnelSignature !== null) {
+            // A pooled handle now carries the current owner's tunnel.
+            $this->poolMayHoldTunnels = true;
+        }
+
+        // Remove all callback functions as they can hold onto references
+        // and are not cleaned up by curl_reset. Using curl_setopt_array
+        // does not work for some reason, so removing each one
+        // individually.
+        \curl_setopt($resource, \CURLOPT_HEADERFUNCTION, null);
+        \curl_setopt($resource, \CURLOPT_READFUNCTION, null);
+        \curl_setopt($resource, \CURLOPT_WRITEFUNCTION, null);
+        \curl_setopt($resource, \CURLOPT_PROGRESSFUNCTION, null);
+        \curl_reset($resource);
+        $this->handles[] = $resource;
     }
 
     /**
@@ -761,12 +803,25 @@ class CurlFactory implements CurlFactoryInterface
             return true;
         }
 
-        return !CurlVersion::supportsProxyCredentialAwareConnectionReuse()
-            && (
-                \array_key_exists('user', $proxyParts)
-                || \array_key_exists('pass', $proxyParts)
-                || self::hasCurlProxyCredentials($conf)
-            );
+        // A proxy client certificate or TLS-SRP authenticates the client to an
+        // HTTPS proxy at the TLS layer; libcurl's connection matcher ignored
+        // TLS-SRP before 7.83.1 (CVE-2022-27782), so an old build can reuse a
+        // tunnel across those identities. Force a fresh one, as the non-share
+        // signature path always does.
+        if (
+            !CurlVersion::supportsProxyTlsCredentialAwareConnectionReuse()
+            && self::hasCurlProxyTlsCredentials($conf)
+        ) {
+            return true;
+        }
+
+        if (CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
+            return false;
+        }
+
+        return \array_key_exists('user', $proxyParts)
+            || \array_key_exists('pass', $proxyParts)
+            || self::hasCurlProxyCredentials($conf);
     }
 
     /**
@@ -774,12 +829,42 @@ class CurlFactory implements CurlFactoryInterface
      */
     private static function usesProxyTunnel(RequestInterface $request, array $conf): bool
     {
-        return 'https' === $request->getUri()->getScheme()
-            || (
-                \defined('CURLOPT_HTTPPROXYTUNNEL')
-                && \array_key_exists((int) \constant('CURLOPT_HTTPPROXYTUNNEL'), $conf)
-                && (bool) $conf[(int) \constant('CURLOPT_HTTPPROXYTUNNEL')]
-            );
+        $scheme = $request->getUri()->getScheme();
+
+        if ('https' === $scheme) {
+            return true;
+        }
+
+        // An HTTP proxy auto-switches to a CONNECT tunnel when CONNECT_TO
+        // redirects the origin, so an http:// target with it set tunnels too.
+        if ('http' === $scheme && self::hasCurlConnectTo($conf)) {
+            return true;
+        }
+
+        return \defined('CURLOPT_HTTPPROXYTUNNEL')
+            && \array_key_exists((int) \constant('CURLOPT_HTTPPROXYTUNNEL'), $conf)
+            && (bool) $conf[(int) \constant('CURLOPT_HTTPPROXYTUNNEL')];
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlConnectTo(array $conf): bool
+    {
+        if (!\defined('CURLOPT_CONNECT_TO')) {
+            return false;
+        }
+
+        $option = (int) \constant('CURLOPT_CONNECT_TO');
+        if (!\array_key_exists($option, $conf)) {
+            return false;
+        }
+
+        $value = $conf[$option];
+
+        return \is_array($value)
+            ? $value !== []
+            : $value !== null && $value !== false && $value !== '';
     }
 
     /**
@@ -843,6 +928,25 @@ class CurlFactory implements CurlFactoryInterface
     /**
      * @param array<int|string, mixed> $conf
      */
+    private static function hasCurlProxyTlsCredentials(array $conf): bool
+    {
+        foreach ([
+            'CURLOPT_PROXY_SSLCERT',
+            'CURLOPT_PROXY_SSLCERT_BLOB',
+            'CURLOPT_PROXY_TLSAUTH_USERNAME',
+            'CURLOPT_PROXY_TLSAUTH_PASSWORD',
+        ] as $option) {
+            if (\defined($option) && \array_key_exists((int) \constant($option), $conf)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
     private static function hasCurlProxyAuthorizationHeader(array $conf): bool
     {
         if (!\defined('CURLOPT_PROXYHEADER')) {
@@ -878,6 +982,114 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         return false;
+    }
+
+    /**
+     * Computes the connection-reuse section signature for a proxy tunnel, or
+     * null when the request does not require sectioning.
+     *
+     * @param array<int|string, mixed> $conf
+     */
+    private static function proxyTunnelSignature(RequestInterface $request, array $conf): ?string
+    {
+        $proxy = self::getEffectiveProxy($conf);
+        if (
+            $proxy === null
+            || !self::usesProxyTunnel($request, $conf)
+            || !self::isHttpProxyForConnectionReuse($proxy, $conf)
+        ) {
+            return null;
+        }
+
+        $headerAuth = self::curlProxyAuthorizationHeaderValues($conf);
+        if ($headerAuth === [] && CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
+            // libcurl keys reuse on parsed proxy credentials only from 8.19.0,
+            // trusted from 8.20.0 (PROXY_CREDENTIAL_REUSE_VERSION); a literal
+            // Proxy-Authorization header is never keyed and always sections.
+            return null;
+        }
+
+        // Hash every proxy channel an old libcurl might not key reuse on. A
+        // changed signature only forces a fresh connection, never relaxes
+        // reuse, so over-covering is always safe; under-covering leaks. Proxy
+        // credentials are the channel CVE-2026-3784 missed; the proxy-TLS
+        // options are load-bearing on builds before the proxy-TLS reuse fixes
+        // (client cert from 7.50.1, CVE-2016-5420; TLS-SRP from 7.83.1,
+        // CVE-2022-27782) and harmless after. The private key and cert/key
+        // encoding are deliberately omitted: the hashed X.509 client cert is
+        // the proxy-visible identity and maps 1:1 to its key.
+        $credentialState = [];
+        foreach ([
+            'CURLOPT_PROXYUSERPWD', 'CURLOPT_PROXYUSERNAME', 'CURLOPT_PROXYPASSWORD',
+            'CURLOPT_PROXYTYPE',
+            'CURLOPT_PROXY_SSLCERT', 'CURLOPT_PROXY_SSLCERT_BLOB', 'CURLOPT_PROXY_SSLKEY',
+            'CURLOPT_PROXY_KEYPASSWD', 'CURLOPT_PROXY_TLSAUTH_USERNAME',
+            'CURLOPT_PROXY_TLSAUTH_PASSWORD', 'CURLOPT_PROXY_SSLVERSION',
+        ] as $name) {
+            $credentialState[$name] = \defined($name)
+                ? ($conf[(int) \constant($name)] ?? null)
+                : null;
+        }
+
+        return \hash('sha256', \serialize([$proxy, $credentialState, $headerAuth]));
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     *
+     * @return list<string>
+     */
+    private static function curlProxyAuthorizationHeaderValues(array $conf): array
+    {
+        if (!\defined('CURLOPT_PROXYHEADER')) {
+            return [];
+        }
+
+        $option = (int) \constant('CURLOPT_PROXYHEADER');
+        if (!\array_key_exists($option, $conf)) {
+            return [];
+        }
+
+        $headers = $conf[$option];
+        if (!\is_array($headers)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($headers as $header) {
+            if (!\is_string($header)) {
+                continue;
+            }
+
+            $parts = \explode(':', $header, 2);
+            if (\count($parts) !== 2) {
+                continue;
+            }
+
+            if (
+                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
+                && \trim($parts[1]) !== ''
+            ) {
+                $values[] = \trim($parts[1]);
+            }
+        }
+
+        // Sort so the signature depends on the set of header credentials, not
+        // their order, which avoids spurious re-sectioning across requests.
+        \sort($values);
+
+        return $values;
+    }
+
+    private function discardIdleHandles(): void
+    {
+        foreach ($this->handles as $id => $handle) {
+            if (PHP_VERSION_ID < 80000) {
+                \curl_close($handle);
+            }
+
+            unset($this->handles[$id]);
+        }
     }
 
     /**
@@ -1436,12 +1648,6 @@ class CurlFactory implements CurlFactoryInterface
 
     public function __destruct()
     {
-        foreach ($this->handles as $id => $handle) {
-            if (PHP_VERSION_ID < 80000) {
-                \curl_close($handle);
-            }
-
-            unset($this->handles[$id]);
-        }
+        $this->discardIdleHandles();
     }
 }

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -74,6 +74,18 @@ class CurlMultiHandler
     private $deferredCancels = [];
 
     /**
+     * @var string|null Owner signature of the proxy tunnels the multi handle's
+     *                  connection cache may hold
+     */
+    private $proxyTunnelOwner;
+
+    /**
+     * @var bool Guards against multi-handle recreation re-entrancy from
+     *           processMessages (a retried transfer re-invokes the handler)
+     */
+    private $processingMessages = false;
+
+    /**
      * This handler accepts the following options:
      *
      * - handle_factory: An optional factory  used to create curl handles
@@ -164,6 +176,7 @@ class CurlMultiHandler
     public function __invoke(RequestInterface $request, array $options): PromiseInterface
     {
         $easy = $this->factory->create($request, $options);
+        $this->applyProxyTunnelOwnership($easy);
         $id = (int) $easy->handle;
 
         $promise = new Promise(
@@ -176,6 +189,49 @@ class CurlMultiHandler
         $this->addRequest(['easy' => $easy, 'deferred' => $promise]);
 
         return $promise;
+    }
+
+    /**
+     * Isolates the connection cache when the request's proxy tunnel section
+     * differs from the one the multi handle's cache may already hold.
+     */
+    private function applyProxyTunnelOwnership(EasyHandle $easy): void
+    {
+        $signature = $easy->proxyTunnelSignature;
+        if ($signature === null || $signature === $this->proxyTunnelOwner) {
+            return;
+        }
+
+        if ($this->proxyTunnelOwner === null) {
+            // No in-domain transfer has ever run on this multi handle: latch
+            // the owner without destroying pooled direct connections.
+            $this->proxyTunnelOwner = $signature;
+
+            return;
+        }
+
+        if (
+            $this->handles === []
+            && !$this->executingMulti
+            && !$this->processingMessages
+            && $this->deferredCancels === []
+        ) {
+            // Idle: hand the connection cache over by recreating the multi
+            // handle (unsetting re-arms the lazy __get initializer, which
+            // re-applies the CURLMOPT_* options).
+            if (isset($this->_mh)) {
+                \curl_multi_close($this->_mh);
+                unset($this->_mh);
+            }
+            $this->proxyTunnelOwner = $signature;
+
+            return;
+        }
+
+        // Busy: isolate this transfer from the owner's pooled tunnels.
+        // Unqualified curl_setopt so the test bootstrap shadow records it.
+        curl_setopt($easy->handle, \CURLOPT_FRESH_CONNECT, true);
+        curl_setopt($easy->handle, \CURLOPT_FORBID_REUSE, true);
     }
 
     /**
@@ -334,38 +390,47 @@ class CurlMultiHandler
 
     private function processMessages(): void
     {
-        while ($done = \curl_multi_info_read($this->_mh)) {
-            if ($done['msg'] !== \CURLMSG_DONE) {
-                // if it's not done, then it would be premature to remove the handle. ref https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216
-                continue;
+        // CurlFactory::finish can retry a transfer by re-invoking this handler
+        // from inside this loop; the guard keeps that re-entry from recreating
+        // the multi handle mid-iteration (see applyProxyTunnelOwnership).
+        $this->processingMessages = true;
+
+        try {
+            while ($done = \curl_multi_info_read($this->_mh)) {
+                if ($done['msg'] !== \CURLMSG_DONE) {
+                    // if it's not done, then it would be premature to remove the handle. ref https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216
+                    continue;
+                }
+                if (!isset($done['handle'])) {
+                    // Work around a PHP issue where cancelled transfers may omit the handle.
+                    // Remove this once we no longer support PHP versions before the fix in
+                    // https://github.com/php/php-src/pull/16302.
+                    continue;
+                }
+                $id = (int) $done['handle'];
+                \curl_multi_remove_handle($this->_mh, $done['handle']);
+
+                if (!isset($this->handles[$id])) {
+                    // Probably was cancelled.
+                    continue;
+                }
+
+                $entry = $this->handles[$id];
+                unset($this->handles[$id], $this->delays[$id]);
+                $entry['easy']->errno = $done['result'];
+
+                try {
+                    $result = CurlFactory::finish($this, $entry['easy'], $this->factory);
+                } catch (\Throwable $e) {
+                    $entry['deferred']->reject($e);
+
+                    continue;
+                }
+
+                $entry['deferred']->resolve($result);
             }
-            if (!isset($done['handle'])) {
-                // Work around a PHP issue where cancelled transfers may omit the handle.
-                // Remove this once we no longer support PHP versions before the fix in
-                // https://github.com/php/php-src/pull/16302.
-                continue;
-            }
-            $id = (int) $done['handle'];
-            \curl_multi_remove_handle($this->_mh, $done['handle']);
-
-            if (!isset($this->handles[$id])) {
-                // Probably was cancelled.
-                continue;
-            }
-
-            $entry = $this->handles[$id];
-            unset($this->handles[$id], $this->delays[$id]);
-            $entry['easy']->errno = $done['result'];
-
-            try {
-                $result = CurlFactory::finish($this, $entry['easy'], $this->factory);
-            } catch (\Throwable $e) {
-                $entry['deferred']->reject($e);
-
-                continue;
-            }
-
-            $entry['deferred']->resolve($result);
+        } finally {
+            $this->processingMessages = false;
         }
     }
 

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -23,11 +23,9 @@ final class CurlVersion
 
     private const SSL_SESSION_SHARING_VERSION = '8.6.0';
 
-    // curl 7.83.1 added the proxy TLS-SRP identity to the connection-reuse
-    // match (CVE-2022-27782); the proxy client certificate was already matched
-    // from the 7.52.0 HTTPS-proxy floor. Below 7.83.1 an HTTPS-proxy tunnel
-    // could be reused across TLS-SRP identities, so proxy TLS credential reuse
-    // is trusted from 7.83.1 onwards.
+    // curl 7.83.1 added proxy TLS-SRP to the connection-reuse match
+    // (CVE-2022-27782); the proxy client certificate was matched from 7.52.0,
+    // so proxy TLS credentials are trusted from 7.83.1 onwards.
     private const PROXY_TLS_CREDENTIAL_REUSE_VERSION = '7.83.1';
 
     // curl 8.19.0 fixed proxy tunnel reuse after credential changes

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -23,6 +23,13 @@ final class CurlVersion
 
     private const SSL_SESSION_SHARING_VERSION = '8.6.0';
 
+    // curl 7.83.1 added the proxy TLS-SRP identity to the connection-reuse
+    // match (CVE-2022-27782); the proxy client certificate was already matched
+    // from the 7.52.0 HTTPS-proxy floor. Below 7.83.1 an HTTPS-proxy tunnel
+    // could be reused across TLS-SRP identities, so proxy TLS credential reuse
+    // is trusted from 7.83.1 onwards.
+    private const PROXY_TLS_CREDENTIAL_REUSE_VERSION = '7.83.1';
+
     // curl 8.19.0 fixed proxy tunnel reuse after credential changes
     // (CVE-2026-3784), but related proxy credential leak flaws were only
     // fixed in 8.20.0, so connection reuse is trusted from 8.20.0 onwards.
@@ -121,6 +128,14 @@ final class CurlVersion
                 self::SSL_SESSION_SHARING_VERSION
             ));
         }
+    }
+
+    public static function supportsProxyTlsCredentialAwareConnectionReuse(): bool
+    {
+        $version = self::getVersion();
+
+        return $version !== null
+            && \version_compare($version, self::PROXY_TLS_CREDENTIAL_REUSE_VERSION, '>=');
     }
 
     public static function supportsProxyCredentialAwareConnectionReuse(): bool

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -56,6 +56,14 @@ final class EasyHandle
     public $effectiveProxy;
 
     /**
+     * Proxy tunnel section signature for connection-reuse isolation, or
+     * null when the request does not require sectioning.
+     *
+     * @var string|null
+     */
+    public $proxyTunnelSignature;
+
+    /**
      * @var \Throwable|null Exception during on_headers (if any)
      */
     public $onHeadersException;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -635,22 +635,23 @@ class CurlFactoryTest extends TestCase
         });
     }
 
-    public function testForcesFreshConnectionForEnvironmentCredentialedProxyOnAffectedCurlVersion(): void
+    public function testSectionsEnvironmentCredentialedProxyOnAffectedCurlVersion(): void
     {
         self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
-            self::createWithCurlVersion('8.19.0', 'https://example.com', []);
+            $factory = new CurlFactory(3);
+            $easy = self::createOnFactory($factory, '8.19.0', 'https://example.com', []);
 
-            self::assertAuthenticatedProxyConnectionReuseOptions();
+            self::assertNotNull($easy->proxyTunnelSignature);
         });
     }
 
-    public function testDoesNotForceFreshConnectionForEnvironmentCredentialedProxyOnFixedCurlVersion(): void
+    public function testDoesNotSectionEnvironmentCredentialedProxyOnFixedCurlVersion(): void
     {
         self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
-            self::createWithCurlVersion('8.20.0', 'https://example.com', []);
+            $factory = new CurlFactory(3);
+            $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', []);
 
-            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+            self::assertNull($easy->proxyTunnelSignature);
         });
     }
 
@@ -931,180 +932,269 @@ class CurlFactoryTest extends TestCase
         self::assertSame($error, self::redactProxyUserInfo($error, 'http://proxy.example.com:8125'));
     }
 
-    public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
+    /**
+     * @dataProvider proxyTunnelSectionProvider
+     */
+    public function testComputesProxyTunnelSignatureByChannel(string $version, string $uri, array $options, bool $sectioned): void
     {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
-        ]);
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, $version, $uri, $options);
 
-        self::assertAuthenticatedProxyConnectionReuseOptions();
-    }
-
-    public function testDoesNotForceFreshConnectionForAuthenticatedHttpsProxyOnFixedCurlVersion(): void
-    {
-        self::createWithCurlVersion('8.20.0', 'https://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
-        ]);
-
+        self::assertSame($sectioned, $easy->proxyTunnelSignature !== null);
+        // The sectioned path never sets FRESH_CONNECT/FORBID_REUSE on a single
+        // create; isolation is achieved by pool ownership, not per-handle.
         self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
         self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
     }
 
-    public function testForcesFreshConnectionForCurlProxyCredentialsOnAffectedCurlVersion(): void
+    public static function proxyTunnelSectionProvider(): array
     {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
-            'proxy' => 'http://proxy.example.com:8080',
-            'curl' => [
-                \CURLOPT_PROXYUSERPWD => 'username:password',
-            ],
-        ]);
+        $cases = [
+            'auth https proxy, affected curl' => ['8.19.0', 'https://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080'], true],
+            'auth https proxy, fixed curl' => ['8.20.0', 'https://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080'], false],
+            'curl proxy credentials, affected curl' => ['8.19.0', 'https://example.com', ['proxy' => 'http://proxy.example.com:8080', 'curl' => [\CURLOPT_PROXYUSERPWD => 'username:password']], true],
+            'curl proxy credentials, fixed curl' => ['8.20.0', 'https://example.com', ['proxy' => 'http://proxy.example.com:8080', 'curl' => [\CURLOPT_PROXYUSERPWD => 'username:password']], false],
+            'anonymous tunnel, affected curl' => ['8.19.0', 'https://example.com', ['proxy' => 'http://proxy.example.com:8080'], true],
+            'anonymous tunnel, fixed curl' => ['8.20.0', 'https://example.com', ['proxy' => 'http://proxy.example.com:8080'], false],
+            'plain http proxy request' => ['8.19.0', 'http://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080'], false],
+            'socks proxy' => ['8.19.0', 'https://example.com', ['proxy' => 'socks5://username:password@proxy.example.com:1080'], false],
+            'no-proxy match' => ['8.19.0', 'https://example.com', ['proxy' => ['https' => 'http://username:password@proxy.example.com:8080', 'no' => ['example.com']]], false],
+        ];
 
-        self::assertAuthenticatedProxyConnectionReuseOptions();
-    }
-
-    public function testDoesNotForceFreshConnectionForCurlProxyCredentialsOnFixedCurlVersion(): void
-    {
-        self::createWithCurlVersion('8.20.0', 'https://example.com', [
-            'proxy' => 'http://proxy.example.com:8080',
-            'curl' => [
-                \CURLOPT_PROXYUSERPWD => 'username:password',
-            ],
-        ]);
-
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
-    }
-
-    public function testDoesNotForceFreshConnectionForUnauthenticatedHttpsProxy(): void
-    {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
-            'proxy' => 'http://proxy.example.com:8080',
-        ]);
-
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
-    }
-
-    public function testDoesNotForceFreshConnectionWhenNoProxyMatches(): void
-    {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
-            'proxy' => [
-                'https' => 'http://username:password@proxy.example.com:8080',
-                'no' => ['example.com'],
-            ],
-        ]);
-
-        self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
-        self::assertNoProxyOption('*');
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
-    }
-
-    public function testAuthenticatedHttpsProxyReuseOptionsCanBeSetOnFixedCurlVersion(): void
-    {
-        self::createWithCurlVersion('8.20.0', 'https://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
-            'curl' => [
-                \CURLOPT_FRESH_CONNECT => false,
-                \CURLOPT_FORBID_REUSE => false,
-            ],
-        ]);
-
-        self::assertFalse($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
-        self::assertFalse($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
-    }
-
-    public function testForcesFreshConnectionForAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
-    {
-        if (!\defined('CURLOPT_HTTPPROXYTUNNEL')) {
-            self::markTestSkipped('CURLOPT_HTTPPROXYTUNNEL is not available.');
+        // CONNECT_TO makes an HTTP proxy tunnel even an http:// target, so it
+        // must section like any other authenticated tunnel.
+        if (\defined('CURLOPT_CONNECT_TO')) {
+            $connectTo = (int) \constant('CURLOPT_CONNECT_TO');
+            $entry = ['example.com:80:backend.example.com:80'];
+            $cases += [
+                'connect-to http tunnel, auth proxy url, affected curl' => ['8.19.0', 'http://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080', 'curl' => [$connectTo => $entry]], true],
+                'connect-to http tunnel, curl credentials, affected curl' => ['8.19.0', 'http://example.com', ['proxy' => 'http://proxy.example.com:8080', 'curl' => [$connectTo => $entry, \CURLOPT_PROXYUSERPWD => 'username:password']], true],
+                'connect-to http tunnel, anonymous, affected curl' => ['8.19.0', 'http://example.com', ['proxy' => 'http://proxy.example.com:8080', 'curl' => [$connectTo => $entry]], true],
+                'connect-to http tunnel, fixed curl' => ['8.20.0', 'http://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080', 'curl' => [$connectTo => $entry]], false],
+                'connect-to socks proxy stays out' => ['8.19.0', 'http://example.com', ['proxy' => 'socks5://username:password@proxy.example.com:1080', 'curl' => [$connectTo => $entry]], false],
+            ];
         }
 
-        self::createWithCurlVersion('8.19.0', 'http://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
-            'curl' => [
-                \CURLOPT_HTTPPROXYTUNNEL => true,
-            ],
-        ]);
-
-        self::assertAuthenticatedProxyConnectionReuseOptions();
+        return $cases;
     }
 
-    public function testForcesFreshConnectionForProxyAuthorizationProxyHeaderOnFixedCurlVersion(): void
+    public function testSectionsProxyAuthorizationHeaderEvenOnFixedCurlVersion(): void
     {
         $proxyHeaderOption = self::proxyHeaderOption();
 
-        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
             ],
         ]);
 
-        self::assertAuthenticatedProxyConnectionReuseOptions();
+        // libcurl cannot key connection reuse on a literal Proxy-Authorization
+        // header, so Guzzle sections it even on the fast-path version.
+        self::assertNotNull($easy->proxyTunnelSignature);
     }
 
-    public function testDoesNotForceFreshConnectionForUnrelatedProxyHeader(): void
+    public function testSectionsConnectToProxyAuthorizationHeaderEvenOnFixedCurlVersion(): void
     {
+        if (!\defined('CURLOPT_CONNECT_TO')) {
+            self::markTestSkipped('CURLOPT_CONNECT_TO is not available.');
+        }
+
         $proxyHeaderOption = self::proxyHeaderOption();
 
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.20.0', 'http://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
-                $proxyHeaderOption => ['X-Proxy-Header: value'],
+                (int) \constant('CURLOPT_CONNECT_TO') => ['example.com:80:backend.example.com:80'],
+                $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
             ],
         ]);
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        // CONNECT_TO tunnels the http:// request, and libcurl cannot key reuse
+        // on a literal Proxy-Authorization header, so it sections even on fixed
+        // libcurl.
+        self::assertNotNull($easy->proxyTunnelSignature);
     }
 
-    public function testDoesNotForceFreshConnectionForEmptyProxyAuthorizationProxyHeader(): void
+    public function testEmptyProxyAuthorizationHeaderIsNotHeaderAuthOnFixedCurlVersion(): void
     {
         $proxyHeaderOption = self::proxyHeaderOption();
 
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 $proxyHeaderOption => ['Proxy-Authorization:'],
             ],
         ]);
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        // An empty header value is not header auth, so the fast path collapses
+        // the section away on a fixed libcurl.
+        self::assertNull($easy->proxyTunnelSignature);
     }
 
-    public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
+    public function testUnrelatedProxyHeaderIsNotHeaderAuthOnFixedCurlVersion(): void
     {
-        self::createWithCurlVersion('8.19.0', 'http://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
-        ]);
+        $proxyHeaderOption = self::proxyHeaderOption();
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
-    }
-
-    public function testDoesNotForceFreshConnectionForAuthenticatedSocksProxy(): void
-    {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
-            'proxy' => 'socks5://username:password@proxy.example.com:1080',
-        ]);
-
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
-    }
-
-    public function testAuthenticatedHttpsProxyReuseOptionsCannotBeOverriddenOnAffectedCurlVersion(): void
-    {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
-                \CURLOPT_FRESH_CONNECT => false,
-                \CURLOPT_FORBID_REUSE => false,
+                $proxyHeaderOption => ['X-Proxy-Header: value'],
             ],
         ]);
 
-        self::assertAuthenticatedProxyConnectionReuseOptions();
+        self::assertNull($easy->proxyTunnelSignature);
+    }
+
+    public function testSectionsAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
+    {
+        if (!\defined('CURLOPT_HTTPPROXYTUNNEL')) {
+            self::markTestSkipped('CURLOPT_HTTPPROXYTUNNEL is not available.');
+        }
+
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.19.0', 'http://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_HTTPPROXYTUNNEL => true,
+            ],
+        ]);
+
+        self::assertNotNull($easy->proxyTunnelSignature);
+    }
+
+    public function testReusesIdleHandleForSameProxyTunnelSignature(): void
+    {
+        $factory = new CurlFactory(3);
+        $options = ['proxy' => 'http://username:password@proxy.example.com:8080'];
+
+        $first = self::createOnFactory($factory, '8.19.0', 'https://example.com', $options);
+        $pooled = $first->handle;
+        $factory->release($first);
+
+        $second = self::createOnFactory($factory, '8.19.0', 'https://example.com', $options);
+
+        self::assertSame($pooled, $second->handle);
+    }
+
+    public function testProxyTlsAuthCredentialChangesProxyTunnelSignature(): void
+    {
+        if (!\defined('CURLOPT_PROXY_TLSAUTH_PASSWORD')) {
+            self::markTestSkipped('CURLOPT_PROXY_TLSAUTH_PASSWORD is not available.');
+        }
+
+        // TLS-SRP is a proxy credential that libcurl did not key connection
+        // reuse on before 7.83.1 (CVE-2022-27782), so on an affected version it
+        // must change the signature for the proxy tunnel to be sectioned.
+        $tlsAuthPassword = (int) \constant('CURLOPT_PROXY_TLSAUTH_PASSWORD');
+
+        $first = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080',
+            $tlsAuthPassword => 'secret1',
+        ]);
+        $second = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080',
+            $tlsAuthPassword => 'secret2',
+        ]);
+
+        self::assertNotNull($first);
+        self::assertNotSame($first, $second);
+    }
+
+    public function testProxyTlsCredentialsRequireFreshConnectionOnAffectedCurlVersion(): void
+    {
+        if (!\defined('CURLOPT_PROXY_TLSAUTH_PASSWORD')) {
+            self::markTestSkipped('CURLOPT_PROXY_TLSAUTH_PASSWORD is not available.');
+        }
+
+        // Under a configured share handle the signature path is bypassed for
+        // the force-fresh path. libcurl did not key connection reuse on TLS-SRP
+        // before 7.83.1 (CVE-2022-27782), so that path must force a fresh
+        // tunnel on an affected version and need not from 7.83.1 onwards.
+        $conf = [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080',
+            (int) \constant('CURLOPT_PROXY_TLSAUTH_PASSWORD') => 'secret',
+        ];
+
+        self::assertTrue(self::computeRequiresFreshForAuthenticatedProxy('7.79.0', 'https://example.com', $conf));
+        self::assertFalse(self::computeRequiresFreshForAuthenticatedProxy('7.83.1', 'https://example.com', $conf));
+    }
+
+    public function testFirstProxyTunnelOwnerReusesPooledHandleWithoutPurging(): void
+    {
+        $factory = new CurlFactory(3);
+
+        // Pool a direct (null-signature) handle.
+        $direct = self::createOnFactory($factory, '8.19.0', 'https://example.com', []);
+        $pooled = $direct->handle;
+        $factory->release($direct);
+
+        // The first in-domain request latches the owner without purging, so
+        // the pooled handle is reused rather than discarded.
+        $tunnel = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertSame($pooled, $tunnel->handle);
+    }
+
+    public function testPurgesIdleHandlesWhenProxyTunnelOwnerChanges(): void
+    {
+        $factory = new CurlFactory(3);
+
+        $first = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://user1:pass1@proxy.example.com:8080',
+        ]);
+        $factory->release($first);
+        self::assertCount(1, self::readIdleHandles($factory));
+
+        // A different owner purges the idle pool before the new handle is
+        // popped, so the foreign tunnel handle does not survive.
+        $second = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://user2:pass2@proxy.example.com:8080',
+        ]);
+        self::assertCount(0, self::readIdleHandles($factory));
+
+        $factory->release($second);
+        self::assertCount(1, self::readIdleHandles($factory));
+    }
+
+    public function testReleaseDropsHandleFromSupersededOwner(): void
+    {
+        $factory = new CurlFactory(3);
+
+        $a = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://a:a@proxy.example.com:8080',
+        ]);
+        // A second owner supersedes the first while the first is still in flight.
+        $b = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://b:b@proxy.example.com:8080',
+        ]);
+
+        $factory->release($a);
+        self::assertCount(0, self::readIdleHandles($factory));
+
+        $factory->release($b);
+        self::assertCount(1, self::readIdleHandles($factory));
+    }
+
+    public function testShareHandleUsesBlanketForceFreshForAuthenticatedProxy(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $shareHandle = \curl_share_init();
+        $factory = new CurlFactory(3, TransportSharing::HANDLER_PREFER, $shareHandle);
+        $easy = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertNull($easy->proxyTunnelSignature);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
     }
 
     private function checkNoProxyForHost($url, $noProxy, $assertUseProxy)
@@ -2155,12 +2245,6 @@ class CurlFactoryTest extends TestCase
         return $readHandles($factory);
     }
 
-    private static function assertAuthenticatedProxyConnectionReuseOptions(): void
-    {
-        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
-        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
-    }
-
     private static function assertNoProxyOption(string $expected): void
     {
         if (!\defined('CURLOPT_NOPROXY')) {
@@ -2212,7 +2296,7 @@ class CurlFactoryTest extends TestCase
     /**
      * @param array<int|string, mixed> $options
      */
-    private static function createWithCurlVersion(string $version, string $uri, array $options): void
+    private static function createOnFactory(CurlFactory $factory, string $version, string $uri, array $options): EasyHandle
     {
         $previousVersionInfo = self::setCurlVersionInfo([
             'version' => $version,
@@ -2220,8 +2304,7 @@ class CurlFactoryTest extends TestCase
         ]);
 
         try {
-            $f = new CurlFactory(3);
-            $f->create(new Psr7\Request('GET', $uri), $options);
+            return $factory->create(new Psr7\Request('GET', $uri), $options);
         } finally {
             self::setCurlVersionInfo($previousVersionInfo);
         }
@@ -2244,6 +2327,47 @@ class CurlFactoryTest extends TestCase
         }
 
         return $method->invoke(null, $error, $proxy);
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function computeProxyTunnelSignature(string $version, string $uri, array $conf): ?string
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => 0,
+        ]);
+
+        try {
+            $method = new \ReflectionMethod(CurlFactory::class, 'proxyTunnelSignature');
+            if (\PHP_VERSION_ID < 80100) {
+                $method->setAccessible(true);
+            }
+
+            return $method->invoke(null, new Psr7\Request('GET', $uri), $conf);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    private static function computeRequiresFreshForAuthenticatedProxy(string $version, string $uri, array $conf): bool
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => 0,
+        ]);
+
+        try {
+            $method = new \ReflectionMethod(CurlFactory::class, 'requiresFreshConnectionForAuthenticatedProxy');
+            if (\PHP_VERSION_ID < 80100) {
+                $method->setAccessible(true);
+            }
+
+            return $method->invoke(null, new Psr7\Request('GET', $uri), $conf[\CURLOPT_PROXY], $conf);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
     }
 
     private static function skipIfCurlShareIsUnavailable(): void

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlFactory;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\Handler\CurlVersion;
+use GuzzleHttp\Handler\EasyHandle;
 use GuzzleHttp\Promise as P;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -330,6 +331,121 @@ class CurlMultiHandlerTest extends TestCase
 
         $this->expectException(\BadMethodCallException::class);
         $h->foo;
+    }
+
+    public function testFirstProxyTunnelOwnerLatchesWithoutRecreatingMultiHandle(): void
+    {
+        $handler = new CurlMultiHandler();
+
+        // Initialize the multi handle so we can detect an unwanted recreation.
+        $mh = self::readMultiProperty($handler, '_mh');
+
+        self::applyProxyTunnelOwnership($handler, self::easyWithSignature('sig-a'));
+
+        self::assertSame('sig-a', self::readMultiProperty($handler, 'proxyTunnelOwner'));
+        self::assertSame($mh, self::readMultiProperty($handler, '_mh'), 'The first owner must not recreate the multi handle.');
+    }
+
+    public function testIdleProxyTunnelOwnerChangeRecreatesMultiHandle(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        $mh = self::readMultiProperty($handler, '_mh');
+
+        self::applyProxyTunnelOwnership($handler, self::easyWithSignature('sig-b'));
+
+        self::assertSame('sig-b', self::readMultiProperty($handler, 'proxyTunnelOwner'));
+        self::assertNotSame($mh, self::readMultiProperty($handler, '_mh'), 'An idle owner change must recreate the multi handle.');
+    }
+
+    public function testBusyProxyTunnelOwnerChangeIsolatesTheTransfer(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        $mh = self::readMultiProperty($handler, '_mh');
+        // A busy multi: another transfer is tracked.
+        self::setMultiProperty($handler, 'handles', [0 => ['busy']]);
+
+        $easy = self::easyWithSignature('sig-b');
+        self::applyProxyTunnelOwnership($handler, $easy);
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        self::assertSame('sig-a', self::readMultiProperty($handler, 'proxyTunnelOwner'), 'A busy owner change must not move the owner.');
+        self::assertSame($mh, self::readMultiProperty($handler, '_mh'), 'A busy owner change must not recreate the multi handle.');
+    }
+
+    public function testProcessingMessagesGuardPreventsMultiRecreation(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        $mh = self::readMultiProperty($handler, '_mh');
+        // The multi is idle by every other measure, but a retried transfer is
+        // re-invoking the handler from inside processMessages.
+        self::setMultiProperty($handler, 'processingMessages', true);
+
+        $easy = self::easyWithSignature('sig-b');
+        self::applyProxyTunnelOwnership($handler, $easy);
+
+        self::assertSame($mh, self::readMultiProperty($handler, '_mh'), 'Recreating the multi handle mid-iteration would corrupt the read loop.');
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testNullSignatureNeverDisturbsProxyTunnelOwnership(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        $mh = self::readMultiProperty($handler, '_mh');
+
+        self::applyProxyTunnelOwnership($handler, self::easyWithSignature(null));
+
+        self::assertSame('sig-a', self::readMultiProperty($handler, 'proxyTunnelOwner'));
+        self::assertSame($mh, self::readMultiProperty($handler, '_mh'));
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
+    }
+
+    private static function easyWithSignature(?string $signature): EasyHandle
+    {
+        $easy = new EasyHandle();
+        $easy->request = new Request('GET', 'https://example.com');
+        $easy->handle = \curl_init();
+        $easy->proxyTunnelSignature = $signature;
+
+        return $easy;
+    }
+
+    private static function applyProxyTunnelOwnership(CurlMultiHandler $handler, EasyHandle $easy): void
+    {
+        $invoke = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->applyProxyTunnelOwnership($easy);
+        }, null, CurlMultiHandler::class);
+
+        $invoke($handler, $easy);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function setMultiProperty(CurlMultiHandler $handler, string $name, $value): void
+    {
+        $set = \Closure::bind(static function (CurlMultiHandler $handler) use ($name, $value): void {
+            $handler->{$name} = $value;
+        }, null, CurlMultiHandler::class);
+
+        $set($handler);
+    }
+
+    /**
+     * @return mixed
+     */
+    private static function readMultiProperty(CurlMultiHandler $handler, string $name)
+    {
+        $get = \Closure::bind(static function (CurlMultiHandler $handler) use ($name) {
+            return $handler->{$name};
+        }, null, CurlMultiHandler::class);
+
+        return $get($handler);
     }
 
     private static function readSelectTimeout(CurlMultiHandler $handler)


### PR DESCRIPTION
This replaces the blanket force-fresh mitigation for authenticated proxy tunnels with credential-sectioned connection reuse, so requests through the same proxy credentials reuse a pooled tunnel while distinct credentials never share one. Each request that establishes an HTTP or HTTPS proxy tunnel computes a section signature from the effective proxy URL, the cURL proxy credential and proxy-TLS identity options, and any literal Proxy-Authorization header values; requests outside that domain, such as plain non-tunnel proxying and SOCKS, are never sectioned. Because an HTTP proxy silently switches to a credential-bearing CONNECT tunnel when CURLOPT_CONNECT_TO redirects the origin, an http target with that option set is now treated as a tunnel too, so those requests are sectioned instead of slipping past the check. The cURL handle factory tracks the signature that its pooled idle handles may hold and purges them when the owner changes, latching the first owner without purging so a warm pool of direct connections survives the first authenticated request. The release path drops a handle whose owner has since been superseded, which closes an async create and release overlap. The multi handler tracks its own owner and either hands the connection cache over by recreating the multi handle when it is idle or isolates the individual transfer with fresh-connect and forbid-reuse when it is busy, with a guard so a retried transfer re-invoking the handler from inside the message loop cannot recreate the multi handle mid-iteration. Anonymous tunnels join the domain so an unauthenticated request never rides an authenticated tunnel. On libcurl 8.20.0 and newer, option-supplied credentials are left to libcurl's own credential-aware matching and only literal Proxy-Authorization headers are still sectioned. When a share handle is configured the factory cannot see pooled connection provenance, so it keeps a conservative blanket behavior that forces a fresh tunnel for an authenticated request; that path now also covers a proxy TLS credential, a client certificate or TLS-SRP, on libcurl older than 7.83.1, the version from which libcurl keys connection reuse on the TLS-SRP identity itself, matching the channels the signature already sections. The performance cost in mixed workloads, where changing credentials discards idle pooled connections and alternating anonymous and authenticated traffic repeats that cost, is documented in the proxy security note. Clarifying comments and reflection regression tests pin the credential channels so a silently dropped one cannot reintroduce a leak.
