### PR TITLE
Reject CURLOPT_SHARE with authenticated proxy tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Section proxy tunnel connection reuse by credential so distinct credentials never share a tunnel
 - Isolate concurrent foreign cURL proxy tunnels added while another owner's tunnel is active
 - Route credentialed HTTP(S) proxy Proxy-Authorization headers through cURL proxy header handling
+- Reject request-level `CURLOPT_SHARE` when combined with authenticated HTTP/HTTPS proxy tunnel configuration
 - Route TLS 1.2 `crypto_method` requests to the stream handler when cURL cannot select TLS 1.2
 - Reject final request URIs missing a scheme or host before transfer
 

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -444,8 +444,6 @@ $client->request('GET', '/', [
 ]);
 ```
 
-The raw `CURLOPT_SHARE` cURL option remains deprecated as a request-level option in 7.x. It is rejected immediately when Guzzle's `transport_sharing` client option is configured, and it is also rejected when it is combined with authenticated HTTP/HTTPS proxy tunnel configuration, because an external share handle can share connection-cache state outside Guzzle's proxy connection-reuse isolation. Use the `transport_sharing` option for Guzzle-managed connection sharing, or a custom handler/factory for unsupported cURL share-handle behavior.
-
 ## debug
 
 Summary

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -444,6 +444,8 @@ $client->request('GET', '/', [
 ]);
 ```
 
+The raw `CURLOPT_SHARE` cURL option remains deprecated as a request-level option in 7.x. It is rejected immediately when Guzzle's `transport_sharing` client option is configured, and it is also rejected when it is combined with authenticated HTTP/HTTPS proxy tunnel configuration, because an external share handle can share connection-cache state outside Guzzle's proxy connection-reuse isolation. Use the `transport_sharing` option for Guzzle-managed connection sharing, or a custom handler/factory for unsupported cURL share-handle behavior.
+
 ## debug
 
 Summary

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -144,6 +144,7 @@ class CurlFactory implements CurlFactoryInterface
 
         self::normalizeCurlHeaderOptions($conf);
         self::applyProxyAuthorizationHeaderHandling($request, $conf);
