### PR TITLE
Reapply authenticated proxy tunnel reuse mitigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.13.0 - Upcoming
+
+### Changed
+
+- Prevent authenticated proxy tunnel reuse on libcurl versions older than 8.20.0
+
+
 ## 7.12.0 - Upcoming
 
 ### Added
@@ -12,7 +19,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Changed
 
 - Constrain cURL transport sharing to safe libcurl DNS and SSL session support
-- Prevent authenticated proxy tunnel reuse on libcurl versions older than 8.20.0
 - Resolve proxy environment variables in the cURL handlers; libcurl no longer reads the environment itself
 - Ignore proxy environment variables when the `proxy` request option makes a decision
 - Disable proxy environment variables on Windows SAPIs other than CLI (httpoxy hardening)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Changed
 
 - Constrain cURL transport sharing to safe libcurl DNS and SSL session support
+- Prevent authenticated proxy tunnel reuse on libcurl versions older than 8.20.0
 - Resolve proxy environment variables in the cURL handlers; libcurl no longer reads the environment itself
 - Ignore proxy environment variables when the `proxy` request option makes a decision
 - Disable proxy environment variables on Windows SAPIs other than CLI (httpoxy hardening)

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -956,6 +956,24 @@ Proxy decisions are made once per request, from the request's initial URI. If li
 
 Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps the uppercase `HTTP_PROXY` (CLI SAPI only), `HTTPS_PROXY`, and `NO_PROXY` environment variables into a default for the `proxy` request option. The client mapping reads `$_SERVER` first, so it does honor SAPI-provided values such as those set with `fastcgi_param` or `SetEnv`. See [Environment Variables](quickstart.md#environment-variables).
 
+> [!NOTE]
+> When sending HTTPS requests, or requests explicitly tunneled with
+> `CURLOPT_HTTPPROXYTUNNEL`, through an authenticated HTTP or HTTPS proxy,
+> libcurl versions before 8.19.0 could reuse an existing proxy tunnel even
+> after proxy credentials changed, and 8.19.0 still contains related proxy
+> credential leak flaws that were fixed in 8.20.0. Guzzle therefore avoids
+> tunnel reuse on libcurl versions older than 8.20.0 when the proxy URL is
+> configured through the `proxy` option or resolved from the environment,
+> including cURL proxy credential options supplied through the `curl` request
+> option. Raw `CURLOPT_PROXY` supplied through the `curl` request option is
+> deprecated but still honored, and receives the same protection. Custom proxy
+> authentication sent with `CURLOPT_PROXYHEADER` also avoids tunnel reuse
+> because libcurl does not include those header values in its connection
+> matching. Fixed libcurl versions keep normal connection reuse behavior for
+> proxy URL and cURL proxy credential options. Advanced users can still
+> control cURL connection reuse explicitly with the `curl` request option and
+> `CURLOPT_FRESH_CONNECT` or `CURLOPT_FORBID_REUSE`.
+
 ## query
 
 Summary

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -129,7 +129,9 @@ class CurlFactory implements CurlFactoryInterface
             $conf = \array_replace($conf, $options['curl']);
         }
 
