### PR TITLE
Route Proxy-Authorization through cURL proxy headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 
 - Section proxy tunnel connection reuse by credential so distinct credentials never share a tunnel
 - Isolate concurrent foreign cURL proxy tunnels added while another owner's tunnel is active
+- Route credentialed HTTP(S) proxy Proxy-Authorization headers through cURL proxy header handling
 - Route TLS 1.2 `crypto_method` requests to the stream handler when cURL cannot select TLS 1.2
 - Reject final request URIs missing a scheme or host before transfer
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1019,6 +1019,8 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 > respected when deciding whether a scheme-less `proxy` option value is an
 > HTTP(S) proxy.
 
+When a `Proxy-Authorization` request header is sent through an effective HTTP or HTTPS proxy, the cURL handlers treat it as proxy-scoped rather than origin-scoped. On libcurl 7.37.0 and newer (with the proxy-header cURL constants available), the header is moved to libcurl's proxy header channel (`CURLOPT_PROXYHEADER`) and separate proxy and origin header handling is enabled, so it authenticates the proxy and participates in the proxy tunnel sectioning described above. Separate proxy/origin header handling is also enabled for any CONNECT tunnel through an effective HTTP/HTTPS proxy, so origin request headers are not sent to the proxy on libcurl 7.37.0 through 7.42.0, whose default is unified. On older libcurl (or a build missing those constants), where the proxy and origin header lists cannot be separated, the header is left in place for compatibility but connection reuse is disabled for proxied requests that carry a non-empty `Proxy-Authorization` credential. Strict proxy/origin header separation therefore requires libcurl 7.37.0 or newer; libcurl 7.42.1 and newer separate the lists securely by default. Proxy credential sectioning remains tunnel-focused: non-tunneled HTTPS-proxy TLS credential behavior is not expanded by this change.
+
 ## query
 
 Summary

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1003,11 +1003,11 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 > connections. Anonymous tunnels are sectioned apart from authenticated ones,
 > so an unauthenticated request never rides an authenticated tunnel. Raw
 > `CURLOPT_PROXY` supplied through the `curl` request option is deprecated but
-> still honored and participates in the same sectioning. A non-empty custom proxy
-> authentication value sent with `CURLOPT_PROXYHEADER` is always sectioned because
-> libcurl cannot key connection reuse on those header values. On libcurl 8.20.0
-> and newer, credential sectioning for option-supplied credentials is left to
-> libcurl's own credential-aware connection matching.
+> still honored and participates in the same sectioning. A non-empty custom
+> proxy authentication value sent with `CURLOPT_PROXYHEADER` is always sectioned
+> because libcurl cannot key connection reuse on those header values. On libcurl
+> 8.20.0 and newer, credential sectioning for option-supplied credentials is
+> left to libcurl's own credential-aware connection matching.
 >
 > Sectioning has a cost in mixed workloads: changing the proxy credentials in
 > use discards the idle pooled connections held for the previous credentials,
@@ -1019,7 +1019,23 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 > respected when deciding whether a scheme-less `proxy` option value is an
 > HTTP(S) proxy.
 
