### PR TITLE
Translate scheme-less proxies and their credentials in the stream handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Fix cURL TLS and HTTP/2 capability detection using libcurl feature checks
 - Fix proxy `no` list matches being re-proxied through environment-configured proxies by libcurl
 - Fix `no` list and `NO_PROXY` matching to support IP CIDR ranges, matching libcurl
+- Fix the stream handler not applying scheme-less proxies and their credentials
 
 
 ## 7.11.2 - 2026-06-12

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -780,7 +780,7 @@ class StreamHandler
 
         if ($parsed['auth']) {
             if (!isset($options['http']['header'])) {
-                $options['http']['header'] = [];
+                $options['http']['header'] = '';
             }
             $options['http']['header'] .= "\r\nProxy-Authorization: {$parsed['auth']}";
         }
@@ -793,16 +793,29 @@ class StreamHandler
     {
         $parsed = \parse_url($url);
 
-        if ($parsed !== false && isset($parsed['scheme']) && $parsed['scheme'] === 'http') {
-            if (isset($parsed['host']) && isset($parsed['port'])) {
-                $auth = null;
-                if (isset($parsed['user']) && isset($parsed['pass'])) {
-                    $auth = \base64_encode("{$parsed['user']}:{$parsed['pass']}");
-                }
+        // parse_url() misreads scheme-less proxy authorities like
+        // "user:pass@host"; re-parse only those forms as HTTP.
+        $schemeLessAuthority = \strpos($url, '://') === false && \strncmp($url, '//', 2) !== 0;
+        if ($schemeLessAuthority) {
+            if (\is_array($parsed) && !isset($parsed['scheme']) && isset($parsed['host'], $parsed['port'])) {
+                $parsed['scheme'] = 'http';
+            } elseif (
+                (!\is_array($parsed) || !isset($parsed['host']))
+                && (\strpos($url, '@') !== false || \strncmp($url, '[', 1) === 0)
+            ) {
+                $parsed = \parse_url('http://'.$url);
+            }
+        }
+
+        if (\is_array($parsed) && isset($parsed['scheme']) && \strcasecmp($parsed['scheme'], 'http') === 0) {
+            if (isset($parsed['host'], $parsed['port'])) {
+                $user = $parsed['user'] ?? '';
+                $pass = $parsed['pass'] ?? '';
+                $auth = ($user !== '' || $pass !== '') ? 'Basic '.\base64_encode("{$user}:{$pass}") : null;
 
                 return [
                     'proxy' => "tcp://{$parsed['host']}:{$parsed['port']}",
-                    'auth' => $auth ? "Basic {$auth}" : null,
+                    'auth' => $auth,
                 ];
             }
         }

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1246,4 +1246,91 @@ class StreamHandlerTest extends TestCase
             ]
         )->wait();
     }
+
+    private function parseProxyResult($url)
+    {
+        $method = new \ReflectionMethod(StreamHandler::class, 'parse_proxy');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        return $method->invokeArgs(new StreamHandler(), [$url]);
+    }
+
+    public function proxyParseProvider()
+    {
+        return [
+            'scheme-less host' => [
+                'proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => null],
+            ],
+            'scheme-less credentials' => [
+                'user:pass@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:pass')],
+            ],
+            'scheme-less username only' => [
+                'user@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:')],
+            ],
+            'scheme-less empty password' => [
+                'user:@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:')],
+            ],
+            'scheme-less empty userinfo' => [
+                '@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => null],
+            ],
+            'scheme-less ipv6' => [
+                '[::1]:8125',
+                ['proxy' => 'tcp://[::1]:8125', 'auth' => null],
+            ],
+            'scheme-less ipv6 credentials' => [
+                'user:pass@[::1]:8125',
+                ['proxy' => 'tcp://[::1]:8125', 'auth' => 'Basic '.\base64_encode('user:pass')],
+            ],
+            'explicit http credentials' => [
+                'http://user:pass@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:pass')],
+            ],
+            'uppercase http scheme' => [
+                'HTTP://user:pass@proxy.example.com:8125',
+                ['proxy' => 'tcp://proxy.example.com:8125', 'auth' => 'Basic '.\base64_encode('user:pass')],
+            ],
+            'raw transport unchanged' => [
+                'ssl://proxy.example.com:8125',
+                ['proxy' => 'ssl://proxy.example.com:8125', 'auth' => null],
+            ],
+            'malformed socks-like unchanged' => [
+                'socks5:127.0.0.1:1080',
+                ['proxy' => 'socks5:127.0.0.1:1080', 'auth' => null],
+            ],
+            'malformed http-like unchanged' => [
+                'http:127.0.0.1:8125',
+                ['proxy' => 'http:127.0.0.1:8125', 'auth' => null],
+            ],
+            'protocol-relative unchanged' => [
+                '//proxy.example.com:8125',
+                ['proxy' => '//proxy.example.com:8125', 'auth' => null],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider proxyParseProvider
+     */
+    public function testTranslatesProxyForStreamContext($url, $expected)
+    {
+        self::assertSame($expected, $this->parseProxyResult($url));
+    }
+
+    public function testAddsProxyAuthorizationHeaderForSchemeLessCredentials()
+    {
+        $context = $this->getProxyContext('user:pass@proxy.example.com:8125');
+
+        self::assertSame('tcp://proxy.example.com:8125', $context['http']['proxy']);
+        self::assertStringContainsString(
+            'Proxy-Authorization: Basic '.\base64_encode('user:pass'),
+            $context['http']['header']
+        );
+    }
 }


### PR DESCRIPTION
PHP's HTTP stream wrapper expects the proxy to be a transport address such as `tcp://host:port` and requires any credentials to be supplied separately in a `Proxy-Authorization` header, but `StreamHandler::parse_proxy()` only performed that translation when the proxy URL carried an explicit `http://` scheme. A proxy configured without a scheme, such as `user:pass@proxy.example.com:8125`, was therefore passed through unchanged, and because `parse_url()` reads the leading `user` as the scheme the credentials were silently dropped and the malformed authority became an unusable proxy target. This change re-parses only the scheme-less authority forms that `parse_url()` actually misreads so that they are translated exactly like an explicit `http://` proxy, while values that merely look scheme-like such as `socks5:host:port` are left untouched rather than being reinterpreted as hosts. The scheme is matched case-insensitively and bracketed IPv6 literals are handled, and credentials are forwarded whenever a username or password is present, including the username-only case where the password is empty, since Basic authentication permits an empty password. Raw transport forms such as `tcp://`, `ssl://`, and `tls://` continue to pass through unchanged. The 8.0 counterpart is #3638.
