### PR TITLE
Harden CurlMultiHandler proxy tunnel isolation

### DIFF
--- a/docs/contributing/curl-connection-reuse.md
+++ b/docs/contributing/curl-connection-reuse.md
@@ -127,6 +127,17 @@ Guzzle forces a fresh connection — purging pooled idle handles that might hold
 foreign tunnel — so libcurl cannot hand one request a tunnel established under a
 different identity.
 
+**`CurlMultiHandler` active-attachment isolation.** A single `CurlMultiHandler`
+reuses one libcurl multi handle — and therefore one connection cache — across
+transfers. It tracks the proxy tunnel section that owns that idle cache in a
+scalar `$proxyTunnelOwner`, handed over only when the handle is fully idle.
+Concurrency is governed separately by a reference-counted map of the proxy
+tunnel signatures *currently attached* to the multi handle. While a foreign
+signature is attached, even an owner-compatible transfer is isolated with
+`CURLOPT_FRESH_CONNECT` + `CURLOPT_FORBID_REUSE` — the `A / B / A` case — because
+the latched owner records who inherited the idle cache, not which sections are in
+flight right now.
+
 ## 5. The signature: what it covers and why
 
 **Domain (when a signature is computed at all).** Only for a request that

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -93,7 +93,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$mh of function curl_multi_add_handle expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-
@@ -124,6 +124,12 @@ parameters:
 			message: '#^Parameter \#1 \$mh of function curl_multi_select expects resource, CurlMultiHandle\|resource given\.$#'
 			identifier: argument.type
 			count: 3
+			path: src/Handler/CurlMultiHandler.php
+
+		-
+			message: '#^Parameter \#2 \$ch of function curl_multi_add_handle expects resource, CurlHandle\|resource given\.$#'
+			identifier: argument.type
+			count: 1
 			path: src/Handler/CurlMultiHandler.php
 
 		-

--- a/src/Handler/CurlMultiHandler.php
+++ b/src/Handler/CurlMultiHandler.php
@@ -85,6 +85,12 @@ final class CurlMultiHandler
      */
     private ?string $proxyTunnelOwner = null;
 
