### PR TITLE
Harden cURL header list options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject invalid `SetCookie` constructor field types instead of coercing them
 - Reject malformed, conflicting, or unrepresentable request `Content-Length` values in built-in handlers
 - Reject raw cURL request options outside the built-in cURL handlers' allow-list
-- Reject invalid raw cURL header-list entries before applying them
+- Reject non-string raw cURL header-list entries before applying them
 - Reject PHP stream context options outside the built-in stream handler allow-list
 - Reject selected request options ignored by incompatible built-in handlers
 - Support retry delay callbacks with retry count only or full retry context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Reject invalid `SetCookie` constructor field types instead of coercing them
 - Reject malformed, conflicting, or unrepresentable request `Content-Length` values in built-in handlers
 - Reject raw cURL request options outside the built-in cURL handlers' allow-list
+- Reject invalid raw cURL header-list entries before applying them
 - Reject PHP stream context options outside the built-in stream handler allow-list
 - Reject selected request options ignored by incompatible built-in handlers
 - Support retry delay callbacks with retry count only or full retry context

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -561,6 +561,8 @@ now reject raw cURL options that override request method, URI, body, headers,
 timeouts, redirects, proxy URLs and types, TLS verification or client
 credentials, progress/debug callbacks, sink handling, cookies, protocols, or
 cURL share handles. Use first-class Guzzle request options for those settings.
+Allowed raw cURL header-list options, such as `CURLOPT_PROXYHEADER`, now accept
+only strings or stringable objects as entries.
 
 The cURL handlers also reject stream-only `stream_context` options, but accept
 `read_timeout` without effect. The stream handler rejects cURL-only options it

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -223,6 +223,8 @@ final class CurlFactory implements CurlFactoryInterface
             $conf = \array_replace($conf, $options['curl']);
         }
 
