### PR TITLE
Normalize scalar body request options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated `Utils::describeType()`
 - Deprecated non-finite floats in the `query` and `form_params` options; 8.0 rejects them
 - Deprecated non-string scalar values in the `body` option; 8.0 rejects them
+- Deprecated non-finite floats in the `multipart` option; 8.0 rejects them
 
 ### Fixed
 
@@ -35,7 +36,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Fix proxy `no` list matches being re-proxied through environment-configured proxies by libcurl
 - Fix `no` list and `NO_PROXY` matching to support IP CIDR ranges, matching libcurl
 - Fix the stream handler not applying scheme-less proxies and their credentials
-- Prevent accepted request option values from triggering equivalent PSR-7 2.12 deprecations inside Guzzle
 
 
 ## 7.11.2 - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Fix proxy `no` list matches being re-proxied through environment-configured proxies by libcurl
 - Fix `no` list and `NO_PROXY` matching to support IP CIDR ranges, matching libcurl
 - Fix the stream handler not applying scheme-less proxies and their credentials
+- Prevent accepted request option values from triggering equivalent PSR-7 2.12 deprecations inside Guzzle
 
 
 ## 7.11.2 - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated PHP stream context options outside the built-in stream handler allow-list
 - Deprecated passing `ntlm` as a built-in `auth` type
 - Deprecated `Utils::describeType()`
-- Deprecated non-finite floats in the `query` and `form_params` options; 8.0 rejects them
-- Deprecated non-finite floats in the `multipart` option; 8.0 rejects them
+- Deprecated non-finite floats in the `query`, `form_params`, and `multipart` options; 8.0 rejects them
 - Deprecated non-string scalar values in the `body` option; 8.0 rejects them
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated PHP stream context options outside the built-in stream handler allow-list
 - Deprecated passing `ntlm` as a built-in `auth` type
 - Deprecated `Utils::describeType()`
-- Deprecated non-finite floats in the `query`, `form_params`, and `multipart` options; 8.0 rejects them
+- Deprecated non-finite floats in the `query` and `form_params` options; 8.0 rejects them
 - Deprecated non-string scalar values in the `body` option; 8.0 rejects them
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Deprecated passing `ntlm` as a built-in `auth` type
 - Deprecated `Utils::describeType()`
 - Deprecated non-finite floats in the `query` and `form_params` options; 8.0 rejects them
-- Deprecated non-string scalar values in the `body` option; 8.0 rejects them
 - Deprecated non-finite floats in the `multipart` option; 8.0 rejects them
+- Deprecated non-string scalar values in the `body` option; 8.0 rejects them
 
 ### Fixed
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1054,7 +1054,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         throw new InvalidArgumentException(\sprintf(
-            'Passing %s to request option "body" is invalid; expected resource|string|null|StreamInterface|callable&object|Iterator|Stringable.',
+            'Passing %s to request option "body" is invalid; expected resource|string|null|int|float|bool|StreamInterface|callable&object|Iterator|Stringable.',
             \get_debug_type($body)
         ));
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -192,6 +192,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         if (\is_array($body)) {
             throw $this->invalidBody();
         }
+        $body = self::normalizeBodyOption($body);
         $request = new Psr7\Request($method, $uri, $headers, $body, $version);
         // Remove the option so that they are not doubly-applied.
         unset($options['headers'], $options['body'], $options['version']);
@@ -864,7 +865,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         if (isset($options['multipart'])) {
-            $options['body'] = new Psr7\MultipartStream($options['multipart']);
+            $options['body'] = new Psr7\MultipartStream(self::normalizeMultipartContents($options['multipart']));
             unset($options['multipart']);
         }
 
@@ -888,17 +889,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($options['body'])) {
                 throw $this->invalidBody();
             }
-            $body = $options['body'];
-            if (!\is_string($body) && \is_scalar($body)) {
-                \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-string scalar to the "body" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-string scalar bodies.');
-
-                // Normalize non-finite floats to dodge PHP 8.5's (string) NAN
-                // coercion warning while the value is still accepted.
-                if (\is_float($body) && !\is_finite($body)) {
-                    $body = \is_nan($body) ? 'NAN' : ($body > 0 ? 'INF' : '-INF');
-                }
-                $body = (string) $body;
-            }
+            $body = self::normalizeBodyOption($options['body']);
             $modify['body'] = Psr7\Utils::streamFor($body);
             unset($options['body']);
         }