+    /** @var array<string, int> Count of attached transfers per proxy tunnel signature. */
+    private array $activeProxyTunnelSignatures = [];
+
+    /** @var array<int, string> Maps an attached handle id to its proxy tunnel signature. */
+    private array $activeProxyTunnelHandles = [];
+
     /**
      * @var bool Guards against multi-handle recreation re-entrancy from
      *           processMessages (a retried transfer re-invokes the handler)
@@ -218,9 +224,75 @@ final class CurlMultiHandler
         }
 
         // Busy: isolate this transfer from the owner's pooled tunnels.
+        $this->isolateProxyTunnelTransfer($easy);
+    }
+
+    private function addHandleToMulti(int $id, EasyHandle $easy): void
+    {
+        $this->isolateFromForeignActiveProxyTunnel($easy);
+        \curl_multi_add_handle($this->getMultiHandle(), $easy->handle);
+        $this->markProxyTunnelActive($id, $easy);
+    }
+
+    private function isolateFromForeignActiveProxyTunnel(EasyHandle $easy): void
+    {
+        $signature = $easy->proxyTunnelSignature;
+
+        if ($signature === null || $this->activeProxyTunnelSignatures === []) {
+            return;
+        }
+
+        if (\count($this->activeProxyTunnelSignatures) === 1 && isset($this->activeProxyTunnelSignatures[$signature])) {
+            return;
+        }
+
+        $this->isolateProxyTunnelTransfer($easy);
+    }
+
+    private function isolateProxyTunnelTransfer(EasyHandle $easy): void
+    {
         // Unqualified curl_setopt so the test bootstrap shadow records it.
         curl_setopt($easy->handle, \CURLOPT_FRESH_CONNECT, true);
         curl_setopt($easy->handle, \CURLOPT_FORBID_REUSE, true);
+    }
+
+    private function markProxyTunnelActive(int $id, EasyHandle $easy): void
+    {
+        $signature = $easy->proxyTunnelSignature;
+        if ($signature === null) {
+            return;
+        }
+
+        if (isset($this->activeProxyTunnelHandles[$id])) {
+            if ($this->activeProxyTunnelHandles[$id] === $signature) {
+                return;
+            }
+
+            $this->unmarkProxyTunnelActiveById($id);
+        }
+
+        $this->activeProxyTunnelHandles[$id] = $signature;
+        $this->activeProxyTunnelSignatures[$signature] = ($this->activeProxyTunnelSignatures[$signature] ?? 0) + 1;
+    }
+
+    private function unmarkProxyTunnelActiveById(int $id): void
+    {
+        if (!isset($this->activeProxyTunnelHandles[$id])) {
+            return;
+        }
+
+        $signature = $this->activeProxyTunnelHandles[$id];
+        unset($this->activeProxyTunnelHandles[$id]);
+
+        if (!isset($this->activeProxyTunnelSignatures[$signature])) {
+            return;
+        }
+
+        --$this->activeProxyTunnelSignatures[$signature];
+
+        if ($this->activeProxyTunnelSignatures[$signature] <= 0) {
+            unset($this->activeProxyTunnelSignatures[$signature]);
+        }
     }
 
     /**
@@ -236,10 +308,7 @@ final class CurlMultiHandler
             foreach ($this->delays as $id => $delay) {
                 if ($currentTime >= $delay) {
                     unset($this->delays[$id]);
-                    \curl_multi_add_handle(
-                        $this->getMultiHandle(),
-                        $this->handles[$id]['easy']->handle
-                    );
+                    $this->addHandleToMulti($id, $this->handles[$id]['easy']);
                 }
             }
         }
@@ -397,6 +466,8 @@ final class CurlMultiHandler
         $this->handles = [];
         $this->delays = [];
         $this->deferredCancels = [];
+        $this->activeProxyTunnelSignatures = [];
+        $this->activeProxyTunnelHandles = [];
         $this->active = 0;
         $this->shareHandleState = null;
         $this->deferredClose = false;
@@ -429,8 +500,8 @@ final class CurlMultiHandler
             $attached = !isset($delays[$id]);
 
             if ($attached && $this->hasMultiHandle() && self::hasEasyHandle($easy)) {
-                $this->captureFailure($failure, function () use ($easy): void {
-                    $this->removeHandleFromMulti($easy->handle);
+                $this->captureFailure($failure, function () use ($id, $easy): void {
+                    $this->removeHandleFromMulti($id, $easy->handle);
                 });
             }
 
@@ -558,9 +629,13 @@ final class CurlMultiHandler
     /**
      * @param resource|\CurlHandle $handle
      */
-    private function removeHandleFromMulti($handle): void
+    private function removeHandleFromMulti(int $id, $handle): void
     {
-        \curl_multi_remove_handle($this->getMultiHandle(), $handle);
+        try {
+            \curl_multi_remove_handle($this->getMultiHandle(), $handle);
+        } finally {
+            $this->unmarkProxyTunnelActiveById($id);
+        }
     }
 
     private function hasMultiHandle(): bool
@@ -579,7 +654,7 @@ final class CurlMultiHandler
         $id = (int) $easy->handle;
         $this->handles[$id] = $entry;
         if (empty($easy->options['delay'])) {
-            \curl_multi_add_handle($this->getMultiHandle(), $easy->handle);
+            $this->addHandleToMulti($id, $easy);
         } else {
             $this->delays[$id] = Utils::currentTime() + ($easy->options['delay'] / 1000);
         }
@@ -610,7 +685,7 @@ final class CurlMultiHandler
         }
 
         if (!$delayed && $this->hasMultiHandle() && self::hasEasyHandle($easy)) {
-            $this->removeHandleFromMulti($easy->handle);
+            $this->removeHandleFromMulti($id, $easy->handle);
         }
 
         $this->disposeEasyHandle($easy);
@@ -627,12 +702,12 @@ final class CurlMultiHandler
         $entries = $this->deferredCancels;
         $this->deferredCancels = [];
 
