### PR TITLE
Fix line wrapping in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -516,9 +516,9 @@ array selects a proxy for the request scheme.
 Handler-specific overrides remain available for finer transport control when
 they do not conflict with Guzzle-managed behavior. The built-in cURL handlers
 now reject raw cURL options that override request method, URI, body, headers,
-timeouts, redirects, proxy URLs and types, TLS verification or client credentials,
-progress/debug callbacks, sink handling, cookies, protocols, or cURL share
-handles. Use first-class Guzzle request options for those settings.
+timeouts, redirects, proxy URLs and types, TLS verification or client
+credentials, progress/debug callbacks, sink handling, cookies, protocols, or
+cURL share handles. Use first-class Guzzle request options for those settings.
 
 The cURL handlers also reject stream-only `stream_context` options, but accept
 `read_timeout` without effect. The stream handler rejects cURL-only options it


### PR DESCRIPTION
Widening "proxy URLs" to "proxy URLs and types" in #3633 pushed a line in the "Handler-Specific Option Overrides" paragraph past the 80-character greedy wrap. This reflows the paragraph so every line fits within 80 characters again.

Docs-only; no behavior change.