### PR TITLE
Restrict followed redirect status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Remove first-class NTLM authentication from the `auth` request option
 - Stop forwarding the generic `auth` request option when following cross-origin redirects
 - Limit the `Referer` header to the origin on cross-origin redirects
+- Follow only redirect status codes 301, 302, 303, 307, and 308
 - Reject invalid `HandlerStack::remove()` arguments
 - Require `Pool` request collections to be iterable
 - Raised the built-in cURL handler floor to libcurl 7.34.0 with SSL support

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -662,6 +662,15 @@ including an `https` to `http` downgrade. This matches the
 If you relied on the full URL crossing origins, collect it with the
 `on_redirect` setting, or disable automatic redirects and follow them manually.
 
+#### Automatic Redirect Status Codes
+
+Guzzle now follows only the redirect status codes 301, 302, 303, 307, and 308
+when `allow_redirects` is enabled. Other 3xx responses, including 300, 304, 305,
+and 306, are returned to the caller unchanged even when they carry a Location
+header, in line with RFC 9110 section 15.4. Code that relied on Guzzle following
+one of those responses should handle it directly or inspect it with an
+on_redirect callback.
+
 #### Host-Only Cookies
 
 Cookies extracted from responses without a `Domain` attribute are now stored as

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -65,6 +65,9 @@ You can also pass an associative array containing the following key value pairs:
 > [!NOTE]
 > When tracking redirects the `X-Guzzle-Redirect-History` header will exclude the initial request's URI and the `X-Guzzle-Redirect-Status-History` header will exclude the final status code. Redirect history is stored in response headers, and those header names are not reserved by Guzzle. If the final response already contains headers with these names, including when no redirect occurs, those values may be server-provided. Do not use these headers as a security boundary. For security-sensitive redirect history, collect values with the `on_redirect` option instead.
 
+> [!NOTE]
+> Guzzle follows only the redirect status codes 301, 302, 303, 307, and 308. Other 3xx responses are returned as-is even when they include a Location header.
+
 ```php
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -90,7 +90,7 @@ class RedirectMiddleware
      */
     public function checkRedirect(RequestInterface $request, array $options, ResponseInterface $response)
     {
-        if (\strpos((string) $response->getStatusCode(), '3') !== 0
+        if (!\in_array($response->getStatusCode(), [301, 302, 303, 307, 308], true)
             || !$response->hasHeader('Location')
         ) {
             return $response;

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -27,7 +27,8 @@ final class RequestOptions
      * redirects by default when the default redirect middleware is present.
      * This option only works if your handler has the RedirectMiddleware. When
      * passing an associative array, you can provide the following key value
-     * pairs:
+     * pairs. Only 301, 302, 303, 307, and 308 responses with a Location header
+     * are followed.
      *
      * - max: (int, default=5) maximum number of allowed redirects.
      * - strict: (bool, default=false) Set to true to use strict redirects

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -44,14 +44,13 @@ class RedirectMiddlewareTest extends TestCase
 
     public function testIgnoresWhenNoLocation(): void
     {
-        $response = new Response(304);
+        $response = new Response(301);
         $stack = new HandlerStack(new MockHandler([$response]));
         $stack->push(Middleware::redirect());
         $handler = $stack->resolve();
         $request = new Request('GET', 'http://example.com');
-        $promise = $handler($request, []);
-        $response = $promise->wait();
-        self::assertSame(304, $response->getStatusCode());
+        $response = $handler($request, ['allow_redirects' => ['max' => 3]])->wait();
+        self::assertSame(301, $response->getStatusCode());
     }
 
     public function testRedirectsWithAbsoluteUri(): void
@@ -382,7 +381,7 @@ class RedirectMiddlewareTest extends TestCase
             new Response(301, ['Location' => 'http://test.com']),
             new Response(302, ['Location' => 'http://test.com']),
             new Response(303, ['Location' => 'http://test.com']),
-            new Response(304, ['Location' => 'http://test.com']),
+            new Response(307, ['Location' => 'http://test.com']),
         ]);
         $stack = new HandlerStack($mock);
         $stack->push(Middleware::redirect());
@@ -393,6 +392,76 @@ class RedirectMiddlewareTest extends TestCase
         $this->expectException(TooManyRedirectsException::class);
         $this->expectExceptionMessage('Will not follow more than 3 redirects');
         $promise->wait();
+    }
+
+    /**
+     * @dataProvider nonRedirectStatusWithLocationProvider
+     */
+    public function testDoesNotFollowNonRedirectStatusWithLocation(int $statusCode): void
+    {
+        $mock = new MockHandler([
+            new Response($statusCode, ['Location' => 'http://example.com/next']),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $called = false;
+
+        $response = $handler(new Request('GET', 'http://example.com'), [
+            'allow_redirects' => [
+                'max' => 2,
+                'track_redirects' => true,
+                'on_redirect' => static function () use (&$called): void {
+                    $called = true;
+                },
+            ],
+        ])->wait();
+
+        self::assertSame($statusCode, $response->getStatusCode());
+        self::assertFalse($called);
+        self::assertSame([], $response->getHeader(RedirectMiddleware::HISTORY_HEADER));
+    }
+
+    public static function nonRedirectStatusWithLocationProvider(): array
+    {
+        return [
+            '300' => [300],
+            '304' => [304],
+            '305' => [305],
+            '306' => [306],
+        ];
+    }
+
+    /**
+     * @dataProvider redirectStatusWithLocationProvider
+     */
+    public function testFollowsRedirectStatusWithLocation(int $statusCode): void
+    {
+        $mock = new MockHandler([
+            new Response($statusCode, ['Location' => 'http://example.com/next']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+
+        $response = $handler(new Request('GET', 'http://example.com'), [
+            'allow_redirects' => ['max' => 2],
+        ])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('http://example.com/next', (string) $mock->getLastRequest()->getUri());
+    }
+
+    public static function redirectStatusWithLocationProvider(): array
+    {
+        return [
+            '301' => [301],
+            '302' => [302],
+            '303' => [303],
+            '307' => [307],
+            '308' => [308],
+        ];
     }
 
     public function testTooManyRedirectsExceptionHasResponse(): void


### PR DESCRIPTION
This restricts Guzzle's automatic redirect following to the redirect status codes defined by RFC 9110 section 15.4, namely 301, 302, 303, 307, and 308. Previously any 3xx response carrying a Location header was followed, so a 300, 304, 305, or 306 response could be treated as a redirect. Those responses are now returned to the caller unchanged. This aligns Guzzle with the HTTP specification and prevents conditional and content-negotiation responses from being misinterpreted as redirect hops.