### PR TITLE
Stop deprecating CURLOPT_PREREQFUNCTION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version
 - Isolate concurrent foreign cURL proxy tunnels added while another owner's tunnel is active
 - Route credentialed HTTP(S) proxy Proxy-Authorization headers through cURL proxy header handling
 - Reject request-level `CURLOPT_SHARE` when combined with authenticated HTTP/HTTPS proxy tunnel configuration
+- Remove deprecation for raw cURL `CURLOPT_PREREQFUNCTION` callbacks when defined by PHP cURL
 - Route TLS 1.2 `crypto_method` requests to the stream handler when cURL cannot select TLS 1.2
 - Reject final request URIs missing a scheme or host before transfer
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -74,6 +74,11 @@ Custom cURL request options remain active during redirects unless Guzzle
 documents otherwise. See [`allow_redirects`](request-options.md#allow_redirects)
 for cross-origin redirect credential behavior.
 
+Callbacks supplied through the raw `curl` request option are passed directly to
+PHP's cURL extension. Guzzle does not normalize exception or abort behavior for
+raw cURL callbacks. Prefer Guzzle's `progress`, `on_headers`, and `on_stats`
+request options when you need Guzzle's documented callback semantics.
+
 ## How can I add custom stream context options?
 
 You can pass allow-listed custom

--- a/docs/request-options.md
+++ b/docs/request-options.md
@@ -421,6 +421,7 @@ an option depending on the runtime. The allow-list is limited to the following
 - `CURLOPT_MAXAGE_CONN`
 - `CURLOPT_MAXCONNECTS`
 - `CURLOPT_MAXLIFETIME_CONN`
+- `CURLOPT_PREREQFUNCTION`
 - `CURLOPT_PROXYHEADER`
 - `CURLOPT_PROXYUSERPWD`
 - `CURLOPT_RESOLVE`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -105,7 +105,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$ch of function curl_setopt expects resource, CurlHandle\|resource given\.$#'
 			identifier: argument.type
-			count: 5
+			count: 6
 			path: src/Handler/CurlFactory.php
 
 		-

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -550,6 +550,7 @@ class CurlFactory implements CurlFactoryInterface
         self::addSupportedCurlOption($options, 'CURLOPT_MAXCONNECTS');
         self::addSupportedCurlOption($options, 'CURLOPT_MAXLIFETIME_CONN');
         self::addSupportedCurlOption($options, 'CURLOPT_HTTPPROXYTUNNEL');
+        self::addSupportedCurlOption($options, 'CURLOPT_PREREQFUNCTION');
         self::addSupportedCurlOption($options, 'CURLOPT_PROXYHEADER');
         self::addSupportedCurlOption($options, 'CURLOPT_PROXYUSERPWD');
         self::addSupportedCurlOption($options, 'CURLOPT_RESOLVE');
@@ -629,6 +630,11 @@ class CurlFactory implements CurlFactoryInterface
         \curl_setopt($resource, \CURLOPT_READFUNCTION, null);
         \curl_setopt($resource, \CURLOPT_WRITEFUNCTION, null);
         \curl_setopt($resource, \CURLOPT_PROGRESSFUNCTION, null);
+
+        if (\defined('CURLOPT_PREREQFUNCTION')) {
+            \curl_setopt($resource, (int) \constant('CURLOPT_PREREQFUNCTION'), null);
+        }
+
         \curl_reset($resource);
         $this->handles[] = $resource;
     }

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -118,6 +118,141 @@ class CurlFactoryTest extends TestCase
         self::assertEquals(10, $_SERVER['_curl'][\CURLOPT_LOW_SPEED_LIMIT]);
     }
 
