### PR TITLE
Reject proxy URLs with a malformed scheme in the cURL handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Fixed
 
 - Reject HTTPS proxies when the installed libcurl lacks HTTPS-proxy support
+- Reject proxy URLs with a malformed scheme in the cURL handlers instead of letting libcurl mishandle them
 
 
 ## 7.12.0 - 2026-06-16

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -939,7 +939,7 @@ $client->request('GET', '/', [
 > [!NOTE]
 > You can provide proxy URLs that contain a scheme, username, and password. For example, `"http://username:password@192.168.16.1:10"`.
 
-HTTPS proxies (an `https://` proxy URL, where the connection to the proxy itself is encrypted) require libcurl 7.52.0 or newer built with HTTPS-proxy support. Without it, libcurl mishandles such a proxy — versions before 7.50.2 silently downgrade it to a plaintext HTTP proxy, while 7.50.2 and later, and builds lacking the feature, fail only at connect time with a cryptic error — so the cURL handlers reject the request up front instead.
+HTTPS proxies (an `https://` proxy URL, where the connection to the proxy itself is encrypted) require libcurl 7.52.0 or newer built with HTTPS-proxy support. When libcurl lacks that support, it mishandles such a proxy: versions before 7.50.2 silently downgrade it to a plaintext HTTP proxy, and later versions fail at connect time with a cryptic error. To avoid both outcomes, the cURL handlers reject the request up front. They also reject a proxy URL with a malformed scheme, such as one with junk before the scheme, which libcurl would otherwise downgrade to a plaintext HTTP proxy.
 
 ### Proxy environment variables
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1036,7 +1036,16 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         if (\is_string($proxyConf) && $proxyConf !== '') {
-            if (self::proxyScheme($proxyConf) === 'https' && !CurlVersion::supportsHttpsProxy()) {
+            $scheme = self::proxyScheme($proxyConf);
+            if ($scheme !== null && \preg_match('/^[a-z][a-z0-9.+-]*$/D', $scheme) !== 1) {
+                // A "://" with a prefix that is not a valid scheme (leading
+                // junk such as a space or non-breaking space) is treated by
+                // libcurl as an unknown scheme and silently downgraded to a
+                // plaintext HTTP proxy. Fail closed before any bytes reach the
+                // wire.
+                throw new RequestException('The proxy URL is malformed.', $easy->request);
+            }
+            if ($scheme === 'https' && !CurlVersion::supportsHttpsProxy()) {
                 // libcurl before 7.50.2 silently downgrades an https:// proxy
                 // to a plaintext HTTP proxy; 7.50.2 through 7.51, and builds
                 // without HTTPS-proxy support, fail at connect time. Fail

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -694,6 +694,27 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public static function malformedProxyUrlProvider(): array
+    {
+        return [
+            [' https://proxy.example.com:3128'],        // leading space before the scheme
+            ["\u{00A0}https://proxy.example.com:3128"], // leading non-breaking space
+            ['ht tps://proxy.example.com:3128'],        // space inside the scheme prefix
+        ];
+    }
+
+    /**
+     * @dataProvider malformedProxyUrlProvider
+     */
+    public function testRejectsMalformedProxyUrls(string $proxy): void
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('The proxy URL is malformed.');
+
+        $f = new CurlFactory(3);
+        $f->create(new Psr7\Request('GET', 'https://example.com'), ['proxy' => $proxy]);
+    }
+
     public static function rejectedHttpsProxyEnvironmentProvider(): array
     {
         return [


### PR DESCRIPTION
Follow-up to #3626 (HTTPS-proxy capability guard), hardening the scheme detection.

#3626 rejects an `https://` proxy when the installed libcurl cannot do HTTPS proxying, detecting the scheme from the literal `://` prefix. A proxy whose scheme prefix is not a valid scheme — leading junk such as a space or a non-breaking space before `https://`, for example — is exactly what libcurl treats as an unknown scheme and silently downgrades to a plaintext HTTP proxy on old versions, so it would slip past the capability guard. This rejects such a proxy up front with a `RequestException`.

No whitelist: a valid but unsupported scheme (`ftp`, `socks*`) still passes through to libcurl as before.