-        foreach ($entries as $entry) {
+        foreach ($entries as $id => $entry) {
             $easy = $entry['easy'];
 
             if ($entry['attached'] && $this->hasMultiHandle() && self::hasEasyHandle($easy)) {
-                $this->captureFailure($failure, function () use ($easy): void {
-                    $this->removeHandleFromMulti($easy->handle);
+                $this->captureFailure($failure, function () use ($id, $easy): void {
+                    $this->removeHandleFromMulti($id, $easy->handle);
                 });
             }
 
@@ -663,7 +738,7 @@ final class CurlMultiHandler
                     continue;
                 }
                 $id = (int) $done['handle'];
-                $this->removeHandleFromMulti($done['handle']);
+                $this->removeHandleFromMulti($id, $done['handle']);
 
                 if (!isset($this->handles[$id])) {
                     // Probably was cancelled.

--- a/tests/Handler/CurlMultiHandlerTest.php
+++ b/tests/Handler/CurlMultiHandlerTest.php
@@ -843,6 +843,212 @@ class CurlMultiHandlerTest extends TestCase
         self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
     }
 
+    public function testActiveForeignProxyTunnelForcesOwnerTransferIsolation(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-a' => 1, 'sig-b' => 1]);
+
+        $easy = self::easyWithSignature('sig-a');
+        $isolate = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->isolateFromForeignActiveProxyTunnel($easy);
+        }, null, CurlMultiHandler::class);
+        $isolate($handler, $easy);
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        self::assertSame('sig-a', self::readMultiProperty($handler, 'proxyTunnelOwner'), 'Isolation must not move the scalar owner.');
+    }
+
+    public function testOwnerMatchingTransferIsNotIsolatedWhenNoForeignSignatureIsActive(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-a' => 1]);
+        unset($_SERVER['_curl']);
+
+        $easy = self::easyWithSignature('sig-a');
+        $isolate = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->isolateFromForeignActiveProxyTunnel($easy);
+        }, null, CurlMultiHandler::class);
+        $isolate($handler, $easy);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
+    }
+
+    public function testForeignTransferIsIsolatedWhenOwnerIsActive(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-a' => 1]);
+
+        $easy = self::easyWithSignature('sig-b');
+        $isolate = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->isolateFromForeignActiveProxyTunnel($easy);
+        }, null, CurlMultiHandler::class);
+        $isolate($handler, $easy);
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testActiveProxyTunnelSignatureCountsAreReferenceCounted(): void
+    {
+        $handler = new CurlMultiHandler();
+        $first = self::easyWithSignature('sig-b');
+        $second = self::easyWithSignature('sig-b');
+
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, int $id, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($id, $easy);
+        }, null, CurlMultiHandler::class);
+        $unmarkById = \Closure::bind(static function (CurlMultiHandler $handler, int $id): void {
+            $handler->unmarkProxyTunnelActiveById($id);
+        }, null, CurlMultiHandler::class);
+
+        $mark($handler, (int) $first->handle, $first);
+        $mark($handler, (int) $second->handle, $second);
+        self::assertSame(['sig-b' => 2], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+
+        $unmarkById($handler, (int) $first->handle);
+        self::assertSame(['sig-b' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+
+        $unmarkById($handler, (int) $second->handle);
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testDelayedTransferIsNotActiveUntilAddedToMultiHandle(): void
+    {
+        $handler = new CurlMultiHandler();
+        $easy = self::easyWithSignature('sig-a');
+        $easy->options = ['delay' => 10000];
+
+        $addRequest = \Closure::bind(static function (CurlMultiHandler $handler, array $entry): void {
+            $handler->addRequest($entry);
+        }, null, CurlMultiHandler::class);
+        $addHandle = \Closure::bind(static function (CurlMultiHandler $handler, int $id, EasyHandle $easy): void {
+            $handler->addHandleToMulti($id, $easy);
+        }, null, CurlMultiHandler::class);
+
+        $addRequest($handler, ['easy' => $easy, 'deferred' => new P\Promise()]);
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'), 'A delayed transfer must not be counted before it attaches.');
+
+        $addHandle($handler, (int) $easy->handle, $easy);
+        self::assertSame(['sig-a' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'), 'The transfer must be counted only once attached.');
+    }
+
+    public function testDeferredCancelDoesNotDoubleDecrementActiveSignature(): void
+    {
+        $handler = new CurlMultiHandler();
+        $easy = self::easyWithSignature('sig-a');
+        $id = (int) $easy->handle;
+
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, int $id, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($id, $easy);
+        }, null, CurlMultiHandler::class);
+        $unmarkById = \Closure::bind(static function (CurlMultiHandler $handler, int $id): void {
+            $handler->unmarkProxyTunnelActiveById($id);
+        }, null, CurlMultiHandler::class);
+
+        $mark($handler, $id, $easy);
+        self::assertSame(['sig-a' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+
+        $unmarkById($handler, $id);
+        $unmarkById($handler, $id);
+
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testCloseClearsActiveProxyTunnelState(): void
+    {
+        $handler = new CurlMultiHandler();
+        $easy = self::easyWithSignature('sig-a');
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, int $id, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($id, $easy);
+        }, null, CurlMultiHandler::class);
+        $mark($handler, (int) $easy->handle, $easy);
+        self::assertSame(['sig-a' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+
+        $handler->close();
+
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testCompletionUnmarksBeforeFinishCanReenter(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::initMultiHandle($handler);
+        $easy = self::easyWithSignature('sig-a');
+        $id = (int) $easy->handle;
+
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, int $id, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($id, $easy);
+        }, null, CurlMultiHandler::class);
+        $remove = \Closure::bind(static function (CurlMultiHandler $handler, int $id, $handle): void {
+            $handler->removeHandleFromMulti($id, $handle);
+        }, null, CurlMultiHandler::class);
+
+        $mark($handler, $id, $easy);
+        self::assertSame(['sig-a' => 1], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([$id => 'sig-a'], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+
+        $remove($handler, $id, $easy->handle);
+
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testNoDelayAddRequestIsolatesAndMarksThroughTheWrapper(): void
+    {
+        $handler = new CurlMultiHandler();
+        self::setMultiProperty($handler, 'proxyTunnelOwner', 'sig-a');
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-b' => 1]);
+        self::setMultiProperty($handler, 'activeProxyTunnelHandles', [-1 => 'sig-b']);
+
+        $addRequest = \Closure::bind(static function (CurlMultiHandler $handler, array $entry): void {
+            $handler->addRequest($entry);
+        }, null, CurlMultiHandler::class);
+
+        $easy = self::easyWithSignature('sig-a');
+        $easy->options = [];
+        $addRequest($handler, ['easy' => $easy, 'deferred' => new P\Promise()]);
+
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        self::assertSame(1, self::readMultiProperty($handler, 'activeProxyTunnelSignatures')['sig-a'] ?? 0, 'The no-delay transfer must be marked active.');
+
+        unset($_SERVER['_curl']);
+        $nullEasy = self::easyWithSignature(null);
+        $nullEasy->options = [];
+        $addRequest($handler, ['easy' => $nullEasy, 'deferred' => new P\Promise()]);
+
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
+        self::assertArrayNotHasKey((int) $nullEasy->handle, self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
+    public function testNullSignatureNeverEntersActiveMaps(): void
+    {
+        $handler = new CurlMultiHandler();
+        $nullEasy = self::easyWithSignature(null);
+
+        $isolate = \Closure::bind(static function (CurlMultiHandler $handler, EasyHandle $easy): void {
+            $handler->isolateFromForeignActiveProxyTunnel($easy);
+        }, null, CurlMultiHandler::class);
+        $mark = \Closure::bind(static function (CurlMultiHandler $handler, int $id, EasyHandle $easy): void {
+            $handler->markProxyTunnelActive($id, $easy);
+        }, null, CurlMultiHandler::class);
+
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', ['sig-b' => 1]);
+        unset($_SERVER['_curl']);
+        $isolate($handler, $nullEasy);
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl'] ?? []);
+
+        self::setMultiProperty($handler, 'activeProxyTunnelSignatures', []);
+        $mark($handler, (int) $nullEasy->handle, $nullEasy);
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelSignatures'));
+        self::assertSame([], self::readMultiProperty($handler, 'activeProxyTunnelHandles'));
+    }
+
     private static function easyWithSignature(?string $signature): EasyHandle
     {
         $easy = new EasyHandle();


### PR DESCRIPTION
CurlMultiHandler can attach transfers from multiple proxy tunnel sections to one multi handle, while its scalar owner only describes idle cache ownership. This adds active signature tracking to the 8.0 lifecycle and documents the concurrent attachment rule.