### PR TITLE
Harden cURL header list options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Route TLS 1.2 `crypto_method` requests to the stream handler when cURL cannot select TLS 1.2
 - Reject final request URIs missing a scheme or host before transfer
 
+### Fixed
+
+- Normalize `Stringable` entries and reject carriage-return/line-feed characters in the cURL `CURLOPT_HTTPHEADER` and `CURLOPT_PROXYHEADER` options, so a smuggled header line, including a `Stringable` `Proxy-Authorization` in a raw `CURLOPT_PROXYHEADER`, can no longer slip past connection-reuse sectioning, and now correctly engages the proxy-tunnel share / fresh-connection safety checks
+
 ### Deprecated
 
 - Deprecate invalid protocols, force_ip_resolve, delay, cookies, and allow_redirects values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Route TLS 1.2 `crypto_method` requests to the stream handler when cURL cannot select TLS 1.2
 - Reject final request URIs missing a scheme or host before transfer
 
-### Fixed
-
-- Normalize `Stringable` entries and reject carriage-return/line-feed characters in the cURL `CURLOPT_HTTPHEADER` and `CURLOPT_PROXYHEADER` options, so a smuggled header line, including a `Stringable` `Proxy-Authorization` in a raw `CURLOPT_PROXYHEADER`, can no longer slip past connection-reuse sectioning, and now correctly engages the proxy-tunnel share / fresh-connection safety checks
-
 ### Deprecated
 
 - Deprecate invalid protocols, force_ip_resolve, delay, cookies, and allow_redirects values

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -142,6 +142,8 @@ class CurlFactory implements CurlFactoryInterface
             $conf = \array_replace($conf, $options['curl']);
         }
 