-When a `Proxy-Authorization` request header is sent through an effective HTTP or HTTPS proxy, the cURL handlers treat it as proxy-scoped rather than origin-scoped. On libcurl 7.37.0 and newer (with the proxy-header cURL constants available), the header is moved to libcurl's proxy header channel (`CURLOPT_PROXYHEADER`) and separate proxy and origin header handling is enabled, so it authenticates the proxy and participates in the proxy tunnel sectioning described above. Separate proxy/origin header handling is also enabled for any CONNECT tunnel through an effective HTTP/HTTPS proxy, so origin request headers are not sent to the proxy on libcurl 7.37.0 through 7.42.0, whose default is unified. On older libcurl (or a build missing those constants), where the proxy and origin header lists cannot be separated, the header is left in place for compatibility but connection reuse is disabled for proxied requests that carry a non-empty `Proxy-Authorization` credential. Strict proxy/origin header separation therefore requires libcurl 7.37.0 or newer; libcurl 7.42.1 and newer separate the lists securely by default. Proxy credential sectioning remains tunnel-focused: non-tunneled HTTPS-proxy TLS credential behavior is not expanded by this change.
+When a `Proxy-Authorization` request header is sent through an effective HTTP or
+HTTPS proxy, the cURL handlers treat it as proxy-scoped rather than
+origin-scoped. On libcurl 7.37.0 and newer (with the proxy-header cURL constants
+available), the header is moved to libcurl's proxy header channel
+(`CURLOPT_PROXYHEADER`) and separate proxy and origin header handling is enabled,
+so it authenticates the proxy and participates in the proxy tunnel sectioning
+described above. Separate proxy/origin header handling is also enabled for any
+CONNECT tunnel through an effective HTTP/HTTPS proxy, so origin request headers
+are not sent to the proxy on libcurl 7.37.0 through 7.42.0, whose default is
+unified. On older libcurl (or a build missing those constants), where the proxy
+and origin header lists cannot be separated, the header is left in place for
+compatibility but connection reuse is disabled for proxied requests that carry a
+non-empty `Proxy-Authorization` credential. Strict proxy/origin header
+separation therefore requires libcurl 7.37.0 or newer; libcurl 7.42.1 and newer
+separate the lists securely by default. Proxy credential sectioning remains
+tunnel-focused: non-tunneled HTTPS-proxy TLS credential behavior is not expanded
+by this change.
 
 ## query
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1003,8 +1003,8 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 > connections. Anonymous tunnels are sectioned apart from authenticated ones,
 > so an unauthenticated request never rides an authenticated tunnel. Raw
 > `CURLOPT_PROXY` supplied through the `curl` request option is deprecated but
-> still honored and participates in the same sectioning. Custom proxy
-> authentication sent with `CURLOPT_PROXYHEADER` is always sectioned because
+> still honored and participates in the same sectioning. A non-empty custom proxy
+> authentication value sent with `CURLOPT_PROXYHEADER` is always sectioned because
 > libcurl cannot key connection reuse on those header values. On libcurl 8.20.0
 > and newer, credential sectioning for option-supplied credentials is left to
 > libcurl's own credential-aware connection matching.

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -1025,17 +1025,13 @@ origin-scoped. On libcurl 7.37.0 and newer (with the proxy-header cURL constants
 available), the header is moved to libcurl's proxy header channel
 (`CURLOPT_PROXYHEADER`) and separate proxy and origin header handling is enabled,
 so it authenticates the proxy and participates in the proxy tunnel sectioning
-described above. Separate proxy/origin header handling is also enabled for any
-CONNECT tunnel through an effective HTTP/HTTPS proxy, so origin request headers
-are not sent to the proxy on libcurl 7.37.0 through 7.42.0, whose default is
-unified. On older libcurl (or a build missing those constants), where the proxy
-and origin header lists cannot be separated, the header is left in place for
-compatibility but connection reuse is disabled for proxied requests that carry a
-non-empty `Proxy-Authorization` credential. Strict proxy/origin header
-separation therefore requires libcurl 7.37.0 or newer; libcurl 7.42.1 and newer
-separate the lists securely by default. Proxy credential sectioning remains
-tunnel-focused: non-tunneled HTTPS-proxy TLS credential behavior is not expanded
-by this change.
+described above. Guzzle also enables separate proxy/origin header handling for
+CONNECT tunnels through an effective HTTP/HTTPS proxy. On older libcurl (or a
+build missing those constants), where the proxy and origin header lists cannot be
+separated, the header is left in place for compatibility but connection reuse is
+disabled for proxied requests that carry a non-empty `Proxy-Authorization`
+credential. Proxy credential sectioning remains tunnel-focused: non-tunneled
+HTTPS-proxy TLS credential behavior is not expanded by this change.
 
 ## query
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -799,8 +799,20 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         $proxy = $conf[\CURLOPT_PROXY];
+        if (!\is_string($proxy) || $proxy === '') {
+            return null;
+        }
 
