### PR TITLE
Support QUERY redirects

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -343,7 +343,7 @@ Guzzle will automatically follow redirects unless you tell it not to. You can cu
 
 - Set to `true` to enable normal redirects with a maximum number of 5 redirects. This is the default setting.
 - Set to `false` to disable redirects.
-- Pass an associative array containing the 'max' key to specify the maximum number of redirects and optionally provide a 'strict' key value to specify whether or not to use strict RFC compliant redirects (meaning redirect POST requests with POST requests vs. doing what most browsers do which is redirect POST requests with GET requests).
+- Pass an associative array containing the 'max' key to specify the maximum number of redirects and optionally provide a 'strict' key value to specify whether or not to use strict RFC compliant redirects (meaning redirect POST requests with POST requests vs. doing what most browsers do which is redirect POST requests with GET requests). The QUERY method keeps its method and body across non-strict 301 and 302 redirects, and a 303 redirect is followed with GET.
 
 See the [`allow_redirects` option](request-options.md#allow_redirects) for cross-origin redirect credential behavior.
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -52,7 +52,7 @@ You can also pass an associative array containing the following key value pairs:
 
 - max: (int, default=5) maximum number of allowed redirects.
 
-- strict: (bool, default=false) Set to true to use strict redirects. Strict RFC compliant redirects mean that POST redirect requests are sent as POST requests vs. doing what most browsers do which is redirect POST requests with GET requests.
+- strict: (bool, default=false) Set to true to use strict redirects. Strict RFC compliant redirects mean that POST redirect requests are sent as POST requests vs. doing what most browsers do which is redirect POST requests with GET requests. The RFC 10008 QUERY method keeps its method and body across non-strict 301 and 302 redirects, matching the 307 and 308 behavior that already applies to every method, and a 303 redirect is followed with a body-less GET.
 
 - referer: (bool, default=false) Set to true to add a `Referer` header when redirecting. On a cross-origin redirect only the origin (scheme, host, and port) is sent, and the header is omitted entirely when the scheme changes, including an `https` to `http` downgrade. See [Cross-Origin Redirects](#cross-origin-redirects).
 
@@ -119,6 +119,8 @@ Same-origin redirects preserve those values. Guzzle does not automatically remov
 When the optional `referer` setting is enabled, Guzzle also limits what it discloses to the new origin. On a cross-origin redirect it sends only the request's origin (scheme, host, and port) in the `Referer` header instead of the full URL, and it omits the header entirely when the scheme changes, including an `https` to `http` downgrade. Same-origin redirects send the full URL. This matches the `strict-origin-when-cross-origin` policy that modern browsers use by default.
 
 If TLS client credentials are only trusted for the original origin, disable automatic redirects and handle redirect responses manually, or use separate clients and request options for trusted origins.
+
+The RFC 10008 QUERY method has method-specific redirect behavior. Guzzle keeps the QUERY method and request body across 301, 302, 307, and 308 redirects, and follows a 303 with a body-less GET. QUERY request bodies can carry sensitive query content. On cross-origin redirects Guzzle removes origin credentials such as the Authorization and Cookie headers and the auth request option, but it does not remove the request body. Disable automatic redirects or use on_redirect if a QUERY body must not be sent to another origin.
 
 ## auth
 

--- a/src/RedirectMiddleware.php
+++ b/src/RedirectMiddleware.php
@@ -188,19 +188,21 @@ class RedirectMiddleware
         if ($statusCode == 303
             || ($statusCode <= 302 && !$options['allow_redirects']['strict'])
         ) {
-            $safeMethods = ['GET', 'HEAD', 'OPTIONS'];
             $requestMethod = $request->getMethod();
-            $streamFactory = $options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory();
-            if (!$streamFactory instanceof StreamFactoryInterface) {
-                throw new \InvalidArgumentException(\sprintf(
-                    '%s must be an instance of %s',
-                    RequestOptions::STREAM_FACTORY,
-                    StreamFactoryInterface::class
-                ));
-            }
 
-            $modify['method'] = \in_array($requestMethod, $safeMethods, true) ? $requestMethod : 'GET';
-            $modify['body'] = $streamFactory->createStream('');
+            if ($requestMethod !== 'QUERY' || !\in_array($statusCode, [301, 302], true)) {
+                $streamFactory = $options[RequestOptions::STREAM_FACTORY] ?? new HttpFactory();
+                if (!$streamFactory instanceof StreamFactoryInterface) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        '%s must be an instance of %s',
+                        RequestOptions::STREAM_FACTORY,
+                        StreamFactoryInterface::class
+                    ));
+                }
+
+                $modify['method'] = \in_array($requestMethod, ['GET', 'HEAD', 'OPTIONS'], true) ? $requestMethod : 'GET';
+                $modify['body'] = $streamFactory->createStream('');
+            }
         }
 
         $uriFactory = $options[RequestOptions::URI_FACTORY] ?? new HttpFactory();

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -33,7 +33,9 @@ final class RequestOptions
      * - max: (int, default=5) maximum number of allowed redirects.
      * - strict: (bool, default=false) Set to true to use strict redirects
      *   meaning redirect POST requests with POST requests vs. doing what most
