### PR TITLE
Reject the CURLOPT_PROXYTYPE cURL request option

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -516,7 +516,7 @@ array selects a proxy for the request scheme.
 Handler-specific overrides remain available for finer transport control when
 they do not conflict with Guzzle-managed behavior. The built-in cURL handlers
 now reject raw cURL options that override request method, URI, body, headers,
-timeouts, redirects, proxy URLs, TLS verification or client credentials,
+timeouts, redirects, proxy URLs and types, TLS verification or client credentials,
 progress/debug callbacks, sink handling, cookies, protocols, or cURL share
 handles. Use first-class Guzzle request options for those settings.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -367,21 +367,44 @@ Raw cURL options outside the built-in cURL handlers' allow-list are rejected.
 Allow-listing means Guzzle passes the option through; PHP, libcurl, or the TLS
 backend may still reject or ignore an option depending on the runtime. The
 allow-list is limited to the following `CURLOPT_*` constants when they are
-defined by the installed PHP cURL extension: `CURLOPT_ADDRESS_SCOPE`,
-`CURLOPT_CONNECT_TO`, `CURLOPT_DNS_CACHE_TIMEOUT`,
-`CURLOPT_DNS_INTERFACE`, `CURLOPT_DNS_LOCAL_IP4`,
-`CURLOPT_DNS_LOCAL_IP6`, `CURLOPT_DNS_SERVERS`,
-`CURLOPT_DNS_SHUFFLE_ADDRESSES`, `CURLOPT_ENCODING`,
-`CURLOPT_FORBID_REUSE`, `CURLOPT_FRESH_CONNECT`,
-`CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS`, `CURLOPT_HTTPAUTH`,
-`CURLOPT_HTTPPROXYTUNNEL`, `CURLOPT_INTERFACE`, `CURLOPT_LOCALPORT`,
-`CURLOPT_LOCALPORTRANGE`, `CURLOPT_LOW_SPEED_LIMIT`, `CURLOPT_LOW_SPEED_TIME`,
-`CURLOPT_MAXAGE_CONN`, `CURLOPT_MAXCONNECTS`, `CURLOPT_MAXLIFETIME_CONN`,
-`CURLOPT_PROXYHEADER`, `CURLOPT_PROXYTYPE`, `CURLOPT_PROXYUSERPWD`,
-`CURLOPT_RESOLVE`, `CURLOPT_SSL_CIPHER_LIST`, `CURLOPT_SSL_EC_CURVES`,
-`CURLOPT_TCP_FASTOPEN`, `CURLOPT_TCP_KEEPALIVE`, `CURLOPT_TCP_KEEPIDLE`,
-`CURLOPT_TCP_KEEPINTVL`, `CURLOPT_TCP_KEEPCNT`, `CURLOPT_TCP_NODELAY`,
-`CURLOPT_TLS13_CIPHERS`, `CURLOPT_UNIX_SOCKET_PATH`, and `CURLOPT_USERPWD`.
+defined by the installed PHP cURL extension:
+
+- `CURLOPT_ADDRESS_SCOPE`
+- `CURLOPT_CONNECT_TO`
+- `CURLOPT_DNS_CACHE_TIMEOUT`
+- `CURLOPT_DNS_INTERFACE`
+- `CURLOPT_DNS_LOCAL_IP4`
+- `CURLOPT_DNS_LOCAL_IP6`
+- `CURLOPT_DNS_SERVERS`
+- `CURLOPT_DNS_SHUFFLE_ADDRESSES`
+- `CURLOPT_ENCODING`
+- `CURLOPT_FORBID_REUSE`
+- `CURLOPT_FRESH_CONNECT`
+- `CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS`
+- `CURLOPT_HTTPAUTH`
+- `CURLOPT_HTTPPROXYTUNNEL`
+- `CURLOPT_INTERFACE`
+- `CURLOPT_LOCALPORT`
+- `CURLOPT_LOCALPORTRANGE`
+- `CURLOPT_LOW_SPEED_LIMIT`
+- `CURLOPT_LOW_SPEED_TIME`
+- `CURLOPT_MAXAGE_CONN`
+- `CURLOPT_MAXCONNECTS`
+- `CURLOPT_MAXLIFETIME_CONN`
+- `CURLOPT_PROXYHEADER`
+- `CURLOPT_PROXYUSERPWD`
+- `CURLOPT_RESOLVE`
+- `CURLOPT_SSL_CIPHER_LIST`
+- `CURLOPT_SSL_EC_CURVES`
+- `CURLOPT_TCP_FASTOPEN`
+- `CURLOPT_TCP_KEEPALIVE`
+- `CURLOPT_TCP_KEEPIDLE`
+- `CURLOPT_TCP_KEEPINTVL`
+- `CURLOPT_TCP_KEEPCNT`
+- `CURLOPT_TCP_NODELAY`
+- `CURLOPT_TLS13_CIPHERS`
+- `CURLOPT_UNIX_SOCKET_PATH`
+- `CURLOPT_USERPWD`
 
 ```php
 $client->request('GET', '/', [
@@ -897,7 +920,7 @@ $client->request('GET', 'https://example.com', [
 ## proxy
 
 Summary
-Pass a string to specify an HTTP proxy, or an array to specify different proxies for different protocols.
+Pass a string to specify a proxy, or an array to specify different proxies for different protocols.
 
 Types
 - string
@@ -915,7 +938,7 @@ Pass a string to specify a proxy for all protocols.
 $client->request('GET', '/', ['proxy' => 'http://localhost:8125']);
 ```
 