+        self::normalizeCurlHeaderOptions($conf);
+
         if ($this->shareHandle !== null) {
             // Conservative blanket mode: a configured share handle hides the
             // pooled connections' provenance, so sectioned reuse cannot reason
@@ -798,6 +800,41 @@ class CurlFactory implements CurlFactoryInterface
         $proxy = $conf[\CURLOPT_PROXY];
 
         return \is_string($proxy) && $proxy !== '' ? $proxy : null;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function normalizeCurlHeaderOptions(array &$conf): void
+    {
+        $options = [\CURLOPT_HTTPHEADER => 'CURLOPT_HTTPHEADER'];
+        if (\defined('CURLOPT_PROXYHEADER')) {
+            $options[(int) \constant('CURLOPT_PROXYHEADER')] = 'CURLOPT_PROXYHEADER';
+        }
+
+        foreach ($options as $option => $label) {
+            if (!\array_key_exists($option, $conf) || !\is_array($conf[$option])) {
+                continue;
+            }
+
+            $normalized = [];
+            foreach ($conf[$option] as $key => $entry) {
+                if (\is_object($entry) && \method_exists($entry, '__toString')) {
+                    $entry = (string) $entry;
+                }
+
+                if (\is_string($entry) && \strpbrk($entry, "\r\n") !== false) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        '%s entries must not contain a carriage return or line feed.',
+                        $label
+                    ));
+                }
+
+                $normalized[$key] = $entry;
+            }
+
+            $conf[$option] = $normalized;
+        }
     }
 
     private static function proxyScheme(string $proxy): ?string

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -821,13 +821,16 @@ class CurlFactory implements CurlFactoryInterface
             foreach ($conf[$option] as $key => $entry) {
                 if (\is_object($entry) && \method_exists($entry, '__toString')) {
                     $entry = (string) $entry;
+                } elseif (\is_float($entry) && !\is_finite($entry)) {
+                    $entry = \is_nan($entry) ? 'NAN' : ($entry > 0 ? 'INF' : '-INF');
+                } elseif (\is_scalar($entry)) {
+                    $entry = (string) $entry;
+                } else {
+                    throw new \InvalidArgumentException(\sprintf('%s entries must be strings, stringable objects, or scalar values.', $label));
                 }
 
-                if (\is_string($entry) && \strpbrk($entry, "\r\n") !== false) {
-                    throw new \InvalidArgumentException(\sprintf(
-                        '%s entries must not contain a carriage return or line feed.',
-                        $label
-                    ));
+                if (\strpbrk($entry, "\r\n") !== false) {
+                    throw new \InvalidArgumentException(\sprintf('%s entries must not contain a carriage return or line feed.', $label));
                 }
 
                 $normalized[$key] = $entry;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -147,7 +147,7 @@ class CurlFactoryTest extends TestCase
         $proxyHeaderOption = self::proxyHeaderOption();
         $conf = [
             \CURLOPT_PROXY => 'http://proxy.example.com:8080',
-            $proxyHeaderOption => [new class() {
+            $proxyHeaderOption => [new class {
                 public function __toString(): string
                 {
                     return 'Proxy-Authorization: Basic abc';
@@ -237,7 +237,7 @@ class CurlFactoryTest extends TestCase
     public function testRejectsStringableCurlHeaderEntriesContainingNewlines(): void
     {
         $conf = [
-            \CURLOPT_HTTPHEADER => [new class() {
+            \CURLOPT_HTTPHEADER => [new class {
                 public function __toString(): string
                 {
                     return "X-Test: value\r\nInjected: yes";

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -166,6 +166,102 @@ class CurlFactoryTest extends TestCase
         self::assertNotSame($delegated, $literalHeader);
     }
 
+    public function testNormalizesScalarCurlHeaderEntries(): void
+    {
+        $conf = [
+            \CURLOPT_HTTPHEADER => [
+                'string' => 'X-String: value',
+                'int' => 123,
+                'float' => 1.5,
+                'true' => true,
+                'false' => false,
+                'nan' => \NAN,
+                'inf' => \INF,
+                '-inf' => -\INF,
+            ],
+        ];
+
+        self::normalizeCurlHeaderOptions($conf);
+
+        self::assertSame([
+            'string' => 'X-String: value',
+            'int' => '123',
+            'float' => '1.5',
+            'true' => '1',
+            'false' => '',
+            'nan' => 'NAN',
+            'inf' => 'INF',
+            '-inf' => '-INF',
+        ], $conf[\CURLOPT_HTTPHEADER]);
+    }
+
+    /**
+     * @dataProvider invalidCurlHeaderEntryProvider
+     *
+     * @param mixed $entry
+     */
+    public function testRejectsInvalidCurlHeaderEntries($entry): void
+    {
+        $conf = [\CURLOPT_HTTPHEADER => [$entry]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_HTTPHEADER entries must be strings, stringable objects, or scalar values.');
+
+        self::normalizeCurlHeaderOptions($conf);
+    }
+
+    public static function invalidCurlHeaderEntryProvider(): iterable
+    {
+        yield 'null' => [null];
+        yield 'array' => [[]];
+        yield 'non-stringable object' => [new \stdClass()];
+    }
+
+    public function testRejectsResourceCurlHeaderEntries(): void
+    {
+        $resource = \fopen(__FILE__, 'r');
+        self::assertIsResource($resource);
+
+        try {
+            $conf = [\CURLOPT_HTTPHEADER => [$resource]];
+
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('CURLOPT_HTTPHEADER entries must be strings, stringable objects, or scalar values.');
+
+            self::normalizeCurlHeaderOptions($conf);
+        } finally {
+            \fclose($resource);
+        }
+    }
+
+    public function testRejectsStringableCurlHeaderEntriesContainingNewlines(): void
+    {
+        $conf = [
+            \CURLOPT_HTTPHEADER => [new class() {
+                public function __toString(): string
+                {
+                    return "X-Test: value\r\nInjected: yes";
+                }
+            }],
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_HTTPHEADER entries must not contain a carriage return or line feed.');
+
+        self::normalizeCurlHeaderOptions($conf);
+    }
+
+    public function testRejectsInvalidCurlProxyHeaderEntries(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        $conf = [$proxyHeaderOption => [[]]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXYHEADER entries must be strings, stringable objects, or scalar values.');
+
+        self::normalizeCurlHeaderOptions($conf);
+    }
+
     public function testLeavesNormalCurlHeaderEntriesUnchanged(): void
     {
         $conf = [\CURLOPT_HTTPHEADER => ['Accept: application/json']];

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -117,6 +117,64 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(10, $_SERVER['_curl'][\CURLOPT_LOW_SPEED_LIMIT]);
     }
 
+    public function testRejectsCurlProxyHeaderEntriesContainingNewlines(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        $factory = new CurlFactory(3);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXYHEADER');
+
+        $factory->create(new Psr7\Request('GET', 'http://example.com'), [
+            'curl' => [
+                $proxyHeaderOption => ["X-Decoy: v\r\nProxy-Authorization: Basic abc"],
+            ],
+        ]);
+    }
+
+    public function testRejectsCurlHttpHeaderEntriesContainingNewlines(): void
+    {
+        $conf = [\CURLOPT_HTTPHEADER => ["X-Decoy: v\r\nProxy-Authorization: Basic abc"]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_HTTPHEADER');
+
+        self::normalizeCurlHeaderOptions($conf);
+    }
+
+    public function testNormalizesStringableCurlHeaderEntriesBeforeProxyTunnelSignature(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        $conf = [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            $proxyHeaderOption => [new class() {
+                public function __toString(): string
+                {
+                    return 'Proxy-Authorization: Basic abc';
+                }
+            }],
+        ];
+
+        self::normalizeCurlHeaderOptions($conf);
+
+        self::assertSame(['Proxy-Authorization: Basic abc'], $conf[$proxyHeaderOption]);
+        $delegated = self::computeProxyTunnelSignature('8.20.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+        ]);
+        $literalHeader = self::computeProxyTunnelSignature('8.20.0', 'https://example.com', $conf);
+        self::assertNotNull($literalHeader);
+        self::assertNotSame($delegated, $literalHeader);
+    }
+
+    public function testLeavesNormalCurlHeaderEntriesUnchanged(): void
+    {
+        $conf = [\CURLOPT_HTTPHEADER => ['Accept: application/json']];
+
+        self::normalizeCurlHeaderOptions($conf);
+
+        self::assertSame(['Accept: application/json'], $conf[\CURLOPT_HTTPHEADER]);
+    }
+
     public function testAppliesConfiguredCurlShareHandle(): void
     {
         self::skipIfCurlShareIsUnavailable();
@@ -2570,6 +2628,19 @@ class CurlFactoryTest extends TestCase
         }
 
         return (int) \constant('CURLOPT_PROXYHEADER');
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function normalizeCurlHeaderOptions(array &$conf): void
+    {
+        $method = new \ReflectionMethod(CurlFactory::class, 'normalizeCurlHeaderOptions');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $method->invokeArgs(null, [&$conf]);
     }
 
     private static function redactProxyUserInfo(string $error, ?string $proxy): string


### PR DESCRIPTION
Normalizes Stringable cURL header-list entries before reuse-sectioning decisions and rejects CR/LF in cURL HTTP and proxy header lists.