### PR TITLE
Validate cURL scheme support before protocol policy

### DIFF
--- a/src/Handler/CurlFactory.php
+++ b/src/Handler/CurlFactory.php
@@ -169,7 +169,7 @@ final class CurlFactory implements CurlFactoryInterface
     public function create(RequestInterface $request, array $options): EasyHandle
     {
         $this->assertOpen();
-        self::validateRequestUri($request);
+        self::validateRequestUriScheme($request);
 
         $protocolVersion = $request->getProtocolVersion();
 
@@ -611,11 +611,15 @@ final class CurlFactory implements CurlFactoryInterface
         }
     }
 
-    private static function validateRequestUri(RequestInterface $request): void
+    private static function validateRequestUriScheme(RequestInterface $request): void
     {
-        $uri = $request->getUri();
-        if ($uri->getScheme() === '' || $uri->getHost() === '') {
+        $scheme = $request->getUri()->getScheme();
+        if ($scheme === '') {
             throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $request);
+        }
+
+        if (!\in_array($scheme, ['http', 'https'], true)) {
+            throw new RequestException(\sprintf("The scheme '%s' is not supported.", $scheme), $request);
         }
     }
 
@@ -1660,20 +1664,25 @@ final class CurlFactory implements CurlFactoryInterface
      */
     private function getDefaultConf(EasyHandle $easy): array
     {
+        $uri = $easy->request->getUri();
+        $protocols = Utils::normalizeProtocols($easy->options['protocols'] ?? ['http', 'https']);
+        $scheme = $uri->getScheme();
+        if (!\in_array($scheme, $protocols, true)) {
+            throw new RequestException(\sprintf('The scheme "%s" is not allowed by the protocols request option.', $scheme), $easy->request);
+        }
+
+        if ($uri->getHost() === '') {
+            throw new RequestException('URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.', $easy->request);
+        }
+
         $conf = [
             '_headers' => $easy->request->getHeaders(),
             \CURLOPT_CUSTOMREQUEST => $easy->request->getMethod(),
-            \CURLOPT_URL => (string) $easy->request->getUri()->withFragment(''),
+            \CURLOPT_URL => (string) $uri->withFragment(''),
             \CURLOPT_RETURNTRANSFER => false,
             \CURLOPT_HEADER => false,
             \CURLOPT_CONNECTTIMEOUT => 300,
         ];
-
-        $protocols = Utils::normalizeProtocols($easy->options['protocols'] ?? ['http', 'https']);
-        $scheme = $easy->request->getUri()->getScheme();
-        if (!\in_array($scheme, $protocols, true)) {
-            throw new RequestException(\sprintf('The scheme "%s" is not allowed by the protocols request option.', $scheme), $easy->request);
-        }
 
         if (CurlVersion::supportsProtocolsStr()) {
             $conf[(int) \constant('CURLOPT_PROTOCOLS_STR')] = \implode(',', $protocols);

--- a/tests/Handler/CurlFactoryTest.php
+++ b/tests/Handler/CurlFactoryTest.php
@@ -907,6 +907,36 @@ class CurlFactoryTest extends TestCase
         $f->create(new Psr7\Request('GET', 'http://example.com'), ['protocols' => ['https']]);
     }
 
+    public function testRejectsUnsupportedScheme(): void
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage("The scheme 'ftp' is not supported.");
+
+        $f->create(new Psr7\Request('GET', 'ftp://example.com'), []);
+    }
+
+    public function testRejectsUnsupportedSchemeBeforeMissingHost(): void
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage("The scheme 'file' is not supported.");
+
+        $f->create(new Psr7\Request('GET', 'file:///etc/passwd'), []);
+    }
+
+    public function testProtocolsOptionRejectsBeforeMissingHost(): void
+    {
+        $f = new CurlFactory(3);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('not allowed by the protocols request option');
+
+        $f->create(new Psr7\Request('GET', 'http:/generate_204'), ['protocols' => ['https']]);
+    }
+
     /**
      * @dataProvider uriMissingSchemeOrHostProvider
      */


### PR DESCRIPTION
This makes the cURL handler reject unsupported URI schemes before applying the request protocols option. It keeps protocol policy as a separate validation step for supported schemes.