### PR TITLE
Snapshot and restore the proxy environment in the Client env test

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -846,10 +846,18 @@ class ClientTest extends TestCase
 
     public function testUsesProxyEnvironmentVariables()
     {
-        unset($_SERVER['HTTP_PROXY'], $_SERVER['HTTPS_PROXY'], $_SERVER['NO_PROXY']);
-        \putenv('HTTP_PROXY=');
-        \putenv('HTTPS_PROXY=');
-        \putenv('NO_PROXY=');
+        // Snapshot the proxy environment so the assertions below run against a
+        // known-empty state and the original values are restored afterwards,
+        // rather than clobbering an inherited proxy env for later tests.
+        $names = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
+        $previousEnv = [];
+        $previousServer = [];
+        foreach ($names as $name) {
+            $previousEnv[$name] = \getenv($name, true);
+            $previousServer[$name] = $_SERVER[$name] ?? null;
+            unset($_SERVER[$name]);
+            \putenv($name);
+        }
 
         try {
             $client = new Client();
@@ -872,9 +880,19 @@ class ClientTest extends TestCase
                 $config['proxy']
             );
         } finally {
-            \putenv('HTTP_PROXY=');
-            \putenv('HTTPS_PROXY=');
-            \putenv('NO_PROXY=');
+            foreach ($names as $name) {
+                if (false === $previousEnv[$name]) {
+                    \putenv($name);
+                } else {
+                    \putenv($name.'='.$previousEnv[$name]);
+                }
+
+                if (null === $previousServer[$name]) {
+                    unset($_SERVER[$name]);
+                } else {
+                    $_SERVER[$name] = $previousServer[$name];
+                }
+            }
         }
     }
 


### PR DESCRIPTION
`testUsesProxyEnvironmentVariables` sets `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` via `putenv` and unsets their `$_SERVER` entries, but its cleanup only reset them to empty strings rather than restoring whatever values the process inherited. Any test running later in the same process then saw an empty proxy environment instead of the real one, and an inherited proxy configuration was silently clobbered. This snapshots each variable's `getenv` value and `$_SERVER` entry before the assertions and restores them exactly in the `finally`, so the test no longer leaks proxy state into the rest of the suite. The equivalent change for 8.0 is #3650.