### PR TITLE
Section proxy tunnel connection reuse by credential

### DIFF
--- a/docs/contributing/curl-connection-reuse.md
+++ b/docs/contributing/curl-connection-reuse.md
@@ -1,0 +1,280 @@
+# cURL connection reuse and sharing (contributor reference)
+
+Guzzle's cURL handlers reuse network connections for performance, and can
+optionally share them across handlers. Reuse is normally invisible, but it
+interacts with proxy credentials, TLS client identity, and DNS in ways that have
+produced real security bugs in libcurl. This document explains, for someone new
+to the handler code, **how connection reuse works, what can go wrong, and the
+safety rules Guzzle enforces — and why.** It assumes general HTTP/TLS
+familiarity; libcurl and PHP-cURL specifics are introduced as they come up.
+
+The connection-reuse safety code lives on both the 7.x maintenance branches and
+8.0; this reference is maintained on 8.0, and 7.x differences are called out
+where they matter. For *which exception type* to throw, see
+[exception-guidelines.md](exception-guidelines.md).
+
+## 1. How the cURL handlers send a request
+
+`GuzzleHttp\Handler\CurlHandler` (synchronous) and `CurlMultiHandler`
+(asynchronous) are the built-in cURL handlers. Both delegate to `CurlFactory`,
+which builds and **pools cURL "easy handles."**
+
+A cURL easy handle (`CurlHandle`) is libcurl's per-transfer object. Creating one
+is cheap; the expensive thing is the network connection it opens. libcurl keeps
+connections alive in a **connection cache** and reuses them for later transfers
+on the same handle — or across handles, if you share them (§3).
+
+`CurlFactory` pools easy handles: on `release()` it calls `curl_reset()` (which
+clears per-request options) and returns the handle to a small pool; `create()`
+pops a pooled handle and re-applies the next request's options. The key fact:
+**`curl_reset()` does not close the underlying connection** — reuse is the whole
+point — so a pooled handle can carry a live connection from one request into the
+next.
+
+The option pipeline is: Guzzle request options (`proxy`, `cert`, …) → an
+internal `$conf` array of `CURLOPT_* => value` → `curl_setopt_array()`.
+Low-level options passed through the `curl` request option are merged in too,
+but only those on an allow-list (`supportedCurlOptions()`); options that
+conflict with Guzzle-managed behavior are rejected. On 8.0 a non-allow-listed or
+conflicting raw option throws; on 7.x it is deprecated (and 8.0 will reject it).
+
+**PHP detail — the `\defined()` guard.** A `CURLOPT_*` constant is only defined
+when the linked libcurl/PHP build supports that option, so code that touches an
+optional option guards with `\defined()`/`\constant()`. This is safe by
+construction: PHP's `curl_setopt()` never forwards an *unknown* option integer
+to libcurl (PHP 8 throws `ValueError`; PHP 7 silently no-ops), and a constant is
+registered under the same `#if LIBCURL_VERSION_NUM` guard as its setopt handler,
+so an undefined constant can never become a live channel.
+
+## 2. Why reuse is both good and dangerous
+
+**Good:** skipping the TCP handshake, the TLS handshake, and (for a proxy
+tunnel) the `CONNECT` exchange is a large latency win.
+
+**Dangerous:** a reused connection carries *identity*. If libcurl reuses a
+connection that was authenticated or encrypted under one identity for a request
+that expects a different one, that is a leak. libcurl decides whether to reuse a
+connection by **matching connection attributes**, and bugs in that matching have
+produced CVEs (§4, §7).
+
+libcurl matches on host, port, scheme, proxy type/host/port, and — for TLS — its
+"primary" SSL config. There is an important split in libcurl's data model that
+several decisions below depend on:
+
+- **`ssl_primary_config` (compared for reuse):** client certificate and cert
+  blob, CA info, TLS version, cipher lists, pinned key, TLS-SRP credentials,
+  verify flags, issuer cert.
+- **`ssl_config_data` (not compared):** the private key, key blob, key
+  passphrase, and the cert/key *encoding* (PEM/DER/…).
+
+## 3. transport_sharing: sharing connections across handlers (CURLSH)
+
+The `transport_sharing` client option attaches a cURL **share handle**
+(`CURLSH`, via `CURLOPT_SHARE`) to the pooled easy handles so they share state.
+Modes: `NONE` (default), `HANDLER_PREFER`/`HANDLER_REQUIRE` (share within one
+handler), and `PERSISTENT_PREFER`/`PERSISTENT_REQUIRE` (share a long-lived
+cache). `*_REQUIRE` errors if sharing is unavailable; `*_PREFER` falls back to
+no sharing.
+
+What a share handle can share, and the libcurl floor Guzzle requires for each
+(see `CurlVersion`):
+
+| Shared state | `CURL_LOCK_DATA_*` | Floor | Constant |
+|---|---|---|---|
+| Share handles usable at all | — | 7.35.0 | `HANDLER_SHARING_VERSION` |
+| DNS cache | `DNS` | 7.35.0 | (with handler sharing) |
+| TLS session cache | `SSL_SESSION` | 8.6.0 | `SSL_SESSION_SHARING_VERSION` |
+| Connection cache | `CONNECT` | 8.20.0 | `CONNECTION_SHARING_VERSION` |
+
+The connection cache is shared only on 8.0 and only from 8.20.0; **7.x never
+shares the connection cache.** Each floor is the version at which that share
+class became safe (§7).
+
+## 4. The proxy-tunnel credential hazard (why `proxyTunnelSignature` exists)
+
+When you tunnel a request through an HTTP(S) proxy, libcurl sends a `CONNECT` to
+the proxy carrying the proxy credentials (`Proxy-Authorization`), then keeps
+that established tunnel in the connection cache.
+
+**The bug (CVE-2026-3784 family).** libcurl 7.7–8.18.0 matched a proxy
+connection by type/host/port but **not** by the proxy credentials. A pooled
+tunnel established with credentials A could therefore be reused for a later
+request carrying credentials B — leaking A's tunnel to B. curl 8.19.0 added a
+credential comparison to `proxy_info_matches()`; 8.20.0 fixed related
+proxy-credential leaks (credentials surviving a redirect, or a port/scheme
+change).
+
+**Guzzle's mitigation.** `CurlFactory::proxyTunnelSignature()` computes a
+per-request signature over the proxy identity. When it changes between requests,
+Guzzle forces a fresh connection — purging pooled idle handles that might hold a
+foreign tunnel — so libcurl cannot hand one request a tunnel established under a
+different identity.
+
+## 5. The signature: what it covers and why
+
+**Domain (when a signature is computed at all).** Only for a request that
+establishes a proxy `CONNECT` tunnel through an HTTP(S), non-SOCKS proxy.
+`usesProxyTunnel()` is true for an `https://` target, an explicit
+`CURLOPT_HTTPPROXYTUNNEL`, or an `http://` target with a non-empty
+`CURLOPT_CONNECT_TO` (§6); `isHttpProxyForConnectionReuse()` excludes SOCKS.
+Direct, SOCKS, and non-tunnel requests get a `null` signature and never disturb
+the pool.
+
+**The channels hashed:** the effective proxy URL, the proxy credential and
+TLS-identity options, and any literal `Proxy-Authorization` header value.
+
+**Necessary vs defense-in-depth.**
+
+- *Necessary:* the proxy credentials (`PROXYUSERPWD`/`PROXYUSERNAME`/
+  `PROXYPASSWORD`) — the exact channel the CVE missed — and the literal
+  `Proxy-Authorization` header (`CURLOPT_PROXYHEADER`), which libcurl **never**
+  keys reuse on at any version (it matches *parsed* credentials, not opaque
+  request headers). The header must therefore be sectioned even on fixed
+  libcurl.
+- *Mostly defense-in-depth:* the proxy-TLS options (client cert, cert blob, TLS
+  version, TLS-SRP). libcurl keys reuse on these via `ssl_primary_config` for an
+  HTTPS proxy — but only from 7.50.1 for the client cert (CVE-2016-5420) and
+  7.83.1 for TLS-SRP (CVE-2022-27782). Below those they are load-bearing; above,
+  redundant-but-free. They are hashed unconditionally rather than version-gated.
+
+**Deliberate omissions.** `PROXY_SSLKEY_BLOB`, `PROXY_SSLKEYTYPE`, and
+`PROXY_SSLCERTTYPE` are **not** hashed. libcurl's reuse matcher never keys on
+the private key or on cert/key encoding (they live in `ssl_config_data`, outside
+`ssl_primary_config`). They are safe to omit because the proxy-visible identity
+is the **X.509 client certificate** — which *is* hashed — and a certificate has
+exactly one matching key, so a key- or encoding-only change cannot present a
+different identity to the proxy.
+
+**The golden rule — over-sectioning is safe.** A non-`null`, changed signature
+only ever forces a *fresh* connection; it never relaxes reuse. So an over-broad
+signature merely costs an extra connection — it can never cause a leak.
+*Under*-covering (omitting a channel libcurl ignores) is the only way to leak.
+**When in doubt, include the channel.**
+
+## 6. CONNECT_TO implicit tunnels
+
+`CURLOPT_CONNECT_TO` redirects the origin connection to a different host:port
+(without changing the `Host` header, SNI, or cert verification). With an HTTP
+proxy, when the connect-to host or port differs, libcurl automatically switches
+to tunnel mode (sets `tunnel_proxy`) — so even a plain `http://` request becomes
+a credential-bearing `CONNECT` tunnel, the same hazard class as §4.
+
+`usesProxyTunnel()` therefore treats an `http://` target with a non-empty
+`CURLOPT_CONNECT_TO` as a possible tunnel. The check is deliberately
+conservative — any non-empty value, not a full parse of CONNECT_TO's
+`host:port:host:port` grammar (including its wildcard and IPv6 forms). By the
+over-section rule, a false positive only forces a needless fresh connection,
+never a leak; reimplementing libcurl's parser to avoid that would be a
+liability, not a feature.
+
+## 7. Connection-sharing safety decisions
+
+**Authenticated proxy + a configured share handle → blanket force-fresh.** When
+`transport_sharing` is configured, the shared connection cache hides which
+tunnel a pooled connection holds, so the signature cannot reason about
+provenance. For an authenticated proxy tunnel Guzzle then sets
+`CURLOPT_FRESH_CONNECT` / `CURLOPT_FORBID_REUSE` (and `PERSISTENT_REQUIRE` turns
+the conflict into an error rather than silently degrading).
+
+"Authenticated" here mirrors the signature's channels, each gated to the libcurl
+version below which libcurl does not itself key reuse on it: a literal
+`Proxy-Authorization` header (every version), Basic/Digest proxy credentials
+(below 8.20.0, `PROXY_CREDENTIAL_REUSE_VERSION`), and a proxy TLS credential — a
+client certificate or TLS-SRP (below 7.83.1,
+`PROXY_TLS_CREDENTIAL_REUSE_VERSION`). libcurl matches the proxy client cert
+from 7.52.0 and TLS-SRP only from 7.83.1 (CVE-2022-27782), so both are keyed
+under the single 7.83.1 floor. The floor matters more here than for the
+signature: `forceFreshConnectionForAuthenticatedProxy` *throws* under
+`PERSISTENT_REQUIRE`, which exists only on libcurl ≥ 8.20.0 — so forcing fresh
+for a TLS credential at every version would turn a shareable mTLS-proxy request
+into an error, while the 7.83.1 gate keeps the force-fresh strictly below the
+versions where persistent sharing (and that throw) exist.
+
+**SSL session sharing floor = 8.6.0 — why it is safe.** Sharing the TLS session
+cache could, in theory, let two handles resume each other's TLS session across
+*different* client certificates. It cannot: libcurl matches the client
+certificate before reusing a cached session on every version Guzzle shares the
+cache on (≥ 8.6.0) — via `match_ssl_primary_config` before 8.12.0 and
+`cf_ssl_scache_match_auth` from 8.12.0 — and this runs for shared caches too.
+8.6.0 is also the CVE-2024-0853 fix release. curl's 8.12.0 `ssl_peer_key` rework
+is a refactor of that same client-cert-aware matching, not a fix 8.6.0 lacks, so
+the floor stays at 8.6.0.
+
+**`CURLOPT_RESOLVE` under sharing → no special handling.** A request-level
+`CURLOPT_RESOLVE` writes the *shared* DNS cache, so its host→IP entries are
+visible to later requests on the same share handle. Guzzle leaves this as-is, on
+purpose: it has a legitimate use (client-wide DNS pinning via the shared cache,
+typically set as a client-level `curl` default), it is advanced custom
+configuration that remains the caller's responsibility (like other raw cURL
+options), and Guzzle cannot distinguish an intentional client-wide pin from an
+accidental per-request one. For per-request routing that does **not** touch the
+DNS cache, use `CURLOPT_CONNECT_TO`. (Contrast `CURLOPT_SHARE`, which *is*
+rejected under a configured share handle: a second, request-level share handle
+is simply incoherent, with no legitimate use.)
+
+## 8. The version trust floor
+
+`PROXY_CREDENTIAL_REUSE_VERSION = 8.20.0`. Below it, hash the credential
+channels: libcurl < 8.19.0 ignored proxy credentials when matching connections,
+and 8.19.x still carried related proxy-credential leaks fixed in 8.20.0. At or
+above it, libcurl keys reuse on option- and URL-supplied proxy credentials
+itself, so `proxyTunnelSignature()` short-circuits to `null` — **except** when a
+literal `Proxy-Authorization` header is present, which always sections because
+libcurl can never key on an opaque request header (§5).
+
+## 9. How the tests enforce this
+
+`tests/Handler/CurlFactoryTest.php` covers the signature by channel and the
+pool's purge/reuse behavior. In particular,
+`testProxyTlsAuthCredentialChangesProxyTunnelSignature` pins the TLS-SRP channel
+as load-bearing; it is a reflection test, so it exercises
+`proxyTunnelSignature()` directly without going through the option allow-list
+(which would otherwise reject the raw proxy-TLS option on 8.0). **When you add
+or remove a channel, add or adjust a test** — a silently dropped channel is
+exactly how a leak gets reintroduced, and CI is the backstop the comments point
+at.
+
+`testProxyTlsCredentialsRequireFreshConnectionOnAffectedCurlVersion` does the
+same for the share-handle force-fresh path: it asserts
+`requiresFreshConnectionForAuthenticatedProxy` forces a fresh tunnel for a proxy
+TLS credential below 7.83.1 and not at or above it.
+
+## 10. Hard rules (summary)
+
+- Never compute a `null` signature for a credential-bearing proxy tunnel.
+  Over-section freely; under-sectioning is the only way to leak.
+- Always hash the proxy credentials and the literal `Proxy-Authorization`
+  header; the header sections on **every** libcurl version.
+- Never trust libcurl `< 8.20` to distinguish proxy credentials itself.
+- Do not key the signature on the private key or on cert/key encoding — the
+  certificate is the proxy-visible identity.
+- `usesProxyTunnel()` must treat `http://` + a non-empty `CURLOPT_CONNECT_TO` as
+  a tunnel.
+- Share the TLS session cache only from 8.6.0 and the connection cache only from
+  8.20.0.
+- Under a configured share handle, force a fresh tunnel for a proxy TLS
+  credential (client cert / TLS-SRP) below 7.83.1, mirroring the signature path;
+  the 7.83.1 gate keeps it below the version where `PERSISTENT_REQUIRE` would
+  throw.
+
+## References
+
+**curl** — CVE-2026-3784 (proxy `CONNECT` credential reuse), CVE-2016-5420
+(proxy client-cert reuse), CVE-2022-27782 (TLS / TLS-SRP config not compared on
+reuse), CVE-2024-0853 (client cert / OCSP on session reuse). Source of record:
+`lib/url.c` (`proxy_info_matches`, the connection matcher, `tunnel_proxy`) and
+`lib/vtls/` (`ssl_primary_config` vs `ssl_config_data`, the session cache and
+`ssl_peer_key`). Docs:
+[`CURLOPT_CONNECT_TO`](https://curl.se/libcurl/c/CURLOPT_CONNECT_TO.html),
+[`CURLOPT_RESOLVE`](https://curl.se/libcurl/c/CURLOPT_RESOLVE.html), and the
+[share interface](https://curl.se/libcurl/c/libcurl-share.html).
+
+**php** — the cURL extension (`curl_setopt`, `curl_reset`, `curl_share_*`).
+`CURLOPT_*` constants exist only when the linked libcurl version supports the
+option, and `curl_setopt()` rejects unknown option integers (PHP 8
+`ValueError`), which is what makes the `\defined()` guard safe.
+
+**guzzle** — `src/Handler/CurlFactory.php` (`proxyTunnelSignature`,
+`usesProxyTunnel`, `isHttpProxyForConnectionReuse`),
+`src/Handler/CurlVersion.php` (the version floors), and
+[exception-guidelines.md](exception-guidelines.md) for exception types.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1031,20 +1031,29 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 
 > [!NOTE]
 > When sending HTTPS requests, or requests explicitly tunneled with
-> `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy,
-> libcurl versions before 8.19.0 could reuse an existing proxy tunnel even
-> after proxy credentials changed, and 8.19.0 still contains related proxy
-> credential leak flaws that were fixed in 8.20.0. Guzzle therefore avoids
-> tunnel reuse on libcurl versions older than 8.20.0 when the proxy URL is
-> configured through the `proxy` option or resolved from the environment,
-> including cURL proxy credential options supplied through the `curl` request
-> option. Raw `CURLOPT_PROXY` is rejected; use the `proxy` request option for
-> the proxy URL. Custom proxy authentication sent with `CURLOPT_PROXYHEADER`
-> also avoids tunnel reuse because libcurl does not include those header values
-> in its connection matching. Fixed libcurl versions keep normal connection
-> reuse behavior for proxy URL and cURL proxy credential options. Advanced
-> users can still control cURL connection reuse explicitly with the `curl`
-> request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
+> `CURLOPT_HTTPPROXYTUNNEL`, through an HTTP or HTTPS proxy, libcurl versions
+> before 8.19.0 could reuse an existing proxy tunnel even after proxy
+> credentials changed, and 8.19.0 still contains related proxy credential leak
+> flaws that were fixed in 8.20.0. Guzzle therefore sections proxy tunnel
+> connection reuse by the proxy credentials in effect: requests with the same
+> credentials reuse a pooled tunnel, while a change of proxy credentials (from
+> the `proxy` option, the environment, or cURL proxy credential options
+> supplied through the `curl` request option) is isolated onto its own
+> connections. Anonymous tunnels are sectioned apart from authenticated ones,
+> so an unauthenticated request never rides an authenticated tunnel. Raw
+> `CURLOPT_PROXY` is rejected; use the `proxy` request option for the proxy
+> URL. Custom proxy authentication sent with `CURLOPT_PROXYHEADER` is always
+> sectioned because libcurl cannot key connection reuse on those header values.
+> On libcurl 8.20.0 and newer, credential sectioning for option-supplied
+> credentials is left to libcurl's own credential-aware connection matching.
+>
+> Sectioning has a cost in mixed workloads: changing the proxy credentials in
+> use discards the idle pooled connections held for the previous credentials,
+> which also drops unrelated direct keep-alive connections pooled alongside
+> them, and alternating anonymous and authenticated traffic through the same
+> proxy repeats that cost on each switch. Advanced users can still control cURL
+> connection reuse explicitly with the `curl` request option and
+> `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
 
 ## query
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -87,7 +87,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 5
+			count: 7
 			path: src/Handler/CurlMultiHandler.php
 
 		-
@@ -99,7 +99,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_close expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Handler/CurlMultiHandler.php
 
 		-

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -626,10 +626,9 @@ final class CurlFactory implements CurlFactoryInterface
             $this->poolMayHoldTunnels = true;
         }
 
-        // Remove all callback functions as they can hold onto references
-        // and are not cleaned up by curl_reset. Using curl_setopt_array
-        // does not work for some reason, so removing each one
-        // individually.
+        // Remove all callback functions as they can hold onto references and
+        // are not cleaned up by curl_reset. Using curl_setopt_array does not
+        // work for some reason, so removing each one individually.
         $this->clearEasyHandleCallbacks($resource);
         \curl_reset($resource);
         $this->handles[] = $resource;
@@ -1233,11 +1232,10 @@ final class CurlFactory implements CurlFactoryInterface
             return true;
         }
 
-        // A proxy client certificate or TLS-SRP authenticates the client to an
-        // HTTPS proxy at the TLS layer; libcurl's connection matcher ignored
-        // TLS-SRP before 7.83.1 (CVE-2022-27782), so an old build can reuse a
-        // tunnel across those identities. Force a fresh one, as the non-share
-        // signature path always does.
+        // A proxy client certificate or TLS-SRP authenticates the client to the
+        // HTTPS proxy at the TLS layer; libcurl ignored TLS-SRP before 7.83.1
+        // (CVE-2022-27782), so an old build can reuse a tunnel across those
+        // identities. Force a fresh one, as the non-share signature path does.
         // See docs/contributing/curl-connection-reuse.md.
         if (
             !CurlVersion::supportsProxyTlsCredentialAwareConnectionReuse()

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -97,6 +97,17 @@ final class CurlFactory implements CurlFactoryInterface
     private array $handles = [];
 
     /**
+     * @var string|null Owner signature of the proxy tunnels that pooled idle
+     *                  handles may still hold
+     */
+    private ?string $proxyTunnelOwner = null;
+
+    /**
+     * @var bool Whether an in-domain handle has been pooled since the last purge
+     */
+    private bool $poolMayHoldTunnels = false;
+
+    /**
      * @var int Total number of idle handles to keep in cache
      */
     private int $maxHandles;
@@ -210,7 +221,25 @@ final class CurlFactory implements CurlFactoryInterface
             $conf = \array_replace($conf, $options['curl']);
         }
 
-        $this->forceFreshConnectionForAuthenticatedProxy($request, $conf);
+        if ($this->shareHandle !== null) {
+            // Conservative blanket mode: a configured share handle hides the
+            // pooled connections' provenance, so sectioned reuse cannot reason
+            // about them.
+            $this->forceFreshConnectionForAuthenticatedProxy($request, $conf);
+        } else {
+            $signature = self::proxyTunnelSignature($request, $conf);
+            $easy->proxyTunnelSignature = $signature;
+            if ($signature !== null && $signature !== $this->proxyTunnelOwner) {
+                if ($this->poolMayHoldTunnels) {
+                    // Pooled idle handles may hold a different owner's tunnel.
+                    $this->discardIdleHandles();
+                    $this->poolMayHoldTunnels = false;
+                }
+                // The first in-domain owner latches without purging: the pool
+                // provably holds no in-domain tunnel yet.
+                $this->proxyTunnelOwner = $signature;
+            }
+        }
 
         $easy->effectiveProxy = self::getEffectiveProxy($conf);
 
@@ -580,17 +609,30 @@ final class CurlFactory implements CurlFactoryInterface
         $resource = $easy->handle;
         unset($easy->handle);
 
-        if (\count($this->handles) >= $this->maxHandles) {
+        if (
+            \count($this->handles) >= $this->maxHandles
+            || ($easy->proxyTunnelSignature !== null && $easy->proxyTunnelSignature !== $this->proxyTunnelOwner)
+        ) {
+            // Pool is full, or this handle belongs to a superseded tunnel
+            // owner (an async create/release overlap can hand a stale-owner
+            // handle back after a purge) - drop it instead of pooling it.
             $this->discardHandle($resource);
-        } else {
-            // Remove all callback functions as they can hold onto references
-            // and are not cleaned up by curl_reset. Using curl_setopt_array
-            // does not work for some reason, so removing each one
-            // individually.
-            $this->clearEasyHandleCallbacks($resource);
-            \curl_reset($resource);
-            $this->handles[] = $resource;
+
+            return;
         }
+
+        if ($easy->proxyTunnelSignature !== null) {
+            // A pooled handle now carries the current owner's tunnel.
+            $this->poolMayHoldTunnels = true;
+        }
+
+        // Remove all callback functions as they can hold onto references
+        // and are not cleaned up by curl_reset. Using curl_setopt_array
+        // does not work for some reason, so removing each one
+        // individually.
+        $this->clearEasyHandleCallbacks($resource);
+        \curl_reset($resource);
+        $this->handles[] = $resource;
     }
 
     /**
@@ -1191,12 +1233,26 @@ final class CurlFactory implements CurlFactoryInterface
             return true;
         }
 
-        return !CurlVersion::supportsProxyCredentialAwareConnectionReuse()
-            && (
-                \array_key_exists('user', $proxyParts)
-                || \array_key_exists('pass', $proxyParts)
-                || self::hasCurlProxyCredentials($conf)
-            );
+        // A proxy client certificate or TLS-SRP authenticates the client to an
+        // HTTPS proxy at the TLS layer; libcurl's connection matcher ignored
+        // TLS-SRP before 7.83.1 (CVE-2022-27782), so an old build can reuse a
+        // tunnel across those identities. Force a fresh one, as the non-share
+        // signature path always does.
+        // See docs/contributing/curl-connection-reuse.md.
+        if (
+            !CurlVersion::supportsProxyTlsCredentialAwareConnectionReuse()
+            && self::hasCurlProxyTlsCredentials($conf)
+        ) {
+            return true;
+        }
+
+        if (CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
+            return false;
+        }
+
+        return \array_key_exists('user', $proxyParts)
+            || \array_key_exists('pass', $proxyParts)
+            || self::hasCurlProxyCredentials($conf);
     }
 
     /**
@@ -1204,12 +1260,42 @@ final class CurlFactory implements CurlFactoryInterface
      */
     private static function usesProxyTunnel(RequestInterface $request, array $conf): bool
     {
-        return 'https' === $request->getUri()->getScheme()
-            || (
-                \defined('CURLOPT_HTTPPROXYTUNNEL')
-                && \array_key_exists((int) \constant('CURLOPT_HTTPPROXYTUNNEL'), $conf)
-                && (bool) $conf[(int) \constant('CURLOPT_HTTPPROXYTUNNEL')]
-            );
+        $scheme = $request->getUri()->getScheme();
+
+        if ('https' === $scheme) {
+            return true;
+        }
+
+        // An HTTP proxy auto-switches to a CONNECT tunnel when CONNECT_TO
+        // redirects the origin, so an http:// target with it set tunnels too.
+        if ('http' === $scheme && self::hasCurlConnectTo($conf)) {
+            return true;
+        }
+
+        return \defined('CURLOPT_HTTPPROXYTUNNEL')
+            && \array_key_exists((int) \constant('CURLOPT_HTTPPROXYTUNNEL'), $conf)
+            && (bool) $conf[(int) \constant('CURLOPT_HTTPPROXYTUNNEL')];
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlConnectTo(array $conf): bool
+    {
+        if (!\defined('CURLOPT_CONNECT_TO')) {
+            return false;
+        }
+
+        $option = (int) \constant('CURLOPT_CONNECT_TO');
+        if (!\array_key_exists($option, $conf)) {
+            return false;
+        }
+
+        $value = $conf[$option];
+
+        return \is_array($value)
+            ? $value !== []
+            : $value !== null && $value !== false && $value !== '';
     }
 
     /**
@@ -1272,6 +1358,25 @@ final class CurlFactory implements CurlFactoryInterface
     /**
      * @param array<int|string, mixed> $conf
      */
+    private static function hasCurlProxyTlsCredentials(array $conf): bool
+    {
+        foreach ([
+            'CURLOPT_PROXY_SSLCERT',
+            'CURLOPT_PROXY_SSLCERT_BLOB',
+            'CURLOPT_PROXY_TLSAUTH_USERNAME',
+            'CURLOPT_PROXY_TLSAUTH_PASSWORD',
+        ] as $option) {
+            if (\defined($option) && \array_key_exists((int) \constant($option), $conf)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
     private static function hasCurlProxyAuthorizationHeader(array $conf): bool
     {
         if (!\defined('CURLOPT_PROXYHEADER')) {
@@ -1307,6 +1412,120 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         return false;
+    }
+
+    /**
+     * Computes the connection-reuse section signature for a proxy tunnel, or
+     * null when the request does not require sectioning.
+     *
+     * @param array<int|string, mixed> $conf
+     */
+    private static function proxyTunnelSignature(RequestInterface $request, array $conf): ?string
+    {
+        $proxy = self::getEffectiveProxy($conf);
+        if (
+            $proxy === null
+            || !self::usesProxyTunnel($request, $conf)
+            || !self::isHttpProxyForConnectionReuse($proxy, $conf)
+        ) {
+            return null;
+        }
+
+        $headerAuth = self::curlProxyAuthorizationHeaderValues($conf);
+        if ($headerAuth === [] && CurlVersion::supportsProxyCredentialAwareConnectionReuse()) {
+            // libcurl keys reuse on parsed proxy credentials only from 8.19.0,
+            // trusted from 8.20.0 (PROXY_CREDENTIAL_REUSE_VERSION); a literal
+            // Proxy-Authorization header is never keyed and always sections.
+            // See docs/contributing/curl-connection-reuse.md.
+            return null;
+        }
+
+        // Hash every proxy channel an old libcurl might not key reuse on. A
+        // changed signature only forces a fresh connection, never relaxes
+        // reuse, so over-covering is always safe; under-covering leaks. Proxy
+        // credentials are the channel CVE-2026-3784 missed; the proxy-TLS
+        // options are load-bearing on builds before the proxy-TLS reuse fixes
+        // (client cert from 7.50.1, CVE-2016-5420; TLS-SRP from 7.83.1,
+        // CVE-2022-27782) and harmless after. The private key and cert/key
+        // encoding are deliberately omitted: the hashed X.509 client cert is
+        // the proxy-visible identity and maps 1:1 to its key. See
+        // docs/contributing/curl-connection-reuse.md.
+        $credentialState = [];
+        foreach ([
+            'CURLOPT_PROXYUSERPWD', 'CURLOPT_PROXYUSERNAME', 'CURLOPT_PROXYPASSWORD',
+            'CURLOPT_PROXYTYPE',
+            'CURLOPT_PROXY_SSLCERT', 'CURLOPT_PROXY_SSLCERT_BLOB', 'CURLOPT_PROXY_SSLKEY',
+            'CURLOPT_PROXY_KEYPASSWD', 'CURLOPT_PROXY_TLSAUTH_USERNAME',
+            'CURLOPT_PROXY_TLSAUTH_PASSWORD', 'CURLOPT_PROXY_SSLVERSION',
+        ] as $name) {
+            $credentialState[$name] = \defined($name)
+                ? ($conf[(int) \constant($name)] ?? null)
+                : null;
+        }
+
+        return \hash('sha256', \serialize([$proxy, $credentialState, $headerAuth]));
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     *
+     * @return list<string>
+     */
+    private static function curlProxyAuthorizationHeaderValues(array $conf): array
+    {
+        if (!\defined('CURLOPT_PROXYHEADER')) {
+            return [];
+        }
+
+        $option = (int) \constant('CURLOPT_PROXYHEADER');
+        if (!\array_key_exists($option, $conf)) {
+            return [];
+        }
+
+        $headers = $conf[$option];
+        if (!\is_array($headers)) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($headers as $header) {
+            if (!\is_string($header)) {
+                continue;
+            }
+
+            $parts = \explode(':', $header, 2);
+            if (\count($parts) !== 2) {
+                continue;
+            }
+
+            if (
+                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
+                && \trim($parts[1]) !== ''
+            ) {
+                $values[] = \trim($parts[1]);
+            }
+        }
+
+        // Sort so the signature depends on the set of header credentials, not
+        // their order, which avoids spurious re-sectioning across requests.
+        \sort($values);
+
+        return $values;
+    }
+
+    private function discardIdleHandles(): void
+    {
+        foreach ($this->handles as $id => $handle) {
+            try {
+                // Best effort: a cleanup hiccup on a superseded idle handle
+                // must not abort the unrelated request that triggered the purge.
+                $this->discardHandle($handle);
+            } catch (\Throwable $e) {
+                // Ignored.
+            } finally {
+                unset($this->handles[$id]);
+            }
+        }
     }
 
     /**

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -80,6 +80,18 @@ final class CurlMultiHandler
     private bool $deferredCloseExplicit = false;
 
     /**
+     * @var string|null Owner signature of the proxy tunnels the multi handle's
+     *                  connection cache may hold
+     */
+    private ?string $proxyTunnelOwner = null;
+
+    /**
+     * @var bool Guards against multi-handle recreation re-entrancy from
+     *           processMessages (a retried transfer re-invokes the handler)
+     */
+    private bool $processingMessages = false;
+
+    /**
      * This handler accepts the following options:
      *
      * - handle_factory: An optional factory  used to create curl handles
@@ -150,6 +162,7 @@ final class CurlMultiHandler
         $this->assertOpen();
 
         $easy = $this->factory->create($request, $options);
+        $this->applyProxyTunnelOwnership($easy);
 
         $id = (int) $easy->handle;
 
@@ -164,6 +177,50 @@ final class CurlMultiHandler
         $this->addRequest(['easy' => $easy, 'deferred' => $promise]);
 
         return $promise;
+    }
+
+    /**
+     * Isolates the connection cache when the request's proxy tunnel section
+     * differs from the one the multi handle's cache may already hold.
+     */
+    private function applyProxyTunnelOwnership(EasyHandle $easy): void
+    {
+        $signature = $easy->proxyTunnelSignature;
+        if ($signature === null || $signature === $this->proxyTunnelOwner) {
+            return;
+        }
+
+        if ($this->proxyTunnelOwner === null) {
+            // No in-domain transfer has ever run on this multi handle: latch
+            // the owner without destroying pooled direct connections.
+            $this->proxyTunnelOwner = $signature;
+
+            return;
+        }
+
+        if (
+            $this->handles === []
+            && !$this->executingMulti
+            && !$this->processingMessages
+            && $this->deferredCancels === []
+            && !$this->deferredClose
+        ) {
+            // Idle: hand the connection cache over by recreating the multi
+            // handle. getMultiHandle() lazily re-initializes it (re-applying
+            // the CURLMOPT_* options) on the next access.
+            if ($this->multiHandle !== null) {
+                \curl_multi_close($this->multiHandle);
+                $this->multiHandle = null;
+            }
+            $this->proxyTunnelOwner = $signature;
+
+            return;
+        }
+
+        // Busy: isolate this transfer from the owner's pooled tunnels.
+        // Unqualified curl_setopt so the test bootstrap shadow records it.
+        curl_setopt($easy->handle, \CURLOPT_FRESH_CONNECT, true);
+        curl_setopt($easy->handle, \CURLOPT_FORBID_REUSE, true);
     }
 
     /**
@@ -587,39 +644,48 @@ final class CurlMultiHandler
 
     private function processMessages(): void
     {
-        while ($done = \curl_multi_info_read($this->getMultiHandle())) {
-            if ($done['msg'] !== \CURLMSG_DONE) {
-                // If it is not done, removing the handle would be premature.
-                // See https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216.
-                continue;
+        // CurlFactory::finish can retry a transfer by re-invoking this handler
+        // from inside this loop; the guard keeps that re-entry from recreating
+        // the multi handle mid-iteration (see applyProxyTunnelOwnership).
+        $this->processingMessages = true;
+
+        try {
+            while ($done = \curl_multi_info_read($this->getMultiHandle())) {
+                if ($done['msg'] !== \CURLMSG_DONE) {
+                    // If it is not done, removing the handle would be premature.
+                    // See https://github.com/guzzle/guzzle/pull/2892#issuecomment-945150216.
+                    continue;
+                }
+                if (!isset($done['handle'])) {
+                    // Work around a PHP issue where cancelled transfers may omit the handle.
+                    // Remove this once we no longer support PHP versions before the fix in
+                    // https://github.com/php/php-src/pull/16302.
+                    continue;
+                }
+                $id = (int) $done['handle'];
+                $this->removeHandleFromMulti($done['handle']);
+
+                if (!isset($this->handles[$id])) {
+                    // Probably was cancelled.
+                    continue;
+                }
+
+                $entry = $this->handles[$id];
+                unset($this->handles[$id], $this->delays[$id]);
+                $entry['easy']->errno = $done['result'];
+
+                try {
+                    $result = CurlFactory::finish($this, $entry['easy'], $this->factory);
+                } catch (\Throwable $e) {
+                    $entry['deferred']->reject($e);
+
+                    continue;
+                }
+
+                $entry['deferred']->resolve($result);
             }
-            if (!isset($done['handle'])) {
-                // Work around a PHP issue where cancelled transfers may omit the handle.
-                // Remove this once we no longer support PHP versions before the fix in
-                // https://github.com/php/php-src/pull/16302.
-                continue;
-            }
-            $id = (int) $done['handle'];
-            $this->removeHandleFromMulti($done['handle']);
-
-            if (!isset($this->handles[$id])) {
-                // Probably was cancelled.
-                continue;
-            }
-
-            $entry = $this->handles[$id];
-            unset($this->handles[$id], $this->delays[$id]);
-            $entry['easy']->errno = $done['result'];
-
-            try {
-                $result = CurlFactory::finish($this, $entry['easy'], $this->factory);
-            } catch (\Throwable $e) {
-                $entry['deferred']->reject($e);
-
-                continue;
-            }
-
-            $entry['deferred']->resolve($result);
+        } finally {
+            $this->processingMessages = false;
         }
     }
 

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -33,11 +33,9 @@ final class CurlVersion
 
     private const CONNECTION_SHARING_VERSION = '8.20.0';
 
-    // curl 7.83.1 added the proxy TLS-SRP identity to the connection-reuse
-    // match (CVE-2022-27782); the proxy client certificate was already matched
-    // from the 7.52.0 HTTPS-proxy floor. Below 7.83.1 an HTTPS-proxy tunnel
-    // could be reused across TLS-SRP identities, so proxy TLS credential reuse
-    // is trusted from 7.83.1 onwards.
+    // curl 7.83.1 added proxy TLS-SRP to the connection-reuse match
+    // (CVE-2022-27782); the proxy client certificate was matched from 7.52.0,
+    // so proxy TLS credentials are trusted from 7.83.1 onwards.
     private const PROXY_TLS_CREDENTIAL_REUSE_VERSION = '7.83.1';
 
     // curl 8.19.0 fixed proxy tunnel reuse after credential changes

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -33,6 +33,13 @@ final class CurlVersion
 
     private const CONNECTION_SHARING_VERSION = '8.20.0';
 
+    // curl 7.83.1 added the proxy TLS-SRP identity to the connection-reuse
+    // match (CVE-2022-27782); the proxy client certificate was already matched
+    // from the 7.52.0 HTTPS-proxy floor. Below 7.83.1 an HTTPS-proxy tunnel
+    // could be reused across TLS-SRP identities, so proxy TLS credential reuse
+    // is trusted from 7.83.1 onwards.
+    private const PROXY_TLS_CREDENTIAL_REUSE_VERSION = '7.83.1';
+
     // curl 8.19.0 fixed proxy tunnel reuse after credential changes
     // (CVE-2026-3784), but related proxy credential leak flaws were only
     // fixed in 8.20.0, so connection reuse is trusted from 8.20.0 onwards.
@@ -154,6 +161,14 @@ final class CurlVersion
                 self::CONNECTION_SHARING_VERSION
             ));
         }
+    }
+
+    public static function supportsProxyTlsCredentialAwareConnectionReuse(): bool
+    {
+        $version = self::get();
+
+        return null !== $version
+            && version_compare($version, self::PROXY_TLS_CREDENTIAL_REUSE_VERSION, '>=');
     }
 
     public static function supportsProxyCredentialAwareConnectionReuse(): bool

--- a/src/Handler/EasyHandle.php
+++ b/src/Handler/EasyHandle.php
@@ -59,6 +59,12 @@ final class EasyHandle
     public ?string $effectiveProxy = null;
 
     /**
+     * Proxy tunnel section signature for connection-reuse isolation, or
+     * null when the request does not require sectioning.
+     */
+    public ?string $proxyTunnelSignature = null;
+
+    /**
      * @var \Throwable|null Exception during on_headers (if any)
      */
     public ?\Throwable $onHeadersException = null;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1245,22 +1245,23 @@ class CurlFactoryTest extends TestCase
         });
     }
 
-    public function testForcesFreshConnectionForEnvironmentCredentialedProxyOnAffectedCurlVersion(): void
+    public function testSectionsEnvironmentCredentialedProxyOnAffectedCurlVersion(): void
     {
         self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
-            self::createWithCurlVersion('8.19.0', 'https://example.com', []);
+            $factory = new CurlFactory(3);
+            $easy = self::createOnFactory($factory, '8.19.0', 'https://example.com', []);
 
-            self::assertAuthenticatedProxyConnectionReuseOptions();
+            self::assertNotNull($easy->proxyTunnelSignature);
         });
     }
 
-    public function testDoesNotForceFreshConnectionForEnvironmentCredentialedProxyOnFixedCurlVersion(): void
+    public function testDoesNotSectionEnvironmentCredentialedProxyOnFixedCurlVersion(): void
     {
         self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
-            self::createWithCurlVersion('8.20.0', 'https://example.com', []);
+            $factory = new CurlFactory(3);
+            $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', []);
 
-            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+            self::assertNull($easy->proxyTunnelSignature);
         });
     }
 
