### PR TITLE
Deprecate invalid numeric-string delay values

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -569,12 +569,11 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
         self::warnIfPresentAndNotBoolOrResource($options, 'debug');
         self::warnIfPresentAndNotBoolOrString($options, 'decode_content');
         self::warnIfPresentAndNotNumber($options, 'delay');
-        if (
-            isset($options['delay'])
-            && (\is_int($options['delay']) || \is_float($options['delay']))
-            && (!\is_finite((float) $options['delay']) || $options['delay'] < 0)
-        ) {
-            self::warnInvalidRequestOptionType('delay', 'finite int|float greater than or equal to 0', $options['delay'], '7.13');
+        if (isset($options['delay']) && \is_numeric($options['delay'])) {
+            $delay = (float) $options['delay'];
+            if (!\is_finite($delay) || $delay < 0.0) {
+                self::warnInvalidRequestOptionType('delay', 'finite int|float greater than or equal to 0', $options['delay'], '7.13');
+            }
         }
         self::warnIfPresentAndNotBoolOrInt($options, 'expect');
 


### PR DESCRIPTION
The `delay` request option accepts milliseconds as an int or float, and in 7.x an invalid numeric string is still normalized into a number before it reaches the handlers while a deprecation is emitted, because 8.0 is where these inputs become strict. The range-specific 7.13 deprecation for negative or non-finite values only ran for native int and float values, so a string such as `'-1'` or `'1e309'` was normalized into a negative or non-finite number without ever triggering the range warning that the equivalent native value receives. This change guards the range check on `is_numeric()` and casts once to float, so invalid numeric-string delays now get the same range-specific deprecation as native values ahead of 8.0, while the existing generic deprecation and the normalization behavior remain unchanged.