+        self::rejectRequestLevelShareWithProxyAuth($request, $options, $conf);
 
         if ($this->shareHandle !== null) {
             // Conservative blanket mode: a configured share handle hides the
@@ -249,6 +250,67 @@ class CurlFactory implements CurlFactoryInterface
         }
 
         throw new \InvalidArgumentException('The request-level CURLOPT_SHARE cURL option cannot be combined with configured transport sharing.');
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function rejectRequestLevelShareWithProxyAuth(RequestInterface $request, array $options, array $conf): void
+    {
+        if (!self::hasRequestLevelCurlShare($options)) {
+            return;
+        }
+
+        $proxy = self::getEffectiveProxy($conf);
+        if (
+            $proxy === null
+            || !self::usesProxyTunnel($request, $conf)
+            || !self::isHttpProxyForConnectionReuse($proxy, $conf)
+            || !self::hasAuthenticatedHttpProxyState($proxy, $conf)
+        ) {
+            return;
+        }
+
+        throw new \InvalidArgumentException('The request-level CURLOPT_SHARE cURL option cannot be combined with authenticated HTTP/HTTPS proxy tunnel configuration; use Guzzle-managed "transport_sharing" or a custom handler/factory instead.');
+    }
+
+    private static function hasRequestLevelCurlShare(array $options): bool
+    {
+        return \defined('CURLOPT_SHARE')
+            && isset($options['curl'])
+            && \is_array($options['curl'])
+            && \array_key_exists((int) \constant('CURLOPT_SHARE'), $options['curl']);
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasAuthenticatedHttpProxyState(string $proxy, array $conf): bool
+    {
+        $proxyForParsing = \strpos($proxy, '://') === false ? 'http://'.$proxy : $proxy;
+        $proxyParts = \parse_url($proxyForParsing);
+
+        if (
+            \is_array($proxyParts)
+            && (\array_key_exists('user', $proxyParts) || \array_key_exists('pass', $proxyParts))
+        ) {
+            return true;
+        }
+
+        if (self::hasCurlProxyCredentials($conf)) {
+            return true;
+        }
+
+        if (self::hasCurlProxyAuthorizationHeader($conf)) {
+            return true;
+        }
+
+        $httpHeaders = $conf[\CURLOPT_HTTPHEADER] ?? [];
+        if (\is_array($httpHeaders) && self::proxyAuthorizationHeaderValuesFromList($httpHeaders) !== []) {
+            return true;
+        }
+
+        return self::hasCurlProxyTlsCredentials($conf);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -378,6 +378,54 @@ class CurlFactoryTest extends TestCase
         $method->invoke(null, new Psr7\Request('GET', 'https://example.com'), $options, $conf);
     }
 
+    public function testRejectsRequestLevelShareWithStringableProxyAuthorizationHeader(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $conf = [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            $proxyHeaderOption => [new class() {
+                public function __toString(): string
+                {
+                    return 'Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=';
+                }
+            }],
+        ];
+        $options = ['curl' => [(int) \constant('CURLOPT_SHARE') => null]];
+        self::normalizeCurlHeaderOptions($conf);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#CURLOPT_SHARE.*authenticated HTTP/HTTPS proxy tunnel configuration#');
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'rejectRequestLevelShareWithProxyAuth');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+        $method->invoke(null, new Psr7\Request('GET', 'https://example.com'), $options, $conf);
+    }
+
+    public function testAllowsRequestLevelShareWithProxyAuthorizationHeaderWhenRawNoProxyDisablesProxy(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::skipIfCurlNoProxyIsUnavailable();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $conf = [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            (int) \constant('CURLOPT_NOPROXY') => '*',
+            $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+        ];
+        $options = ['curl' => [(int) \constant('CURLOPT_SHARE') => null]];
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'rejectRequestLevelShareWithProxyAuth');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        self::assertNull($method->invoke(null, new Psr7\Request('GET', 'https://example.com'), $options, $conf));
+    }
+
     public function testRejectsRequestLevelShareWithLegacyProxyAuthorizationHeader(): void
     {
         self::skipIfCurlShareIsUnavailable();

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -385,7 +385,7 @@ class CurlFactoryTest extends TestCase
 
         $conf = [
             \CURLOPT_PROXY => 'http://proxy.example.com:8080',
-            $proxyHeaderOption => [new class() {
+            $proxyHeaderOption => [new class {
                 public function __toString(): string
                 {
                     return 'Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=';

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -320,6 +320,107 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public function testRejectsRequestLevelShareWithProxyUrlCredentials(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $conf = [\CURLOPT_PROXY => 'http://username:password@proxy.example.com:8080'];
+        $options = ['curl' => [(int) \constant('CURLOPT_SHARE') => null]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#CURLOPT_SHARE.*authenticated HTTP/HTTPS proxy tunnel configuration#');
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'rejectRequestLevelShareWithProxyAuth');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+        $method->invoke(null, new Psr7\Request('GET', 'https://example.com'), $options, $conf);
+    }
+
+    public function testRejectsRequestLevelShareWithProxyUserPwd(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $conf = [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            \CURLOPT_PROXYUSERPWD => 'username:password',
+        ];
+        $options = ['curl' => [(int) \constant('CURLOPT_SHARE') => null]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#CURLOPT_SHARE.*authenticated HTTP/HTTPS proxy tunnel configuration#');
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'rejectRequestLevelShareWithProxyAuth');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+        $method->invoke(null, new Psr7\Request('GET', 'https://example.com'), $options, $conf);
+    }
+
+    public function testRejectsRequestLevelShareWithProxyAuthorizationHeader(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $conf = [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            $proxyHeaderOption => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+        ];
+        $options = ['curl' => [(int) \constant('CURLOPT_SHARE') => null]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#CURLOPT_SHARE.*authenticated HTTP/HTTPS proxy tunnel configuration#');
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'rejectRequestLevelShareWithProxyAuth');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+        $method->invoke(null, new Psr7\Request('GET', 'https://example.com'), $options, $conf);
+    }
+
+    public function testRejectsRequestLevelShareWithLegacyProxyAuthorizationHeader(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $conf = [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            \CURLOPT_HTTPHEADER => ['Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='],
+        ];
+        $options = ['curl' => [(int) \constant('CURLOPT_SHARE') => null]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#CURLOPT_SHARE.*authenticated HTTP/HTTPS proxy tunnel configuration#');
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'rejectRequestLevelShareWithProxyAuth');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+        $method->invoke(null, new Psr7\Request('GET', 'https://example.com'), $options, $conf);
+    }
+
+    public function testRejectsRequestLevelShareWithProxyTlsCredential(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        if (!\defined('CURLOPT_PROXY_SSLCERT')) {
+            self::markTestSkipped('CURLOPT_PROXY_SSLCERT is not available.');
+        }
+
+        $conf = [
+            \CURLOPT_PROXY => 'https://proxy.example.com:3128',
+            (int) \constant('CURLOPT_PROXY_SSLCERT') => '/path/to/proxy-client.pem',
+        ];
+        $options = ['curl' => [(int) \constant('CURLOPT_SHARE') => null]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('#CURLOPT_SHARE.*authenticated HTTP/HTTPS proxy tunnel configuration#');
+
+        $method = new \ReflectionMethod(CurlFactory::class, 'rejectRequestLevelShareWithProxyAuth');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+        $method->invoke(null, new Psr7\Request('GET', 'https://example.com'), $options, $conf);
+    }
+
     /**
      * @dataProvider requestTransportSharingOptionProvider
      *


### PR DESCRIPTION
Adds a targeted 7.x rejection for request-level CURLOPT_SHARE only when it is combined with authenticated HTTP/HTTPS proxy tunnel state. This keeps the existing deprecation for other request-level share uses while avoiding external connection-cache sharing for credentialed CONNECT tunnels.