### PR TITLE
Reject multipart non-finite floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Pass the request as the second argument to `on_headers` callbacks
 - Declare strict types across remaining source files
 - Reject invalid `idn_conversion`, `retries`, and built-in handler `on_stats` option values before use
-- Reject non-finite floats in the `query` and `form_params` options
+- Reject non-finite floats in the `query`, `form_params`, and `multipart` options
 - Reject non-string scalar values in the `body` option
 - Reject invalid `SetCookie` constructor field types instead of coercing them
 - Reject malformed, conflicting, or unrepresentable request `Content-Length` values in built-in handlers

--- a/src/Client.php
+++ b/src/Client.php
@@ -1050,6 +1050,8 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
 
             if (!\array_key_exists('contents', $part)) {
                 self::invalidRequestOptionType($path, 'array{name: string|int, contents: mixed, headers?: array<array-key, string>, filename?: string}', $part);
+            } else {
+                self::assertMultipartContentsFinite($part['contents'], $path.'.contents');
             }
 
             if (\array_key_exists('headers', $part)) {
@@ -1069,6 +1071,27 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             if (\array_key_exists('filename', $part) && !\is_string($part['filename'])) {
                 self::invalidRequestOptionType($path.'.filename', 'string', $part['filename']);
             }
+        }
+    }
+
+    /**
+     * @param mixed $contents
+     */
+    private static function assertMultipartContentsFinite($contents, string $path): void
+    {
+        if (\is_array($contents)) {
+            foreach ($contents as $key => $value) {
+                self::assertMultipartContentsFinite($value, $path.'.'.(string) $key);
+            }
+
+            return;
+        }
+
+        if (\is_float($contents) && !\is_finite($contents)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Passing a non-finite float to request option "%s" is invalid; non-finite floats are not supported.',
+                $path
+            ));
         }
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1936,6 +1936,34 @@ class ClientTest extends TestCase
         $client->get('http://foo.com', ['query' => ['score' => $value]]);
     }
 
+    /**
+     * @dataProvider nonFiniteFloatProvider
+     */
+    public function testMultipartRejectsNonFiniteFloatContents(float $value): void
+    {
+        $client = new Client(['handler' => new MockHandler([new Response()])]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Passing a non-finite float to request option "multipart.0.contents" is invalid; non-finite floats are not supported.');
+        $client->post('http://foo.com', [
+            'multipart' => [['name' => 'score', 'contents' => $value]],
+        ]);
+    }
+
+    /**
+     * @dataProvider nonFiniteFloatProvider
+     */
+    public function testMultipartRejectsNestedNonFiniteFloatContents(float $value): void
+    {
+        $client = new Client(['handler' => new MockHandler([new Response()])]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Passing a non-finite float to request option "multipart.0.contents.score" is invalid; non-finite floats are not supported.');
+        $client->post('http://foo.com', [
+            'multipart' => [['name' => 'data', 'contents' => ['score' => $value]]],
+        ]);
+    }
+
     public static function nonFiniteFloatProvider(): array
     {
         return [


### PR DESCRIPTION
This rejects non-finite float multipart contents before creating multipart request bodies. It extends the existing non-finite float request option enforcement to the multipart option.