### PR TITLE
Explain why createBodyStream narrows the body callable arm

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -721,6 +721,10 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             return $streamFactory->createStream((string) $body);
         }
 
+        // Only invokable objects reach this branch: callable-name strings are
+        // stored as literal bodies above, and array callables are rejected
+        // before createBodyStream() is called, so the documented body type
+        // narrows the callable arm to callable&object rather than callable.
         if (\is_callable($body)) {
             return Psr7\Utils::streamFor($body);
         }


### PR DESCRIPTION
The body request option documents its callable arm as `(callable&object)`, but `createBodyStream()` dispatches it through a plain `is_callable()` check that on its own would also accept array callables. This adds a comment explaining that callable-name strings are handled as literal bodies earlier and array bodies are rejected before `createBodyStream()` runs, so only invokable objects can reach that branch and the narrower `callable&object` type is accurate.