### PR TITLE
Fix crypto_method_max deprecation version and document PHP requirements

### DIFF
--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -369,8 +369,10 @@ $client->request('GET', '/foo', [
 > This setting must be set to one of the `STREAM_CRYPTO_METHOD_TLS*_CLIENT`
 > constants. It may be combined with `crypto_method` to set an allowed TLS
 > version range. The maximum version must be greater than or equal to the
-> minimum version. cURL 7.54.0 or higher is required to use maximum TLS-version
-> bounds with the cURL handler.
+> minimum version. On the stream handler, PHP 7.3 or higher is required to set
+> a maximum TLS version, and PHP 7.4 or higher is required to use TLS 1.3.
+> cURL 7.54.0 or higher is required to use maximum TLS-version bounds with the
+> cURL handler.
 
 ## curl
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -565,7 +565,7 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         self::warnIfPresentAndNotString($options, 'cert_type');
         self::warnIfPresentAndNotNumber($options, 'connect_timeout');
         self::warnIfPresentAndNotInt($options, 'crypto_method');
-        self::warnIfPresentAndNotInt($options, 'crypto_method_max');
+        self::warnIfPresentAndNotInt($options, 'crypto_method_max', null, '7.13');
         self::warnIfPresentAndNotBoolOrResource($options, 'debug');
         self::warnIfPresentAndNotBoolOrString($options, 'decode_content');
         self::warnIfPresentAndNotNumber($options, 'delay');
@@ -912,10 +912,14 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         }
     }
 
-    private static function warnIfPresentAndNotInt(array $options, string $option, ?string $path = null): void
-    {
+    private static function warnIfPresentAndNotInt(
+        array $options,
+        string $option,
+        ?string $path = null,
+        string $since = '7.11'
+    ): void {
         if (\array_key_exists($option, $options) && !\is_int($options[$option])) {
-            self::warnInvalidRequestOptionType($path ?? $option, 'int', $options[$option]);
+            self::warnInvalidRequestOptionType($path ?? $option, 'int', $options[$option], $since);
         }
     }
 

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -103,9 +103,10 @@ final class RequestOptions
      * version to use.
      *
      * This setting must be set to one of the
-     * ``STREAM_CRYPTO_METHOD_TLS*_CLIENT`` constants. cURL 7.54.0 or higher
-     * is required in order to specify a maximum TLS version with the cURL
-     * handler.
+     * ``STREAM_CRYPTO_METHOD_TLS*_CLIENT`` constants. On the stream handler,
+     * PHP 7.3 or higher is required to set a maximum TLS version, and PHP 7.4
+     * or higher is required to use TLS 1.3. cURL 7.54.0 or higher is required
+     * in order to specify a maximum TLS version with the cURL handler.
      */
     public const CRYPTO_METHOD_MAX = 'crypto_method_max';
 


### PR DESCRIPTION
The `crypto_method_max` request option is new in 7.13, but when a non-integer value is passed its type deprecation reported the shared helper's default since-version of 7.11. Consumers could not have received that option-level deprecation before the option existed, so this corrects the reported version to 7.13 by threading an explicit since-version through the `warnIfPresentAndNotInt` helper while leaving the existing 7.11 callers unchanged.

It also documents the stream-handler runtime requirements that the implementation already enforces, namely that PHP 7.3 or higher is needed to set a maximum TLS version and PHP 7.4 or higher is needed for TLS 1.3, alongside the existing note about cURL 7.54.0. Both the `RequestOptions::CRYPTO_METHOD_MAX` docblock and the request options documentation are updated to match.
