### PR TITLE
Support QUERY redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Added
 
 - Added the `crypto_method_max` request option to cap the maximum TLS protocol version
+- Added HTTP QUERY redirect support, preserving method and body on 301 and 302
 
 ### Changed
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -436,7 +436,7 @@ Guzzle will automatically follow redirects unless you tell it not to. You can cu
 
 - Set to `true` to enable normal redirects with a maximum number of 5 redirects. This is the default setting.
 - Set to `false` to disable redirects.
-- Pass an associative array containing the 'max' key to specify the maximum number of redirects and optionally provide a 'strict' key value to specify whether or not to use strict RFC compliant redirects (meaning redirect POST requests with POST requests vs. doing what most browsers do which is redirect POST requests with GET requests).
+- Pass an associative array containing the 'max' key to specify the maximum number of redirects and optionally provide a 'strict' key value to specify whether or not to use strict RFC compliant redirects (meaning redirect POST requests with POST requests vs. doing what most browsers do which is redirect POST requests with GET requests). The QUERY method keeps its method and body across non-strict 301 and 302 redirects, and a 303 redirect is followed with GET.
 
 See the [`allow_redirects` option](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -52,7 +52,7 @@ You can also pass an associative array containing the following key value pairs:
 
 - max: (int, default=5) maximum number of allowed redirects.
 
-- strict: (bool, default=false) Set to true to use strict redirects. Strict RFC compliant redirects mean that POST redirect requests are sent as POST requests vs. doing what most browsers do which is redirect POST requests with GET requests.
+- strict: (bool, default=false) Set to true to use strict redirects. Strict RFC compliant redirects mean that POST redirect requests are sent as POST requests vs. doing what most browsers do which is redirect POST requests with GET requests. The RFC 10008 QUERY method keeps its method and body across non-strict 301 and 302 redirects, matching the 307 and 308 behavior that already applies to every method, and a 303 redirect is followed with a body-less GET.
 
 - referer: (bool, default=false) Set to true to enable adding the Referer header when redirecting.
 
@@ -114,6 +114,9 @@ On cross-origin redirects, Guzzle removes the `Authorization` and `Cookie` heade
 Guzzle does not automatically remove other request options or headers solely because the redirect is cross-origin. This matches curl's redirect model. In particular, TLS client authentication options such as `cert`, `ssl_key`, custom cURL TLS options, and stream context TLS options are not removed automatically on cross-origin redirects.
 
 If TLS client credentials are only trusted for the original origin, disable automatic redirects and handle redirect responses manually, or use separate clients and request options for trusted origins.
+
+> [!NOTE]
+> QUERY request bodies can carry sensitive query content. On cross-origin redirects Guzzle removes origin credentials such as the Authorization and Cookie headers, but it does not remove the request body. Disable automatic redirects or use on_redirect if a QUERY body must not be sent to another origin.
 
 ## auth
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -169,11 +169,12 @@ class RedirectMiddleware
         if ($statusCode == 303
             || ($statusCode <= 302 && !$options['allow_redirects']['strict'])
         ) {
-            $safeMethods = ['GET', 'HEAD', 'OPTIONS'];
             $requestMethod = $request->getMethod();
 
-            $modify['method'] = in_array($requestMethod, $safeMethods) ? $requestMethod : 'GET';
-            $modify['body'] = '';
+            if ($requestMethod !== 'QUERY' || !\in_array($statusCode, [301, 302], true)) {
+                $modify['method'] = \in_array($requestMethod, ['GET', 'HEAD', 'OPTIONS'], true) ? $requestMethod : 'GET';
+                $modify['body'] = '';
+            }
         }
 
         $uri = self::redirectUri($request, $response, $protocols);

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -20,7 +20,9 @@ final class RequestOptions
      * - max: (int, default=5) maximum number of allowed redirects.
      * - strict: (bool, default=false) Set to true to use strict redirects
      *   meaning redirect POST requests with POST requests vs. doing what most
-     *   browsers do which is redirect POST requests with GET requests
+     *   browsers do which is redirect POST requests with GET requests. The
+     *   QUERY method keeps its method and body across non-strict 301 and 302
+     *   redirects, and a 303 redirect is followed with a body-less GET.
      * - referer: (bool, default=false) Set to true to enable the Referer
      *   header.
      * - protocols: (non-empty-array<array-key, string>, default=['http', 'https'])

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -496,6 +496,177 @@ class RedirectMiddlewareTest extends TestCase
     }
 
     /**
+     * @dataProvider queryRedirectStatusProvider
+     */
+    public function testPreservesQueryMethodAndBodyOnRedirect($statusCode)
+    {
+        $mock = new MockHandler([
+            new Response($statusCode, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [
+            'Content-Type' => 'application/json',
+        ], '{"q":"foo"}');
+
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('QUERY', $lastRequest->getMethod());
+        self::assertSame('http://example.com/foo', (string) $lastRequest->getUri());
+        self::assertSame('{"q":"foo"}', (string) $lastRequest->getBody());
+        self::assertSame('application/json', $lastRequest->getHeaderLine('Content-Type'));
+    }
+
+    public static function queryRedirectStatusProvider()
+    {
+        return [
+            '301' => [301],
+            '302' => [302],
+            '307' => [307],
+            '308' => [308],
+        ];
+    }
+
+    /**
+     * @dataProvider queryMovedRedirectStatusProvider
+     */
+    public function testPreservesQueryMethodAndBodyOnStrictRedirect($statusCode)
+    {
+        $mock = new MockHandler([
+            new Response($statusCode, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [], 'a=b');
+
+        $response = $handler($request, [
+            'allow_redirects' => ['max' => 2, 'strict' => true],
+        ])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('QUERY', $lastRequest->getMethod());
+        self::assertSame('a=b', (string) $lastRequest->getBody());
+    }
+
+    public static function queryMovedRedirectStatusProvider()
+    {
+        return [
+            '301' => [301],
+            '302' => [302],
+        ];
+    }
+
+    public function testDowngradesQueryToBodilessGetOnSeeOther()
+    {
+        $mock = new MockHandler([
+            new Response(303, ['Location' => 'http://example.com/stored-query/42']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [
+            'Content-Type' => 'application/json',
+        ], '{"q":"foo"}');
+
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('GET', $lastRequest->getMethod());
+        self::assertSame('http://example.com/stored-query/42', (string) $lastRequest->getUri());
+        self::assertSame('', (string) $lastRequest->getBody());
+    }
+
+    public function testDowngradesQueryToBodilessGetOnSeeOtherWithStrictRedirects()
+    {
+        $mock = new MockHandler([
+            new Response(303, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [], 'a=b');
+
+        $response = $handler($request, [
+            'allow_redirects' => ['max' => 2, 'strict' => true],
+        ])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('GET', $lastRequest->getMethod());
+        self::assertSame('', (string) $lastRequest->getBody());
+    }
+
+    public function testDowngradesQueryToBodilessGetOnMultipleChoices()
+    {
+        $mock = new MockHandler([
+            new Response(300, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [], 'a=b');
+
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('GET', $lastRequest->getMethod());
+        self::assertSame('', (string) $lastRequest->getBody());
+    }
+
+    public function testDowngradesPostToBodilessGetOnNonStrictRedirect()
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('POST', 'http://example.com', [], 'a=b');
+
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('GET', $lastRequest->getMethod());
+        self::assertSame('', (string) $lastRequest->getBody());
+    }
+
+    public function testCrossOriginQueryRedirectStripsCredentialsButPreservesBody()
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'https://other.example/search']),
+            static function (RequestInterface $request) {
+                self::assertSame('QUERY', $request->getMethod());
+                self::assertSame('secret=query', (string) $request->getBody());
+                self::assertFalse($request->hasHeader('Authorization'));
+                self::assertFalse($request->hasHeader('Cookie'));
+
+                return new Response(200);
+            },
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $client->send(new Request('QUERY', 'https://example.com/search', [
+            'Authorization' => 'Bearer token',
+            'Cookie' => 'session=abc',
+        ], 'secret=query'));
+    }
+
+    /**
      * Verifies how RedirectMiddleware::modifyRequest() modifies the method and body of a request issued when
      * encountering a redirect response.
      *


### PR DESCRIPTION
This updates redirect handling for the HTTP QUERY method so non-strict 301 and 302 redirects keep the original method and request body, matching the redirect semantics defined by RFC 10008. A 303 response is still followed as a body-less GET, while 307 and 308 continue to preserve method and body through the existing path. This fixes #3699 and supersedes #3700. The broader over-following of responses such as 304 with Location is a pre-existing, separate redirect-status concern being handled on 8.0 rather than in this minimal 7.13 maintenance change.