### PR TITLE
Reject non-string scalar values in the body request option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Declare strict types across remaining source files
 - Reject invalid `idn_conversion`, `retries`, and built-in handler `on_stats` option values before use
 - Reject non-finite floats in the `query` and `form_params` options
+- Reject non-string scalar values in the `body` option
 - Reject invalid `SetCookie` constructor field types instead of coercing them
 - Reject malformed, conflicting, or unrepresentable request `Content-Length` values in built-in handlers
 - Reject raw cURL request options outside the built-in cURL handlers' allow-list

--- a/src/Client.php
+++ b/src/Client.php
@@ -81,7 +81,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -205,7 +205,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -293,7 +293,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -397,7 +397,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -513,7 +513,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -709,8 +709,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             return $streamFactory->createStream();
         }
 
-        if (\is_scalar($body)) {
-            return $streamFactory->createStream((string) $body);
+        if (\is_string($body)) {
+            return $streamFactory->createStream($body);
         }
 
         if ($body instanceof \Iterator) {
@@ -726,7 +726,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         throw new InvalidArgumentException(\sprintf(
-            'Passing %s to request option "body" is invalid; expected resource|string|null|int|float|bool|StreamInterface|callable&object|Iterator|Stringable.',
+            'Passing %s to request option "body" is invalid; expected resource|string|null|StreamInterface|callable&object|Iterator|Stringable.',
             \get_debug_type($body)
         ));
     }
@@ -1341,18 +1341,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($options['body'])) {
                 throw $this->invalidBody();
             }
-            $body = $options['body'];
-            if (!\is_string($body) && \is_scalar($body)) {
-                \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-string scalar to the "body" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-string scalar bodies.');
-
-                // Normalize non-finite floats to dodge PHP 8.5's (string) NAN
-                // coercion warning while the value is still accepted.
-                if (\is_float($body) && !\is_finite($body)) {
-                    $body = \is_nan($body) ? 'NAN' : ($body > 0 ? 'INF' : '-INF');
-                }
-                $body = (string) $body;
-            }
-            $modify['body'] = self::createBodyStream($body, $streamFactory);
+            $modify['body'] = self::createBodyStream($options['body'], $streamFactory);
             unset($options['body']);
         }
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -45,7 +45,7 @@ interface ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -125,7 +125,7 @@ interface ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -210,7 +210,7 @@ interface ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -295,7 +295,7 @@ interface ClientInterface
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null

--- a/src/ClientTrait.php
+++ b/src/ClientTrait.php
@@ -45,7 +45,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -129,7 +129,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -216,7 +216,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -303,7 +303,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -390,7 +390,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -477,7 +477,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -564,7 +564,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -652,7 +652,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -736,7 +736,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -823,7 +823,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -910,7 +910,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -997,7 +997,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -1084,7 +1084,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null
@@ -1171,7 +1171,7 @@ trait ClientTrait
      *         1: string,
      *         2?: string|null
      *     }|string|false|null,
-     *     body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *     body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *     cert?: string|array{
      *         0: string,
      *         1?: string|null

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -61,7 +61,7 @@ class Pool implements PromisorInterface
      *             1: string,
      *             2?: string|null
      *         }|string|false|null,
-     *         body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *         body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *         cert?: string|array{
      *             0: string,
      *             1?: string|null
@@ -186,7 +186,7 @@ class Pool implements PromisorInterface
      *             1: string,
      *             2?: string|null
      *         }|string|false|null,
-     *         body?: resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable,
+     *         body?: resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable,
      *         cert?: string|array{
      *             0: string,
      *             1?: string|null

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -60,7 +60,7 @@ final class RequestOptions
     public const AUTH = 'auth';
 
     /**
-     * body: (resource|string|null|int|float|bool|StreamInterface|(callable&object)|\Iterator|\Stringable)
+     * body: (resource|string|null|StreamInterface|(callable&object)|\Iterator|\Stringable)
      * Body to send in the request. Scalar, resource, and stringable object
      * values are converted using the configured stream_factory. Callable and
      * iterator bodies use Guzzle's existing stream handling. Strings are used

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1460,7 +1460,12 @@ class ClientTest extends TestCase
 
         yield 'body' => [
             ['body' => new \stdClass()],
-            'Passing stdClass to request option "body" is invalid; expected resource|string|null|int|float|bool|StreamInterface|callable&object|Iterator|Stringable.',
+            'Passing stdClass to request option "body" is invalid; expected resource|string|null|StreamInterface|callable&object|Iterator|Stringable.',
+        ];
+
+        yield 'body int' => [
+            ['body' => 1],
+            'Passing int to request option "body" is invalid; expected resource|string|null|StreamInterface|callable&object|Iterator|Stringable.',
         ];
 
         yield 'cert password' => [


### PR DESCRIPTION
This makes guzzlehttp/guzzle 8.0 reject the non-string scalar bodies that were deprecated on 7.12, matching guzzlehttp/psr7 3.0 rejecting non-string scalar stream bodies. Client::createBodyStream() now only accepts strings among the scalar types, so passing an integer, float, or boolean to the body request option throws an InvalidArgumentException rather than being cast to a string. The int, float, and bool types are dropped from the body request-option shape across the client, trait, interface, pool, and request options documentation, and the body request-option validation test covers the scalar case.