### PR TITLE
Route proxy authorization headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Add `ProxyOptions` for proxy option resolution
 - Add `ResponseException` for request failures with responses
 - Add auth middleware for built-in Basic and Digest authentication
-- Added the `crypto_method_max` request option to cap the maximum TLS protocol version across built-in handlers.
 
 ### Changed
 
@@ -49,6 +48,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject malformed, conflicting, or unrepresentable request `Content-Length` values in built-in handlers
 - Reject raw cURL request options outside the built-in cURL handlers' allow-list
 - Reject non-string raw cURL header-list entries before applying them
+- Reject proxy-auth header fresh connections when persistent transport sharing requires reuse
 - Reject PHP stream context options outside the built-in stream handler allow-list
 - Reject selected request options ignored by incompatible built-in handlers
 - Support retry delay callbacks with retry count only or full retry context

--- a/docs/contributing/curl-connection-reuse.md
+++ b/docs/contributing/curl-connection-reuse.md
@@ -175,11 +175,11 @@ inputs in 8.0.
 **Necessary vs defense-in-depth.**
 
 - *Necessary:* the proxy credentials (`PROXYUSERPWD`/`PROXYUSERNAME`/
-  `PROXYPASSWORD`) — the exact channel the CVE missed — and the literal
-  `Proxy-Authorization` header (`CURLOPT_PROXYHEADER`), which libcurl **never**
-  keys reuse on at any version (it matches *parsed* credentials, not opaque
-  request headers). The header must therefore be sectioned even on fixed
-  libcurl.
+  `PROXYPASSWORD`) — the exact channel the CVE missed — and the non-empty
+  literal `Proxy-Authorization` header (`CURLOPT_PROXYHEADER`), which libcurl
+  **never** keys reuse on at any version (it matches *parsed* credentials, not
+  opaque request headers). The non-empty header must therefore be sectioned even
+  on fixed libcurl.
 - *Mostly defense-in-depth:* the proxy-TLS options (client cert, cert blob, TLS
   version, TLS-SRP). libcurl keys reuse on these via `ssl_primary_config` for an
   HTTPS proxy — but only from 7.52.0 for the proxy client cert (CVE-2016-5420 in
@@ -193,14 +193,21 @@ inputs in 8.0.
 path as fallback hardening — libcurl's mTLS private-key matching on reuse was
 incomplete before 8.21.0 (CVE-2026-8932), see §10. This is not a complete
 pre-8.21.0 mitigation: it does not cover the delegated path (>= 8.20.0 with no
-literal proxy-auth header) or configured share handles. The blob and the two
-encoding types are an **accepted residual**, not proven-safe.
+non-empty literal proxy-auth header) or configured share handles. The blob and
+the two encoding types are an **accepted residual**, not proven-safe.
 
 **The golden rule — over-sectioning is safe.** A non-`null`, changed signature
 only ever forces a *fresh* connection; it never relaxes reuse. So an over-broad
 signature merely costs an extra connection — it can never cause a leak.
 *Under*-covering (omitting a channel libcurl ignores) is the only way to leak.
 **When in doubt, include the channel.**
+
+Raw `CURLOPT_PROXY`/`CURLOPT_NOPROXY` are rejected before this logic in 8.0. On
+branches that still accept raw `CURLOPT_NOPROXY`, effective-proxy detection must
+model only the exact, untrimmed `CURLOPT_NOPROXY === '*'` bypass-all case. Host,
+domain, CIDR, and port values must be treated as still proxied; that can
+over-section a request libcurl would route direct, but it cannot under-section a
+real proxy tunnel.
 
 ## 6. CONNECT_TO implicit tunnels
 
@@ -228,7 +235,7 @@ provenance. For an authenticated proxy tunnel Guzzle then sets
 the conflict into an error rather than silently degrading).
 
 "Authenticated" here mirrors the signature's channels, each gated to the libcurl