@@ -1368,48 +1369,50 @@ class CurlFactoryTest extends TestCase
         self::assertSame($error, self::redactProxyUserInfo($error, 'http://proxy.example.com:8125'));
     }
 
-    public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
+    /**
+     * @dataProvider proxyTunnelSectionProvider
+     */
+    public function testComputesProxyTunnelSignatureByChannel(string $version, string $uri, array $options, bool $sectioned): void
     {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
-        ]);
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, $version, $uri, $options);
 
-        self::assertAuthenticatedProxyConnectionReuseOptions();
-    }
-
-    public function testDoesNotForceFreshConnectionForAuthenticatedHttpsProxyOnFixedCurlVersion(): void
-    {
-        self::createWithCurlVersion('8.20.0', 'https://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
-        ]);
-
+        self::assertSame($sectioned, $easy->proxyTunnelSignature !== null);
+        // The sectioned path never sets FRESH_CONNECT/FORBID_REUSE on a single
+        // create; isolation is achieved by pool ownership, not per-handle.
         self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
         self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
     }
 
-    public function testDoesNotForceFreshConnectionForCurlProxyCredentialsOnFixedCurlVersion(): void
+    public static function proxyTunnelSectionProvider(): array
     {
-        self::createWithCurlVersion('8.20.0', 'https://example.com', [
-            'proxy' => 'http://proxy.example.com:8080',
-            'curl' => [
-                \CURLOPT_PROXYUSERPWD => 'username:password',
-            ],
-        ]);
+        $cases = [
+            'auth https proxy, affected curl' => ['8.19.0', 'https://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080'], true],
+            'auth https proxy, fixed curl' => ['8.20.0', 'https://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080'], false],
+            'curl proxy credentials, affected curl' => ['8.19.0', 'https://example.com', ['proxy' => 'http://proxy.example.com:8080', 'curl' => [\CURLOPT_PROXYUSERPWD => 'username:password']], true],
+            'curl proxy credentials, fixed curl' => ['8.20.0', 'https://example.com', ['proxy' => 'http://proxy.example.com:8080', 'curl' => [\CURLOPT_PROXYUSERPWD => 'username:password']], false],
+            'anonymous tunnel, affected curl' => ['8.19.0', 'https://example.com', ['proxy' => 'http://proxy.example.com:8080'], true],
+            'anonymous tunnel, fixed curl' => ['8.20.0', 'https://example.com', ['proxy' => 'http://proxy.example.com:8080'], false],
+            'plain http proxy request' => ['8.19.0', 'http://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080'], false],
+            'socks proxy' => ['8.19.0', 'https://example.com', ['proxy' => 'socks5://username:password@proxy.example.com:1080'], false],
+            'no-proxy match' => ['8.19.0', 'https://example.com', ['proxy' => ['https' => 'http://username:password@proxy.example.com:8080', 'no' => ['example.com']]], false],
+        ];
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
-    }
+        // CONNECT_TO makes an HTTP proxy tunnel even an http:// target, so it
+        // must section like any other authenticated tunnel.
+        if (\defined('CURLOPT_CONNECT_TO')) {
+            $connectTo = (int) \constant('CURLOPT_CONNECT_TO');
+            $entry = ['example.com:80:backend.example.com:80'];
+            $cases += [
+                'connect-to http tunnel, auth proxy url, affected curl' => ['8.19.0', 'http://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080', 'curl' => [$connectTo => $entry]], true],
+                'connect-to http tunnel, curl credentials, affected curl' => ['8.19.0', 'http://example.com', ['proxy' => 'http://proxy.example.com:8080', 'curl' => [$connectTo => $entry, \CURLOPT_PROXYUSERPWD => 'username:password']], true],
+                'connect-to http tunnel, anonymous, affected curl' => ['8.19.0', 'http://example.com', ['proxy' => 'http://proxy.example.com:8080', 'curl' => [$connectTo => $entry]], true],
+                'connect-to http tunnel, fixed curl' => ['8.20.0', 'http://example.com', ['proxy' => 'http://username:password@proxy.example.com:8080', 'curl' => [$connectTo => $entry]], false],
+                'connect-to socks proxy stays out' => ['8.19.0', 'http://example.com', ['proxy' => 'socks5://username:password@proxy.example.com:1080', 'curl' => [$connectTo => $entry]], false],
+            ];
+        }
 
