### PR TITLE
Reject final URIs missing scheme or host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Section proxy tunnel connection reuse by credential so distinct credentials never share a tunnel
 - Isolate concurrent foreign cURL proxy tunnels added while another owner's tunnel is active
 - Route TLS 1.2 `crypto_method` requests to the stream handler when cURL cannot select TLS 1.2
-- Reject final request URIs missing a scheme or host
+- Reject final request URIs missing a scheme or host before transfer
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Section proxy tunnel connection reuse by credential so distinct credentials never share a tunnel
 - Isolate concurrent foreign cURL proxy tunnels added while another owner's tunnel is active
 - Route TLS 1.2 `crypto_method` requests to the stream handler when cURL cannot select TLS 1.2
+- Reject final request URIs missing a scheme or host
 
 ### Deprecated
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -260,7 +260,15 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $uri = Utils::idnUriConvert($uri, $idnOptions);
         }
 
-        return $uri->getScheme() === '' && $uri->getHost() !== '' ? $uri->withScheme('http') : $uri;
+        if ($uri->getScheme() === '' && $uri->getHost() !== '') {
+            $uri = $uri->withScheme('http');
+        }
+
+        if ($uri->getScheme() === '' || $uri->getHost() === '') {
+            throw new InvalidArgumentException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.');
+        }
+
+        return $uri;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1064,16 +1064,39 @@ class ClientTest extends TestCase
         self::assertSame('http://example.org/test', (string) $mockHandler->getLastRequest()->getUri());
     }
 
-    public function testOnlyAddSchemeWhenHostIsPresent()
+    /**
+     * @dataProvider invalidFinalUriProvider
+     */
+    public function testRejectsFinalUriWithoutSchemeOrHost($uri)
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $client->request('GET', 'baz');
-        self::assertSame(
-            'baz',
-            (string) $mockHandler->getLastRequest()->getUri()
-        );
+        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('URI must include a scheme and host');
+
+        $client->request('GET', $uri);
+    }
+
+    public static function invalidFinalUriProvider()
+    {
+        return [
+            'relative path' => ['baz'],
+            'host-like relative path' => ['gstatic.com/generate_204'],
+            'path starting with colon-slash-slash' => ['://gstatic.com/generate_204'],
+            'absolute path' => ['/generate_204'],
+        ];
+    }
+
+    public function testRejectsSendRequestWhenFinalUriHasNoSchemeOrHost()
+    {
+        $mockHandler = new MockHandler([new Response()]);
+        $client = new Client(['handler' => $mockHandler]);
+
+        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('URI must include a scheme and host');
+
+        $client->send(new Request('GET', '/baz'));
     }
 
     /**


### PR DESCRIPTION
Guzzle should reject final request URIs that cannot identify a network target. This validates the resolved URI at the client boundary while preserving absolute URLs, network-path references, and relative URLs resolved through base_uri.