### PR TITLE
Preserve QUERY method and body across redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.12.4 - Upcoming
+
+### Fixed
+
+- Preserve the `QUERY` method and request body when following a non-strict 301/302 redirect (RFC 10008)
+
+
 ## 7.12.3 - 2026-06-23
 
 ### Changed

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -169,11 +169,19 @@ class RedirectMiddleware
         if ($statusCode == 303
             || ($statusCode <= 302 && !$options['allow_redirects']['strict'])
         ) {
-            $safeMethods = ['GET', 'HEAD', 'OPTIONS'];
             $requestMethod = $request->getMethod();
 
-            $modify['method'] = in_array($requestMethod, $safeMethods) ? $requestMethod : 'GET';
-            $modify['body'] = '';
+            // RFC 10008 defines QUERY as a safe, idempotent method that carries
+            // a request body, so a non-strict 301/302 redirect keeps both the
+            // method and the body instead of downgrading to GET like the other
+            // body-enclosing methods. A 303 still resolves to a body-less GET,
+            // per RFC 10008 section 2.4.
+            if ($requestMethod !== 'QUERY' || $statusCode == 303) {
+                $safeMethods = ['GET', 'HEAD', 'OPTIONS'];
+
+                $modify['method'] = in_array($requestMethod, $safeMethods) ? $requestMethod : 'GET';
+                $modify['body'] = '';
+            }
         }
 
         $uri = self::redirectUri($request, $response, $protocols);

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -524,6 +524,54 @@ class RedirectMiddlewareTest extends TestCase
         self::assertEquals(0, $modifiedRequest->getBody()->getSize());
     }
 
+    public function testPreservesQueryMethodAndBodyOnNonStrictRedirect()
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [], 'a=b');
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('QUERY', $mock->getLastRequest()->getMethod());
+        self::assertSame('a=b', (string) $mock->getLastRequest()->getBody());
+    }
+
+    public function testDowngradesQueryToBodilessGetOnSeeOther()
+    {
+        $mock = new MockHandler([
+            new Response(303, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [], 'a=b');
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('GET', $mock->getLastRequest()->getMethod());
+        self::assertSame('', (string) $mock->getLastRequest()->getBody());
+    }
+
+    public function testDowngradesPostToBodilessGetOnNonStrictRedirect()
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('POST', 'http://example.com', [], 'a=b');
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('GET', $mock->getLastRequest()->getMethod());
+        self::assertSame('', (string) $mock->getLastRequest()->getBody());
+    }
+
     /**
      * @return array
      */


### PR DESCRIPTION
RFC 10008 standardizes the HTTP `QUERY` method: safe, idempotent, and carrying a request body. `RedirectMiddleware::modifyRequest()` only preserved the method for `GET`/`HEAD`/`OPTIONS` and emptied the body unconditionally inside the redirect branch, so a `QUERY` that followed a 303 or a 301/302 in the default non-strict mode was silently downgraded to a body-less `GET`.

This treats `QUERY` like the other safe methods on a non-strict 301/302 redirect, keeping both the method and the body. The behavior of every other method is unchanged (verified for `GET`/`HEAD`/`OPTIONS`/`POST` on 301/302/303, and for strict mode and 307/308).

Fixes #3699.

### Open design question — 303 handling

This PR makes a `QUERY` follow a **303 See Other** as a body-less `GET`, matching HTTP 303 semantics and RFC 10008 section 2.4 (fetch the advertised `Location` with `GET`). This is the one point still under discussion in #3699 — a maintainer should confirm or override it. Preserving `QUERY` on 303 instead would be a one-line change (drop the `|| $statusCode == 303` guard).

### Target branch

I asked in #3699 which branch this should target; opened here against `7.12` (the current default) and happy to rebase onto whatever you prefer.