-Pass an associative array to specify HTTP proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair as a comma- or whitespace-delimited string or an array of entries that should not be proxied to; array entries are taken as-is and are never re-split. The `http`, `https`, and `no` entries may be set to `null` to leave that entry unconfigured.
+Pass an associative array to specify proxies for specific URI schemes (i.e., "http", "https"). Provide a `no` key value pair as a comma- or whitespace-delimited string or an array of entries that should not be proxied to; array entries are taken as-is and are never re-split. The `http`, `https`, and `no` entries may be set to `null` to leave that entry unconfigured.
 
 The `no` list supports the following entry forms:
 
@@ -1019,9 +1042,7 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 > in its connection matching. Fixed libcurl versions keep normal connection
 > reuse behavior for proxy URL and cURL proxy credential options. Advanced
 > users can still control cURL connection reuse explicitly with the `curl`
-> request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`; raw
-> `CURLOPT_PROXYTYPE` is respected when deciding whether a scheme-less `proxy`
-> option value is an HTTP(S) proxy.
+> request option and `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
 
 ## query
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -459,6 +459,7 @@ final class CurlFactory implements CurlFactoryInterface
         self::addConflictingCurlOption($options, 'CURLOPT_STDERR', 'the "debug" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_PROXY', 'the "proxy" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_NOPROXY', 'the "proxy" request option');
+        self::addConflictingCurlOption($options, 'CURLOPT_PROXYTYPE', 'the "proxy" request option with a scheme-prefixed URL');
         self::addConflictingCurlOption($options, 'CURLOPT_FOLLOWLOCATION', 'the "allow_redirects" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_MAXREDIRS', 'the "allow_redirects" request option');
         self::addConflictingCurlOption($options, 'CURLOPT_POSTREDIR', 'the "allow_redirects" request option');
@@ -525,7 +526,6 @@ final class CurlFactory implements CurlFactoryInterface
         self::addSupportedCurlOption($options, 'CURLOPT_MAXLIFETIME_CONN');
         self::addSupportedCurlOption($options, 'CURLOPT_HTTPPROXYTUNNEL');
         self::addSupportedCurlOption($options, 'CURLOPT_PROXYHEADER');
-        self::addSupportedCurlOption($options, 'CURLOPT_PROXYTYPE');
         self::addSupportedCurlOption($options, 'CURLOPT_PROXYUSERPWD');
         self::addSupportedCurlOption($options, 'CURLOPT_RESOLVE');
         self::addSupportedCurlOption($options, 'CURLOPT_SSL_CIPHER_LIST');

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1282,6 +1282,18 @@ class CurlFactoryTest extends TestCase
         ]);
     }
 
+    public function testRejectsRawCurlProxyTypeOption(): void
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXYTYPE');
+
+        $f->create(new Psr7\Request('GET', 'https://example.com'), [
+            'curl' => [\CURLOPT_PROXYTYPE => \defined('CURLPROXY_HTTPS') ? \constant('CURLPROXY_HTTPS') : 2],
+        ]);
+    }
+
     public function testRejectsRawCurlProxyOverride(): void
     {
         $f = new CurlFactory(3);


### PR DESCRIPTION
The proxy type is fully expressible through a scheme-prefixed `proxy` request option URL, which is handler-agnostic and routes through Guzzle's full proxy pipeline (no-proxy resolution, environment fallback, connection-reuse sectioning, HTTP/3 downgrade):

| `CURLOPT_PROXYTYPE`                            | scheme-prefixed `proxy` URL                          |
|------------------------------------------------|------------------------------------------------------|
| `CURLPROXY_HTTP`                               | `http://`                                            |
| `CURLPROXY_HTTPS`                              | `https://`                                           |
| `CURLPROXY_SOCKS4`/`4A`/`5`/`5_HOSTNAME`       | `socks4://`/`socks4a://`/`socks5://`/`socks5h://`    |

8.0 already rejects raw `CURLOPT_PROXY` in favour of the `proxy` option, so the raw proxy *type* was the only remaining raw proxy lever. This moves `CURLOPT_PROXYTYPE` from the allow-list to the conflicting list, so it is rejected with an actionable `InvalidArgumentException` pointing at the `proxy` request option with a scheme-prefixed URL.

`CURLPROXY_HTTP_1_0` has no scheme-prefixed equivalent and is not carried over; it is a curl-only HTTP/1.0-to-proxy compatibility shim with negligible real-world use.

The rejection is covered by the existing "Reject raw cURL request options outside the allow-list" changelog entry, so no new line is added. `UPGRADING.md` is widened from "proxy URLs" to "proxy URLs and types".

Docs: the raw cURL option allow-list is reformatted as a bullet list, and the "HTTP proxy" wording in the `proxy` option description is generalised to "proxy".

This is the non-security groundwork split out of #3627 so that PR can stay focused on the HTTPS-proxy capability guard and the stream-handler scheme strictness.