@@ -1025,6 +1016,73 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
     }
 
     /**
+     * @param mixed $body
+     *
+     * @return mixed
+     */
+    private static function normalizeBodyOption($body)
+    {
+        if (!\is_string($body) && \is_scalar($body)) {
+            \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-string scalar to the "body" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-string scalar bodies.');
+
+            return self::stringifyScalar($body);
+        }
+
+        return $body;
+    }
+
+    private static function stringifyScalar($value): string
+    {
+        // Normalize non-finite floats to dodge PHP 8.5's (string) NAN
+        // coercion warning while the value is still accepted.
+        if (\is_float($value) && !\is_finite($value)) {
+            $value = \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+        }
+
+        return (string) $value;
+    }
+
+    private static function normalizeMultipartContents(array $parts): array
+    {
+        foreach ($parts as $index => $part) {
+            if (!\is_array($part) || !\array_key_exists('contents', $part)) {
+                continue;
+            }
+
+            $part['contents'] = self::normalizeMultipartContent($part['contents']);
+            $parts[$index] = $part;
+        }
+
+        return $parts;
+    }
+
+    /**
+     * @param mixed $contents
+     *
+     * @return mixed
+     */
+    private static function normalizeMultipartContent($contents)
+    {
+        if (\is_array($contents)) {
+            foreach ($contents as $key => $value) {
+                $contents[$key] = self::normalizeMultipartContent($value);
+            }
+
+            return $contents;
+        }
+
+        if (\is_float($contents) && !\is_finite($contents)) {
+            return self::normalizeNonFiniteFloat($contents, 'multipart');
+        }
+
+        if (!\is_string($contents) && \is_scalar($contents)) {
+            return (string) $contents;
+        }
+
+        return $contents;
+    }
+
+    /**
      * Converts non-finite floats in the array to the strings PHP coerces
      * them to, as implicit coercion of NAN emits a warning on PHP 8.5.
      */
@@ -1034,13 +1092,18 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($value)) {
                 $values[$key] = self::normalizeNonFiniteFloats($value, $option);
             } elseif (\is_float($value) && !\is_finite($value)) {
-                \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-finite float in the "%s" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-finite floats.', $option);
-
-                $values[$key] = \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+                $values[$key] = self::normalizeNonFiniteFloat($value, $option);
             }
         }
 
         return $values;
+    }
+
+    private static function normalizeNonFiniteFloat(float $value, string $option): string
+    {
+        \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-finite float in the "%s" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-finite floats.', $option);
+
+        return \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -192,7 +192,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         if (\is_array($body)) {
             throw $this->invalidBody();
         }
-        $body = self::normalizeBodyOption($body);
+        $body = self::createBodyStream($body);
         $request = new Psr7\Request($method, $uri, $headers, $body, $version);
         // Remove the option so that they are not doubly-applied.
         unset($options['headers'], $options['body'], $options['version']);
@@ -889,8 +889,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($options['body'])) {
                 throw $this->invalidBody();
             }
-            $body = self::normalizeBodyOption($options['body']);
-            $modify['body'] = Psr7\Utils::streamFor($body);
+            $modify['body'] = self::createBodyStream($options['body']);
             unset($options['body']);
         }
 
@@ -1017,20 +1016,52 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
     /**
      * @param mixed $body
-     *
-     * @return mixed
      */
