### PR TITLE
Allow middleware to rewrite partial URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Please refer to [UPGRADING](UPGRADING.md) guide for upgrading to a major version.
 
 
+## 7.13.1 - Upcoming
+
+### Fixed
+
+- Allow middleware to rewrite partial URIs before transports validate them
+
+
 ## 7.13.0 - 2026-06-29
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -264,10 +264,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $uri = $uri->withScheme('http');
         }
 
-        if ($uri->getScheme() === '' || $uri->getHost() === '') {
-            throw new InvalidArgumentException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.');
-        }
-
         return $uri;
     }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -101,6 +101,8 @@ class CurlFactory implements CurlFactoryInterface
 
     public function create(RequestInterface $request, array $options): EasyHandle
     {
+        self::validateRequestUri($request);
+
         $protocolVersion = $request->getProtocolVersion();
 
         if ('' === $protocolVersion) {
@@ -1834,6 +1836,14 @@ class CurlFactory implements CurlFactoryInterface
         throw new \InvalidArgumentException(
             'Invalid crypto_method_max request option: maximum TLS version control is not supported by your version of cURL'
         );
+    }
+
+    private static function validateRequestUri(RequestInterface $request): void
+    {
+        $uri = $request->getUri();
+        if ($uri->getScheme() === '' || $uri->getHost() === '') {
+            throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
+        }
     }
 
     /**

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -344,7 +344,12 @@ class StreamHandler
             $methods = \array_flip(\get_class_methods(__CLASS__));
         }
 
-        $scheme = $request->getUri()->getScheme();
+        $uri = $request->getUri();
+        $scheme = $uri->getScheme();
+        if ($scheme === '' || $uri->getHost() === '') {
+            throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
+        }
+
         if (!\in_array($scheme, ['http', 'https'], true)) {
             throw new RequestException(\sprintf("The scheme '%s' is not supported.", $scheme), $request);
         }

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -346,7 +346,7 @@ class StreamHandler
 
         $uri = $request->getUri();
         $scheme = $uri->getScheme();
-        if ($scheme === '' || $uri->getHost() === '') {
+        if ($scheme === '') {
             throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
         }
 
@@ -357,6 +357,10 @@ class StreamHandler
         $protocols = Utils::normalizeProtocols($options['protocols'] ?? ['http', 'https']);
         if (!\in_array($scheme, $protocols, true)) {
             throw new RequestException(\sprintf('The scheme "%s" is not allowed by the protocols request option.', $scheme), $request);
+        }
+
+        if ($uri->getHost() === '') {
+            throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
         }
 
         // HTTP/1.1 streams using the PHP stream wrapper require a

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -18,6 +18,7 @@ use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Server\Server;
 use GuzzleHttp\TransportSharing;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class ClientTest extends TestCase
@@ -1065,20 +1066,19 @@ class ClientTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidFinalUriProvider
+     * @dataProvider partialUriProvider
      */
-    public function testRejectsFinalUriWithoutSchemeOrHost($uri)
+    public function testMockHandlerReceivesPartialUri($uri)
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('URI must include a scheme and host');
-
         $client->request('GET', $uri);
+
+        self::assertSame($uri, (string) $mockHandler->getLastRequest()->getUri());
     }
 
-    public static function invalidFinalUriProvider()
+    public static function partialUriProvider()
     {
         return [
             'relative path' => ['baz'],
@@ -1088,15 +1088,32 @@ class ClientTest extends TestCase
         ];
     }
 
-    public function testRejectsSendRequestWhenFinalUriHasNoSchemeOrHost()
+    public function testMockHandlerReceivesPartialRequestUri()
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $this->expectException(\GuzzleHttp\Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('URI must include a scheme and host');
-
         $client->send(new Request('GET', '/baz'));
+
+        self::assertSame('/baz', (string) $mockHandler->getLastRequest()->getUri());
+    }
+
+    public function testMiddlewareCanRewritePartialUriBeforeHandler()
+    {
+        $mockHandler = new MockHandler([new Response()]);
+        $stack = HandlerStack::create($mockHandler);
+        $stack->push(static function (callable $handler): callable {
+            return static function (RequestInterface $request, array $options) use ($handler) {
+                $uri = Psr7\UriResolver::resolve(new Uri('https://example.com/base/'), $request->getUri());
+
+                return $handler($request->withUri($uri), $options);
+            };
+        });
+        $client = new Client(['handler' => $stack]);
+
+        $client->request('GET', 'some/path');
+
+        self::assertSame('https://example.com/base/some/path', (string) $mockHandler->getLastRequest()->getUri());
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -705,6 +705,28 @@ class CurlFactoryTest extends TestCase
     }
 
     /**
+     * @dataProvider uriMissingSchemeOrHostProvider
+     */
+    public function testRejectsRequestUriMissingSchemeOrHost($uri)
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('URI must include a scheme and host');
+
+        $f->create(new Psr7\Request('GET', $uri), []);
+    }
+
+    public static function uriMissingSchemeOrHostProvider(): iterable
+    {
+        yield 'relative path' => ['baz'];
+        yield 'host-like relative path' => ['gstatic.com/generate_204'];
+        yield 'path starting with colon-slash-slash' => ['://gstatic.com/generate_204'];
+        yield 'absolute path' => ['/generate_204'];
+        yield 'scheme without host' => ['https:/generate_204'];
+    }
+
+    /**
      * @dataProvider invalidProtocolsProvider
      *
      * @param mixed $protocols

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -1403,6 +1403,33 @@ class StreamHandlerTest extends TestCase
         )->wait();
     }
 
+    /**
+     * @dataProvider uriMissingSchemeOrHostProvider
+     */
+    public function testRejectsRequestUriMissingSchemeOrHost($uri)
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('URI must include a scheme and host');
+
+        $handler(
+            new Request('GET', $uri),
+            [
+                RequestOptions::STREAM => true,
+            ]
+        )->wait();
+    }
+
+    public static function uriMissingSchemeOrHostProvider(): iterable
+    {
+        yield 'relative path' => ['baz'];
+        yield 'host-like relative path' => ['gstatic.com/generate_204'];
+        yield 'path starting with colon-slash-slash' => ['://gstatic.com/generate_204'];
+        yield 'absolute path' => ['/generate_204'];
+        yield 'scheme without host' => ['https:/generate_204'];
+    }
+
     public function testProtocolsOptionRejectsDisallowedStreamScheme()
     {
         $handler = new StreamHandler();


### PR DESCRIPTION
This moves missing scheme and host validation out of the client URI builder so middleware can provide the final request URI. The cURL and stream transports still reject requests with incomplete URIs before setting up the transfer.