-version below which libcurl does not itself key reuse on it: a literal
+version below which libcurl does not itself key reuse on it: a non-empty literal
 `Proxy-Authorization` header (every version), Basic/Digest proxy credentials
 (below 8.20.0, `PROXY_CREDENTIAL_REUSE_VERSION`), and a proxy TLS credential — a
 client certificate or TLS-SRP (below 7.83.1,
@@ -247,19 +254,20 @@ channel's gate and 8.12.0 decides whether the throw can fire:
   persistent-capable build is never turned into a force-fresh or a
   `PERSISTENT_REQUIRE` error by this path; forcing fresh at every version would
   have done exactly that, which is why the 7.83.1 gate is correct.
-- The proxy Basic/Digest gate at 8.20.0 sits *above* 8.12.0, and a literal
-  `Proxy-Authorization` header forces fresh at every version. So on libcurl
-  8.12.0–8.19.x a `PERSISTENT_REQUIRE` request that carries proxy Basic/Digest
-  credentials, or a literal `Proxy-Authorization` header, reaches
-  `forceFreshConnectionForAuthenticatedProxy` and **throws**: persistent sharing
-  is active there, but libcurl on those builds does not yet key reuse on the
-  proxy credential, so the only safe options are a fresh connection or, under
-  `PERSISTENT_REQUIRE`, rejection. This is intended; it rejects unsafe
-  persistent reuse rather than silently sharing a tunnel across credentials, and
-  it became reachable when the connection-sharing floor moved from 8.20.0 down
-  to 8.12.0. From 8.20.0 the credential is keyed by libcurl, so the throw no
-  longer applies to parsed credentials; the literal-header case still does,
-  since libcurl can never key on an opaque request header.
+- The proxy Basic/Digest gate at 8.20.0 sits *above* 8.12.0, and a non-empty
+  literal `Proxy-Authorization` header forces fresh at every version. So on
+  libcurl 8.12.0–8.19.x a `PERSISTENT_REQUIRE` request that carries proxy
+  Basic/Digest credentials, or a non-empty literal `Proxy-Authorization`
+  header, reaches `forceFreshConnectionForAuthenticatedProxy` and **throws**:
+  persistent sharing is active there, but libcurl on those builds does not yet
+  key reuse on the proxy credential, so the only safe options are a fresh
+  connection or, under `PERSISTENT_REQUIRE`, rejection. This is intended; it
+  rejects unsafe persistent reuse rather than silently sharing a tunnel across
+  credentials, and it became reachable when the connection-sharing floor moved
+  from 8.20.0 down to 8.12.0. From 8.20.0 the credential is keyed by libcurl,
+  so the throw no longer applies to parsed credentials; the non-empty
+  literal-header case still does, since libcurl can never key on an opaque
+  request header.
 
 **SSL session sharing floor = 8.6.0 — why it is safe.** Sharing the TLS session
 cache could, in theory, let two handles resume each other's TLS session across
@@ -307,8 +315,9 @@ channels: libcurl < 8.19.0 ignored proxy credentials when matching connections,
 and 8.19.x still carried related proxy-credential leaks fixed in 8.20.0. At or
 above it, libcurl keys reuse on option- and URL-supplied proxy credentials
 itself, so `proxyTunnelSignature()` returns a shared delegated-owner sentinel —
-**except** when a literal `Proxy-Authorization` header is present, which always
-sections because libcurl can never key on an opaque request header (§5).
+**except** when a non-empty literal `Proxy-Authorization` header is present,
+which always sections because libcurl can never key on an opaque request header
+(§5).
 
 This proxy-credential floor (8.20.0) is **distinct** from the connection-cache
 sharing floor (`CONNECTION_SHARING_VERSION = 8.12.0`, §3). The former gates how
@@ -343,8 +352,9 @@ TLS credential below 7.83.1 and not at or above it.
 
 - Never compute a `null` signature for a credential-bearing proxy tunnel.
   Over-section freely; under-sectioning is the only way to leak.
-- Always hash the proxy credentials and the literal `Proxy-Authorization`
-  header; the header sections on **every** libcurl version.
+- Always hash the proxy credentials and the non-empty literal
+  `Proxy-Authorization` header; the non-empty header sections on **every**
+  libcurl version.
 - Use a non-`null` delegated sentinel for real proxy tunnels whose parsed proxy
   credentials, if any, are trusted to libcurl.
 - Never trust libcurl `< 8.20` to distinguish proxy credentials itself.

--- a/docs/contributing/curl-connection-reuse.md
+++ b/docs/contributing/curl-connection-reuse.md
@@ -150,8 +150,27 @@ the pool. Real delegated tunnels on fixed libcurl get a non-`null` sentinel, so
 they stay distinct from genuine non-tunnels and from literal proxy-header tunnel
 owners.
 
+> Non-tunnel proxy requests get a `null` signature and are deliberately left unsectioned. For per-request (HTTP Basic) proxy auth this is safe: `proxy` URL userinfo and the allow-listed `CURLOPT_PROXYUSERPWD` re-authenticate on every request, so a reused non-tunnel proxy connection cannot inherit a foreign identity. Connection-oriented schemes (NTLM, Negotiate) bind identity to the TCP connection, and a caller can still express one through a literal `Proxy-Authorization` header — sent as a PSR header or via the allow-listed raw `CURLOPT_PROXYHEADER` — even though raw `CURLOPT_PROXYAUTH` is rejected. A non-tunnel request carrying such a header is therefore an accepted residual: it is left unsectioned, because sectioning non-tunnel proxy connections would extend the signature domain beyond CONNECT tunnels, which is intentionally out of scope. (A single static header value cannot complete NTLM's multi-leg handshake, but a single-leg Negotiate token can, so the residual is real.)
+
 **The channels hashed:** the effective proxy URL, the proxy credential and
 TLS-identity options, and any literal `Proxy-Authorization` header value.
+
+PSR `Proxy-Authorization` headers are normalized into the proxy-header channel
+(`CURLOPT_PROXYHEADER` with `CURLOPT_HEADEROPT => CURLHEADER_SEPARATE`) for
+effective HTTP and HTTPS proxies wherever libcurl supports header separation
+(7.37.0+). A non-empty literal `Proxy-Authorization: <value>` header is never something
+libcurl can key connection reuse on, even on versions that key parsed proxy
+credentials (8.20.0+), so a tunnel carrying one always sections — its signature
+is hashed, never the delegated owner. (The empty `Proxy-Authorization;` form is
+migrated for wire correctness but carries no credential, so it does not section.) On libcurl older than 7.37.0 the header cannot be
+separated; the handlers keep a non-empty credential header on the wire but force a fresh,
+non-reused connection, which under `PERSISTENT_REQUIRE` is reported as a conflict rather
+than silently degrading reuse.
+
+Proxy TLS credential coverage stays tunnel-only and private: it is
+reflection-tested hardening for CONNECT tunnels, not public non-tunneled
+HTTPS-proxy behavior, because raw proxy TLS cURL options are rejected as public
+inputs in 8.0.
 
 **Necessary vs defense-in-depth.**
 
@@ -163,17 +182,19 @@ TLS-identity options, and any literal `Proxy-Authorization` header value.
   libcurl.
 - *Mostly defense-in-depth:* the proxy-TLS options (client cert, cert blob, TLS
   version, TLS-SRP). libcurl keys reuse on these via `ssl_primary_config` for an
-  HTTPS proxy — but only from 7.50.1 for the client cert (CVE-2016-5420) and
-  7.83.1 for TLS-SRP (CVE-2022-27782). Below those they are load-bearing; above,
+  HTTPS proxy — but only from 7.52.0 for the proxy client cert (CVE-2016-5420 in
+  7.50.1 is the origin-cert precedent, predating HTTPS-proxy support) and 7.83.1
+  for TLS-SRP (CVE-2022-27782). Below those they are load-bearing; above,
   redundant-but-free. They are hashed unconditionally rather than version-gated.
 
 **Deliberate omissions.** `PROXY_SSLKEY_BLOB`, `PROXY_SSLKEYTYPE`, and
-`PROXY_SSLCERTTYPE` are **not** hashed. libcurl's reuse matcher never keys on
-the private key or on cert/key encoding (they live in `ssl_config_data`, outside
-`ssl_primary_config`). They are safe to omit because the proxy-visible identity
-is the **X.509 client certificate** — which *is* hashed — and a certificate has
-exactly one matching key, so a key- or encoding-only change cannot present a
-different identity to the proxy.
+`PROXY_SSLCERTTYPE` are **not** hashed. The private-key *file* and passphrase
+(`PROXY_SSLKEY`, `PROXY_KEYPASSWD`) *are* hashed on the non-delegated signature
+path as fallback hardening — libcurl's mTLS private-key matching on reuse was
+incomplete before 8.21.0 (CVE-2026-8932), see §10. This is not a complete
+pre-8.21.0 mitigation: it does not cover the delegated path (>= 8.20.0 with no
+literal proxy-auth header) or configured share handles. The blob and the two
+encoding types are an **accepted residual**, not proven-safe.
 
 **The golden rule — over-sectioning is safe.** A non-`null`, changed signature
 only ever forces a *fresh* connection; it never relaxes reuse. So an over-broad
@@ -327,8 +348,11 @@ TLS credential below 7.83.1 and not at or above it.
 - Use a non-`null` delegated sentinel for real proxy tunnels whose parsed proxy
   credentials, if any, are trusted to libcurl.
 - Never trust libcurl `< 8.20` to distinguish proxy credentials itself.
-- Do not key the signature on the private key or on cert/key encoding — the
-  certificate is the proxy-visible identity.
+- On the non-delegated signature path, key on the proxy private-key file and
+  passphrase as fallback hardening (libcurl's mTLS private-key matching on reuse
+  was incomplete below 8.21.0, CVE-2026-8932; the delegated path and configured
+  share handles are not covered). The key blob and cert/key encoding are an
+  accepted residual, not proven-safe.
 - `usesProxyTunnel()` must treat `http://` + a non-empty `CURLOPT_CONNECT_TO` as
   a tunnel.
 - Share the TLS session cache only from 8.6.0 and the connection cache only from
@@ -341,7 +365,7 @@ TLS credential below 7.83.1 and not at or above it.
 ## References
 
 **curl** — CVE-2026-3784 (proxy `CONNECT` credential reuse), CVE-2016-5420
-(proxy client-cert reuse), CVE-2022-27782 (TLS / TLS-SRP config not compared on
+(origin client-cert reuse), CVE-2022-27782 (TLS / TLS-SRP config not compared on
 reuse), CVE-2024-0853 (client cert / OCSP on session reuse),
 CVE-2026-6253/6429/7168 (proxy-credential leaks on reuse, fixed 8.20.0),
 CVE-2026-8932 (incomplete mTLS private-key matching on reuse, fixed 8.21.0); the

--- a/docs/contributing/curl-connection-reuse.md
+++ b/docs/contributing/curl-connection-reuse.md
@@ -27,9 +27,9 @@ on the same handle — or across handles, if you share them (§3).
 `CurlFactory` pools easy handles: on `release()` it calls `curl_reset()` (which
 clears per-request options) and returns the handle to a small pool; `create()`
 pops a pooled handle and re-applies the next request's options. The key fact:
-**`curl_reset()` does not close the underlying connection** — reuse is the whole
-point — so a pooled handle can carry a live connection from one request into the
-next.
+**`curl_reset()` does not close the underlying connection** — reuse is the
+whole point — so a pooled handle can carry a live connection from one request
+into the next.
 
 The option pipeline is: Guzzle request options (`proxy`, `cert`, …) → an
 internal `$conf` array of `CURLOPT_* => value` → `curl_setopt_array()`.
@@ -41,13 +41,13 @@ This gate is about option-key availability and known conflicts only. Unless
 Guzzle documents a specific mitigation, the meaning, safety, and runtime effects
 of raw cURL option values remain the caller's responsibility.
 
-**PHP detail — the `\defined()` guard.** A `CURLOPT_*` constant is only defined
-when the linked libcurl/PHP build supports that option, so code that touches an
-optional option guards with `\defined()`/`\constant()`. This is safe by
-construction: PHP's `curl_setopt()` never forwards an *unknown* option integer
-to libcurl (PHP 8 throws `ValueError`; PHP 7 silently no-ops), and a constant is
-registered under the same `#if LIBCURL_VERSION_NUM` guard as its setopt handler,
-so an undefined constant can never become a live channel.
+**PHP detail — the `\defined()` guard.** A `CURLOPT_*` constant is only
+defined when the linked libcurl/PHP build supports that option, so code that
+touches an optional option guards with `\defined()`/`\constant()`. This is safe
+by construction: PHP's `curl_setopt()` never forwards an *unknown* option
+integer to libcurl (PHP 8 throws `ValueError`; PHP 7 silently no-ops), and a
+constant is registered under the same `#if LIBCURL_VERSION_NUM` guard as its
+setopt handler, so an undefined constant can never become a live channel.
 
 ## 2. Why reuse is both good and dangerous
 
@@ -60,9 +60,9 @@ that expects a different one, that is a leak. libcurl decides whether to reuse a
 connection by **matching connection attributes**, and bugs in that matching have
 produced CVEs (§4, §7).
 
-libcurl matches on host, port, scheme, proxy type/host/port, and — for TLS — its
-"primary" SSL config. There is an important split in libcurl's data model that
-several decisions below depend on:
+libcurl matches on host, port, scheme, proxy type/host/port, and — for TLS —
+its "primary" SSL config. There is an important split in libcurl's data model
+that several decisions below depend on:
 
 - **`ssl_primary_config` (compared for reuse):** client certificate and cert
   blob, CA info, TLS version, cipher lists, pinned key, TLS-SRP credentials,
@@ -123,20 +123,21 @@ change).
 
 **Guzzle's mitigation.** `CurlFactory::proxyTunnelSignature()` computes a
 per-request signature over the proxy identity. When it changes between requests,
-Guzzle forces a fresh connection — purging pooled idle handles that might hold a
-foreign tunnel — so libcurl cannot hand one request a tunnel established under a
-different identity.
+Guzzle forces a fresh connection — purging pooled idle handles that might hold
+a foreign tunnel — so libcurl cannot hand one request a tunnel established
+under a different identity.
 
-**`CurlMultiHandler` active-attachment isolation.** A single `CurlMultiHandler`
-reuses one libcurl multi handle — and therefore one connection cache — across
-transfers. It tracks the proxy tunnel section that owns that idle cache in a
-scalar `$proxyTunnelOwner`, handed over only when the handle is fully idle.
+**`CurlMultiHandler` active-attachment isolation.** A single
+`CurlMultiHandler` reuses one libcurl multi handle — and therefore one
+connection cache — across transfers. It tracks the proxy tunnel section that
+owns that idle cache in a scalar `$proxyTunnelOwner`, handed over only when the
+handle is fully idle.
 Concurrency is governed separately by a reference-counted map of the proxy
 tunnel signatures *currently attached* to the multi handle. While a foreign
 signature is attached, even an owner-compatible transfer is isolated with
-`CURLOPT_FRESH_CONNECT` + `CURLOPT_FORBID_REUSE` — the `A / B / A` case — because
-the latched owner records who inherited the idle cache, not which sections are in
-flight right now.
+`CURLOPT_FRESH_CONNECT` + `CURLOPT_FORBID_REUSE` — the `A / B / A` case —
+because the latched owner records who inherited the idle cache, not which
+sections are in flight right now.
 
 ## 5. The signature: what it covers and why
 
@@ -150,7 +151,19 @@ the pool. Real delegated tunnels on fixed libcurl get a non-`null` sentinel, so
 they stay distinct from genuine non-tunnels and from literal proxy-header tunnel
 owners.
 
-> Non-tunnel proxy requests get a `null` signature and are deliberately left unsectioned. For per-request (HTTP Basic) proxy auth this is safe: `proxy` URL userinfo and the allow-listed `CURLOPT_PROXYUSERPWD` re-authenticate on every request, so a reused non-tunnel proxy connection cannot inherit a foreign identity. Connection-oriented schemes (NTLM, Negotiate) bind identity to the TCP connection, and a caller can still express one through a literal `Proxy-Authorization` header — sent as a PSR header or via the allow-listed raw `CURLOPT_PROXYHEADER` — even though raw `CURLOPT_PROXYAUTH` is rejected. A non-tunnel request carrying such a header is therefore an accepted residual: it is left unsectioned, because sectioning non-tunnel proxy connections would extend the signature domain beyond CONNECT tunnels, which is intentionally out of scope. (A single static header value cannot complete NTLM's multi-leg handshake, but a single-leg Negotiate token can, so the residual is real.)
+> Non-tunnel proxy requests get a `null` signature and are deliberately left
+> unsectioned. For per-request (HTTP Basic) proxy auth this is safe: `proxy` URL
+> userinfo and the allow-listed `CURLOPT_PROXYUSERPWD` re-authenticate on every
+> request, so a reused non-tunnel proxy connection cannot inherit a foreign
+> identity. Connection-oriented schemes (NTLM, Negotiate) bind identity to the
+> TCP connection, and a caller can still express one through a literal
+> `Proxy-Authorization` header — sent as a PSR header or via the allow-listed
+> raw `CURLOPT_PROXYHEADER` — even though raw `CURLOPT_PROXYAUTH` is rejected.
+> A non-tunnel request carrying such a header is therefore an accepted residual:
+> it is left unsectioned, because sectioning non-tunnel proxy connections would
+> extend the signature domain beyond CONNECT tunnels, which is intentionally out
+> of scope. (A single static header value cannot complete NTLM's multi-leg
+> handshake, but a single-leg Negotiate token can, so the residual is real.)
 
 **The channels hashed:** the effective proxy URL, the proxy credential and
 TLS-identity options, and any literal `Proxy-Authorization` header value.
@@ -158,14 +171,15 @@ TLS-identity options, and any literal `Proxy-Authorization` header value.
 PSR `Proxy-Authorization` headers are normalized into the proxy-header channel
 (`CURLOPT_PROXYHEADER` with `CURLOPT_HEADEROPT => CURLHEADER_SEPARATE`) for
 effective HTTP and HTTPS proxies wherever libcurl supports header separation
-(7.37.0+). A non-empty literal `Proxy-Authorization: <value>` header is never something
-libcurl can key connection reuse on, even on versions that key parsed proxy
-credentials (8.20.0+), so a tunnel carrying one always sections — its signature
-is hashed, never the delegated owner. (The empty `Proxy-Authorization;` form is
-migrated for wire correctness but carries no credential, so it does not section.) On libcurl older than 7.37.0 the header cannot be
-separated; the handlers keep a non-empty credential header on the wire but force a fresh,
-non-reused connection, which under `PERSISTENT_REQUIRE` is reported as a conflict rather
-than silently degrading reuse.
+(7.37.0+). A non-empty literal `Proxy-Authorization: <value>` header is never
+something libcurl can key connection reuse on, even on versions that key parsed
+proxy credentials (8.20.0+), so a tunnel carrying one always sections — its
+signature is hashed, never the delegated owner. (The empty
+`Proxy-Authorization;` form is migrated for wire correctness but carries no
+credential, so it does not section.) On libcurl older than 7.37.0 the header
+cannot be separated; the handlers keep a non-empty credential header on the wire
+but force a fresh, non-reused connection, which under `PERSISTENT_REQUIRE` is
+reported as a conflict rather than silently degrading reuse.
 
 Proxy TLS credential coverage stays tunnel-only and private: it is
 reflection-tested hardening for CONNECT tunnels, not public non-tunneled
@@ -182,10 +196,11 @@ inputs in 8.0.
   on fixed libcurl.
 - *Mostly defense-in-depth:* the proxy-TLS options (client cert, cert blob, TLS
   version, TLS-SRP). libcurl keys reuse on these via `ssl_primary_config` for an
-  HTTPS proxy — but only from 7.52.0 for the proxy client cert (CVE-2016-5420 in
-  7.50.1 is the origin-cert precedent, predating HTTPS-proxy support) and 7.83.1
-  for TLS-SRP (CVE-2022-27782). Below those they are load-bearing; above,
-  redundant-but-free. They are hashed unconditionally rather than version-gated.
+  HTTPS proxy — but only from 7.52.0 for the proxy client cert (CVE-2016-5420
+  in 7.50.1 is the origin-cert precedent, predating HTTPS-proxy support) and
+  7.83.1 for TLS-SRP (CVE-2022-27782). Below those they are load-bearing;
+  above, redundant-but-free. They are hashed unconditionally rather than
+  version-gated.
 
 **Deliberate omissions.** `PROXY_SSLKEY_BLOB`, `PROXY_SSLKEYTYPE`, and
 `PROXY_SSLCERTTYPE` are **not** hashed. The private-key *file* and passphrase
@@ -213,9 +228,10 @@ real proxy tunnel.
 
 `CURLOPT_CONNECT_TO` redirects the origin connection to a different host:port
 (without changing the `Host` header, SNI, or cert verification). With an HTTP
-proxy, when the connect-to host or port differs, libcurl automatically switches
-to tunnel mode (sets `tunnel_proxy`) — so even a plain `http://` request becomes
-a credential-bearing `CONNECT` tunnel, the same hazard class as §4.
+proxy, when the connect-to host or port differs, libcurl automatically
+switches to tunnel mode (sets `tunnel_proxy`) — so even a plain `http://`
+request becomes a credential-bearing `CONNECT` tunnel, the same hazard class as
+§4.
 
 `usesProxyTunnel()` therefore treats an `http://` target with a non-empty
 `CURLOPT_CONNECT_TO` as a possible tunnel. The check is deliberately
@@ -227,8 +243,8 @@ liability, not a feature.
 
 ## 7. Connection-sharing safety decisions
 
-**Authenticated proxy + a configured share handle → blanket force-fresh.** When
-`transport_sharing` is configured, the shared connection cache hides which
+**Authenticated proxy + a configured share handle → blanket force-fresh.**
+When `transport_sharing` is configured, the shared connection cache hides which
 tunnel a pooled connection holds, so the signature cannot reason about
 provenance. For an authenticated proxy tunnel Guzzle then sets
 `CURLOPT_FRESH_CONNECT` / `CURLOPT_FORBID_REUSE` (and `PERSISTENT_REQUIRE` turns
@@ -237,8 +253,8 @@ the conflict into an error rather than silently degrading).
 "Authenticated" here mirrors the signature's channels, each gated to the libcurl
 version below which libcurl does not itself key reuse on it: a non-empty literal
 `Proxy-Authorization` header (every version), Basic/Digest proxy credentials
-(below 8.20.0, `PROXY_CREDENTIAL_REUSE_VERSION`), and a proxy TLS credential — a
-client certificate or TLS-SRP (below 7.83.1,
+(below 8.20.0, `PROXY_CREDENTIAL_REUSE_VERSION`), and a proxy TLS credential —
+a client certificate or TLS-SRP (below 7.83.1,
 `PROXY_TLS_CREDENTIAL_REUSE_VERSION`). libcurl matches the proxy client cert
 from 7.52.0 and TLS-SRP only from 7.83.1 (CVE-2022-27782), so both are keyed
 under the single 7.83.1 floor. The floor matters more here than for the
@@ -269,9 +285,9 @@ channel's gate and 8.12.0 decides whether the throw can fire:
   literal-header case still does, since libcurl can never key on an opaque
   request header.
 
-**SSL session sharing floor = 8.6.0 — why it is safe.** Sharing the TLS session
-cache could, in theory, let two handles resume each other's TLS session across
-*different* client certificates. It cannot: libcurl matches the client
+**SSL session sharing floor = 8.6.0 — why it is safe.** Sharing the TLS
+session cache could, in theory, let two handles resume each other's TLS session
+across *different* client certificates. It cannot: libcurl matches the client
 certificate before reusing a cached session on every version Guzzle shares the
 cache on (≥ 8.6.0) — via `match_ssl_primary_config` before 8.12.0 and
 `cf_ssl_scache_match_auth` from 8.12.0 — and this runs for shared caches too.
@@ -314,7 +330,8 @@ is simply incoherent, with no legitimate use.)
 channels: libcurl < 8.19.0 ignored proxy credentials when matching connections,
 and 8.19.x still carried related proxy-credential leaks fixed in 8.20.0. At or
 above it, libcurl keys reuse on option- and URL-supplied proxy credentials
-itself, so `proxyTunnelSignature()` returns a shared delegated-owner sentinel —
+itself, so `proxyTunnelSignature()` returns a shared delegated-owner
+sentinel —
 **except** when a non-empty literal `Proxy-Authorization` header is present,
 which always sections because libcurl can never key on an opaque request header
 (§5).

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -455,23 +455,21 @@ sets it internally to `CURLHEADER_SEPARATE` whenever it configures
 proxy header is configured, so proxy headers stay separate from origin request
 headers; passing `CURLOPT_HEADEROPT` yourself is rejected.
 
-When an effective HTTP or HTTPS proxy is used, the built-in cURL handlers move a
-PSR `Proxy-Authorization` request header out of the origin request headers and
-onto cURL's proxy-header channel (`CURLOPT_PROXYHEADER`), so the credential
-authenticates the proxy rather than leaking to the origin. This covers both the
-`Proxy-Authorization: <value>` form and cURL's empty-header
-`Proxy-Authorization;` form. Direct (no-proxy) and SOCKS-proxy requests are left
-untouched.
+When an effective HTTP or HTTPS proxy is used, the built-in cURL handlers treat
+PSR `Proxy-Authorization` as proxy-scoped rather than origin-scoped. On libcurl
+7.37.0 and newer (with the proxy-header cURL constants available), the header is
+moved to cURL's proxy-header channel (`CURLOPT_PROXYHEADER`), so it authenticates
+the proxy rather than leaking to the origin. Direct (no-proxy) and SOCKS-proxy
+requests are left untouched.
 
-Because libcurl cannot key connection reuse on an opaque `Proxy-Authorization`
-value, a proxy CONNECT tunnel carrying a non-empty
-`Proxy-Authorization: <value>` credential requires a fresh connection. Under
-`TransportSharing::PERSISTENT_REQUIRE`, which requires reuse, such a request is
-rejected with an `InvalidArgumentException` instead of silently degrading reuse.
-On libcurl older than 7.37.0 (or a build missing the proxy-header constants),
-the handlers cannot separate proxy headers, so they leave a literal
-`Proxy-Authorization` header in place and, when it carries a non-empty
-credential, force a fresh, non-reused connection.
+A proxy CONNECT tunnel carrying a non-empty `Proxy-Authorization` credential
+requires a fresh connection, because libcurl cannot key connection reuse on that
+opaque header value. Under `TransportSharing::PERSISTENT_REQUIRE`, which requires
+reuse, such a request is rejected with an `InvalidArgumentException` instead of
+silently degrading reuse. On older libcurl (or a build missing the proxy-header
+constants), where proxy headers cannot be separated, the header is left in place
+for compatibility and a non-empty credential forces a fresh, non-reused
+connection.
 
 Raw proxy TLS credential options (such as `CURLOPT_PROXY_SSLCERT` or
 `CURLOPT_PROXY_TLSAUTH_PASSWORD`) are not on the allow-list and are not supported

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -464,20 +464,21 @@ authenticates the proxy rather than leaking to the origin. This covers both the
 untouched.
 
 Because libcurl cannot key connection reuse on an opaque `Proxy-Authorization`
-value, a proxy CONNECT tunnel carrying a non-empty `Proxy-Authorization: <value>`
-credential requires a fresh connection. Under `TransportSharing::PERSISTENT_REQUIRE`,
-which requires reuse, such a request is rejected with an `InvalidArgumentException`
-instead of silently degrading reuse. On libcurl older than 7.37.0 (or a build
-missing the proxy-header constants), the handlers cannot separate proxy headers, so
-they leave a literal `Proxy-Authorization` header in place and, when it carries a
-non-empty credential, force a fresh, non-reused connection.
+value, a proxy CONNECT tunnel carrying a non-empty
+`Proxy-Authorization: <value>` credential requires a fresh connection. Under
+`TransportSharing::PERSISTENT_REQUIRE`, which requires reuse, such a request is
+rejected with an `InvalidArgumentException` instead of silently degrading reuse.
+On libcurl older than 7.37.0 (or a build missing the proxy-header constants),
+the handlers cannot separate proxy headers, so they leave a literal
+`Proxy-Authorization` header in place and, when it carries a non-empty
+credential, force a fresh, non-reused connection.
 
 Raw proxy TLS credential options (such as `CURLOPT_PROXY_SSLCERT` or
 `CURLOPT_PROXY_TLSAUTH_PASSWORD`) are not on the allow-list and are not supported
-public raw `curl` inputs in 8.0: the `proxy` request option configures proxy URL
-selection and userinfo only — it does not expose proxy mTLS or TLS-SRP credential
-configuration. Raw `CURLOPT_PROXYTYPE` is likewise rejected; use the `proxy`
-request option to select the proxy instead.
+public raw `curl` inputs in 8.0: the `proxy` request option configures proxy
+URL selection and userinfo only — it does not expose proxy mTLS or TLS-SRP
+credential configuration. Raw `CURLOPT_PROXYTYPE` is likewise rejected; use the
+`proxy` request option to select the proxy instead.
 
 ## debug
 
@@ -1110,10 +1111,11 @@ Separately from the handler-level resolution above, a `GuzzleHttp\Client` maps t
 > connections. Anonymous tunnels are sectioned apart from authenticated ones,
 > so an unauthenticated request never rides an authenticated tunnel. Raw
 > `CURLOPT_PROXY` is rejected; use the `proxy` request option for the proxy
-> URL. Custom proxy authentication sent with `CURLOPT_PROXYHEADER` is always
-> sectioned because libcurl cannot key connection reuse on those header values.
-> On libcurl 8.20.0 and newer, credential sectioning for option-supplied
-> credentials is left to libcurl's own credential-aware connection matching.
+> URL. A non-empty custom proxy authentication value sent with
+> `CURLOPT_PROXYHEADER` is always sectioned because libcurl cannot key
+> connection reuse on those header values. On libcurl 8.20.0 and newer,
+> credential sectioning for option-supplied credentials is left to libcurl's own
+> credential-aware connection matching.
 >
 > Sectioning has a cost in mixed workloads: changing the proxy credentials in
 > use discards the idle pooled connections held for the previous credentials,

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -471,13 +471,6 @@ constants), where proxy headers cannot be separated, the header is left in place
 for compatibility and a non-empty credential forces a fresh, non-reused
 connection.
 
-Raw proxy TLS credential options (such as `CURLOPT_PROXY_SSLCERT` or
-`CURLOPT_PROXY_TLSAUTH_PASSWORD`) are not on the allow-list and are not supported
-public raw `curl` inputs in 8.0: the `proxy` request option configures proxy
-URL selection and userinfo only — it does not expose proxy mTLS or TLS-SRP
-credential configuration. Raw `CURLOPT_PROXYTYPE` is likewise rejected; use the
-`proxy` request option to select the proxy instead.
-
 ## debug
 
 Summary

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -449,6 +449,36 @@ $client->request('GET', '/', [
 ]);
 ```
 
+`CURLOPT_HEADEROPT` is intentionally absent from the allow-list above. Guzzle
+sets it internally to `CURLHEADER_SEPARATE` whenever it configures
+`CURLOPT_PROXYHEADER`, and also for an HTTP(S) proxy CONNECT tunnel even when no
+proxy header is configured, so proxy headers stay separate from origin request
+headers; passing `CURLOPT_HEADEROPT` yourself is rejected.
+
+When an effective HTTP or HTTPS proxy is used, the built-in cURL handlers move a
+PSR `Proxy-Authorization` request header out of the origin request headers and
+onto cURL's proxy-header channel (`CURLOPT_PROXYHEADER`), so the credential
+authenticates the proxy rather than leaking to the origin. This covers both the
+`Proxy-Authorization: <value>` form and cURL's empty-header
+`Proxy-Authorization;` form. Direct (no-proxy) and SOCKS-proxy requests are left
+untouched.
+
+Because libcurl cannot key connection reuse on an opaque `Proxy-Authorization`
+value, a proxy CONNECT tunnel carrying a non-empty `Proxy-Authorization: <value>`
+credential requires a fresh connection. Under `TransportSharing::PERSISTENT_REQUIRE`,
+which requires reuse, such a request is rejected with an `InvalidArgumentException`
+instead of silently degrading reuse. On libcurl older than 7.37.0 (or a build
+missing the proxy-header constants), the handlers cannot separate proxy headers, so
+they leave a literal `Proxy-Authorization` header in place and, when it carries a
+non-empty credential, force a fresh, non-reused connection.
+
+Raw proxy TLS credential options (such as `CURLOPT_PROXY_SSLCERT` or
+`CURLOPT_PROXY_TLSAUTH_PASSWORD`) are not on the allow-list and are not supported
+public raw `curl` inputs in 8.0: the `proxy` request option configures proxy URL
+selection and userinfo only — it does not expose proxy mTLS or TLS-SRP credential
+configuration. Raw `CURLOPT_PROXYTYPE` is likewise rejected; use the `proxy`
+request option to select the proxy instead.
+
 ## debug
 
 Summary

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -43,6 +43,8 @@ final class CurlFactory implements CurlFactoryInterface
 
     private const DELEGATED_PROXY_TUNNEL_OWNER = 'proxy-tunnel:delegated-to-libcurl';
 
+    private const PERSISTENT_REQUIRE_FRESH_PROXY_TUNNEL_MESSAGE = 'Persistent cURL sharing is required, but this request requires a fresh proxy tunnel connection.';
+
     private const CURL_CONNECTION_ERRORS = [
         5 => true,   // CURLE_COULDNT_RESOLVE_PROXY
         6 => true,   // CURLE_COULDNT_RESOLVE_HOST
@@ -224,6 +226,7 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         self::normalizeCurlHeaderOptions($conf);
+        $this->applyProxyAuthorizationHeaderHandling($request, $conf);
 
         if ($this->shareHandle !== null) {
             // Conservative blanket mode: a configured share handle hides the
@@ -1162,7 +1165,7 @@ final class CurlFactory implements CurlFactoryInterface
         }
 
         if ($this->shareMode === TransportSharing::PERSISTENT_REQUIRE) {
-            throw new InvalidArgumentException('Persistent cURL sharing is required, but this request requires a fresh proxy tunnel connection.');
+            throw new InvalidArgumentException(self::PERSISTENT_REQUIRE_FRESH_PROXY_TUNNEL_MESSAGE);
         }
 
         $conf[\CURLOPT_FRESH_CONNECT] = true;
@@ -1415,39 +1418,130 @@ final class CurlFactory implements CurlFactoryInterface
      */
     private static function hasCurlProxyAuthorizationHeader(array $conf): bool
     {
-        if (!\defined('CURLOPT_PROXYHEADER')) {
-            return false;
+        return self::curlProxyAuthorizationHeaderValues($conf) !== [];
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private function applyProxyAuthorizationHeaderHandling(RequestInterface $request, array &$conf): void
+    {
+        $proxy = self::getEffectiveProxy($conf);
+        if ($proxy === null || !self::isHttpProxyForConnectionReuse($proxy, $conf)) {
+            return;
         }
 
+        $httpHeaders = $conf[\CURLOPT_HTTPHEADER] ?? null;
+        $movedHeaders = [];
+        $originHeaders = [];
+
+        if (\is_array($httpHeaders)) {
+            foreach ($httpHeaders as $header) {
+                if (\is_string($header) && self::curlHeaderLineNameMatches($header, 'Proxy-Authorization')) {
+                    $movedHeaders[] = $header;
+
+                    continue;
+                }
+
+                $originHeaders[] = $header;
+            }
+        }
+
+        if (CurlVersion::supportsProxyHeaderSeparation()) {
+            if ($movedHeaders !== []) {
+                $conf[\CURLOPT_HTTPHEADER] = $originHeaders;
+                self::appendCurlProxyHeaders($conf, $movedHeaders);
+            }
+
+            // On libcurl 7.37.0-7.42.0 the default is CURLHEADER_UNIFIED.
+            if ($movedHeaders !== [] || self::hasCurlProxyHeaderOption($conf) || self::usesProxyTunnel($request, $conf)) {
+                $conf[(int) \constant('CURLOPT_HEADEROPT')] = (int) \constant('CURLHEADER_SEPARATE');
+            }
+
+            return;
+        }
+
+        if (!\is_array($httpHeaders) || self::proxyAuthorizationHeaderValuesFromList($httpHeaders) === []) {
+            return;
+        }
+
+        if ($this->shareMode === TransportSharing::PERSISTENT_REQUIRE) {
+            throw new InvalidArgumentException(self::PERSISTENT_REQUIRE_FRESH_PROXY_TUNNEL_MESSAGE);
+        }
+
+        $conf[\CURLOPT_FRESH_CONNECT] = true;
+        $conf[\CURLOPT_FORBID_REUSE] = true;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     * @param list<string>             $headers
+     */
+    private static function appendCurlProxyHeaders(array &$conf, array $headers): void
+    {
         $option = (int) \constant('CURLOPT_PROXYHEADER');
-        if (!\array_key_exists($option, $conf)) {
+
+        if (\array_key_exists($option, $conf)) {
+            if (!\is_array($conf[$option])) {
+                throw new InvalidArgumentException('CURLOPT_PROXYHEADER must be an array when Proxy-Authorization is migrated from CURLOPT_HTTPHEADER.');
+            }
+
+            $headers = \array_merge($conf[$option], $headers);
+        }
+
+        $conf[$option] = $headers;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function hasCurlProxyHeaderOption(array $conf): bool
+    {
+        return \defined('CURLOPT_PROXYHEADER')
+            && \array_key_exists((int) \constant('CURLOPT_PROXYHEADER'), $conf);
+    }
+
+    private static function curlHeaderLineNameMatches(string $header, string $name): bool
+    {
+        $length = \strcspn($header, ':;');
+
+        if ($length === \strlen($header)) {
             return false;
         }
 
-        $headers = $conf[$option];
-        if (!\is_array($headers)) {
-            return false;
-        }
+        return 0 === \strcasecmp(\trim(\substr($header, 0, $length)), $name);
+    }
+
+    /**
+     * @param mixed[] $headers
+     *
+     * @return list<string>
+     */
+    private static function proxyAuthorizationHeaderValuesFromList(array $headers): array
+    {
+        $values = [];
 
         foreach ($headers as $header) {
             if (!\is_string($header)) {
                 continue;
             }
 
-            $parts = \explode(':', $header, 2);
-            if (\count($parts) !== 2) {
+            $position = \strpos($header, ':');
+            if ($position === false) {
                 continue;
             }
 
-            if (
-                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
-                && \trim($parts[1]) !== ''
-            ) {
-                return true;
+            if (0 !== \strcasecmp(\trim(\substr($header, 0, $position)), 'Proxy-Authorization')) {
+                continue;
+            }
+
+            $value = \trim(\substr($header, $position + 1));
+            if ($value !== '') {
+                $values[] = $value;
             }
         }
 
-        return false;
+        return $values;
     }
 
     /**
@@ -1481,10 +1575,16 @@ final class CurlFactory implements CurlFactoryInterface
         // reuse, so over-covering is always safe; under-covering leaks. Proxy
         // credentials are the channel CVE-2026-3784 missed; the proxy-TLS
         // options are load-bearing on builds before the proxy-TLS reuse fixes
-        // (client cert from 7.50.1, CVE-2016-5420; TLS-SRP from 7.83.1,
-        // CVE-2022-27782) and harmless after. The private key and cert/key
-        // encoding are deliberately omitted: the hashed X.509 client cert is
-        // the proxy-visible identity and maps 1:1 to its key. See
+        // (the proxy client cert is keyed from 7.52.0, libcurl's first
+        // HTTPS-proxy release; CVE-2016-5420 (7.50.1) is only the origin-cert
+        // precedent; TLS-SRP from 7.83.1, CVE-2022-27782) and harmless after.
+        // The private-key file and passphrase are hashed on this non-delegated
+        // path too, as fallback hardening: libcurl's mTLS private-key matching
+        // on reuse was incomplete before 8.21.0 (CVE-2026-8932). This does not
+        // cover the delegated path (the early return above) or configured share
+        // handles, so it is not a complete pre-8.21.0 mitigation. The key blob
+        // and cert/key type encodings (PROXY_SSLKEY_BLOB, PROXY_SSLKEYTYPE,
+        // PROXY_SSLCERTTYPE) are not hashed and are an accepted residual. See
         // docs/contributing/curl-connection-reuse.md.
         $credentialState = [];
         foreach ([
@@ -1523,30 +1623,7 @@ final class CurlFactory implements CurlFactoryInterface
             return [];
         }
 
-        $values = [];
-        foreach ($headers as $header) {
-            if (!\is_string($header)) {
-                continue;
-            }
-
-            $parts = \explode(':', $header, 2);
-            if (\count($parts) !== 2) {
-                continue;
-            }
-
-            if (
-                0 === \strcasecmp(\trim($parts[0]), 'Proxy-Authorization')
-                && \trim($parts[1]) !== ''
-            ) {
-                $values[] = \trim($parts[1]);
-            }
-        }
-
-        // Sort so the signature depends on the set of header credentials, not
-        // their order, which avoids spurious re-sectioning across requests.
-        \sort($values);
-
-        return $values;
+        return self::proxyAuthorizationHeaderValuesFromList($headers);
     }
 
     private function discardIdleHandles(): void

--- a/src/Handler/CurlVersion.php
+++ b/src/Handler/CurlVersion.php
@@ -43,6 +43,8 @@ final class CurlVersion
     // fixed in 8.20.0, so connection reuse is trusted from 8.20.0 onwards.
     private const PROXY_CREDENTIAL_REUSE_VERSION = '8.20.0';
 
+    private const PROXY_HEADER_SEPARATION_VERSION = '7.37.0';
+
     /**
      * @var array{version: string, features: int}|false|null
      */
@@ -175,6 +177,17 @@ final class CurlVersion
 
         return null !== $version
             && version_compare($version, self::PROXY_CREDENTIAL_REUSE_VERSION, '>=');
+    }
+
+    public static function supportsProxyHeaderSeparation(): bool
+    {
+        $version = self::get();
+
+        return null !== $version
+            && version_compare($version, self::PROXY_HEADER_SEPARATION_VERSION, '>=')
+            && \defined('CURLOPT_PROXYHEADER')
+            && \defined('CURLOPT_HEADEROPT')
+            && \defined('CURLHEADER_SEPARATE');
     }
 
     public static function supportsProtocolsStr(): bool

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -569,7 +569,7 @@ class CurlFactoryTest extends TestCase
             $factory->create(new Psr7\Request('GET', 'https://example.com'), [
                 'proxy' => 'http://proxy.example.com:8080',
                 'curl' => [
-                    $proxyHeaderOption => [new class() {
+                    $proxyHeaderOption => [new class {
                         public function __toString(): string
                         {
                             return 'Proxy-Authorization: Basic abc';

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -553,6 +553,35 @@ class CurlFactoryTest extends TestCase
         }
     }
 
+    public function testPersistentRequireRejectsStringableProxyAuthorizationHeaderThatRequiresFreshProxyTunnelConnection(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $proxyHeaderOption = self::proxyHeaderOption();
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, TransportSharing::PERSISTENT_REQUIRE, $shareHandle);
+
+        try {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('fresh proxy tunnel connection');
+
+            $factory->create(new Psr7\Request('GET', 'https://example.com'), [
+                'proxy' => 'http://proxy.example.com:8080',
+                'curl' => [
+                    $proxyHeaderOption => [new class() {
+                        public function __toString(): string
+                        {
+                            return 'Proxy-Authorization: Basic abc';
+                        }
+                    }],
+                ],
+            ]);
+        } finally {
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
+    }
+
     /**
      * @dataProvider parsedProxyCredentialOptions
      */
@@ -1706,6 +1735,9 @@ class CurlFactoryTest extends TestCase
         $proxyHeaderOption = self::proxyHeaderOption();
 
         $factory = new CurlFactory(3);
+        $delegatedBaseline = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+        ])->proxyTunnelSignature;
         $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
@@ -1714,6 +1746,7 @@ class CurlFactoryTest extends TestCase
         ]);
 
         self::assertNotNull($easy->proxyTunnelSignature);
+        self::assertSame($delegatedBaseline, $easy->proxyTunnelSignature);
     }
 
     public function testEmptyProxyAuthorizationHeaderUsesDelegatedOwnerOnFixedCurlVersion(): void
@@ -1721,6 +1754,9 @@ class CurlFactoryTest extends TestCase
         $proxyHeaderOption = self::proxyHeaderOption();
 
         $factory = new CurlFactory(3);
+        $delegatedBaseline = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+        ])->proxyTunnelSignature;
         $easy = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
             'proxy' => 'http://proxy.example.com:8080',
             'curl' => [
@@ -1729,6 +1765,7 @@ class CurlFactoryTest extends TestCase
         ]);
 
         self::assertNotNull($easy->proxyTunnelSignature);
+        self::assertSame($delegatedBaseline, $easy->proxyTunnelSignature);
     }
 
     public function testDelegatedProxyTunnelOwnerIsDistinctFromLiteralProxyAuthorizationOwner(): void

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -1754,6 +1754,374 @@ class CurlFactoryTest extends TestCase
         self::assertNotSame($delegated, $literalHeader);
     }
 
+    public function testMigratesPsrProxyAuthorizationHeaderToProxyHeaderWhenSupported(): void
+    {
+        self::requireProxyHeaderSeparationConstants();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $factory = new CurlFactory(3);
+        self::createRequestOnFactory(
+            $factory,
+            '7.37.0',
+            new Psr7\Request('GET', 'http://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+            ['proxy' => 'http://proxy.example.com:8080']
+        );
+
+        self::assertNotContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+        self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][$proxyHeaderOption]);
+        self::assertSame((int) \constant('CURLHEADER_SEPARATE'), $_SERVER['_curl'][(int) \constant('CURLOPT_HEADEROPT')]);
+    }
+
+    public function testMigratedPsrProxyAuthorizationHeaderSectionsTunnelEvenOnFixedCurl(): void
+    {
+        self::requireProxyHeaderSeparationConstants();
+
+        $factory = new CurlFactory(3);
+        $first = self::createRequestOnFactory(
+            $factory,
+            '8.20.0',
+            new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => 'Basic dXNlcjpvbmU=']),
+            ['proxy' => 'http://proxy.example.com:8080']
+        )->proxyTunnelSignature;
+        $second = self::createRequestOnFactory(
+            $factory,
+            '8.20.0',
+            new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => 'Basic dXNlcjp0d28=']),
+            ['proxy' => 'http://proxy.example.com:8080']
+        )->proxyTunnelSignature;
+
+        // libcurl cannot key connection reuse on a literal Proxy-Authorization
+        // header, so the migrated credential sections the tunnel even on the
+        // fast-path version, and distinct credentials section distinctly.
+        self::assertNotNull($first);
+        self::assertNotNull($second);
+        self::assertNotSame($first, $second);
+    }
+
+    public function testProxyHeaderSeparationIsSetForExistingProxyHeader(): void
+    {
+        self::requireProxyHeaderSeparationConstants();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $factory = new CurlFactory(3);
+        self::createOnFactory($factory, '7.37.0', 'http://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+            'curl' => [
+                $proxyHeaderOption => ['X-Proxy-Header: value'],
+            ],
+        ]);
+
+        // The raw CURLOPT_PROXYHEADER option remains allowed, and Guzzle sets
+        // CURLOPT_HEADEROPT internally so the proxy headers stay separate.
+        self::assertSame(['X-Proxy-Header: value'], $_SERVER['_curl'][$proxyHeaderOption]);
+        self::assertSame((int) \constant('CURLHEADER_SEPARATE'), $_SERVER['_curl'][(int) \constant('CURLOPT_HEADEROPT')]);
+    }
+
+    public function testProxyHeaderSeparationIsSetForConnectTunnelWithoutProxyHeader(): void
+    {
+        self::requireProxyHeaderSeparationConstants();
+
+        $factory = new CurlFactory(3);
+        self::createRequestOnFactory(
+            $factory,
+            '7.37.0',
+            new Psr7\Request('GET', 'https://example.com'),
+            ['proxy' => 'http://proxy.example.com:8080']
+        );
+
+        // The HTTPS target tunnels via CONNECT; even with no proxy header,
+        // usesProxyTunnel() is true, so Guzzle sets CURLHEADER_SEPARATE.
+        self::assertSame((int) \constant('CURLHEADER_SEPARATE'), $_SERVER['_curl'][(int) \constant('CURLOPT_HEADEROPT')]);
+    }
+
+    public function testMigratedProxyAuthorizationAppendsToExistingProxyHeaders(): void
+    {
+        self::requireProxyHeaderSeparationConstants();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $factory = new CurlFactory(3);
+        self::createRequestOnFactory(
+            $factory,
+            '7.37.0',
+            new Psr7\Request('GET', 'http://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+            [
+                'proxy' => 'http://proxy.example.com:8080',
+                'curl' => [
+                    $proxyHeaderOption => ['X-Proxy-Header: value'],
+                ],
+            ]
+        );
+
+        // The migrated PSR credential is appended after the pre-existing proxy
+        // header, preserving order.
+        self::assertSame([
+            'X-Proxy-Header: value',
+            'Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+        ], $_SERVER['_curl'][$proxyHeaderOption]);
+    }
+
+    public function testSupportedProxyAuthorizationConflictsWithPersistentRequireAfterMigration(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::requireProxyHeaderSeparationConstants();
+
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, TransportSharing::PERSISTENT_REQUIRE, $shareHandle);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('fresh proxy tunnel connection');
+
+            // The HTTPS target tunnels through the http:// proxy; the PSR header
+            // migrates into CURLOPT_PROXYHEADER before the configured-share
+            // fresh-connection logic observes it and rejects the reuse.
+            self::createRequestOnFactory(
+                $factory,
+                '7.37.0',
+                new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+        } finally {
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
+    }
+
+    public function testSupportedProxyAuthorizationWithoutTunnelIsAcceptedUnderPersistentRequire(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+        self::requireProxyHeaderSeparationConstants();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, TransportSharing::PERSISTENT_REQUIRE, $shareHandle);
+
+        try {
+            // Supported separation + a NON-tunnel (plain http) target: the header
+            // migrates to CURLOPT_PROXYHEADER and the tunnel-gated fresh-connection
+            // logic never runs, so PERSISTENT_REQUIRE must ACCEPT the request.
+            $easy = self::createRequestOnFactory(
+                $factory,
+                '7.37.0',
+                new Psr7\Request('GET', 'http://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+
+            self::assertNull($easy->proxyTunnelSignature);
+            self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][$proxyHeaderOption]);
+            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        } finally {
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
+    }
+
+    public function testDirectRequestDoesNotMoveProxyAuthorizationHeader(): void
+    {
+        self::withProxyEnvironment([], static function (): void {
+            $factory = new CurlFactory(3);
+            $factory->create(
+                new Psr7\Request('GET', 'http://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+                ['proxy' => '']
+            );
+
+            // With no effective proxy the header is left in CURLOPT_HTTPHEADER
+            // and none of the proxy-header machinery is engaged.
+            self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+            if (\defined('CURLOPT_PROXYHEADER')) {
+                self::assertArrayNotHasKey((int) \constant('CURLOPT_PROXYHEADER'), $_SERVER['_curl']);
+            }
+            if (\defined('CURLOPT_HEADEROPT')) {
+                self::assertArrayNotHasKey((int) \constant('CURLOPT_HEADEROPT'), $_SERVER['_curl']);
+            }
+            self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+            self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+        });
+    }
+
+    public function testSocksProxyDoesNotMoveProxyAuthorizationHeader(): void
+    {
+        $factory = new CurlFactory(3);
+        self::createRequestOnFactory(
+            $factory,
+            '7.37.0',
+            new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+            ['proxy' => 'socks5://proxy.example.com:1080']
+        );
+
+        // SOCKS proxy auth is not carried in CURLOPT_PROXYHEADER, so the header
+        // is left untouched in CURLOPT_HTTPHEADER.
+        self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+        if (\defined('CURLOPT_PROXYHEADER')) {
+            self::assertArrayNotHasKey((int) \constant('CURLOPT_PROXYHEADER'), $_SERVER['_curl']);
+        }
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testLegacyCurlPreservesProxyAuthorizationAndForcesFreshConnection(): void
+    {
+        $factory = new CurlFactory(3);
+        self::createRequestOnFactory(
+            $factory,
+            '7.36.0',
+            new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+            ['proxy' => 'http://proxy.example.com:8080']
+        );
+
+        // Legacy libcurl cannot separate proxy headers, so the credential stays
+        // on the wire via CURLOPT_HTTPHEADER and Guzzle forces a fresh,
+        // non-reused connection instead.
+        self::assertContains('Proxy-Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FRESH_CONNECT]);
+        self::assertTrue($_SERVER['_curl'][\CURLOPT_FORBID_REUSE]);
+    }
+
+    public function testLegacyProxyAuthorizationConflictsWithPersistentRequire(): void
+    {
+        self::skipIfCurlShareIsUnavailable();
+
+        $shareHandle = \curl_share_init();
+        self::assertNotFalse($shareHandle);
+        $factory = new CurlFactory(3, TransportSharing::PERSISTENT_REQUIRE, $shareHandle);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('fresh proxy tunnel connection');
+
+            // Plain http:// target through an http:// proxy is NOT a tunnel; the
+            // legacy fallback throws from applyProxyAuthorizationHeaderHandling()
+            // itself, which is deliberately not gated by usesProxyTunnel().
+            self::createRequestOnFactory(
+                $factory,
+                '7.36.0',
+                new Psr7\Request('GET', 'http://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+                ['proxy' => 'http://proxy.example.com:8080']
+            );
+        } finally {
+            self::closeShareHandleOnPhp7($shareHandle);
+        }
+    }
+
+    public function testRawHeaderOptIsRejected(): void
+    {
+        if (!\defined('CURLOPT_HEADEROPT')) {
+            self::markTestSkipped('CURLOPT_HEADEROPT is not available.');
+        }
+
+        $headerOpt = (int) \constant('CURLOPT_HEADEROPT');
+        $separate = \defined('CURLHEADER_SEPARATE') ? (int) \constant('CURLHEADER_SEPARATE') : 1;
+
+        try {
+            (new CurlFactory(3))->create(new Psr7\Request('GET', Server::$url), [
+                'curl' => [
+                    $headerOpt => $separate,
+                ],
+            ]);
+
+            self::fail('Expected InvalidArgumentException.');
+        } catch (\InvalidArgumentException $e) {
+            // CURLOPT_HEADEROPT is owned internally by Guzzle and is not on the
+            // public allow-list, so passing it raw is rejected.
+            self::assertStringContainsString('CURLOPT_HEADEROPT', $e->getMessage());
+            self::assertStringContainsString("outside the built-in cURL handlers' allow-list", $e->getMessage());
+        }
+    }
+
+    public function testProxyAuthorizationHeaderOrderAffectsSignature(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $first = self::computeProxyTunnelSignature('8.20.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            $proxyHeaderOption => [
+                'Proxy-Authorization: Basic dXNlcjpvbmU=',
+                'Proxy-Authorization: Basic dXNlcjp0d28=',
+            ],
+        ]);
+        $second = self::computeProxyTunnelSignature('8.20.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            $proxyHeaderOption => [
+                'Proxy-Authorization: Basic dXNlcjp0d28=',
+                'Proxy-Authorization: Basic dXNlcjpvbmU=',
+            ],
+        ]);
+
+        // With the sort() removed, the signature reflects wire order: the same
+        // credentials in a different order section separately.
+        self::assertNotNull($first);
+        self::assertNotSame($first, $second);
+    }
+
+    public function testMigratesEmptyPsrProxyAuthorizationHeaderWithoutTreatingItAsCredential(): void
+    {
+        self::requireProxyHeaderSeparationConstants();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $factory = new CurlFactory(3);
+        $easy = self::createRequestOnFactory(
+            $factory,
+            '8.20.0',
+            new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => '']),
+            ['proxy' => 'http://proxy.example.com:8080']
+        );
+
+        // cURL serializes an empty PSR header as "Proxy-Authorization;"; it is
+        // migrated to the proxy-header channel but is not credential material.
+        self::assertNotContains('Proxy-Authorization;', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+        self::assertContains('Proxy-Authorization;', $_SERVER['_curl'][$proxyHeaderOption]);
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+
+        // The empty value carries no credential, so the tunnel is delegated to
+        // libcurl, the same owner as an unauthenticated proxy.
+        $unauthenticated = self::createOnFactory($factory, '8.20.0', 'https://example.com', [
+            'proxy' => 'http://proxy.example.com:8080',
+        ])->proxyTunnelSignature;
+        self::assertSame($unauthenticated, $easy->proxyTunnelSignature);
+    }
+
+    public function testLegacyCurlEmptyProxyAuthorizationHeaderDoesNotForceFreshConnection(): void
+    {
+        $factory = new CurlFactory(3);
+        self::createRequestOnFactory(
+            $factory,
+            '7.36.0',
+            new Psr7\Request('GET', 'https://example.com', ['Proxy-Authorization' => '']),
+            ['proxy' => 'http://proxy.example.com:8080']
+        );
+
+        // On legacy libcurl the empty header is left in place, and because it
+        // carries no credential value no fresh/no-reuse is forced.
+        self::assertContains('Proxy-Authorization;', $_SERVER['_curl'][\CURLOPT_HTTPHEADER]);
+        self::assertArrayNotHasKey(\CURLOPT_FRESH_CONNECT, $_SERVER['_curl']);
+        self::assertArrayNotHasKey(\CURLOPT_FORBID_REUSE, $_SERVER['_curl']);
+    }
+
+    public function testNonArrayProxyHeaderThrowsWhenMigrationWouldAppend(): void
+    {
+        self::requireProxyHeaderSeparationConstants();
+        $proxyHeaderOption = self::proxyHeaderOption();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXYHEADER');
+
+        // CURLOPT_PROXYHEADER is allow-listed but must be an array; a non-array
+        // value plus a PSR Proxy-Authorization header to migrate is rejected.
+        self::createRequestOnFactory(
+            new CurlFactory(3),
+            '7.37.0',
+            new Psr7\Request('GET', 'http://example.com', ['Proxy-Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=']),
+            [
+                'proxy' => 'http://proxy.example.com:8080',
+                'curl' => [
+                    $proxyHeaderOption => 'not-an-array',
+                ],
+            ]
+        );
+    }
+
     public function testRejectsRawCurlSocksProxyTypeWithProxyUrl(): void
     {
         if (!\defined('CURLPROXY_SOCKS5')) {
@@ -1936,6 +2304,45 @@ class CurlFactoryTest extends TestCase
         $second = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
             \CURLOPT_PROXY => 'https://proxy.example.com:8080',
             $tlsAuthPassword => 'secret2',
+        ]);
+
+        self::assertNotNull($first);
+        self::assertNotSame($first, $second);
+    }
+
+    public function testProxySslKeyChangesProxyTunnelSignature(): void
+    {
+        if (!\defined('CURLOPT_PROXY_SSLKEY')) {
+            self::markTestSkipped('CURLOPT_PROXY_SSLKEY is not available.');
+        }
+
+        // On this non-delegated (pre-8.20.0) path the proxy private-key file is
+        // keyed as fallback hardening: libcurl's mTLS private-key matching on reuse
+        // was incomplete before 8.21.0 (CVE-2026-8932).
+        $sslKey = (int) \constant('CURLOPT_PROXY_SSLKEY');
+        $first = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080', $sslKey => '/path/to/key-a.pem',
+        ]);
+        $second = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080', $sslKey => '/path/to/key-b.pem',
+        ]);
+
+        self::assertNotNull($first);
+        self::assertNotSame($first, $second);
+    }
+
+    public function testProxyKeyPasswdChangesProxyTunnelSignature(): void
+    {
+        if (!\defined('CURLOPT_PROXY_KEYPASSWD')) {
+            self::markTestSkipped('CURLOPT_PROXY_KEYPASSWD is not available.');
+        }
+
+        $keyPasswd = (int) \constant('CURLOPT_PROXY_KEYPASSWD');
+        $first = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080', $keyPasswd => 'secret-a',
+        ]);
+        $second = self::computeProxyTunnelSignature('8.19.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'https://proxy.example.com:8080', $keyPasswd => 'secret-b',
         ]);
 
         self::assertNotNull($first);
@@ -6189,6 +6596,35 @@ class CurlFactoryTest extends TestCase
             return $factory->create(new Psr7\Request('GET', $uri), $options);
         } finally {
             self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    /**
+     * Mirrors createOnFactory() but drives a caller-supplied request so a PSR
+     * Proxy-Authorization header can be exercised.
+     *
+     * @param array<int|string, mixed> $options
+     */
+    private static function createRequestOnFactory(CurlFactory $factory, string $version, RequestInterface $request, array $options): EasyHandle
+    {
+        $previousVersionInfo = self::setCurlVersionInfo([
+            'version' => $version,
+            'features' => self::curlSslFeature(),
+        ]);
+
+        try {
+            return $factory->create($request, $options);
+        } finally {
+            self::setCurlVersionInfo($previousVersionInfo);
+        }
+    }
+
+    private static function requireProxyHeaderSeparationConstants(): void
+    {
+        foreach (['CURLOPT_PROXYHEADER', 'CURLOPT_HEADEROPT', 'CURLHEADER_SEPARATE'] as $constant) {
+            if (!\defined($constant)) {
+                self::markTestSkipped($constant.' is not available.');
+            }
         }
     }
 

--- a/tests/Handler/CurlVersionTest.php
+++ b/tests/Handler/CurlVersionTest.php
@@ -239,6 +239,59 @@ class CurlVersionTest extends TestCase
         self::assertTrue(CurlVersion::supportsProxyCredentialAwareConnectionReuse());
     }
 
+    public function testSupportsProxyHeaderSeparationIsFalseBelowMinimumVersion(): void
+    {
+        self::setVersionInfo([
+            'version' => '7.36.0',
+            'features' => 0,
+        ]);
+
+        self::assertFalse(CurlVersion::supportsProxyHeaderSeparation());
+    }
+
+    public function testSupportsProxyHeaderSeparationIsTrueAtMinimumVersion(): void
+    {
+        self::requiresProxyHeaderSeparationConstants();
+
+        self::setVersionInfo([
+            'version' => '7.37.0',
+            'features' => 0,
+        ]);
+
+        self::assertTrue(CurlVersion::supportsProxyHeaderSeparation());
+    }
+
+    public function testSupportsProxyHeaderSeparationIsTrueAboveMinimumVersion(): void
+    {
+        self::requiresProxyHeaderSeparationConstants();
+
+        self::setVersionInfo([
+            'version' => '7.42.0',
+            'features' => 0,
+        ]);
+
+        self::assertTrue(CurlVersion::supportsProxyHeaderSeparation());
+    }
+
+    public function testSupportsProxyHeaderSeparationIsTrueAtPatchVersion(): void
+    {
+        self::requiresProxyHeaderSeparationConstants();
+
+        self::setVersionInfo([
+            'version' => '7.42.1',
+            'features' => 0,
+        ]);
+
+        self::assertTrue(CurlVersion::supportsProxyHeaderSeparation());
+    }
+
+    public function testSupportsProxyHeaderSeparationIsFalseWhenVersionInfoIsUnavailable(): void
+    {
+        self::setVersionInfo(false);
+
+        self::assertFalse(CurlVersion::supportsProxyHeaderSeparation());
+    }
+
     public function testEnsureSupportedRejectsCurlWithoutSslSupport(): void
     {
         if (!\defined('CURL_SSLVERSION_TLSv1_2')) {
@@ -314,6 +367,15 @@ class CurlVersionTest extends TestCase
     {
         if (!\defined('CURLOPT_PROTOCOLS_STR')) {
             self::markTestSkipped('CURLOPT_PROTOCOLS_STR is not available.');
+        }
+    }
+
+    private static function requiresProxyHeaderSeparationConstants(): void
+    {
+        foreach (['CURLOPT_PROXYHEADER', 'CURLOPT_HEADEROPT', 'CURLHEADER_SEPARATE'] as $constant) {
+            if (!\defined($constant)) {
+                self::markTestSkipped($constant.' is not available.');
+            }
         }
     }
 


### PR DESCRIPTION
Routes PSR Proxy-Authorization through cURL proxy headers on 8.0 and rejects persistent-sharing conflicts when a fresh authenticated proxy tunnel is required.