-    public function testForcesFreshConnectionForAuthenticatedHttpsProxyWithCurlProxyCredentialsOnAffectedCurlVersion(): void
-    {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
-            'proxy' => 'http://proxy.example.com:8080',
-            'curl' => [
-                \CURLOPT_PROXYUSERPWD => 'username:password',
-            ],
-        ]);
-
-        self::assertAuthenticatedProxyConnectionReuseOptions();
+        return $cases;
     }
 
     public function testRejectsRawCurlProxyUrl(): void
@@ -1437,62 +1440,91 @@ class CurlFactoryTest extends TestCase
         ]);
     }
 
-    public function testForcesFreshConnectionForAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
+    public function testSectionsAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
     {
-        self::createWithCurlVersion('8.19.0', 'http://example.com', [
+        if (!\defined('CURLOPT_HTTPPROXYTUNNEL')) {
+            self::markTestSkipped('CURLOPT_HTTPPROXYTUNNEL is not available.');
+        }
+
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.19.0', 'http://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_HTTPPROXYTUNNEL => true,
             ],
         ]);
 
-        self::assertAuthenticatedProxyConnectionReuseOptions();
+        self::assertNotNull($easy->proxyTunnelSignature);
     }
 
-    public function testProxyAuthorizationProxyHeaderReuseOptionsCannotBeOverriddenOnFixedCurlVersion(): void
+    public function testSectionsProxyAuthorizationHeaderEvenOnFixedCurlVersion(): void
     {
         $proxyHeaderOption = self::proxyHeaderOption();
 
-        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
-                \CURLOPT_FRESH_CONNECT => false,
-                \CURLOPT_FORBID_REUSE => false,
             ],
         ]);
 