+        self::normalizeCurlHeaderOptions($conf);
+
         if ($this->shareHandle !== null) {
             // Conservative blanket mode: a configured share handle hides the
             // pooled connections' provenance, so sectioned reuse cannot reason
@@ -1213,6 +1215,41 @@ final class CurlFactory implements CurlFactoryInterface
         $proxy = $conf[\CURLOPT_PROXY];
 
         return \is_string($proxy) && $proxy !== '' ? $proxy : null;
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function normalizeCurlHeaderOptions(array &$conf): void
+    {
+        $options = [\CURLOPT_HTTPHEADER => 'CURLOPT_HTTPHEADER'];
+        if (\defined('CURLOPT_PROXYHEADER')) {
+            $options[(int) \constant('CURLOPT_PROXYHEADER')] = 'CURLOPT_PROXYHEADER';
+        }
+
+        foreach ($options as $option => $label) {
+            if (!\array_key_exists($option, $conf) || !\is_array($conf[$option])) {
+                continue;
+            }
+
+            $normalized = [];
+            foreach ($conf[$option] as $key => $entry) {
+                if (\is_object($entry) && \method_exists($entry, '__toString')) {
+                    $entry = (string) $entry;
+                }
+
+                if (\is_string($entry) && \strpbrk($entry, "\r\n") !== false) {
+                    throw new InvalidArgumentException(\sprintf(
+                        '%s entries must not contain a carriage return or line feed.',
+                        $label
+                    ));
+                }
+
+                $normalized[$key] = $entry;
+            }
+
+            $conf[$option] = $normalized;
+        }
     }
 
     /**

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -1236,13 +1236,12 @@ final class CurlFactory implements CurlFactoryInterface
             foreach ($conf[$option] as $key => $entry) {
                 if (\is_object($entry) && \method_exists($entry, '__toString')) {
                     $entry = (string) $entry;
+                } elseif (!\is_string($entry)) {
+                    throw new InvalidArgumentException(\sprintf('%s entries must be strings or stringable objects.', $label));
                 }
 
-                if (\is_string($entry) && \strpbrk($entry, "\r\n") !== false) {
-                    throw new InvalidArgumentException(\sprintf(
-                        '%s entries must not contain a carriage return or line feed.',
-                        $label
-                    ));
+                if (\strpbrk($entry, "\r\n") !== false) {
+                    throw new InvalidArgumentException(\sprintf('%s entries must not contain a carriage return or line feed.', $label));
                 }
 
                 $normalized[$key] = $entry;

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -248,6 +248,102 @@ class CurlFactoryTest extends TestCase
         self::assertNotSame($delegated, $literalHeader);
     }
 
+    public function testNormalizesStringableCurlHeaderEntries(): void
+    {
+        $conf = [
+            \CURLOPT_HTTPHEADER => [
+                'literal' => 'Accept: application/json',
+                'stringable' => new class() {
+                    public function __toString(): string
+                    {
+                        return 'X-Test: value';
+                    }
+                },
+            ],
+        ];
+
+        self::normalizeCurlHeaderOptions($conf);
+
+        self::assertSame([
+            'literal' => 'Accept: application/json',
+            'stringable' => 'X-Test: value',
+        ], $conf[\CURLOPT_HTTPHEADER]);
+    }
+
+    /**
+     * @dataProvider invalidCurlHeaderEntryProvider
+     *
+     * @param mixed $entry
+     */
+    public function testRejectsInvalidCurlHeaderEntries($entry): void
+    {
+        $conf = [\CURLOPT_HTTPHEADER => [$entry]];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_HTTPHEADER entries must be strings or stringable objects.');
+
+        self::normalizeCurlHeaderOptions($conf);
+    }
+
+    public static function invalidCurlHeaderEntryProvider(): iterable
+    {
+        yield 'int' => [123];
+        yield 'float' => [1.5];
+        yield 'true' => [true];
+        yield 'false' => [false];
+        yield 'null' => [null];
+        yield 'array' => [[]];
+        yield 'non-stringable object' => [new \stdClass()];
+        yield 'nan' => [\NAN];
+        yield 'inf' => [\INF];
+        yield '-inf' => [-\INF];
+    }
+
+    public function testRejectsResourceCurlHeaderEntries(): void
+    {
+        $resource = \fopen(__FILE__, 'r');
+        self::assertIsResource($resource);
+
+        try {
+            $conf = [\CURLOPT_HTTPHEADER => [$resource]];
+
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('CURLOPT_HTTPHEADER entries must be strings or stringable objects.');
+
+            self::normalizeCurlHeaderOptions($conf);
+        } finally {
+            \fclose($resource);
+        }
+    }
+
+    public function testRejectsStringableCurlHeaderEntriesContainingNewlines(): void
+    {
+        $conf = [
+            \CURLOPT_HTTPHEADER => [new class() {
+                public function __toString(): string
+                {
+                    return "X-Test: value\r\nInjected: yes";
+                }
+            }],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_HTTPHEADER entries must not contain a carriage return or line feed.');
+
+        self::normalizeCurlHeaderOptions($conf);
+    }
+
+    public function testRejectsInvalidCurlProxyHeaderEntries(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        $conf = [$proxyHeaderOption => [123]];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXYHEADER entries must be strings or stringable objects.');
+
+        self::normalizeCurlHeaderOptions($conf);
+    }
+
     public function testLeavesNormalCurlHeaderEntriesUnchanged(): void
     {
         $conf = [\CURLOPT_HTTPHEADER => ['Accept: application/json']];

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -7,6 +7,7 @@ namespace GuzzleHttp\Tests\Handler;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ConnectTimeoutException;
+use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\NetworkException;
 use GuzzleHttp\Exception\NetworkTimeoutException;
 use GuzzleHttp\Exception\RequestException;
@@ -196,6 +197,64 @@ class CurlFactoryTest extends TestCase
         $req = new Psr7\Request('GET', Server::$url);
         $a($req, ['curl' => [\CURLOPT_LOW_SPEED_LIMIT => 10]]);
         self::assertEquals(10, $_SERVER['_curl'][\CURLOPT_LOW_SPEED_LIMIT]);
+    }
+
+    public function testRejectsCurlProxyHeaderEntriesContainingNewlines(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        $factory = new CurlFactory(3);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_PROXYHEADER');
+
+        $factory->create(new Psr7\Request('GET', 'http://example.com'), [
+            'curl' => [
+                $proxyHeaderOption => ["X-Decoy: v\r\nProxy-Authorization: Basic abc"],
+            ],
+        ]);
+    }
+
+    public function testRejectsCurlHttpHeaderEntriesContainingNewlines(): void
+    {
+        $conf = [\CURLOPT_HTTPHEADER => ["X-Decoy: v\r\nProxy-Authorization: Basic abc"]];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('CURLOPT_HTTPHEADER');
+
+        self::normalizeCurlHeaderOptions($conf);
+    }
+
+    public function testNormalizesStringableCurlHeaderEntriesBeforeProxyTunnelSignature(): void
+    {
+        $proxyHeaderOption = self::proxyHeaderOption();
+        $conf = [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+            $proxyHeaderOption => [new class() {
+                public function __toString(): string
+                {
+                    return 'Proxy-Authorization: Basic abc';
+                }
+            }],
+        ];
+
+        self::normalizeCurlHeaderOptions($conf);
+
+        self::assertSame(['Proxy-Authorization: Basic abc'], $conf[$proxyHeaderOption]);
+        $delegated = self::computeProxyTunnelSignature('8.20.0', 'https://example.com', [
+            \CURLOPT_PROXY => 'http://proxy.example.com:8080',
+        ]);
+        $literalHeader = self::computeProxyTunnelSignature('8.20.0', 'https://example.com', $conf);
+        self::assertNotNull($literalHeader);
+        self::assertNotSame($delegated, $literalHeader);
+    }
+
+    public function testLeavesNormalCurlHeaderEntriesUnchanged(): void
+    {
+        $conf = [\CURLOPT_HTTPHEADER => ['Accept: application/json']];
+
+        self::normalizeCurlHeaderOptions($conf);
+
+        self::assertSame(['Accept: application/json'], $conf[\CURLOPT_HTTPHEADER]);
     }
 
     public function testAppliesConfiguredCurlShareHandle(): void
@@ -6044,6 +6103,19 @@ class CurlFactoryTest extends TestCase
         }
 
         return (int) \constant('CURLOPT_PROXYHEADER');
+    }
+
+    /**
+     * @param array<int|string, mixed> $conf
+     */
+    private static function normalizeCurlHeaderOptions(array &$conf): void
+    {
+        $method = new \ReflectionMethod(CurlFactory::class, 'normalizeCurlHeaderOptions');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        $method->invokeArgs(null, [&$conf]);
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -229,7 +229,7 @@ class CurlFactoryTest extends TestCase
         $proxyHeaderOption = self::proxyHeaderOption();
         $conf = [
             \CURLOPT_PROXY => 'http://proxy.example.com:8080',
-            $proxyHeaderOption => [new class() {
+            $proxyHeaderOption => [new class {
                 public function __toString(): string
                 {
                     return 'Proxy-Authorization: Basic abc';
@@ -253,7 +253,7 @@ class CurlFactoryTest extends TestCase
         $conf = [
             \CURLOPT_HTTPHEADER => [
                 'literal' => 'Accept: application/json',
-                'stringable' => new class() {
+                'stringable' => new class {
                     public function __toString(): string
                     {
                         return 'X-Test: value';
@@ -319,7 +319,7 @@ class CurlFactoryTest extends TestCase
     public function testRejectsStringableCurlHeaderEntriesContainingNewlines(): void
     {
         $conf = [
-            \CURLOPT_HTTPHEADER => [new class() {
+            \CURLOPT_HTTPHEADER => [new class {
                 public function __toString(): string
                 {
                     return "X-Test: value\r\nInjected: yes";


### PR DESCRIPTION
Normalizes Stringable cURL header-list entries before reuse-sectioning decisions and rejects CR/LF in cURL HTTP and proxy header lists.