### PR TITLE
Deprecate non-string scalar values in the body request option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated passing `ntlm` as a built-in `auth` type
 - Deprecated `Utils::describeType()`
 - Deprecated non-finite floats in the `query` and `form_params` options; 8.0 rejects them
+- Deprecated non-string scalar values in the `body` option; 8.0 rejects them
 
 ### Fixed
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -888,7 +888,18 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($options['body'])) {
                 throw $this->invalidBody();
             }
-            $modify['body'] = Psr7\Utils::streamFor($options['body']);
+            $body = $options['body'];
+            if (!\is_string($body) && \is_scalar($body)) {
+                \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-string scalar to the "body" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-string scalar bodies.');
+
+                // Normalize non-finite floats to dodge PHP 8.5's (string) NAN
+                // coercion warning while the value is still accepted.
+                if (\is_float($body) && !\is_finite($body)) {
+                    $body = \is_nan($body) ? 'NAN' : ($body > 0 ? 'INF' : '-INF');
+                }
+                $body = (string) $body;
+            }
+            $modify['body'] = Psr7\Utils::streamFor($body);
             unset($options['body']);
         }
 


### PR DESCRIPTION
The body request option accepts non-string scalars today, but guzzlehttp/guzzle 8.0 will reject them in line with guzzlehttp/psr7 rejecting non-string scalar stream bodies. This deprecates passing an integer, float, or boolean to the body option, mirroring how the query and form_params options already deprecate values that 8.0 rejects. The value is still cast to a string so output is unchanged during the deprecation window, and non-finite floats are normalized so the cast does not emit the PHP 8.5 coercion warning.