-     *   browsers do which is redirect POST requests with GET requests
+     *   browsers do which is redirect POST requests with GET requests. The
+     *   QUERY method keeps its method and body across non-strict 301 and 302
+     *   redirects, and a 303 redirect is followed with a body-less GET.
      * - referer: (bool, default=false) Set to true to enable the Referer
      *   header.
      * - protocols: (non-empty-array<array-key, 'http'|'https'>,

--- a/tests/RedirectMiddlewareTest.php
+++ b/tests/RedirectMiddlewareTest.php
@@ -978,6 +978,247 @@ class RedirectMiddlewareTest extends TestCase
     }
 
     /**
+     * @dataProvider queryRedirectStatusProvider
+     */
+    public function testPreservesQueryMethodAndBodyOnRedirect(int $statusCode): void
+    {
+        $mock = new MockHandler([
+            new Response($statusCode, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [
+            'Content-Type' => 'application/json',
+        ], '{"q":"foo"}');
+
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('QUERY', $lastRequest->getMethod());
+        self::assertSame('http://example.com/foo', (string) $lastRequest->getUri());
+        self::assertSame('{"q":"foo"}', (string) $lastRequest->getBody());
+        self::assertSame('application/json', $lastRequest->getHeaderLine('Content-Type'));
+    }
+
+    public static function queryRedirectStatusProvider(): array
+    {
+        return [
+            '301' => [301],
+            '302' => [302],
+            '307' => [307],
+            '308' => [308],
+        ];
+    }
+
+    /**
+     * @dataProvider queryMovedRedirectStatusProvider
+     */
+    public function testPreservesQueryMethodAndBodyOnStrictRedirect(int $statusCode): void
+    {
+        $mock = new MockHandler([
+            new Response($statusCode, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [], 'a=b');
+
+        $response = $handler($request, [
+            'allow_redirects' => ['max' => 2, 'strict' => true],
+        ])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('QUERY', $mock->getLastRequest()->getMethod());
+        self::assertSame('a=b', (string) $mock->getLastRequest()->getBody());
+    }
+
+    public static function queryMovedRedirectStatusProvider(): array
+    {
+        return [
+            '301' => [301],
+            '302' => [302],
+        ];
+    }
+
+    public function testDowngradesQueryToBodilessGetOnSeeOther(): void
+    {
+        $mock = new MockHandler([
+            new Response(303, ['Location' => 'http://example.com/stored-query/42']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [
+            'Content-Type' => 'application/json',
+        ], '{"q":"foo"}');
+
+        $response = $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('GET', $lastRequest->getMethod());
+        self::assertSame('http://example.com/stored-query/42', (string) $lastRequest->getUri());
+        self::assertSame('', (string) $lastRequest->getBody());
+    }
+
+    public function testDowngradesQueryToBodilessGetOnSeeOtherWithStrictRedirects(): void
+    {
+        $mock = new MockHandler([
+            new Response(303, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [], 'a=b');
+
+        $response = $handler($request, [
+            'allow_redirects' => ['max' => 2, 'strict' => true],
+        ])->wait();
+        $lastRequest = $mock->getLastRequest();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('GET', $lastRequest->getMethod());
+        self::assertSame('', (string) $lastRequest->getBody());
+    }
+
+    /**
+     * @dataProvider nonCanonicalQueryMethodProvider
+     */
+    public function testDoesNotPreserveNonCanonicalQueryMethodOnNonStrictRedirect(string $method): void
+    {
+        $redirectMiddleware = new RedirectMiddleware(static function (): void {
+        });
+        $request = (new RedirectTestMethodRequest($method, 'http://example.com'))
+            ->withBody(Psr7\Utils::streamFor('a=b'));
+
+        $modifiedRequest = $redirectMiddleware->modifyRequest($request, [
+            'allow_redirects' => [
+                'protocols' => ['http', 'https'],
+                'strict' => false,
+                'referer' => false,
+            ],
+        ], new Response(302, ['Location' => 'http://example.com/foo']));
+
+        self::assertSame('GET', $modifiedRequest->getMethod());
+        self::assertSame('', (string) $modifiedRequest->getBody());
+    }
+
+    public static function nonCanonicalQueryMethodProvider(): array
+    {
+        return [
+            'query' => ['query'],
+            'Query' => ['Query'],
+            'QuErY' => ['QuErY'],
+        ];
+    }
+
+    public function testPreservedQueryRedirectDoesNotUseStreamFactory(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com/foo']),
+            new Response(200),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+
+        $response = $stack->resolve()(new Request('QUERY', 'http://example.com', [], 'a=b'), [
+            'allow_redirects' => ['max' => 2],
+            RequestOptions::STREAM_FACTORY => new \stdClass(),
+        ])->wait();
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('QUERY', $mock->getLastRequest()->getMethod());
+        self::assertSame('a=b', (string) $mock->getLastRequest()->getBody());
+    }
+
+    public function testPreservedQueryRedirectBodyRewindFailureThrowsResponseException(): void
+    {
+        $previous = new \RuntimeException('cannot rewind');
+        $body = Psr7\FnStream::decorate(Psr7\Utils::streamFor('data'), [
+            'tell' => static function (): int {
+                return 4;
+            },
+            'rewind' => static function () use ($previous): void {
+                throw $previous;
+            },
+        ]);
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'http://example.com/redirected']),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $request = new Request('QUERY', 'http://example.com', [], $body);
+
+        try {
+            $handler($request, ['allow_redirects' => ['max' => 2]])->wait();
+            self::fail('Expected ResponseException');
+        } catch (ResponseException $e) {
+            self::assertNotInstanceOf(BadResponseException::class, $e);
+            self::assertSame($request, $e->getRequest());
+            self::assertSame(302, $e->getResponse()->getStatusCode());
+            self::assertSame(
+                'Redirect failed because the request body could not be rewound',
+                $e->getMessage()
+            );
+            self::assertSame($previous, $e->getPrevious());
+        }
+    }
+
+    public function testQueryRedirectIsNotFollowedOnNotModified(): void
+    {
+        $mock = new MockHandler([
+            new Response(304, ['Location' => 'http://example.com/foo']),
+        ]);
+        $stack = new HandlerStack($mock);
+        $stack->push(Middleware::redirect());
+        $handler = $stack->resolve();
+        $called = false;
+        $request = new Request('QUERY', 'http://example.com', [], 'a=b');
+
+        $response = $handler($request, [
+            'allow_redirects' => [
+                'max' => 2,
+                'on_redirect' => static function () use (&$called): void {
+                    $called = true;
+                },
+            ],
+        ])->wait();
+
+        self::assertSame(304, $response->getStatusCode());
+        self::assertFalse($called);
+    }
+
+    public function testCrossOriginQueryRedirectStripsCredentialsButPreservesBody(): void
+    {
+        $mock = new MockHandler([
+            new Response(302, ['Location' => 'https://other.example/search']),
+            static function (RequestInterface $request, array $options): ResponseInterface {
+                self::assertSame('QUERY', $request->getMethod());
+                self::assertSame('secret=query', (string) $request->getBody());
+                self::assertFalse($request->hasHeader('Authorization'));
+                self::assertFalse($request->hasHeader('Cookie'));
+                self::assertArrayNotHasKey('auth', $options);
+
+                return new Response(200);
+            },
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $client->send(new Request('QUERY', 'https://example.com/search', [
+            'Authorization' => 'Bearer token',
+            'Cookie' => 'session=abc',
+        ], 'secret=query'), ['auth' => 'custom']);
+    }
+
+    /**
      * Verifies how RedirectMiddleware::modifyRequest() modifies the method and body of a request issued when
      * encountering a redirect response.
      *


### PR DESCRIPTION
This adds support for the HTTP QUERY method defined by RFC 10008. QUERY is a safe and idempotent method that carries a request body, so when following a non-strict 301 or 302 redirect Guzzle now keeps the QUERY method and its body instead of rewriting the request to a body-less GET. A 303 response is still followed with a GET, and 307 and 308 continue to preserve the method and body as before. QUERY bodies can contain sensitive content, so on a cross-origin redirect Guzzle removes origin credentials while keeping the body. This fixes #3699 and supersedes #3700.