### PR TITLE
Reject final URIs missing scheme or host

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -614,7 +614,15 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $uri = Utils::idnUriConvert($uri, $idnOptions);
         }
 
-        return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;
+        if ($uri->getScheme() === '' && $uri->getHost() !== '') {
+            $uri = $uri->withScheme('http');
+        }
+
+        if ($uri->getScheme() === '' || $uri->getHost() === '') {
+            throw new InvalidArgumentException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.');
+        }
+
+        return $uri;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2424,16 +2424,37 @@ class ClientTest extends TestCase
         self::assertSame('http://example.org/test', (string) $mockHandler->getLastRequest()->getUri());
     }
 
-    public function testOnlyAddSchemeWhenHostIsPresent(): void
+    /**
+     * @dataProvider invalidFinalUriProvider
+     */
+    public function testRejectsFinalUriWithoutSchemeOrHost(string $uri): void
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $client->request('GET', 'baz');
-        self::assertSame(
-            'baz',
-            (string) $mockHandler->getLastRequest()->getUri()
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('URI must include a scheme and host');
+
+        $client->request('GET', $uri);
+    }
+
+    public static function invalidFinalUriProvider(): iterable
+    {
+        yield 'relative path' => ['baz'];
+        yield 'host-like relative path' => ['gstatic.com/generate_204'];
+        yield 'path starting with colon-slash-slash' => ['://gstatic.com/generate_204'];
+        yield 'absolute path' => ['/generate_204'];
+    }
+
+    public function testRejectsSendRequestWhenFinalUriHasNoSchemeOrHost(): void
+    {
+        $mockHandler = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mockHandler]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('URI must include a scheme and host');
+
+        $client->send(new Request('GET', '/baz'));
     }
 
     /**


### PR DESCRIPTION
Guzzle should reject final request URIs that cannot identify a network target. This validates the resolved URI at the client boundary while preserving absolute URLs, network-path references, and relative URLs resolved through base_uri.