### PR TITLE
Translate scheme-less proxies and their credentials in the stream handler

### DIFF
--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -1131,7 +1131,7 @@ final class StreamHandler
 
         if ($parsed['auth']) {
             if (!isset($context['http']['header'])) {
-                $context['http']['header'] = [];
+                $context['http']['header'] = '';
             }
             $context['http']['header'] .= "\r\nProxy-Authorization: {$parsed['auth']}";
         }
@@ -1144,16 +1144,29 @@ final class StreamHandler
     {
         $parsed = \parse_url($url);
 
-        if ($parsed !== false && isset($parsed['scheme']) && $parsed['scheme'] === 'http') {
-            if (isset($parsed['host']) && isset($parsed['port'])) {
-                $auth = null;
-                if (isset($parsed['user']) && isset($parsed['pass'])) {
-                    $auth = \base64_encode("{$parsed['user']}:{$parsed['pass']}");
-                }
+        // parse_url() misreads scheme-less proxy authorities like
+        // "user:pass@host"; re-parse only those forms as HTTP.
+        $schemeLessAuthority = \strpos($url, '://') === false && \strncmp($url, '//', 2) !== 0;
+        if ($schemeLessAuthority) {
+            if (\is_array($parsed) && !isset($parsed['scheme']) && isset($parsed['host'], $parsed['port'])) {
+                $parsed['scheme'] = 'http';
+            } elseif (
+                (!\is_array($parsed) || !isset($parsed['host']))
+                && (\strpos($url, '@') !== false || \strncmp($url, '[', 1) === 0)
+            ) {
+                $parsed = \parse_url('http://'.$url);
+            }
+        }
+
+        if (\is_array($parsed) && isset($parsed['scheme']) && \strcasecmp($parsed['scheme'], 'http') === 0) {
+            if (isset($parsed['host'], $parsed['port'])) {
+                $user = $parsed['user'] ?? '';
+                $pass = $parsed['pass'] ?? '';
+                $auth = ($user !== '' || $pass !== '') ? 'Basic '.\base64_encode("{$user}:{$pass}") : null;
 
                 return [
                     'proxy' => "tcp://{$parsed['host']}:{$parsed['port']}",
-                    'auth' => $auth ? "Basic {$auth}" : null,
+                    'auth' => $auth,
                 ];
             }
         }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -3152,4 +3152,106 @@ class StreamHandlerTest extends TestCase
             ]
         )->wait();
     }
+
+    private function parseProxyResult(string $url): array
+    {
+        $method = new \ReflectionMethod(StreamHandler::class, 'parseProxy');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        return $method->invokeArgs(new StreamHandler(), [$url]);
+    }
+
+    private function getProxyContext(string $proxy, string $uri = 'http://example.com'): array
+    {
+        $handler = new StreamHandler();
+        $request = new Request('GET', $uri);
+        $context = ['http' => []];
+        $method = new \ReflectionMethod(StreamHandler::class, 'applyProxyOption');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $method->invokeArgs($handler, [$request, &$context, $proxy]);
+
+        return $context;
+    }
+
+    public function proxyParseProvider(): array
+    {
+        return [
+            'scheme-less host' => [
+                'proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => null],
+            ],
+            'scheme-less credentials' => [
+                'user:pass@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:pass')],
+            ],
+            'scheme-less username only' => [
+                'user@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:')],
+            ],
+            'scheme-less empty password' => [
+                'user:@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:')],
+            ],
+            'scheme-less empty userinfo' => [
+                '@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => null],
+            ],
+            'scheme-less ipv6' => [
+                '[::1]:8125',
+                ['proxy' => 'tcp://[::1]:8125', 'auth' => null],
+            ],
+            'scheme-less ipv6 credentials' => [
+                'user:pass@[::1]:8125',
+                ['proxy' => 'tcp://[::1]:8125', 'auth' => 'Basic '.\base64_encode('user:pass')],
+            ],
+            'explicit http credentials' => [
+                'http://user:pass@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:pass')],
+            ],
+            'uppercase http scheme' => [
+                'HTTP://user:pass@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:pass')],
+            ],
+            'raw transport unchanged' => [
+                'ssl://proxy.example.com:8125',
+                ['proxy' => 'ssl://proxy.example.com:8125', 'auth' => null],
+            ],
+            'malformed socks-like unchanged' => [
+                'socks5:127.0.0.1:1080',
+                ['proxy' => 'socks5:127.0.0.1:1080', 'auth' => null],
+            ],
+            'malformed http-like unchanged' => [
+                'http:127.0.0.1:8125',
+                ['proxy' => 'http:127.0.0.1:8125', 'auth' => null],
+            ],
+            'protocol-relative unchanged' => [
+                '//proxy.example.com:8125',
+                ['proxy' => '//proxy.example.com:8125', 'auth' => null],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider proxyParseProvider
+     */
+    public function testTranslatesProxyForStreamContext(string $url, array $expected): void
+    {
+        self::assertSame($expected, $this->parseProxyResult($url));
+    }
+
+    public function testAddsProxyAuthorizationHeaderForSchemeLessCredentials(): void
+    {
+        $context = $this->getProxyContext('user:pass@proxy.example.com:8125');
+
+        self::assertSame('tcp://proxy.example.com:8125', $context['http']['proxy']);
+        self::assertStringContainsString(
+            'Proxy-Authorization: Basic '.\base64_encode('user:pass'),
+            $context['http']['header']
+        );
+    }
 }


### PR DESCRIPTION
PHP's HTTP stream wrapper expects the proxy to be a transport address such as `tcp://host:port` and requires any credentials to be supplied separately in a `Proxy-Authorization` header, but `StreamHandler::parseProxy()` only performed that translation when the proxy URL carried an explicit `http://` scheme. A proxy configured without a scheme, such as `user:pass@proxy.example.com:8125`, was therefore passed through unchanged, and because `parse_url()` reads the leading `user` as the scheme the credentials were silently dropped and the malformed authority became an unusable proxy target. This change re-parses only the scheme-less authority forms that `parse_url()` actually misreads so that they are translated exactly like an explicit `http://` proxy, while values that merely look scheme-like such as `socks5:host:port` are left untouched rather than being reinterpreted as hosts. The scheme is matched case-insensitively and bracketed IPv6 literals are handled, and credentials are forwarded whenever a username or password is present, including the username-only case where the password is empty, since Basic authentication permits an empty password. Raw transport forms such as `tcp://`, `ssl://`, and `tls://` continue to pass through unchanged. This is the 8.0 counterpart of #3639.