-        self::assertAuthenticatedProxyConnectionReuseOptions();
+        // libcurl cannot key connection reuse on a literal Proxy-Authorization
+        // header, so Guzzle sections it even on the fast-path version.
+        self::assertNotNull($easy->proxyTunnelSignature);
     }
 
-    public function testDoesNotForceFreshConnectionForUnrelatedProxyHeader(): void
+    public function testSectionsConnectToProxyAuthorizationHeaderEvenOnFixedCurlVersion(): void
+    {
+        if (!\defined('CURLOPT_CONNECT_TO')) {
+            self::markTestSkipped('CURLOPT_CONNECT_TO is not available.');
+        }
+
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.20.0', 'http://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                (int) \constant('CURLOPT_CONNECT_TO') => ['example.com:80:backend.example.com:80'],
+                $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+            ],
+        ]);
+
+        // CONNECT_TO tunnels the http:// request, and libcurl cannot key reuse
+        // on a literal Proxy-Authorization header, so it sections even on fixed
+        // libcurl.
+        self::assertNotNull($easy->proxyTunnelSignature);
+    }
+
+    public function testUnrelatedProxyHeaderIsNotHeaderAuthOnFixedCurlVersion(): void
     {
         $proxyHeaderOption = self::proxyHeaderOption();
 
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 $proxyHeaderOption => ['X-Proxy-Header: value'],
             ],
         ]);
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        self::assertNull($easy->proxyTunnelSignature);
     }
 