-        $easy->effectiveProxy = self::getEffectiveProxy($conf);
+        self::forceFreshConnectionForAuthenticatedProxy($request, $conf);
+
+        $easy->effectiveProxy = self::getProxyForConnectionReuse($conf);
 
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
         if ($this->shareHandle !== null) {
@@ -706,7 +708,22 @@ class CurlFactory implements CurlFactoryInterface
     /**
      * @param array<int|string, mixed> $conf
      */
-    private static function getEffectiveProxy(array $conf): ?string
+    private static function forceFreshConnectionForAuthenticatedProxy(RequestInterface $request, array &$conf): void
+    {
+        $proxy = self::getProxyForConnectionReuse($conf);
+
+        if ($proxy === null || !self::requiresFreshConnectionForAuthenticatedProxy($request, $proxy, $conf)) {
+            return;
+        }
+
+        $conf[\CURLOPT_FRESH_CONNECT] = true;
+        $conf[\CURLOPT_FORBID_REUSE] = true;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function getProxyForConnectionReuse(array $conf): ?string
     {
         if (!\array_key_exists(\CURLOPT_PROXY, $conf)) {
             return null;
@@ -715,6 +732,145 @@ class CurlFactory implements CurlFactoryInterface
         $proxy = $conf[\CURLOPT_PROXY];
 
         return \is_string($proxy) && $proxy !== '' ? $proxy : null;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function requiresFreshConnectionForAuthenticatedProxy(RequestInterface $request, string $proxy, array $conf): bool
+    {
+        if (!self::usesProxyTunnel($request, $conf) || !self::isHttpProxyForConnectionReuse($proxy, $conf)) {
+            return false;
+        }
+
+        $proxyForParsing = \strpos($proxy, '://') === false ? 'http://'.$proxy : $proxy;
+        $proxyParts = \parse_url($proxyForParsing);
+
+        if (!\is_array($proxyParts)) {
+            return false;
+        }
+
+        if (self::hasCurlProxyAuthorizationHeader($conf)) {
+            return true;
+        }
+
+        return !CurlVersion::supportsProxyCredentialAwareConnectionReuse()
+            && (
+                \array_key_exists('user', $proxyParts)
+                || \array_key_exists('pass', $proxyParts)
+                || self::hasCurlProxyCredentials($conf)
+            );
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function usesProxyTunnel(RequestInterface $request, array $conf): bool
+    {
+        return 'https' === $request->getUri()->getScheme()
+            || (
+                \defined('CURLOPT_HTTPPROXYTUNNEL')
+                && \array_key_exists((int) \constant('CURLOPT_HTTPPROXYTUNNEL'), $conf)
+                && (bool) $conf[(int) \constant('CURLOPT_HTTPPROXYTUNNEL')]
+            );
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function isHttpProxyForConnectionReuse(string $proxy, array $conf): bool
+    {
+        if (\strpos($proxy, '://') !== false) {
+            $proxyParts = \parse_url($proxy);
+
+            if (!\is_array($proxyParts) || !isset($proxyParts['scheme'])) {
+                return false;
+            }
+
+            $proxyScheme = \strtolower($proxyParts['scheme']);
+
+            return $proxyScheme === 'http' || $proxyScheme === 'https';
+        }
+
+        return !self::isSocksProxyType($conf[\CURLOPT_PROXYTYPE] ?? null);
+    }
+
+    /**
+     * @param mixed $proxyType
+     */
+    private static function isSocksProxyType($proxyType): bool
+    {
+        if (!\is_int($proxyType)) {
+            return false;
+        }
+
+        foreach ([
+            'CURLPROXY_SOCKS4' => 4,
+            'CURLPROXY_SOCKS5' => 5,
+            'CURLPROXY_SOCKS4A' => 6,
+            'CURLPROXY_SOCKS5_HOSTNAME' => 7,
+        ] as $name => $fallback) {
+            $value = \defined($name) ? (int) \constant($name) : $fallback;
+            if ($proxyType === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlProxyCredentials(array $conf): bool
+    {
+        foreach (['CURLOPT_PROXYUSERPWD', 'CURLOPT_PROXYUSERNAME', 'CURLOPT_PROXYPASSWORD'] as $option) {
+            if (\defined($option) && \array_key_exists((int) \constant($option), $conf)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlProxyAuthorizationHeader(array $conf): bool
+    {
+        if (!\defined('CURLOPT_PROXYHEADER')) {
+            return false;
+        }
+
+        $option = (int) \constant('CURLOPT_PROXYHEADER');
+        if (!\array_key_exists($option, $conf)) {
+            return false;
+        }
+
+        $headers = $conf[$option];
+        if (!\is_array($headers)) {
+            return false;
+        }
+
+        foreach ($headers as $header) {
+            if (!\is_string($header)) {
+                continue;
+            }
+
+            $parts = \explode(':', $header, 2);
+            if (\count($parts) !== 2) {
+                continue;
+            }
+
+            if (
+                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
+                && \trim($parts[1]) !== ''
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -131,7 +131,7 @@ class CurlFactory implements CurlFactoryInterface
 
         self::forceFreshConnectionForAuthenticatedProxy($request, $conf);
 
-        $easy->effectiveProxy = self::getProxyForConnectionReuse($conf);
+        $easy->effectiveProxy = self::getEffectiveProxy($conf);
 
         $conf[\CURLOPT_HEADERFUNCTION] = $this->createHeaderFn($easy);
         if ($this->shareHandle !== null) {
@@ -710,7 +710,7 @@ class CurlFactory implements CurlFactoryInterface
      */
     private static function forceFreshConnectionForAuthenticatedProxy(RequestInterface $request, array &$conf): void
     {
-        $proxy = self::getProxyForConnectionReuse($conf);
+        $proxy = self::getEffectiveProxy($conf);
 
         if ($proxy === null || !self::requiresFreshConnectionForAuthenticatedProxy($request, $proxy, $conf)) {
             return;
@@ -723,7 +723,7 @@ class CurlFactory implements CurlFactoryInterface
     /**
      * @param array<int|string, mixed> $conf
      */
-    private static function getProxyForConnectionReuse(array $conf): ?string
+    private static function getEffectiveProxy(array $conf): ?string
     {
         if (!\array_key_exists(\CURLOPT_PROXY, $conf)) {
             return null;

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -17,6 +17,11 @@ final class CurlVersion
 
     private const SSL_SESSION_SHARING_VERSION = '8.6.0';
 
+    // curl 8.19.0 fixed proxy tunnel reuse after credential changes
+    // (CVE-2026-3784), but related proxy credential leak flaws were only
+    // fixed in 8.20.0, so connection reuse is trusted from 8.20.0 onwards.
+    private const PROXY_CREDENTIAL_REUSE_VERSION = '8.20.0';
+
     /**
      * @var array{version: string, features: int}|false|null
      */
@@ -97,6 +102,14 @@ final class CurlVersion
                 self::SSL_SESSION_SHARING_VERSION
             ));
         }
+    }
+
+    public static function supportsProxyCredentialAwareConnectionReuse(): bool
+    {
+        $version = self::getVersion();
+
+        return $version !== null
+            && \version_compare($version, self::PROXY_CREDENTIAL_REUSE_VERSION, '>=');
     }
 
     private static function supportsSsl(): bool

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -635,6 +635,25 @@ class CurlFactoryTest extends TestCase
         });
     }
 
+    public function testForcesFreshConnectionForEnvironmentCredentialedProxyOnAffectedCurlVersion(): void
+    {
+        self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
+            self::createWithCurlVersion('8.19.0', 'https://example.com', []);
+
+            self::assertAuthenticatedProxyConnectionReuseOptions();
+        });
+    }
+
+    public function testDoesNotForceFreshConnectionForEnvironmentCredentialedProxyOnFixedCurlVersion(): void
+    {
+        self::withProxyEnvironment(['https_proxy' => 'http://username:password@proxy.example.com:8080'], static function (): void {
+            self::createWithCurlVersion('8.20.0', 'https://example.com', []);
+
+            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        });
+    }
+
     public function testRedactsProxyCredentialsInCurlErrorMessages(): void
     {
         $handler = new Handler\CurlHandler();
@@ -716,6 +735,182 @@ class CurlFactoryTest extends TestCase
         $error = 'Failed to connect to proxy.example.com:8125';
 
         self::assertSame($error, self::redactProxyUserInfo($error, 'http://proxy.example.com:8125'));
+    }
+
+    public function testForcesFreshConnectionForAuthenticatedHttpsProxyOnAffectedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedHttpsProxyOnFixedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testForcesFreshConnectionForCurlProxyCredentialsOnAffectedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_PROXYUSERPWD => 'username:password',
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testDoesNotForceFreshConnectionForCurlProxyCredentialsOnFixedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_PROXYUSERPWD => 'username:password',
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForUnauthenticatedHttpsProxy(): void
+    {
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionWhenNoProxyMatches(): void
+    {
+        self::createWithCurlVersion('8.18.0', 'https://example.com', [
+            'proxy' => [
+                'https' => 'http://username:password@proxy.example.com:8080',
+                'no' => ['example.com'],
+            ],
+        ]);
+
+        self::assertSame('', $_SERVER['_curl'][\CURLOPT_PROXY]);
+        self::assertNoProxyOption('*');
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testAuthenticatedHttpsProxyReuseOptionsCanBeSetOnFixedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_FRESH_CONNECT => false,
+                \CURLOPT_FORBID_REUSE => false,
+            ],
+        ]);
+
+        self::assertFalse($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertFalse($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testForcesFreshConnectionForAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
+    {
+        if (!\defined('CURLOPT_HTTPPROXYTUNNEL')) {
+            self::markTestSkipped('CURLOPT_HTTPPROXYTUNNEL is not available.');
+        }
+
+        self::createWithCurlVersion('8.19.0', 'http://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_HTTPPROXYTUNNEL => true,
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testForcesFreshConnectionForProxyAuthorizationProxyHeaderOnFixedCurlVersion(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
+    }
+
+    public function testDoesNotForceFreshConnectionForUnrelatedProxyHeader(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['X-Proxy-Header: value'],
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForEmptyProxyAuthorizationProxyHeader(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['Proxy-Authorization:'],
+            ],
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedHttpProxyRequest(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'http://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testDoesNotForceFreshConnectionForAuthenticatedSocksProxy(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'socks5://username:password@proxy.example.com:1080',
+        ]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testAuthenticatedHttpsProxyReuseOptionsCannotBeOverriddenOnAffectedCurlVersion(): void
+    {
+        self::createWithCurlVersion('8.19.0', 'https://example.com', [
+            'proxy' => 'http://username:password@proxy.example.com:8080',
+            'curl' => [
+                \CURLOPT_FRESH_CONNECT => false,
+                \CURLOPT_FORBID_REUSE => false,
+            ],
+        ]);
+
+        self::assertAuthenticatedProxyConnectionReuseOptions();
     }
 
     private function checkNoProxyForHost($url, $noProxy, $assertUseProxy)
@@ -1766,6 +1961,12 @@ class CurlFactoryTest extends TestCase
         return $readHandles($factory);
     }
 
+    private static function assertAuthenticatedProxyConnectionReuseOptions(): void
+    {
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
     private static function assertNoProxyOption(string $expected): void
     {
         if (!\defined('CURLOPT_NOPROXY')) {
@@ -1812,6 +2013,33 @@ class CurlFactoryTest extends TestCase
                 }
             }
         }
+    }
+
+    /**
+     * @param array<int|string, mixed> $options
+     */
+    private static function createWithCurlVersion(string $version, string $uri, array $options): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => 0,
+        ]);
+
+        try {
+            $f = new CurlFactory(3);
+            $f->create(new Psr7\Request('GET', $uri), $options);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    private static function proxyHeaderOption(): int
+    {
+        if (!\defined('CURLOPT_PROXYHEADER')) {
+            self::markTestSkipped('CURLOPT_PROXYHEADER is not available.');
+        }
+
+        return (int) \constant('CURLOPT_PROXYHEADER');
     }
 
     private static function redactProxyUserInfo(string $error, ?string $proxy): string

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -126,6 +126,20 @@ class CurlVersionTest extends TestCase
         }
     }
 
+    public function testSupportsProxyCredentialAwareConnectionReuseUsesSafeVersion(): void
+    {
+        $previous = self::setCurlVersionInfo(['version' => '8.19.0', 'features' => 0]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsProxyCredentialAwareConnectionReuse());
+
+            self::setCurlVersionInfo(['version' => '8.20.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsProxyCredentialAwareConnectionReuse());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
     public function testGetVersionReturnsNullWhenVersionIsUnavailable(): void
     {
         $previous = self::setCurlVersionInfo(false);


### PR DESCRIPTION
This is not the final form. There will be a follow-up PR to make this smarter. When we are making sequential requests using the same proxy and auth, we don't need to force curl to nuke the connection. This current PR is not wrong, but it is more heavy handed than necessary.