-        return \is_string($proxy) && $proxy !== '' ? $proxy : null;
+        // Only the exact raw wildcard is modeled here: libcurl treats '*' as
+        // bypass-all by whole-string comparison, without trimming or host matching.
+        if (\defined('CURLOPT_NOPROXY')) {
+            $noProxy = $conf[(int) \constant('CURLOPT_NOPROXY')] ?? null;
+            if (\is_string($noProxy) && $noProxy === '*') {
+                return null;
+            }
+        }
+
+        return $proxy;
     }
 
     /**

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -143,6 +143,7 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         self::normalizeCurlHeaderOptions($conf);
+        self::applyProxyAuthorizationHeaderHandling($request, $conf);
 
         if ($this->shareHandle !== null) {
             // Conservative blanket mode: a configured share handle hides the
@@ -1012,39 +1013,131 @@ class CurlFactory implements CurlFactoryInterface
      */
     private static function hasCurlProxyAuthorizationHeader(array $conf): bool
     {
-        if (!\defined('CURLOPT_PROXYHEADER')) {
-            return false;
+        return self::curlProxyAuthorizationHeaderValues($conf) !== [];
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function applyProxyAuthorizationHeaderHandling(RequestInterface $request, array &$conf): void
+    {
+        $proxy = self::getEffectiveProxy($conf);
+        if ($proxy === null || !self::isHttpProxyForConnectionReuse($proxy, $conf)) {
+            return;
         }
 
+        $httpHeaders = $conf[\CURLOPT_HTTPHEADER] ?? null;
+        $movedHeaders = [];
+        $originHeaders = [];
+
+        if (\is_array($httpHeaders)) {
+            foreach ($httpHeaders as $header) {
+                if (\is_string($header) && self::isProxyAuthorizationHeaderLine($header)) {
+                    $movedHeaders[] = $header;
+
+                    continue;
+                }
+
+                $originHeaders[] = $header;
+            }
+        }
+
+        if (CurlVersion::supportsProxyHeaderSeparation()) {
+            if ($movedHeaders !== []) {
+                $conf[\CURLOPT_HTTPHEADER] = $originHeaders;
+                self::appendCurlProxyHeaders($conf, $movedHeaders);
+            }
+
+            // On libcurl 7.37.0-7.42.0 the default is CURLHEADER_UNIFIED.
+            if ($movedHeaders !== [] || self::hasCurlProxyHeaderOption($conf) || self::usesProxyTunnel($request, $conf)) {
+                $conf[(int) \constant('CURLOPT_HEADEROPT')] = (int) \constant('CURLHEADER_SEPARATE');
+            }
+
+            return;
+        }
+
+        if (\is_array($httpHeaders) && self::proxyAuthorizationHeaderValuesFromList($httpHeaders) !== []) {
+            $conf[\CURLOPT_FRESH_CONNECT] = true;
+            $conf[\CURLOPT_FORBID_REUSE] = true;
+        }
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     * @param list<string>             $headers
+     */
+    private static function appendCurlProxyHeaders(array &$conf, array $headers): void
+    {
         $option = (int) \constant('CURLOPT_PROXYHEADER');
-        if (!\array_key_exists($option, $conf)) {
+
+        if (\array_key_exists($option, $conf)) {
+            if (!\is_array($conf[$option])) {
+                throw new \InvalidArgumentException('CURLOPT_PROXYHEADER must be an array when Proxy-Authorization is migrated from CURLOPT_HTTPHEADER.');
+            }
+
+            $headers = \array_merge($conf[$option], $headers);
+        }
+
+        $conf[$option] = $headers;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlProxyHeaderOption(array $conf): bool
+    {
+        return \defined('CURLOPT_PROXYHEADER')
+            && \array_key_exists((int) \constant('CURLOPT_PROXYHEADER'), $conf);
+    }
+
+    private static function isProxyAuthorizationHeaderLine(string $header): bool
+    {
+        $length = \strcspn($header, ':;');
+
+        if ($length === \strlen($header)) {
             return false;
         }
 
-        $headers = $conf[$option];
-        if (!\is_array($headers)) {
-            return false;
+        return 0 === \strcasecmp(\trim(\substr($header, 0, $length)), 'Proxy-Authorization');
+    }
+
+    private static function proxyAuthorizationHeaderValue(string $header): ?string
+    {
+        $position = \strpos($header, ':');
+        if ($position === false) {
+            return null;
         }
+
+        if (0 !== \strcasecmp(\trim(\substr($header, 0, $position)), 'Proxy-Authorization')) {
+            return null;
+        }
+
+        $value = \trim(\substr($header, $position + 1));
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @param mixed[] $headers
+     *
+     * @return list<string>
+     */
+    private static function proxyAuthorizationHeaderValuesFromList(array $headers): array
+    {
+        $values = [];
 
         foreach ($headers as $header) {
             if (!\is_string($header)) {
                 continue;
             }
 
-            $parts = \explode(':', $header, 2);
-            if (\count($parts) !== 2) {
-                continue;
-            }
-
-            if (
-                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
-                && \trim($parts[1]) !== ''
-            ) {
-                return true;
+            $value = self::proxyAuthorizationHeaderValue($header);
+            if ($value !== null) {
+                $values[] = $value;
             }
         }
 
-        return false;
+        return $values;
     }
 
     /**
@@ -1077,10 +1170,16 @@ class CurlFactory implements CurlFactoryInterface
         // reuse, so over-covering is always safe; under-covering leaks. Proxy
         // credentials are the channel CVE-2026-3784 missed; the proxy-TLS
         // options are load-bearing on builds before the proxy-TLS reuse fixes
-        // (client cert from 7.50.1, CVE-2016-5420; TLS-SRP from 7.83.1,
-        // CVE-2022-27782) and harmless after. The private key and cert/key
-        // encoding are deliberately omitted: the hashed X.509 client cert is
-        // the proxy-visible identity and maps 1:1 to its key.
+        // (the proxy client cert is keyed from 7.52.0, libcurl's first
+        // HTTPS-proxy release; CVE-2016-5420 (7.50.1) is only the origin-cert
+        // precedent; TLS-SRP from 7.83.1, CVE-2022-27782) and harmless after.
+        // The private-key file and passphrase are hashed on this non-delegated
+        // path too, as fallback hardening: libcurl's mTLS private-key matching
+        // on reuse was incomplete before 8.21.0 (CVE-2026-8932). This does not
+        // cover the delegated path (the early return above) or configured share
+        // handles, so it is not a complete pre-8.21.0 mitigation. The key blob
+        // and cert/key type encodings (PROXY_SSLKEY_BLOB, PROXY_SSLKEYTYPE,
+        // PROXY_SSLCERTTYPE) are not hashed and are an accepted residual.
         $credentialState = [];
         foreach ([
             'CURLOPT_PROXYUSERPWD', 'CURLOPT_PROXYUSERNAME', 'CURLOPT_PROXYPASSWORD',
@@ -1118,30 +1217,7 @@ class CurlFactory implements CurlFactoryInterface
             return [];
         }
 
-        $values = [];
-        foreach ($headers as $header) {
-            if (!\is_string($header)) {
-                continue;
-            }
-
-            $parts = \explode(':', $header, 2);
-            if (\count($parts) !== 2) {
-                continue;
-            }
-
-            if (
-                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
-                && \trim($parts[1]) !== ''
-            ) {
-                $values[] = \trim($parts[1]);
-            }
-        }
-
-        // Sort so the signature depends on the set of header credentials, not
-        // their order, which avoids spurious re-sectioning across requests.
-        \sort($values);
-
-        return $values;
+        return self::proxyAuthorizationHeaderValuesFromList($headers);
     }
 
     private function discardIdleHandles(): void

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -33,6 +33,8 @@ final class CurlVersion
     // fixed in 8.20.0, so connection reuse is trusted from 8.20.0 onwards.
     private const PROXY_CREDENTIAL_REUSE_VERSION = '8.20.0';
 
+    private const PROXY_HEADER_SEPARATION_VERSION = '7.37.0';
+
     /**
      * @var array{version: string, features: int}|false|null
      */
@@ -142,6 +144,17 @@ final class CurlVersion
 
         return $version !== null
             && \version_compare($version, self::PROXY_CREDENTIAL_REUSE_VERSION, '>=');
+    }
+
+    public static function supportsProxyHeaderSeparation(): bool
+    {
+        $version = self::getVersion();
+
+        return $version !== null
+            && \version_compare($version, self::PROXY_HEADER_SEPARATION_VERSION, '>=')
+            && \defined('CURLOPT_PROXYHEADER')
+            && \defined('CURLOPT_HEADEROPT')
+            && \defined('CURLHEADER_SEPARATE');
     }
 
     private static function supportsSsl(): bool

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Server\Server;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\TransportSharing;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -1223,6 +1224,301 @@ class CurlFactoryTest extends TestCase
         self::assertNotNull($delegated);
         self::assertSame($delegated, $anonymousDelegated);
         self::assertNotSame($delegated, $literalHeader);
+    }
+
+    public function testMigratesPsrProxyAuthorizationHeaderToProxyHeaderWhenSupported(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        self::skipIfProxyHeaderSeparationUnavailable();
+
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.37.0', 'features' => 0]);
+
+        try {
+            (new CurlFactory(3))->create(
+                new Psr7\Request('GET', 'http://example.com', [
+                    'Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                ]),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+
+            self::assertNotContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+            self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][$proxyHeaderOption]);
+            self::assertSame((int) \constant('CURLHEADER_SEPARATE'), $_SERVER['_curl'][(int) \constant('CURLOPT_HEADEROPT')]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testMigratedPsrProxyAuthorizationHeaderSectionsTunnelEvenOnFixedCurl(): void
+    {
+        self::skipIfProxyHeaderSeparationUnavailable();
+
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '8.20.0', 'features' => 0]);
+
+        try {
+            $factory = new CurlFactory(3);
+            $first = $factory->create(
+                new Psr7\Request('GET', 'https://example.com', [
+                    'Proxy-Authorization' => 'Basic dXNlcjE6cGFzczE=',
+                ]),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+            $second = $factory->create(
+                new Psr7\Request('GET', 'https://example.com', [
+                    'Proxy-Authorization' => 'Basic dXNlcjI6cGFzczI=',
+                ]),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+
+            self::assertNotNull($first->proxyTunnelSignature);
+            self::assertNotNull($second->proxyTunnelSignature);
+            self::assertNotSame($first->proxyTunnelSignature, $second->proxyTunnelSignature);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testMigratedProxyAuthorizationAppendsToExistingProxyHeaders(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        self::skipIfProxyHeaderSeparationUnavailable();
+
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.42.1', 'features' => 0]);
+
+        try {
+            (new CurlFactory(3))->create(
+                new Psr7\Request('GET', 'http://example.com', [
+                    'Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                ]),
+                [
+                    'proxy' => 'http://proxy.example.com:8080',
+                    'curl' => [$proxyHeaderOption => ['X-Proxy-Trace: 1']],
+                ]
+            );
+
+            self::assertSame(
+                ['X-Proxy-Trace: 1', 'Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+                $_SERVER['_curl'][$proxyHeaderOption]
+            );
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testProxyHeaderSeparationIsSetWhenProxyHeaderAlreadyPresent(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        self::skipIfProxyHeaderSeparationUnavailable();
+
+        $factory = new CurlFactory(3);
+        self::createOnFactory($factory, '7.42.1', 'http://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [$proxyHeaderOption => ['X-Proxy-Trace: 1']],
+        ]);
+
+        self::assertSame((int) \constant('CURLHEADER_SEPARATE'), $_SERVER['_curl'][(int) \constant('CURLOPT_HEADEROPT')]);
+    }
+
+    public function testProxyHeaderSeparationIsSetForConnectTunnelWithoutProxyHeader(): void
+    {
+        self::skipIfProxyHeaderSeparationUnavailable();
+
+        $factory = new CurlFactory(3);
+        self::createOnFactory($factory, '7.37.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+        ]);
+
+        self::assertSame((int) \constant('CURLHEADER_SEPARATE'), $_SERVER['_curl'][(int) \constant('CURLOPT_HEADEROPT')]);
+    }
+
+    public function testLegacyCurlPreservesProxyAuthorizationHeaderAndForcesFreshConnection(): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.36.0', 'features' => 0]);
+
+        try {
+            (new CurlFactory(3))->create(
+                new Psr7\Request('GET', 'http://example.com', [
+                    'Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                ]),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+
+            self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+            self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+            self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testDirectRequestDoesNotMoveProxyAuthorizationHeader(): void
+    {
+        self::withProxyEnvironment([], static function (): void {
+            $previousVersionInfo = self::setCurlVersionInfo(['version' => '8.20.0', 'features' => 0]);
+
+            try {
+                (new CurlFactory(3))->create(
+                    new Psr7\Request('GET', 'http://example.com', [
+                        'Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                    ]),
+                    ['proxy' => '']
+                );
+
+                self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+                self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+                self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+                if (\defined('CURLOPT_PROXYHEADER')) {
+                    self::assertArrayNotHasKey((int) \constant('CURLOPT_PROXYHEADER'), $_SERVER['_curl']);
+                }
+                if (\defined('CURLOPT_HEADEROPT')) {
+                    self::assertArrayNotHasKey((int) \constant('CURLOPT_HEADEROPT'), $_SERVER['_curl']);
+                }
+            } finally {
+                self::setCurlVersionInfo($previousVersionInfo);
+            }
+        });
+    }
+
+    public function testSocksProxyDoesNotMoveProxyAuthorizationHeader(): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '8.20.0', 'features' => 0]);
+
+        try {
+            (new CurlFactory(3))->create(
+                new Psr7\Request('GET', 'http://example.com', [
+                    'Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                ]),
+                ['proxy' => 'socks5://proxy.example.com:1080']
+            );
+
+            self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+            if (\defined('CURLOPT_PROXYHEADER')) {
+                self::assertArrayNotHasKey((int) \constant('CURLOPT_PROXYHEADER'), $_SERVER['_curl']);
+            }
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testNonArrayProxyHeaderThrowsWhenMigrationWouldAppend(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        self::skipIfProxyHeaderSeparationUnavailable();
+
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.42.1', 'features' => 0]);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('CURLOPT_PROXYHEADER');
+
+            (new CurlFactory(3))->create(
+                new Psr7\Request('GET', 'http://example.com', [
+                    'Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                ]),
+                [
+                    'proxy' => 'http://proxy.example.com:8080',
+                    'curl' => [$proxyHeaderOption => 'not-an-array'],
+                ]
+            );
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testMigratesEmptyPsrProxyAuthorizationHeaderWithoutTreatingItAsCredential(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        self::skipIfProxyHeaderSeparationUnavailable();
+
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '8.20.0', 'features' => 0]);
+
+        try {
+            $easy = (new CurlFactory(3))->create(
+                new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => '']),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+
+            self::assertNotContains('Proxy-Authorization;', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+            self::assertContains('Proxy-Authorization;', $_SERVER['_curl'][$proxyHeaderOption]);
+            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+
+            $baseline = self::createOnFactory(new CurlFactory(3), '8.20.0', 'https://example.com', [
+                'proxy' => 'http://proxy.example.com:8080',
+            ]);
+            self::assertSame($baseline->proxyTunnelSignature, $easy->proxyTunnelSignature);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testLegacyCurlEmptyProxyAuthorizationHeaderDoesNotForceFreshConnection(): void
+    {
+        $previousVersionInfo = self::setCurlVersionInfo(['version' => '7.36.0', 'features' => 0]);
+
+        try {
+            (new CurlFactory(3))->create(
+                new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => '']),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+
+            self::assertContains('Proxy-Authorization;', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    public function testMigratesRawHttpHeaderProxyAuthorizationWhenSupportedUsingHelper(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        self::skipIfProxyHeaderSeparationUnavailable();
+
+        $conf = self::invokeProxyAuthorizationHeaderHandling('7.37.0', new Psr7\Request('GET', 'http://example.com'), [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            \CURLOPT_HTTPHEADER => ['Accept:', 'Proxy-Authorization: Basic raw'],
+        ]);
+
+        self::assertSame(['Accept:'], $conf[\CURLOPT_HTTPHEADER]);
+        self::assertContains('Proxy-Authorization: Basic raw', $conf[$proxyHeaderOption]);
+        self::assertSame((int) \constant('CURLHEADER_SEPARATE'), $conf[(int) \constant('CURLOPT_HEADEROPT')]);
+    }
+
+    public function testLegacyCurlRawHttpHeaderProxyAuthorizationForcesFreshConnectionUsingHelper(): void
+    {
+        $conf = self::invokeProxyAuthorizationHeaderHandling('7.36.0', new Psr7\Request('GET', 'http://example.com'), [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            \CURLOPT_HTTPHEADER => ['Proxy-Authorization: Basic raw'],
+        ]);
+
+        self::assertContains('Proxy-Authorization: Basic raw', $conf[\CURLOPT_HTTPHEADER]);
+        self::assertTrue($conf[\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($conf[\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testProxyAuthorizationHeaderOrderAffectsSignature(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $first = self::computeProxyTunnelSignature('8.20.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            $proxyHeaderOption => [
+                'Proxy-Authorization: Basic dXNlcjE6cGFzczE=',
+                'Proxy-Authorization: Basic dXNlcjI6cGFzczI=',
+            ],
+        ]);
+        $second = self::computeProxyTunnelSignature('8.20.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            $proxyHeaderOption => [
+                'Proxy-Authorization: Basic dXNlcjI6cGFzczI=',
+                'Proxy-Authorization: Basic dXNlcjE6cGFzczE=',
+            ],
+        ]);
+
+        self::assertNotNull($first);
+        self::assertNotNull($second);
+        self::assertNotSame($first, $second);
     }
 
     public function testSectionsAuthenticatedHttpProxyTunnelOnAffectedCurlVersion(): void
@@ -2737,6 +3033,43 @@ class CurlFactoryTest extends TestCase
         }
 
         $method->invokeArgs(null, [&$conf]);
+    }
+
+    private static function skipIfProxyHeaderSeparationUnavailable(): void
+    {
+        if (
+            !\defined('CURLOPT_PROXYHEADER')
+            || !\defined('CURLOPT_HEADEROPT')
+            || !\defined('CURLHEADER_SEPARATE')
+        ) {
+            self::markTestSkipped('Proxy header separation cURL constants are unavailable.');
+        }
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     *
+     * @return array<int|string, mixed>
+     */
+    private static function invokeProxyAuthorizationHeaderHandling(string $version, RequestInterface $request, array $conf): array
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => 0,
+        ]);
+
+        try {
+            $method = new \ReflectionMethod(CurlFactory::class, 'applyProxyAuthorizationHeaderHandling');
+            if (\PHP_VERSION_ID < 80100) {
+                $method->setAccessible(true);
+            }
+
+            $method->invokeArgs(null, [$request, &$conf]);
+
+            return $conf;
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
     }
 
     private static function redactProxyUserInfo(string $error, ?string $proxy): string

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1133,6 +1133,46 @@ class CurlFactoryTest extends TestCase
         return $cases;
     }
 
+    public function testRawCurlNoProxyWildcardDisablesEffectiveProxy(): void
+    {
+        self::skipIfCurlNoProxyIsUnavailable();
+
+        self::assertNull(self::getEffectiveProxy([
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            (int) \constant('CURLOPT_NOPROXY') => '*',
+        ]));
+    }
+
+    /**
+     * @dataProvider nonWildcardRawCurlNoProxyProvider
+     */
+    public function testRawCurlNoProxyWildcardMustMatchExactly(string $noProxy): void
+    {
+        self::skipIfCurlNoProxyIsUnavailable();
+
+        self::assertSame('http://proxy.example.com:8080', self::getEffectiveProxy([
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            (int) \constant('CURLOPT_NOPROXY') => $noProxy,
+        ]));
+    }
+
+    public static function nonWildcardRawCurlNoProxyProvider(): array
+    {
+        return [
+            'space padded wildcard' => [' * '],
+            'tab padded wildcard' => ["\t*\t"],
+            'nul-prefixed wildcard' => ["\0*"],
+            'host pattern' => ['example.com'],
+        ];
+    }
+
+    public function testEffectiveProxyWithoutRawCurlNoProxyIsUnchanged(): void
+    {
+        self::assertSame('http://proxy.example.com:8080', self::getEffectiveProxy([
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+        ]));
+    }
+
     public function testSectionsProxyAuthorizationHeaderEvenOnFixedCurlVersion(): void
     {
         $proxyHeaderOption = self::proxyHeaderOption();
@@ -1178,6 +1218,9 @@ class CurlFactoryTest extends TestCase
         $proxyHeaderOption = self::proxyHeaderOption();
 
         $factory = new CurlFactory(3);
+        $delegatedBaseline = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+        ])->proxyTunnelSignature;
         $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
@@ -1186,6 +1229,7 @@ class CurlFactoryTest extends TestCase
         ]);
 
         self::assertNotNull($easy->proxyTunnelSignature);
+        self::assertSame($delegatedBaseline, $easy->proxyTunnelSignature);
     }
 
     public function testUnrelatedProxyHeaderUsesDelegatedOwnerOnFixedCurlVersion(): void
@@ -1193,6 +1237,9 @@ class CurlFactoryTest extends TestCase
         $proxyHeaderOption = self::proxyHeaderOption();
 
         $factory = new CurlFactory(3);
+        $delegatedBaseline = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+        ])->proxyTunnelSignature;
         $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
@@ -1201,6 +1248,7 @@ class CurlFactoryTest extends TestCase
         ]);
 
         self::assertNotNull($easy->proxyTunnelSignature);
+        self::assertSame($delegatedBaseline, $easy->proxyTunnelSignature);
     }
 
     public function testDelegatedProxyTunnelOwnerIsDistinctFromLiteralProxyAuthorizationOwner(): void
@@ -1570,6 +1618,45 @@ class CurlFactoryTest extends TestCase
         $second = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
             \CURLOPT_PROXY => 'https://proxy.example.com:8080',
             $tlsAuthPassword => 'secret2',
+        ]);
+
+        self::assertNotNull($first);
+        self::assertNotSame($first, $second);
+    }
+
+    public function testProxySslKeyChangesProxyTunnelSignature(): void
+    {
+        if (!\defined('CURLOPT_PROXY_SSLKEY')) {
+            self::markTestSkipped('CURLOPT_PROXY_SSLKEY is not available.');
+        }
+
+        // On this non-delegated (pre-8.20.0) path the proxy private-key file is
+        // keyed as fallback hardening: libcurl's mTLS private-key matching on reuse
+        // was incomplete before 8.21.0 (CVE-2026-8932).
+        $sslKey = (int) \constant('CURLOPT_PROXY_SSLKEY');
+        $first = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080', $sslKey => '/path/to/key-a.pem',
+        ]);
+        $second = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080', $sslKey => '/path/to/key-b.pem',
+        ]);
+
+        self::assertNotNull($first);
+        self::assertNotSame($first, $second);
+    }
+
+    public function testProxyKeyPasswdChangesProxyTunnelSignature(): void
+    {
+        if (!\defined('CURLOPT_PROXY_KEYPASSWD')) {
+            self::markTestSkipped('CURLOPT_PROXY_KEYPASSWD is not available.');
+        }
+
+        $keyPasswd = (int) \constant('CURLOPT_PROXY_KEYPASSWD');
+        $first = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080', $keyPasswd => 'secret-a',
+        ]);
+        $second = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080', $keyPasswd => 'secret-b',
         ]);
 
         self::assertNotNull($first);
@@ -3020,6 +3107,26 @@ class CurlFactoryTest extends TestCase
         }
 
         return (int) \constant('CURLOPT_PROXYHEADER');
+    }
+
+    private static function skipIfCurlNoProxyIsUnavailable(): void
+    {
+        if (!\defined('CURLOPT_NOPROXY')) {
+            self::markTestSkipped('CURLOPT_NOPROXY is not available.');
+        }
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function getEffectiveProxy(array $conf): ?string
+    {
+        $method = new \ReflectionMethod(CurlFactory::class, 'getEffectiveProxy');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        return $method->invoke(null, $conf);
     }
 
     /**

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -162,6 +162,33 @@ class CurlVersionTest extends TestCase
         }
     }
 
+    public function testSupportsProxyHeaderSeparationUsesMinimumVersion(): void
+    {
+        if (!\defined('CURLOPT_PROXYHEADER') || !\defined('CURLOPT_HEADEROPT') || !\defined('CURLHEADER_SEPARATE')) {
+            self::markTestSkipped('Proxy header separation cURL constants are unavailable.');
+        }
+
+        $previous = self::setCurlVersionInfo(['version' => '7.36.0', 'features' => 0]);
+
+        try {
+            self::assertFalse(CurlVersion::supportsProxyHeaderSeparation());
+
+            self::setCurlVersionInfo(['version' => '7.37.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsProxyHeaderSeparation());
+
+            self::setCurlVersionInfo(['version' => '7.42.0', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsProxyHeaderSeparation());
+
+            self::setCurlVersionInfo(['version' => '7.42.1', 'features' => 0]);
+            self::assertTrue(CurlVersion::supportsProxyHeaderSeparation());
+
+            self::setCurlVersionInfo(false);
+            self::assertFalse(CurlVersion::supportsProxyHeaderSeparation());
+        } finally {
+            self::setCurlVersionInfo($previous);
+        }
+    }
+
     public function testGetVersionReturnsNullWhenVersionIsUnavailable(): void
     {
         $previous = self::setCurlVersionInfo(false);


### PR DESCRIPTION
Routes Proxy-Authorization request headers through libcurl's proxy header channel for HTTP(S) proxies when supported, and disables reuse on legacy libcurl when they cannot be separated. This keeps proxy credentials proxy-scoped and lets the existing tunnel signature logic section literal credentials.