-    public function testDoesNotForceFreshConnectionForEmptyProxyAuthorizationProxyHeader(): void
+    public function testEmptyProxyAuthorizationHeaderIsNotHeaderAuthOnFixedCurlVersion(): void
     {
         $proxyHeaderOption = self::proxyHeaderOption();
 
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+        $factory = new CurlFactory(3);
+        $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
                 $proxyHeaderOption => ['Proxy-Authorization:'],
             ],
         ]);
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        self::assertNull($easy->proxyTunnelSignature);
     }
 
     public function testRejectsRawCurlSocksProxyTypeWithProxyUrl(): void
@@ -1557,67 +1589,97 @@ class CurlFactoryTest extends TestCase
         ]);
     }
 
-    public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
+    public function testReusesIdleHandleForSameProxyTunnelSignature(): void
     {
-        self::createWithCurlVersion('8.18.0', 'http://example.com', [
+        $factory = new CurlFactory(3);
+        $options = ['proxy' => 'http://username:password@proxy.example.com:8080'];
+
+        $first = self::createOnFactory($factory, '8.19.0', 'https://example.com', $options);
+        $pooled = $first->handle;
+        $factory->release($first);
+
+        $second = self::createOnFactory($factory, '8.19.0', 'https://example.com', $options);
+
+        self::assertSame($pooled, $second->handle);
+    }
+
+    public function testFirstProxyTunnelOwnerReusesPooledHandleWithoutPurging(): void
+    {
+        $factory = new CurlFactory(3);
+
+        $direct = self::createOnFactory($factory, '8.19.0', 'https://example.com', []);
+        $pooled = $direct->handle;
+        $factory->release($direct);
+
+        $tunnel = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
         ]);
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        self::assertSame($pooled, $tunnel->handle);
     }
 