+    public function testCanAddPrereqFunctionCurlOption(): void
+    {
+        if (!\defined('CURLOPT_PREREQFUNCTION')) {
+            self::markTestSkipped('CURLOPT_PREREQFUNCTION is not available.');
+        }
+        if (!\defined('CURL_PREREQFUNC_OK')) {
+            self::markTestSkipped('CURL_PREREQFUNC_OK is not available.');
+        }
+
+        $option = (int) \constant('CURLOPT_PREREQFUNCTION');
+        $ok = (int) \constant('CURL_PREREQFUNC_OK');
+        $callback = static function () use ($ok): int {
+            return $ok;
+        };
+
+        $factory = new CurlFactory(1);
+        $easy = null;
+
+        try {
+            $easy = $factory->create(new Psr7\Request('GET', Server::$url), [
+                'curl' => [
+                    $option => $callback,
+                ],
+            ]);
+
+            self::assertSame($callback, $_SERVER['_curl'][$option]);
+        } finally {
+            if ($easy !== null) {
+                $factory->release($easy);
+            }
+        }
+    }
+
+    public function testPrereqFunctionIsInSupportedCurlOptionsAllowList(): void
+    {
+        if (!\defined('CURLOPT_PREREQFUNCTION')) {
+            self::markTestSkipped('CURLOPT_PREREQFUNCTION is not available.');
+        }
+
+        $option = (int) \constant('CURLOPT_PREREQFUNCTION');
+        $method = new \ReflectionMethod(CurlFactory::class, 'supportedCurlOptions');
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+
+        /** @var array<int, true> $supported */
+        $supported = $method->invoke(null);
+
+        self::assertArrayHasKey(
+            $option,
+            $supported,
+            'CURLOPT_PREREQFUNCTION must be in the built-in cURL handlers\' allow-list so it no longer triggers the raw cURL option deprecation.'
+        );
+    }
+
+    public function testPrereqFunctionIsClearedBeforeReusingCurlHandle(): void
+    {
+        if (!\defined('CURLOPT_PREREQFUNCTION')) {
+            self::markTestSkipped('CURLOPT_PREREQFUNCTION is not available.');
+        }
+        if (!\defined('CURL_PREREQFUNC_OK')) {
+            self::markTestSkipped('CURL_PREREQFUNC_OK is not available.');
+        }
+
+        $option = (int) \constant('CURLOPT_PREREQFUNCTION');
+        $ok = (int) \constant('CURL_PREREQFUNC_OK');
+
+        Server::flush();
+        Server::enqueue([
+            new Psr7\Response(200),
+            new Psr7\Response(200),
+        ]);
+
+        $factory = new CurlFactory(1);
+        $handler = new Handler\CurlHandler(['handle_factory' => $factory]);
+        $called = 0;
+        $request = new Psr7\Request('GET', Server::$url);
+
+        $handler($request, [
+            'curl' => [
+                $option => static function () use (&$called, $ok): int {
+                    ++$called;
+
+                    return $ok;
+                },
+            ],
+        ])->wait();
+
+        $afterFirst = $called;
+        self::assertSame(1, $afterFirst);
+
+        $handler($request, [
+            'curl' => [
+                \CURLOPT_FRESH_CONNECT => true,
+            ],
+        ])->wait();
+
+        self::assertSame($afterFirst, $called);
+    }
+
+    public function testPrereqFunctionAbortUsesExistingCurlErrorPath(): void
+    {
+        if (!\defined('CURLOPT_PREREQFUNCTION')) {
+            self::markTestSkipped('CURLOPT_PREREQFUNCTION is not available.');
+        }
+        if (!\defined('CURL_PREREQFUNC_ABORT')) {
+            self::markTestSkipped('CURL_PREREQFUNC_ABORT is not available.');
+        }
+
+        $option = (int) \constant('CURLOPT_PREREQFUNCTION');
+        $abort = (int) \constant('CURL_PREREQFUNC_ABORT');
+        $called = 0;
+
+        Server::flush();
+
+        $handler = new Handler\CurlHandler(['handle_factory' => new CurlFactory(1)]);
+        $promise = $handler(new Psr7\Request('GET', Server::$url), [
+            'curl' => [
+                $option => static function () use (&$called, $abort): int {
+                    ++$called;
+
+                    return $abort;
+                },
+            ],
+        ]);
+
+        try {
+            $promise->wait();
+            self::fail('Expected a RequestException from the aborted prereq callback.');
+        } catch (RequestException $e) {
+            self::assertStringContainsString('cURL error', $e->getMessage());
+            self::assertSame(1, $called);
+        }
+    }
+
     public function testRejectsCurlProxyHeaderEntriesContainingNewlines(): void
     {
         $proxyHeaderOption = self::proxyHeaderOption();


### PR DESCRIPTION
Summary: Allow raw CURLOPT_PREREQFUNCTION callbacks when defined, clear them before pooled handle reuse, and update the scoped 7.13 docs/tests. Testing: Not run per request.