-    private static function normalizeBodyOption($body)
+    private static function createBodyStream($body): StreamInterface
     {
-        if (!\is_string($body) && \is_scalar($body)) {
-            \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-string scalar to the "body" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-string scalar bodies.');
-
-            return self::stringifyScalar($body);
+        if ($body instanceof StreamInterface) {
+            return $body;
         }
 
-        return $body;
+        if (\is_resource($body)) {
+            return Psr7\Utils::streamFor($body);
+        }
+
+        if ($body === null) {
+            return Psr7\Utils::streamFor();
+        }
+
+        if (\is_string($body)) {
+            return Psr7\Utils::streamFor($body);
+        }
+
+        if (\is_scalar($body)) {
+            \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-string scalar to the "body" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-string scalar bodies.');
+
+            return Psr7\Utils::streamFor(self::stringifyScalar($body));
+        }
+
+        if ($body instanceof \Iterator) {
+            return Psr7\Utils::streamFor($body);
+        }
+
+        if (\is_object($body) && \method_exists($body, '__toString')) {
+            return Psr7\Utils::streamFor((string) $body);
+        }
+
+        if (\is_callable($body)) {
+            return Psr7\Utils::streamFor($body);
+        }
+
+        throw new InvalidArgumentException(\sprintf(
+            'Passing %s to request option "body" is invalid; expected resource|string|null|StreamInterface|callable&object|Iterator|Stringable.',
+            \get_debug_type($body)
+        ));
     }
 
+    /**
+     * @param bool|float|int|string $value
+     */
     private static function stringifyScalar($value): string
     {
         // Normalize non-finite floats to dodge PHP 8.5's (string) NAN

--- a/src/Client.php
+++ b/src/Client.php
@@ -1082,6 +1082,13 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         return $contents;
     }
 
+    private static function normalizeNonFiniteFloat(float $value, string $option): string
+    {
+        \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-finite float in the "%s" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-finite floats.', $option);
+
+        return \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+    }
+
     /**
      * Converts non-finite floats in the array to the strings PHP coerces
      * them to, as implicit coercion of NAN emits a warning on PHP 8.5.
@@ -1097,13 +1104,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         return $values;
-    }
-
-    private static function normalizeNonFiniteFloat(float $value, string $option): string
-    {
-        \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-finite float in the "%s" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-finite floats.', $option);
-
-        return \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -1023,7 +1023,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             return $body;
         }
 
-        if (\is_resource($body) || $body === null || \is_string($body)) {
+        if (\is_resource($body) || $body === null || \is_string($body) || $body instanceof \Iterator) {
             return Psr7\Utils::streamFor($body);
         }
 
@@ -1031,10 +1031,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-string scalar to the "body" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-string scalar bodies.');
 
             return Psr7\Utils::streamFor(self::stringifyScalar($body));
-        }
-
-        if ($body instanceof \Iterator) {
-            return Psr7\Utils::streamFor($body);
         }
 
         if (\is_object($body) && \method_exists($body, '__toString')) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -1023,15 +1023,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             return $body;
         }
 
-        if (\is_resource($body)) {
-            return Psr7\Utils::streamFor($body);
-        }
-
-        if ($body === null) {
-            return Psr7\Utils::streamFor();
-        }
-
-        if (\is_string($body)) {
+        if (\is_resource($body) || $body === null || \is_string($body)) {
             return Psr7\Utils::streamFor($body);
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -865,7 +865,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
 
         if (isset($options['multipart'])) {
-            $options['body'] = new Psr7\MultipartStream(self::normalizeMultipartContents($options['multipart']));
+            $options['body'] = new Psr7\MultipartStream($options['multipart']);
             unset($options['multipart']);
         }
 
@@ -1061,53 +1061,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         return (string) $value;
     }
 
-    private static function normalizeMultipartContents(array $parts): array
-    {
-        foreach ($parts as $index => $part) {
-            if (!\is_array($part) || !\array_key_exists('contents', $part)) {
-                continue;
-            }
-
-            $part['contents'] = self::normalizeMultipartContent($part['contents']);
-            $parts[$index] = $part;
-        }
-
-        return $parts;
-    }
-
-    /**
-     * @param mixed $contents
-     *
-     * @return mixed
-     */
-    private static function normalizeMultipartContent($contents)
-    {
-        if (\is_array($contents)) {
-            foreach ($contents as $key => $value) {
-                $contents[$key] = self::normalizeMultipartContent($value);
-            }
-
-            return $contents;
-        }
-
-        if (\is_float($contents) && !\is_finite($contents)) {
-            return self::normalizeNonFiniteFloat($contents, 'multipart');
-        }
-
-        if (!\is_string($contents) && \is_scalar($contents)) {
-            return (string) $contents;
-        }
-
-        return $contents;
-    }
-
-    private static function normalizeNonFiniteFloat(float $value, string $option): string
-    {
-        \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-finite float in the "%s" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-finite floats.', $option);
-
-        return \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
-    }
-
     /**
      * Converts non-finite floats in the array to the strings PHP coerces
      * them to, as implicit coercion of NAN emits a warning on PHP 8.5.
@@ -1118,7 +1071,9 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\is_array($value)) {
                 $values[$key] = self::normalizeNonFiniteFloats($value, $option);
             } elseif (\is_float($value) && !\is_finite($value)) {
-                $values[$key] = self::normalizeNonFiniteFloat($value, $option);
+                \trigger_deprecation('guzzlehttp/guzzle', '7.12', 'Passing a non-finite float in the "%s" request option is deprecated; guzzlehttp/guzzle 8.0 will reject non-finite floats.', $option);
+
+                $values[$key] = \is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
             }
         }
 


### PR DESCRIPTION
This routes body request option values through a Guzzle-owned body stream conversion path so non-string scalar body values are deprecated and cast before PSR-7 sees them.