-    public function testDoesNotForceFreshConnectionForUnauthenticatedHttpsProxy(): void
+    public function testPurgesIdleHandlesWhenProxyTunnelOwnerChanges(): void
     {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
-            'proxy' => 'http://proxy.example.com:8080',
-        ]);
+        $factory = new CurlFactory(3);
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        $first = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://user1:pass1@proxy.example.com:8080',
+        ]);
+        $factory->release($first);
+        self::assertCount(1, self::readIdleHandles($factory));
+
+        $second = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://user2:pass2@proxy.example.com:8080',
+        ]);
+        self::assertCount(0, self::readIdleHandles($factory));
+
+        $factory->release($second);
+        self::assertCount(1, self::readIdleHandles($factory));
     }
 
-    public function testDoesNotForceFreshConnectionForAuthenticatedSocksProxy(): void
+    public function testReleaseDropsHandleFromSupersededOwner(): void
     {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
-            'proxy' => 'socks5://username:password@proxy.example.com:1080',
+        $factory = new CurlFactory(3);
+
+        $a = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://a:a@proxy.example.com:8080',
+        ]);
+        $b = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+            'proxy' => 'http://b:b@proxy.example.com:8080',
         ]);
 
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        $factory->release($a);
+        self::assertCount(0, self::readIdleHandles($factory));
+
+        $factory->release($b);
+        self::assertCount(1, self::readIdleHandles($factory));
     }
 
