### PR TITLE
Allow middleware to rewrite partial URIs

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -618,10 +618,6 @@ class Client implements ClientInterface, \Psr\Http\Client\ClientInterface
             $uri = $uri->withScheme('http');
         }
 
-        if ($uri->getScheme() === '' || $uri->getHost() === '') {
-            throw new InvalidArgumentException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.');
-        }
-
         return $uri;
     }
 

--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -169,6 +169,7 @@ final class CurlFactory implements CurlFactoryInterface
     public function create(RequestInterface $request, array $options): EasyHandle
     {
         $this->assertOpen();
+        self::validateRequestUri($request);
 
         $protocolVersion = $request->getProtocolVersion();
 
@@ -607,6 +608,14 @@ final class CurlFactory implements CurlFactoryInterface
         $value = \constant($constant);
         if (\is_int($value)) {
             $options[$value] = $replacement;
+        }
+    }
+
+    private static function validateRequestUri(RequestInterface $request): void
+    {
+        $uri = $request->getUri();
+        if ($uri->getScheme() === '' || $uri->getHost() === '') {
+            throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
         }
     }
 

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -672,7 +672,7 @@ final class StreamHandler
     {
         $uri = $request->getUri();
         $scheme = $uri->getScheme();
-        if ($scheme === '' || $uri->getHost() === '') {
+        if ($scheme === '') {
             throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
         }
 
@@ -683,6 +683,10 @@ final class StreamHandler
         $protocols = Utils::normalizeProtocols($options['protocols'] ?? ['http', 'https']);
         if (!\in_array($scheme, $protocols, true)) {
             throw new RequestException(\sprintf('The scheme "%s" is not allowed by the protocols request option.', $scheme), $request);
+        }
+
+        if ($uri->getHost() === '') {
+            throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
         }
 
         // HTTP/1.1 streams using the PHP stream wrapper require a

--- a/src/Handler/StreamHandler.php
+++ b/src/Handler/StreamHandler.php
@@ -670,7 +670,12 @@ final class StreamHandler
      */
     private function createStream(RequestInterface $request, array $options)
     {
-        $scheme = $request->getUri()->getScheme();
+        $uri = $request->getUri();
+        $scheme = $uri->getScheme();
+        if ($scheme === '' || $uri->getHost() === '') {
+            throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
+        }
+
         if (!\in_array($scheme, ['http', 'https'], true)) {
             throw new RequestException(\sprintf("The scheme '%s' is not supported.", $scheme), $request);
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2425,20 +2425,19 @@ class ClientTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidFinalUriProvider
+     * @dataProvider partialUriProvider
      */
-    public function testRejectsFinalUriWithoutSchemeOrHost(string $uri): void
+    public function testMockHandlerReceivesPartialUri(string $uri): void
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('URI must include a scheme and host');
-
         $client->request('GET', $uri);
+
+        self::assertSame($uri, (string) $mockHandler->getLastRequest()->getUri());
     }
 
-    public static function invalidFinalUriProvider(): iterable
+    public static function partialUriProvider(): iterable
     {
         yield 'relative path' => ['baz'];
         yield 'host-like relative path' => ['gstatic.com/generate_204'];
@@ -2446,15 +2445,32 @@ class ClientTest extends TestCase
         yield 'absolute path' => ['/generate_204'];
     }
 
-    public function testRejectsSendRequestWhenFinalUriHasNoSchemeOrHost(): void
+    public function testMockHandlerReceivesPartialRequestUri(): void
     {
         $mockHandler = new MockHandler([new Response()]);
         $client = new Client(['handler' => $mockHandler]);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('URI must include a scheme and host');
-
         $client->send(new Request('GET', '/baz'));
+
+        self::assertSame('/baz', (string) $mockHandler->getLastRequest()->getUri());
+    }
+
+    public function testMiddlewareCanRewritePartialUriBeforeHandler(): void
+    {
+        $mockHandler = new MockHandler([new Response()]);
+        $stack = HandlerStack::create($mockHandler);
+        $stack->push(static function (callable $handler): callable {
+            return static function (RequestInterface $request, array $options) use ($handler): PromiseInterface {
+                $uri = Psr7\UriResolver::resolve(new Uri('https://example.com/base/'), $request->getUri());
+
+                return $handler($request->withUri($uri), $options);
+            };
+        });
+        $client = new Client(['handler' => $stack]);
+
+        $client->request('GET', 'some/path');
+
+        self::assertSame('https://example.com/base/some/path', (string) $mockHandler->getLastRequest()->getUri());
     }
 
     /**

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -908,6 +908,28 @@ class CurlFactoryTest extends TestCase
     }
 
     /**
+     * @dataProvider uriMissingSchemeOrHostProvider
+     */
+    public function testRejectsRequestUriMissingSchemeOrHost(string $uri): void
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('URI must include a scheme and host');
+
+        $f->create(new Psr7\Request('GET', $uri), []);
+    }
+
+    public static function uriMissingSchemeOrHostProvider(): iterable
+    {
+        yield 'relative path' => ['baz'];
+        yield 'host-like relative path' => ['gstatic.com/generate_204'];
+        yield 'path starting with colon-slash-slash' => ['://gstatic.com/generate_204'];
+        yield 'absolute path' => ['/generate_204'];
+        yield 'scheme without host' => ['https:/generate_204'];
+    }
+
+    /**
      * @dataProvider invalidProtocolsProvider
      *
      * @param mixed $protocols

--- a/tests/Handler/StreamHandlerTest.php
+++ b/tests/Handler/StreamHandlerTest.php
@@ -3093,6 +3093,33 @@ class StreamHandlerTest extends TestCase
         )->wait();
     }
 
+    /**
+     * @dataProvider uriMissingSchemeOrHostProvider
+     */
+    public function testRejectsRequestUriMissingSchemeOrHost(string $uri): void
+    {
+        $handler = new StreamHandler();
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('URI must include a scheme and host');
+
+        $handler(
+            new Request('GET', $uri),
+            [
+                RequestOptions::STREAM => true,
+            ]
+        )->wait();
+    }
+
+    public static function uriMissingSchemeOrHostProvider(): iterable
+    {
+        yield 'relative path' => ['baz'];
+        yield 'host-like relative path' => ['gstatic.com/generate_204'];
+        yield 'path starting with colon-slash-slash' => ['://gstatic.com/generate_204'];
+        yield 'absolute path' => ['/generate_204'];
+        yield 'scheme without host' => ['https:/generate_204'];
+    }
+
     public function testResponseMessageIsBuiltViaResponseFactory(): void
     {
         $handler = new StreamHandler();


### PR DESCRIPTION
This moves missing scheme and host validation out of the client URI builder so middleware can provide the final request URI. The cURL and stream transports still reject requests with incomplete URIs before setting up the transfer.