### PR TITLE
Deprecate the CURLOPT_PROXYTYPE cURL request option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - Deprecated the request-level `handler` option, which will be ignored in 8.0
 - Deprecated raw cURL request options outside the built-in cURL handlers' allow-list
+- Deprecated the `CURLOPT_PROXYTYPE` cURL request option; set the proxy type via a scheme-prefixed proxy URL
 - Deprecated PHP stream context options outside the built-in stream handler allow-list
 - Deprecated passing `ntlm` as a built-in `auth` type
 - Deprecated `Utils::describeType()`

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -366,20 +366,43 @@ Allow-listing means Guzzle passes the option through without its own
 deprecation warning; PHP, libcurl, or the TLS backend may still reject or ignore
 an option depending on the runtime. The allow-list is limited to the following
 `CURLOPT_*` constants when they are defined by the installed PHP cURL extension:
-`CURLOPT_ADDRESS_SCOPE`, `CURLOPT_CONNECT_TO`,
-`CURLOPT_DNS_CACHE_TIMEOUT`, `CURLOPT_DNS_INTERFACE`,
-`CURLOPT_DNS_LOCAL_IP4`, `CURLOPT_DNS_LOCAL_IP6`, `CURLOPT_DNS_SERVERS`,
-`CURLOPT_DNS_SHUFFLE_ADDRESSES`, `CURLOPT_ENCODING`,
-`CURLOPT_FORBID_REUSE`, `CURLOPT_FRESH_CONNECT`,
-`CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS`, `CURLOPT_HTTPAUTH`,
-`CURLOPT_HTTPPROXYTUNNEL`, `CURLOPT_INTERFACE`, `CURLOPT_LOCALPORT`,
-`CURLOPT_LOCALPORTRANGE`, `CURLOPT_LOW_SPEED_LIMIT`, `CURLOPT_LOW_SPEED_TIME`,
-`CURLOPT_MAXAGE_CONN`, `CURLOPT_MAXCONNECTS`, `CURLOPT_MAXLIFETIME_CONN`,
-`CURLOPT_PROXYHEADER`, `CURLOPT_PROXYTYPE`, `CURLOPT_PROXYUSERPWD`,
-`CURLOPT_RESOLVE`, `CURLOPT_SSL_CIPHER_LIST`, `CURLOPT_SSL_EC_CURVES`,
-`CURLOPT_TCP_FASTOPEN`, `CURLOPT_TCP_KEEPALIVE`, `CURLOPT_TCP_KEEPIDLE`,
-`CURLOPT_TCP_KEEPINTVL`, `CURLOPT_TCP_KEEPCNT`, `CURLOPT_TCP_NODELAY`,
-`CURLOPT_TLS13_CIPHERS`, `CURLOPT_UNIX_SOCKET_PATH`, and `CURLOPT_USERPWD`.
+
+- `CURLOPT_ADDRESS_SCOPE`
+- `CURLOPT_CONNECT_TO`
+- `CURLOPT_DNS_CACHE_TIMEOUT`
+- `CURLOPT_DNS_INTERFACE`
+- `CURLOPT_DNS_LOCAL_IP4`
+- `CURLOPT_DNS_LOCAL_IP6`
+- `CURLOPT_DNS_SERVERS`
+- `CURLOPT_DNS_SHUFFLE_ADDRESSES`
+- `CURLOPT_ENCODING`
+- `CURLOPT_FORBID_REUSE`
+- `CURLOPT_FRESH_CONNECT`
+- `CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS`
+- `CURLOPT_HTTPAUTH`
+- `CURLOPT_HTTPPROXYTUNNEL`
+- `CURLOPT_INTERFACE`
+- `CURLOPT_LOCALPORT`
+- `CURLOPT_LOCALPORTRANGE`
+- `CURLOPT_LOW_SPEED_LIMIT`
+- `CURLOPT_LOW_SPEED_TIME`
+- `CURLOPT_MAXAGE_CONN`
+- `CURLOPT_MAXCONNECTS`
+- `CURLOPT_MAXLIFETIME_CONN`
+- `CURLOPT_PROXYHEADER`
+- `CURLOPT_PROXYUSERPWD`
+- `CURLOPT_RESOLVE`
+- `CURLOPT_SSL_CIPHER_LIST`
+- `CURLOPT_SSL_EC_CURVES`
+- `CURLOPT_TCP_FASTOPEN`
+- `CURLOPT_TCP_KEEPALIVE`
+- `CURLOPT_TCP_KEEPIDLE`
+- `CURLOPT_TCP_KEEPINTVL`
+- `CURLOPT_TCP_KEEPCNT`
+- `CURLOPT_TCP_NODELAY`
+- `CURLOPT_TLS13_CIPHERS`
+- `CURLOPT_UNIX_SOCKET_PATH`
+- `CURLOPT_USERPWD`
 
 ```php
 $client->request('GET', '/', [
@@ -880,7 +903,7 @@ $client->request('GET', 'https://example.com', [
 ## proxy
 
 Summary
-Pass a string to specify an HTTP proxy, or an array to specify different proxies for different protocols.
+Pass a string to specify a proxy, or an array to specify different proxies for different protocols.
 
 Types
 - string
@@ -898,7 +921,7 @@ Pass a string to specify a proxy for all protocols.
 $client->request('GET', '/', ['proxy' => 'http://localhost:8125']);
 ```
 