-    public function testDoesNotForceFreshConnectionWhenNoProxyMatches(): void
+    public function testShareHandleUsesBlanketForceFreshForAuthenticatedProxy(): void
     {
-        self::createWithCurlVersion('8.18.0', 'https://example.com', [
-            'proxy' => [
-                'https' => 'http://username:password@proxy.example.com:8080',
-                'no' => ['example.com'],
-            ],
-        ]);
+        self::skipIfCurlShareIsUnavailable();
 
-        self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
-        self::assertSame('*', $_SERVER['_curl'][\CURLOPT_NOPROXY]);
-        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
-        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
-    }
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, TransportSharing::HANDLER_PREFER, $shareHandle);
 
-    public function testAuthenticatedHttpsProxyReuseOptionsCannotBeOverriddenOnAffectedCurlVersion(): void
-    {
-        self::createWithCurlVersion('8.19.0', 'https://example.com', [
-            'proxy' => 'http://username:password@proxy.example.com:8080',
-            'curl' => [
-                \CURLOPT_FRESH_CONNECT => false,
-                \CURLOPT_FORBID_REUSE => false,
-            ],
-        ]);
+        try {
+            $easy = self::createOnFactory($factory, '8.19.0', 'https://example.com', [
+                'proxy' => 'http://username:password@proxy.example.com:8080',
+            ]);
 
-        self::assertAuthenticatedProxyConnectionReuseOptions();
+            self::assertNull($easy->proxyTunnelSignature);
+            self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+            self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        } finally {
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
     }
 
     public function testAuthenticatedHttpsProxyReuseOptionsCanBeSetOnFixedCurlVersion(): void
     {
-        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+        $factory = new CurlFactory(3);
+        self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://username:password@proxy.example.com:8080',
             'curl' => [
                 \CURLOPT_FRESH_CONNECT => false,
@@ -1627,6 +1689,49 @@ class CurlFactoryTest extends TestCase
 
         self::assertFalse($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
         self::assertFalse($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testProxyTlsAuthCredentialChangesProxyTunnelSignature(): void
+    {
+        if (!\defined('CURLOPT_PROXY_TLSAUTH_PASSWORD')) {
+            self::markTestSkipped('CURLOPT_PROXY_TLSAUTH_PASSWORD is not available.');
+        }
+
+        // TLS-SRP is a proxy credential that libcurl did not key connection
+        // reuse on before 7.83.1 (CVE-2022-27782), so on an affected version it
+        // must change the signature for the proxy tunnel to be sectioned.
+        $tlsAuthPassword = (int) \constant('CURLOPT_PROXY_TLSAUTH_PASSWORD');
+
+        $first = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080',
+            $tlsAuthPassword => 'secret1',
+        ]);
+        $second = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080',
+            $tlsAuthPassword => 'secret2',
+        ]);
+
+        self::assertNotNull($first);
+        self::assertNotSame($first, $second);
+    }
+
+    public function testProxyTlsCredentialsRequireFreshConnectionOnAffectedCurlVersion(): void
+    {
+        if (!\defined('CURLOPT_PROXY_TLSAUTH_PASSWORD')) {
+            self::markTestSkipped('CURLOPT_PROXY_TLSAUTH_PASSWORD is not available.');
+        }
+
+        // Under a configured share handle the signature path is bypassed for
+        // the force-fresh path. libcurl did not key connection reuse on TLS-SRP
+        // before 7.83.1 (CVE-2022-27782), so that path must force a fresh
+        // tunnel on an affected version and need not from 7.83.1 onwards.
+        $conf = [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080',
+            (int) \constant('CURLOPT_PROXY_TLSAUTH_PASSWORD') => 'secret',
+        ];
+
+        self::assertTrue(self::computeRequiresFreshForAuthenticatedProxy('7.79.0', 'https://example.com', $conf));
+        self::assertFalse(self::computeRequiresFreshForAuthenticatedProxy('7.83.1', 'https://example.com', $conf));
     }
 
     /**
@@ -5594,12 +5699,6 @@ class CurlFactoryTest extends TestCase
         }
     }
 
-    private static function assertAuthenticatedProxyConnectionReuseOptions(): void
-    {
-        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
-        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
-    }
-
     /**
      * @param string[] $expectedProtocols
      */
@@ -5639,7 +5738,7 @@ class CurlFactoryTest extends TestCase
     /**
      * @param array<int|string, mixed> $options
      */
-    private static function createWithCurlVersion(string $version, string $uri, array $options): void
+    private static function createOnFactory(CurlFactory $factory, string $version, string $uri, array $options): EasyHandle
     {
         $previousVersionInfo = self::setCurlVersionInfo([
             'version' => $version,
@@ -5647,8 +5746,7 @@ class CurlFactoryTest extends TestCase
         ]);
 
         try {
-            $f = new CurlFactory(3);
-            $f->create(new Psr7\Request('GET', $uri), $options);
+            return $factory->create(new Psr7\Request('GET', $uri), $options);
         } finally {
             self::setCurlVersionInfo($previousVersionInfo);
         }
@@ -5691,6 +5789,47 @@ class CurlFactoryTest extends TestCase
         }
 
         return $method->invoke(null, $error, $proxy);
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function computeProxyTunnelSignature(string $version, string $uri, array $conf): ?string
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => 0,
+        ]);
+
+        try {
+            $method = new \ReflectionMethod(CurlFactory::class, 'proxyTunnelSignature');
+            if (\PHP_VERSION_ID < 80100) {
+                $method->setAccessible(true);
+            }
+
+            return $method->invoke(null, new Psr7\Request('GET', $uri), $conf);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    private static function computeRequiresFreshForAuthenticatedProxy(string $version, string $uri, array $conf): bool
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => 0,
+        ]);
+
+        try {
+            $method = new \ReflectionMethod(CurlFactory::class, 'requiresFreshConnectionForAuthenticatedProxy');
+            if (\PHP_VERSION_ID < 80100) {
+                $method->setAccessible(true);
+            }
+
+            return $method->invoke(null, new Psr7\Request('GET', $uri), $conf[\CURLOPT_PROXY], $conf);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
     }
 
     private static function requireHttp3TestConstants(): void

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -774,6 +774,139 @@ class CurlMultiHandlerTest extends TestCase
         }
     }
 
