### PR TITLE
Harden CurlMultiHandler proxy tunnel isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 ### Changed
 
 - Section proxy tunnel connection reuse by credential so distinct credentials never share a tunnel
+- Isolate concurrent foreign cURL proxy tunnels added while another owner's tunnel is active
 - Route TLS 1.2 `crypto_method` requests to the stream handler when cURL cannot select TLS 1.2
 
 ### Deprecated

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -165,7 +165,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_add_handle expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-
@@ -199,8 +199,20 @@ parameters:
 			path: src/Handler/CurlMultiHandler.php
 
 		-
+			message: '#^Parameter \#2 \$ch of function curl_multi_add_handle expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Handler/CurlMultiHandler.php
+
+		-
 			message: '#^Parameter \#2 \$ch of function curl_multi_remove_handle expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
+			count: 2
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: '#^Parameter \$handle of method GuzzleHttp\\Handler\\CurlMultiHandler\:\:removeCompletedHandleFromMulti\(\) has invalid type CurlHandle\.$#'
+			identifier: class.notFound
 			count: 1
 			path: src/Handler/CurlMultiHandler.php
 

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -79,6 +79,12 @@ class CurlMultiHandler
      */
     private $proxyTunnelOwner;
 
+    /** @var array<string, int> Count of attached transfers per proxy tunnel signature. */
+    private $activeProxyTunnelSignatures = [];
+
+    /** @var array<int, string> Maps an attached handle id to its proxy tunnel signature. */
+    private $activeProxyTunnelHandles = [];
+
     /**
      * @var bool Guards against multi-handle recreation re-entrancy from
      *           processMessages (a retried transfer re-invokes the handler)
@@ -229,9 +235,90 @@ class CurlMultiHandler
         }
 
         // Busy: isolate this transfer from the owner's pooled tunnels.
+        $this->isolateProxyTunnelTransfer($easy);
+    }
+
+    private function addCurlHandle(EasyHandle $easy): void
+    {
+        $this->isolateFromForeignActiveProxyTunnel($easy);
+        \curl_multi_add_handle($this->_mh, $easy->handle);
+        $this->markProxyTunnelActive($easy);
+    }
+
+    /**
+     * @param resource|\CurlHandle $handle
+     */
+    private function removeCompletedHandleFromMulti(int $id, $handle): void
+    {
+        \curl_multi_remove_handle($this->_mh, $handle);
+        $this->unmarkProxyTunnelActiveById($id);
+    }
+
+    private function isolateFromForeignActiveProxyTunnel(EasyHandle $easy): void
+    {
+        $signature = $easy->proxyTunnelSignature;
+
+        if ($signature === null || $this->activeProxyTunnelSignatures === []) {
+            return;
+        }
+
+        if (\count($this->activeProxyTunnelSignatures) === 1 && isset($this->activeProxyTunnelSignatures[$signature])) {
+            return;
+        }
+
+        $this->isolateProxyTunnelTransfer($easy);
+    }
+
+    private function isolateProxyTunnelTransfer(EasyHandle $easy): void
+    {
         // Unqualified curl_setopt so the test bootstrap shadow records it.
         curl_setopt($easy->handle, \CURLOPT_FRESH_CONNECT, true);
         curl_setopt($easy->handle, \CURLOPT_FORBID_REUSE, true);
+    }
+
+    private function markProxyTunnelActive(EasyHandle $easy): void
+    {
+        $signature = $easy->proxyTunnelSignature;
+        if ($signature === null) {
+            return;
+        }
+
+        $id = (int) $easy->handle;
+        if (isset($this->activeProxyTunnelHandles[$id])) {
+            if ($this->activeProxyTunnelHandles[$id] === $signature) {
+                return;
+            }
+
+            $this->unmarkProxyTunnelActiveById($id);
+        }
+
+        $this->activeProxyTunnelHandles[$id] = $signature;
+        $this->activeProxyTunnelSignatures[$signature] = ($this->activeProxyTunnelSignatures[$signature] ?? 0) + 1;
+    }
+
+    private function unmarkProxyTunnelActive(EasyHandle $easy): void
+    {
+        $this->unmarkProxyTunnelActiveById((int) $easy->handle);
+    }
+
+    private function unmarkProxyTunnelActiveById(int $id): void
+    {
+        if (!isset($this->activeProxyTunnelHandles[$id])) {
+            return;
+        }
+
+        $signature = $this->activeProxyTunnelHandles[$id];
+        unset($this->activeProxyTunnelHandles[$id]);
+
+        if (!isset($this->activeProxyTunnelSignatures[$signature])) {
+            return;
+        }
+
+        --$this->activeProxyTunnelSignatures[$signature];
+
+        if ($this->activeProxyTunnelSignatures[$signature] <= 0) {
+            unset($this->activeProxyTunnelSignatures[$signature]);
+        }
     }
 
     /**
@@ -245,10 +332,7 @@ class CurlMultiHandler
             foreach ($this->delays as $id => $delay) {
                 if ($currentTime >= $delay) {
                     unset($this->delays[$id]);
-                    \curl_multi_add_handle(
-                        $this->_mh,
-                        $this->handles[$id]['easy']->handle
-                    );
+                    $this->addCurlHandle($this->handles[$id]['easy']);
                 }
             }
         }
@@ -326,7 +410,7 @@ class CurlMultiHandler
         $id = (int) $easy->handle;
         $this->handles[$id] = $entry;
         if (empty($easy->options['delay'])) {
-            \curl_multi_add_handle($this->_mh, $easy->handle);
+            $this->addCurlHandle($easy);
         } else {
             $this->delays[$id] = Utils::currentTime() + ($easy->options['delay'] / 1000);
         }
@@ -382,6 +466,7 @@ class CurlMultiHandler
     {
         $handle = $easy->handle;
         \curl_multi_remove_handle($this->_mh, $handle);
+        $this->unmarkProxyTunnelActive($easy);
 
         if (PHP_VERSION_ID < 80000) {
             \curl_close($handle);
@@ -408,7 +493,7 @@ class CurlMultiHandler
                     continue;
                 }
                 $id = (int) $done['handle'];
-                \curl_multi_remove_handle($this->_mh, $done['handle']);
+                $this->removeCompletedHandleFromMulti($id, $done['handle']);
 
                 if (!isset($this->handles[$id])) {
                     // Probably was cancelled.

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -405,6 +405,200 @@ class CurlMultiHandlerTest extends TestCase
         self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
     }
 
+    public function testActiveForeignProxyTunnelForcesOwnerTransferIsolation(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-a' => 1, 'sig-b' => 1]);
+
+        $easy = self::easyWithSignature('sig-a');
+        $isolate = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->isolateFromForeignActiveProxyTunnel($easy);
+        }, null, CurlMultiHandler::class);
+        $isolate($handler, $easy);
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        self::assertSame('sig-a', self::readMultiProperty($handler, 'proxyTunnelOwner'), 'Isolation must not move the scalar owner.');
+    }
+
+    public function testOwnerMatchingTransferIsNotIsolatedWhenNoForeignSignatureIsActive(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-a' => 1]);
+        unset($_SERVER['_curl']);
+
+        $easy = self::easyWithSignature('sig-a');
+        $isolate = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->isolateFromForeignActiveProxyTunnel($easy);
+        }, null, CurlMultiHandler::class);
+        $isolate($handler, $easy);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
+    }
+
+    public function testForeignTransferIsIsolatedWhenOwnerIsActive(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-a' => 1]);
+
+        $easy = self::easyWithSignature('sig-b');
+        $isolate = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->isolateFromForeignActiveProxyTunnel($easy);
+        }, null, CurlMultiHandler::class);
+        $isolate($handler, $easy);
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testActiveProxyTunnelSignatureCountsAreReferenceCounted(): void
+    {
+        $handler = new CurlMultiHandler();
+        $first = self::easyWithSignature('sig-b');
+        $second = self::easyWithSignature('sig-b');
+        $idFirst = (int) $first->handle;
+        $idSecond = (int) $second->handle;
+
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($easy);
+        }, null, CurlMultiHandler::class);
+        $unmarkById = \Closure::bind(static function (CurlMultiHandler $handler, int $id): void {
+            $handler->unmarkProxyTunnelActiveById($id);
+        }, null, CurlMultiHandler::class);
+
+        $mark($handler, $first);
+        $mark($handler, $second);
+        self::assertSame(['sig-b' => 2], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+
+        $unmarkById($handler, $idFirst);
+        self::assertSame(['sig-b' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+
+        $unmarkById($handler, $idSecond);
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testDelayedTransferIsNotActiveUntilAddedToMultiHandle(): void
+    {
+        $handler = new CurlMultiHandler();
+        $easy = self::easyWithSignature('sig-a');
+        $easy->options = ['delay' => 10000];
+
+        $addRequest = \Closure::bind(static function (CurlMultiHandler $handler, array $entry): void {
+            $handler->addRequest($entry);
+        }, null, CurlMultiHandler::class);
+        $addCurlHandle = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->addCurlHandle($easy);
+        }, null, CurlMultiHandler::class);
+
+        $addRequest($handler, ['easy' => $easy, 'deferred' => new P\Promise()]);
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'), 'A delayed transfer must not be counted before it attaches.');
+
+        $addCurlHandle($handler, $easy);
+        self::assertSame(['sig-a' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'), 'The transfer must be counted only once attached.');
+    }
+
+    public function testDeferredCancelCleanupDoesNotDoubleDecrementActiveSignature(): void
+    {
+        $handler = new CurlMultiHandler();
+        $easy = self::easyWithSignature('sig-a');
+        $id = (int) $easy->handle;
+
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($easy);
+        }, null, CurlMultiHandler::class);
+        $unmarkById = \Closure::bind(static function (CurlMultiHandler $handler, int $id): void {
+            $handler->unmarkProxyTunnelActiveById($id);
+        }, null, CurlMultiHandler::class);
+        $unmark = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->unmarkProxyTunnelActive($easy);
+        }, null, CurlMultiHandler::class);
+
+        $mark($handler, $easy);
+        self::assertSame(['sig-a' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+
+        $unmarkById($handler, $id);
+        $unmark($handler, $easy);
+
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testCompletionUnmarksBeforeFinishCanReenter(): void
+    {
+        $handler = new CurlMultiHandler();
+        $easy = self::easyWithSignature('sig-a');
+        $id = (int) $easy->handle;
+
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($easy);
+        }, null, CurlMultiHandler::class);
+        $removeCompleted = \Closure::bind(static function (CurlMultiHandler $handler, int $id, $handle): void {
+            $handler->removeCompletedHandleFromMulti($id, $handle);
+        }, null, CurlMultiHandler::class);
+
+        $mark($handler, $easy);
+        self::assertSame(['sig-a' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([$id => 'sig-a'], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+
+        $removeCompleted($handler, $id, $easy->handle);
+
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testNoDelayAddRequestIsolatesAndMarksThroughTheWrapper(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-b' => 1]);
+        self::setMultiProperty($handler, 'activeProxyTunnelHandles', [-1 => 'sig-b']);
+
+        $addRequest = \Closure::bind(static function (CurlMultiHandler $handler, array $entry): void {
+            $handler->addRequest($entry);
+        }, null, CurlMultiHandler::class);
+
+        $easy = self::easyWithSignature('sig-a');
+        $easy->options = [];
+        $addRequest($handler, ['easy' => $easy, 'deferred' => new P\Promise()]);
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        self::assertSame(1, self::readMultiProperty($handler, 'activeProxyTunnelSignatures')['sig-a'] ?? 0, 'The no-delay transfer must be marked active.');
+
+        unset($_SERVER['_curl']);
+        $nullEasy = self::easyWithSignature(null);
+        $nullEasy->options = [];
+        $addRequest($handler, ['easy' => $nullEasy, 'deferred' => new P\Promise()]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
+        self::assertArrayNotHasKey((int) $nullEasy->handle, self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testNullSignatureNeverEntersActiveMaps(): void
+    {
+        $handler = new CurlMultiHandler();
+        $nullEasy = self::easyWithSignature(null);
+
+        $isolate = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->isolateFromForeignActiveProxyTunnel($easy);
+        }, null, CurlMultiHandler::class);
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($easy);
+        }, null, CurlMultiHandler::class);
+
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-b' => 1]);
+        unset($_SERVER['_curl']);
+        $isolate($handler, $nullEasy);
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
+
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', []);
+        $mark($handler, $nullEasy);
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
     private static function easyWithSignature(?string $signature): EasyHandle
     {
         $easy = new EasyHandle();


### PR DESCRIPTION
CurlMultiHandler can attach transfers from multiple proxy tunnel sections to one multi handle, while its scalar owner only describes idle cache ownership. This adds active signature tracking so a new transfer is forced fresh whenever a foreign tunnel section is currently attached.