-Pass an associative array to specify HTTP proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair as a comma-delimited string or an array to provide a list of host names that should not be proxied to. No-proxy entries may include ports, for example `example.com:8080` or `[::1]:8080`, or IP CIDR ranges, for example `10.0.0.0/8` or `fd00::/8`. The `http`, `https`, and `no` entries may be set to `null` to leave that entry unconfigured.
+Pass an associative array to specify proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair as a comma-delimited string or an array to provide a list of host names that should not be proxied to. No-proxy entries may include ports, for example `example.com:8080` or `[::1]:8080`, or IP CIDR ranges, for example `10.0.0.0/8` or `fd00::/8`. The `http`, `https`, and `no` entries may be set to `null` to leave that entry unconfigured.
 
 > [!NOTE]
 > Guzzle will automatically populate this value with your environment's `NO_PROXY` environment variable. However, when providing a `proxy` request option, it is up to you to provide the `no` value from the `NO_PROXY` environment variable.
@@ -949,9 +972,7 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 > matching. Fixed libcurl versions keep normal connection reuse behavior for
 > proxy URL and cURL proxy credential options. Advanced users can still
 > control cURL connection reuse explicitly with the `curl` request option and
-> `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`; raw `CURLOPT_PROXYTYPE`
-> is respected when deciding whether a scheme-less `proxy` option value is an
-> HTTP(S) proxy.
+> `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
 
 ## query
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -432,7 +432,6 @@ class CurlFactory implements CurlFactoryInterface
         self::addSupportedCurlOption($options, 'CURLOPT_MAXLIFETIME_CONN');
         self::addSupportedCurlOption($options, 'CURLOPT_HTTPPROXYTUNNEL');
         self::addSupportedCurlOption($options, 'CURLOPT_PROXYHEADER');
-        self::addSupportedCurlOption($options, 'CURLOPT_PROXYTYPE');
         self::addSupportedCurlOption($options, 'CURLOPT_PROXYUSERPWD');
         self::addSupportedCurlOption($options, 'CURLOPT_RESOLVE');
         self::addSupportedCurlOption($options, 'CURLOPT_SSL_CIPHER_LIST');


### PR DESCRIPTION
The proxy type is fully expressible through a scheme-prefixed `proxy` request option URL, which is handler-agnostic and routes through Guzzle's full proxy pipeline (no-proxy resolution, environment fallback, connection-reuse sectioning):

| `CURLOPT_PROXYTYPE`                            | scheme-prefixed `proxy` URL                          |
|------------------------------------------------|------------------------------------------------------|
| `CURLPROXY_HTTP`                               | `http://`                                            |
| `CURLPROXY_HTTPS`                              | `https://`                                           |
| `CURLPROXY_SOCKS4`/`4A`/`5`/`5_HOSTNAME`       | `socks4://`/`socks4a://`/`socks5://`/`socks5h://`    |

Raw `CURLOPT_PROXY` is already deprecated in favour of the `proxy` option, so the raw proxy *type* was the only remaining raw proxy lever. This removes it from the cURL handlers' allow-list, so it now deprecates through the standard unsupported-option path (at the correct `7.12` version) and stays honored on this branch.

`CURLPROXY_HTTP_1_0` has no scheme-prefixed equivalent and is not carried over; it is a curl-only HTTP/1.0-to-proxy compatibility shim with negligible real-world use.

Docs: the raw cURL option allow-list is reformatted as a bullet list, and the "HTTP proxy" wording in the `proxy` option description is generalised to "proxy".

This is the non-security groundwork split out of #3626 so that PR can stay focused on the HTTPS-proxy capability guard.