+    public function testFirstProxyTunnelOwnerLatchesWithoutRecreatingMultiHandle(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::initMultiHandle($handler);
+        $mh = self::readMultiHandle($handler);
+
+        self::applyProxyTunnelOwnership($handler, self::easyWithSignature('sig-a'));
+
+        self::assertSame('sig-a', self::readMultiProperty($handler, 'proxyTunnelOwner'));
+        self::assertSame($mh, self::readMultiHandle($handler), 'The first owner must not recreate the multi handle.');
+    }
+
+    public function testIdleProxyTunnelOwnerChangeRecreatesMultiHandle(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        self::initMultiHandle($handler);
+
+        self::applyProxyTunnelOwnership($handler, self::easyWithSignature('sig-b'));
+
+        self::assertSame('sig-b', self::readMultiProperty($handler, 'proxyTunnelOwner'));
+        self::assertNull(self::readMultiHandle($handler), 'An idle owner change must release the multi handle for lazy recreation.');
+    }
+
+    public function testBusyProxyTunnelOwnerChangeIsolatesTheTransfer(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        self::initMultiHandle($handler);
+        $mh = self::readMultiHandle($handler);
+        self::setMultiProperty($handler, 'handles', [0 => ['busy']]);
+
+        self::applyProxyTunnelOwnership($handler, self::easyWithSignature('sig-b'));
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        self::assertSame('sig-a', self::readMultiProperty($handler, 'proxyTunnelOwner'), 'A busy owner change must not move the owner.');
+        self::assertSame($mh, self::readMultiHandle($handler), 'A busy owner change must not recreate the multi handle.');
+    }
+
+    public function testProcessingMessagesGuardPreventsMultiRecreation(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        self::initMultiHandle($handler);
+        $mh = self::readMultiHandle($handler);
+        self::setMultiProperty($handler, 'processingMessages', true);
+
+        self::applyProxyTunnelOwnership($handler, self::easyWithSignature('sig-b'));
+
+        self::assertSame($mh, self::readMultiHandle($handler), 'Recreating the multi handle mid-iteration would corrupt the read loop.');
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testNullSignatureNeverDisturbsProxyTunnelOwnership(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        self::initMultiHandle($handler);
+        $mh = self::readMultiHandle($handler);
+
+        self::applyProxyTunnelOwnership($handler, self::easyWithSignature(null));
+
+        self::assertSame('sig-a', self::readMultiProperty($handler, 'proxyTunnelOwner'));
+        self::assertSame($mh, self::readMultiHandle($handler));
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
+    }
+
+    private static function easyWithSignature(?string $signature): EasyHandle
+    {
+        $easy = new EasyHandle();
+        $easy->request = new Request('GET', 'https://example.com');
+        $easy->handle = \curl_init();
+        $easy->proxyTunnelSignature = $signature;
+
+        return $easy;
+    }
+
+    private static function applyProxyTunnelOwnership(CurlMultiHandler $handler, EasyHandle $easy): void
+    {
+        $invoke = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->applyProxyTunnelOwnership($easy);
+        }, null, CurlMultiHandler::class);
+
+        $invoke($handler, $easy);
+    }
+
+    private static function initMultiHandle(CurlMultiHandler $handler): void
+    {
+        $init = \Closure::bind(static function (CurlMultiHandler $handler): void {
+            $handler->getMultiHandle();
+        }, null, CurlMultiHandler::class);
+
+        $init($handler);
+    }
+
+    /**
+     * @return resource|\CurlMultiHandle|null
+     */
+    private static function readMultiHandle(CurlMultiHandler $handler)
+    {
+        $get = \Closure::bind(static function (CurlMultiHandler $handler) {
+            return $handler->multiHandle;
+        }, null, CurlMultiHandler::class);
+
+        return $get($handler);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function setMultiProperty(CurlMultiHandler $handler, string $name, $value): void
+    {
+        $set = \Closure::bind(static function (CurlMultiHandler $handler) use ($name, $value): void {
+            $handler->{$name} = $value;
+        }, null, CurlMultiHandler::class);
+
+        $set($handler);
+    }
+
+    /**
+     * @return mixed
+     */
+    private static function readMultiProperty(CurlMultiHandler $handler, string $name)
+    {
+        $get = \Closure::bind(static function (CurlMultiHandler $handler) use ($name) {
+            return $handler->{$name};
+        }, null, CurlMultiHandler::class);
+
+        return $get($handler);
+    }
+
     private static function readSelectTimeout(CurlMultiHandler $handler): float
     {
         $readSelectTimeout = \Closure::bind(static function (CurlMultiHandler $handler): float {


### PR DESCRIPTION
This is the 8.0 counterpart to the credential-sectioned proxy tunnel pooling on the 7.13 branch, replacing the blanket force-fresh mitigation with connection reuse that is isolated per proxy credential. Each request that establishes an HTTP or HTTPS proxy tunnel computes a section signature from the effective proxy URL, the cURL proxy credential and proxy-TLS identity options, and any literal Proxy-Authorization header values. Because an HTTP proxy silently switches to a credential-bearing CONNECT tunnel when CURLOPT_CONNECT_TO redirects the origin, an http target with that option set is treated as a tunnel too so those requests are sectioned. The cURL handle factory tracks the signature its pooled idle handles may hold and purges them when the owner changes, latching the first owner without purging so a warm pool of direct connections survives the first authenticated request, and the release path drops a handle whose owner has since been superseded. The multi handler tracks its own owner and either hands the connection cache over by recreating the multi handle when it is idle or isolates the individual transfer with fresh-connect and forbid-reuse when it is busy, with a guard so a retried transfer re-invoking the handler from inside the message loop cannot recreate the multi handle mid-iteration. Anonymous tunnels join the domain so an unauthenticated request never rides an authenticated tunnel, and on libcurl 8.20.0 and newer option-supplied credentials are left to libcurl's own credential-aware matching while only literal Proxy-Authorization headers are still sectioned. A configured share handle keeps the conservative blanket behavior, which preserves the existing persistent-require rejection of authenticated tunnels; that blanket path now also forces a fresh tunnel for a proxy TLS credential, a client certificate or TLS-SRP, on libcurl older than 7.83.1, the version from which libcurl keys connection reuse on the TLS-SRP identity, so enabling transport sharing no longer drops the TLS-credential sectioning the signature path applies. A contributor reference under docs/contributing explains the connection reuse and sharing model, the credential channels, and the libcurl version floors, and reflection regression tests pin those channels.

This deliberately reuses the conservative single-multi-handle approach from the 7.13 branch rather than the more elaborate per-signature multi-handle design, keeping the connection footprint bounded and avoiding the resource and event-loop complexity of running several multi handles at once. The branches are not merged into one another here; each connection-pooling pull request stands alone.
